### PR TITLE
Death to "build-log (23).txt"!

### DIFF
--- a/jenkins/diff-job-config-patch.sh
+++ b/jenkins/diff-job-config-patch.sh
@@ -33,7 +33,7 @@ set -o nounset
 set -o pipefail
 
 readonly JOB_CONFIGS_ROOT="jenkins/job-configs"
-readonly JOB_BUILDER_IMAGE='gcr.io/google_containers/kubekins-job-builder:2'
+readonly JOB_BUILDER_IMAGE='gcr.io/google_containers/kubekins-job-builder:3'
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd)
 REPO_DIR=${REPO_DIR:-"${REPO_ROOT}"}

--- a/jenkins/job-builder-image/Makefile
+++ b/jenkins/job-builder-image/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 2
+TAG = 3
 
 all:
 	docker build -t gcr.io/google_containers/kubekins-job-builder:$(TAG) .

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -40,6 +40,8 @@
             timeout: '{jenkins-timeout}'
             fail: true
         - timestamps
+        - workspace-cleanup:
+            external-deletion-command: 'sudo rm -rf %s'
 
 - project:
     name: kubernetes-builds

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -54,19 +54,8 @@
             timeout: '{jenkins-timeout}'
             fail: true
         - timestamps
-        - raw:
-            xml: |
-                <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.28">
-                    <patterns>
-                        <hudson.plugins.ws__cleanup.Pattern>
-                            <pattern>*</pattern>
-                            <type>INCLUDE</type>
-                        </hudson.plugins.ws__cleanup.Pattern>
-                    </patterns>
-                    <deleteDirs>true</deleteDirs>
-                    <cleanupParameter/>
-                    <externalDelete>sudo rm -rf %s</externalDelete>
-                </hudson.plugins.ws__cleanup.PreBuildCleanup>
+        - workspace-cleanup:
+            external-deletion-command: 'sudo rm -rf %s'
 
 - project:
     name: kubernetes-test-go

--- a/jenkins/update-jobs.sh
+++ b/jenkins/update-jobs.sh
@@ -33,7 +33,7 @@ if ! docker inspect job-builder &> /dev/null; then
       --net host \
       --name job-builder \
       --restart always \
-      gcr.io/google_containers/kubekins-job-builder:2
+      gcr.io/google_containers/kubekins-job-builder:3
     docker cp jenkins_jobs.ini job-builder:/etc/jenkins_jobs
   else
     echo "jenkins_jobs.ini not found in workspace" >&2


### PR DESCRIPTION
Bumping up to the latest Jenkins Job Builder version to get my recent changes to support newer GCS and workspace-cleanup features.

The second commit cleans up some raw XML, and it uses `sudo rm -rf` to clean up the kubernetes-build workspaces, rather than trying to use the previous build image (which is fragile and caused https://github.com/kubernetes/kubernetes/issues/25086).

Diff from using the new version of Jenkins Job Builder is here: https://gist.github.com/ixdy/091e7204065081b81ba619aba7a8cdb1
Travis should generate the diff for the second commit (though I've examined it locally and it looks correct).

@fejta @rmmh @apelisse 