### PR TITLE
Send fewer emails

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -1,13 +1,3 @@
-# Mail Watcher Plugin alerts the specified address whenever a job config is updated or deleted.
-- property:
-    name: mail-watcher
-    properties:
-        - raw:
-            xml: |
-                <org.jenkinsci.plugins.mailwatcher.WatcherJobProperty plugin="mail-watcher-plugin@1.13">
-                    <watcherAddresses>cloud-kubernetes-team@google.com</watcherAddresses>
-                </org.jenkinsci.plugins.mailwatcher.WatcherJobProperty>
-
 - publisher:
     name: gcs-uploader
     publishers:
@@ -120,7 +110,7 @@
 - defaults:
     name: global
     disable_job: false
-    emails: '$DEFAULT_RECIPIENTS'
+    emails: ''
     cron-string: 'H/30 * * * *'  # Set a 30m floor to start jobs.
     sq-cron-string: 'H/5 * * * *'  # Lower floor to 5m for blocking jobs.
     # How long to wait after sending TERM to send KILL (minutes)

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -9,20 +9,16 @@
         - shell: |
             timeout -k {kill-timeout}m {timeout}m ./hack/jenkins/build.sh && rc=$? || rc=$?
             {report-rc}
-    properties:
-        - mail-watcher
     publishers:
         - claim-build
         - gcs-uploader
         - log-parser
         - email-ext:
-            recipients: $DEFAULT_RECIPIENTS, cloud-kubernetes-team@google.com
             presend-script: $DEFAULT_PRESEND_SCRIPT
             fail: true
             fixed: true
             send-to:
                 - culprits
-                - recipients
     scm:
         - git:
             url: https://github.com/kubernetes/kubernetes

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -30,8 +30,6 @@
                 fi
             fi
             {report-rc}
-    properties:
-        - mail-watcher
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -153,7 +151,7 @@
         - 'gce-ubernetes-lite':
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GCE, in parallel, and in a multi-zone (Ubernetes-lite) cluster.'
             timeout: 150
-            emails: '$DEFAULT_RECIPIENTS, quinton@google.com, justin@fathomdb.com'
+            emails: 'quinton@google.com, justin@fathomdb.com'
             test-owner: 'quinton'
             job-env: |
                 export PROJECT="k8s-jkns-e2e-gce-ubelite"
@@ -228,7 +226,7 @@
         - 'gke-multizone':
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel, and in a multi-zone (Ubernetes-lite) cluster.'
             timeout: 150
-            emails: '$DEFAULT_RECIPIENTS, cloud-kubernetes-alerts@google.com, arob@google.com, quinton@google.com'
+            emails: 'arob@google.com, quinton@google.com'
             job-env: |
                 export PROJECT="k8s-jkns-e2e-gke-multizone"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
@@ -542,7 +540,7 @@
         - 'gce-es-logging':
             description: 'Run [Feature:Elasticsearch] tests on GCE using the latest successful build.'
             timeout: 90
-            emails: '$DEFAULT_RECIPIENTS, mixia@google.com'
+            emails: 'mixia@google.com'
             test-owner: 'mixia'
             provider-env: '{gce-provider-env}'
             job-env: |

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -11,8 +11,6 @@
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
-    properties:
-        - mail-watcher
     publishers:
         - claim-build
         - junit-publisher

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
@@ -74,8 +74,6 @@
             {post-env}
             timeout -k {kill-timeout}m 60m {runner} && rc=$? || rc=$?
             {report-rc}
-    properties:
-        - mail-watcher
     publishers:
         - claim-build
         # No junit-publisher, since we're not running any tests
@@ -111,8 +109,6 @@
             {post-env}
             timeout -k {kill-timeout}m 300m {runner} && rc=$? || rc=$?
             {report-rc}
-    properties:
-        - mail-watcher
     publishers:
         - claim-build
         - junit-publisher


### PR DESCRIPTION
We're burning through our SendGrid quota at an alarming rate, much of the time to groups which aren't accepting the emails anyway. Let's only send email when we really want to.

@spxtr @fejta @rmmh @apelisse 