### PR TITLE
Add config for daily shame mail job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/daily-shame-mail.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/daily-shame-mail.yaml
@@ -1,0 +1,30 @@
+- job:
+    name: 'daily-shame-mail'
+    description: 'Send the daily flaky issue shame email. Test owner: test infra team.'
+    logrotate:
+        numToKeep: 20
+    triggers:
+        - timed: 'H 8 * * 1-5'
+    wrappers:
+        - credentials-binding:
+            - text:
+                credential-id: '8864846d-2090-4173-9b00-163a79c51913'  # read-only GitHub API token
+                variable: 'GITHUB_API_TOKEN'
+            - username-password-separated:
+                credential-id: '8184516b-02e3-426f-be2c-81296ff6d545'  # sendgrid credentials
+                username: 'SMTP_USER'
+                password: 'SMTP_PASS'
+    builders:
+        - shell: |
+            set +x  # Don't echo credentials into the build log
+            IMAGE=gcr.io/google_containers/shame-mailer:2016-05-03-a8b2ceb
+            echo "Running ${IMAGE}"
+            docker run \
+              -e ALLOWED_SHAME_DOMAINS="google.com,redhat.com" \
+              -e GITHUB_API_TOKEN="${GITHUB_API_TOKEN}" \
+              -e SHAME_FROM="kubernetes-sig-testing+flakereport@googlegroups.com" \
+              -e SHAME_CC="jgrafton+k8s-flakereport@google.com" \
+              -e SMTP_SERVER="smtp.sendgrid.net:2525" \
+              -e SMTP_USER="${SMTP_USER}" \
+              -e SMTP_PASS="${SMTP_PASS}" \
+              "${IMAGE}"


### PR DESCRIPTION
cc @fejta @rmmh @apelisse 

We probably should have this email our alias if it fails, though I'm not sure I want address advertised in the external repo.