### PR TITLE
Bind secret credentials (ssh keys etc) in dockerized e2e jobs

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -158,6 +158,10 @@
         export MASTER_SIZE="m3.medium"
         export NODE_SIZE="m3.medium"
         export NUM_NODES="3"
+        export AWS_CONFIG_FILE=/workspace/.aws/credentials
+        # This is needed to be able to create PD from the e2e test
+        export AWS_SHARED_CREDENTIALS_FILE=/workspace/.aws/credentials
+        export KUBE_SSH_USER=admin
     post-env: |
         # Nothing should want Jenkins $HOME
         export HOME=${{WORKSPACE}}

--- a/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
@@ -1,0 +1,13 @@
+- wrapper:
+    name: e2e-credentials-binding
+    wrappers:
+        - credentials-binding:
+            - file:
+                credential-id: 'f4502d38-b004-49cb-bb4c-674d316fe590'
+                variable: 'JENKINS_GCE_SSH_KEY_FILE'
+            - file:
+                credential-id: '8b422542-f930-4415-b827-e06e2ad3a3d4'
+                variable: 'JENKINS_AWS_SSH_KEY_FILE'
+            - file:
+                credential-id: '00711c20-7f9e-409d-81f1-80401fac2dfb'
+                variable: 'JENKINS_AWS_CREDENTIALS_FILE'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -40,6 +40,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+        - e2e-credentials-binding
 
 # Template for most e2e test jobs.
 - job-template:
@@ -574,27 +575,23 @@
     trigger-job: ''
     timeout: 240
     jenkins_node: 'master'
-    runner: '{legacy-runner}'
-    provider-env: |
-        {aws-provider-env}
-        export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-        export GINKGO_PARALLEL="y"
-        export PROJECT="k8s-jkns-e2e-aws"
-        export AWS_CONFIG_FILE='/var/lib/jenkins/.aws/credentials'
-        export AWS_SSH_KEY='/var/lib/jenkins/.ssh/kube_aws_rsa'
-        export KUBE_SSH_USER='admin'
-        # This is needed to be able to create PD from the e2e test
-        export AWS_SHARED_CREDENTIALS_FILE='/var/lib/jenkins/.aws/credentials'
+    provider-env: '{aws-provider-env}'
     suffix:
         - 'aws':
             description: 'Run e2e tests on AWS using the latest successful Kubernetes build.'
             job-env: |
                 export E2E_NAME="e2e-aws-master"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-e2e-aws"
         - 'aws-release-1.2':
             description: 'Run e2e tests on AWS using the latest successful 1.2 Kubernetes build.'
             job-env: |
                 export E2E_NAME="e2e-aws-1-2"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-e2e-aws"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -30,6 +30,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+        - e2e-credentials-binding
 
 - project:
     name: kubernetes-kubemark


### PR DESCRIPTION
The other half of the change to support running AWS e2e jobs in dockerized e2e. Depends on https://github.com/kubernetes/kubernetes/pull/25118.

cc @fejta @rmmh @apelisse