### PR TITLE
Match directories on workspace cleanup

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -41,6 +41,7 @@
             fail: true
         - timestamps
         - workspace-cleanup:
+            dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
 
 - project:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -55,6 +55,7 @@
             fail: true
         - timestamps
         - workspace-cleanup:
+            dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
 
 - project:


### PR DESCRIPTION
I guess we need to set this to true after all - otherwise the -build- and -test-go- jobs fail.

It seems to only matter when using `external-deletion-command` - other jobs which use git (like node-e2e) are still working fine.