### PR TITLE
Use 'sudo rm -rf' to clean up dockerized e2e workspaces

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -37,7 +37,9 @@
             timeout: '{jenkins-timeout}'
             fail: true
         - timestamps
-        - workspace-cleanup
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
 
 # Template for most e2e test jobs.
 - job-template:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -30,7 +30,9 @@
             timeout: '{jenkins-timeout}'
             fail: true
         - timestamps
-        - workspace-cleanup
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
 
 - project:
     name: kubernetes-kubemark

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -29,7 +29,9 @@
             timeout: '{jenkins-timeout}'
             fail: true
         - timestamps
-        - workspace-cleanup
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
 
 - job-template:
     name: 'kubernetes-soak-continuous-e2e-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
@@ -88,7 +88,9 @@
             timeout: '{jenkins-timeout}'
             fail: true
         - timestamps
-        - workspace-cleanup
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
 
 - job-template:
     name: 'kubernetes-upgrade-{provider}-{version-old}-{version-new}-{step}'

--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -103,7 +103,9 @@
                 GOROOT=/usr/local/go
                 GOPATH=$WORKSPACE/go
                 PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
-        - workspace-cleanup
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
 
 - project:
     name: node-docker-canary-build
@@ -122,7 +124,9 @@
     jobs:
         - '{gitproject}-dockercanarybuild-ci'
     wrappers:
-        - workspace-cleanup
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
 
 - project:
     name: node-gce-e2e

--- a/jenkins/job-configs/kubernetes-jenkins/test-linkchecker.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/test-linkchecker.yaml
@@ -33,4 +33,6 @@
             timeout: 60
             fail: true
         - timestamps
-        - workspace-cleanup
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'


### PR DESCRIPTION
Proper fix for https://github.com/kubernetes/kubernetes/issues/25017.

Dockerized e2e runs are producing artifacts owned by root, so the workspace cleanup plugin isn't able to delete them.