### PR TITLE
Document how to add a federated test job to test history dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Kubernetes Test Infrastructure
 
 [![Build Status](https://travis-ci.org/kubernetes/test-infra.svg?branch=master)](https://travis-ci.org/kubernetes/test-infra)
+
+## Test Results History
+
+The [Kubernetes test history
+dashboard](http://storage.googleapis.com/kubernetes-test-history/static/index.html)
+contains e2e test results from the last 24 hours.  The test history is
+implemented by two components in this repository:
+
+1. `jenkins/test-history/` - scripts that periodically gather results from e2e
+   test jobs and generate the above status page.
+2. `gubernator/` - parses and presents the error message of a failed scenario.
+   The test-history page links failed scenarios to the output of gubernator.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ implemented by two components in this repository:
    test jobs and generate the above status page.
 2. `gubernator/` - parses and presents the error message of a failed scenario.
    The test-history page links failed scenarios to the output of gubernator.
+
+## Federated Testing
+
+The Kubernetes project encourages organizations to contribute execution of e2e
+test jobs for a variety of platforms (e.g., Azure, rktnetes).  The test-history
+scripts gather e2e results from these federated jobs.  For information about
+how to contribute test results, see [Federated Testing](docs/federated_testing.md).

--- a/docs/federated_testing.md
+++ b/docs/federated_testing.md
@@ -1,0 +1,86 @@
+# Federated Testing
+
+The quality of Kubernetes depends on exercising the software on a
+variety of platforms.  The Kubernetes project welcomes contributions of
+test results from organizations that execute e2e test jobs.  The
+[Kubernetes test history
+dashboard](http://storage.googleapis.com/kubernetes-test-history/static/index.html)
+displays the latest results from all federated test jobs.
+
+
+## Overview
+
+To contribute test results for a platform, an organization executes the
+e2e test cases and uploads the test results to a Google Cloud Storage
+(GCS) bucket.  The Kubernetes project contains scripts in `hack/` to run
+the tests and to upload the results.
+
+The test history dashboard is generated periodically by scripts in this
+repository that read test results from all of the GCS buckets.  The test
+history shows test results from jobs run during the previous 24 hours.
+A test job should execute at least once every 24 hours.
+
+The remainder of this document explains how to contribute test results.
+
+
+### Run the e2e tests and upload results
+
+Setup a periodic test job that will run at least once per day.  The test
+job runs e2e tests and uploads the results.
+
+1. Create a Google Cloud Storage bucket that will store the test
+   results.  The bucket should have public read access.  The GCS URL
+   must be stored in an environment variable named
+   JENKINS_GCS_LOGS_PATH.  For example, Google's Jenkins server stores
+   results to `gs://kubernetes-jenkins/logs/`.
+2. Run `hack/jenkins/e2e-runner.sh`.  There are several environment
+   variables that affect the behavior of this script.  See [e2e-runner
+   Environment Variables](#e2e-runner-environment-variables).
+3. Run `JENKINS_BUILD_FINISHED={SUCCESS|UNSTABLE|FAILURE|ABORTED}
+   hack/jenkins/upload-to-gcs.sh` to upload the results to the GCS
+   bucket.  If running from a Jenkins job, it is recommend to perform
+   this step as a post-build step.  See
+   `jenkins/job-configs/global.yaml` for an example.
+
+
+### Include results in test history
+
+Modify scripts that collect results from federate test jobs to include
+the Google Cloud Storage bucket in the list of buckets that are read.
+
+1. Add the name of the Google Cloud Storage bucket to
+   `BUCKET_WHITELIST` in [gubernator/main.py](gubnerator/main.py).
+2. Add an entry for the test job in
+   [`jenkins/test-history/buckets.json`](jenkins/test-history/buckets.json).
+   The key for each entry is a Google Cloud Storage bucket URL.  Each
+   bucket has a `prefix` field that used to identify tests in the
+   test history dashboard.
+
+
+### e2e-runner Environment Variables
+
+The following environment variables should be set appropriately before
+running the `e2e-runner.sh` script:
+
+- WORKSPACE *
+- JOB_NAME *
+- BUILD_NUMBER *
+- GINKGO_TEST_ARGS
+- JENKINS_GCS_LOGS_PATH
+- JENKINS_USE_EXISTING_BINARIES (optional. Set to "y" for locally built binaries.)
+- E2E_TEST="true"
+
+\* If using Jenkins to execute the e2e test job, then these environment
+   variables may be set by Jenkins.  Otherwise, they must be set before
+   executing `e2e-runner.sh`.  See above for how they affect how results
+   are uploaded to a GCS bucket.
+
+Test results are stored in
+`gs://$JENKINS_GCS_LOGS_PATH/$JOB_NAME/$BUILD_NUMBER`.
+
+If the platform should be setup or torn down by `e2e-runner.sh`, then
+optionally set:
+
+- E2E_UP="true"
+- E2E_DOWN="true"
+

--- a/jenkins/test-history/buckets.json
+++ b/jenkins/test-history/buckets.json
@@ -1,0 +1,11 @@
+{
+    "gs://kubernetes-jenkins/logs/": {
+        "prefix": ""
+    },
+    "gs://kube_azure_log/": {
+        "prefix": "azure$"
+    },
+    "gs://rktnetes-jenkins/logs/": {
+        "prefix": "rktnetes$"
+    }
+}

--- a/jenkins/test-history/gen_history
+++ b/jenkins/test-history/gen_history
@@ -30,11 +30,14 @@ gsutil -q cp "${jsonpath}" "tests.json" || true
 
 # Create JSON report
 time python gen_json.py \
-  --jobs_dirs gs://kubernetes-jenkins/logs/ gs://kube_azure_log/ gs://rktnetes-jenkins/logs/ \
+  --buckets=buckets.json \
   "--match=^kubernetes|kubernetes-build|kubelet-gce-e2e-ci"
 
 # Create static HTML reports out of the JSON
-python gen_html.py --output-dir=static --input=tests.json
+python gen_html.py \
+    --output-dir=static \
+    --input=tests.json \
+    --buckets=buckets.json
 
 # Upload to GCS
 readonly gcs_acl="public-read"

--- a/jenkins/test-history/gen_json.py
+++ b/jenkins/test-history/gen_json.py
@@ -329,10 +329,9 @@ def get_options(argv):
     """Process command line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--jobs_dirs',
-        help='locations of test artifacts on GCS',
-        nargs='+',
-        default=['gs://kubernetes-jenkins/logs/'],
+        '--buckets',
+        help='JSON file with GCS bucket locations',
+        required=True,
     )
     parser.add_argument(
         '--match',
@@ -353,10 +352,19 @@ def get_options(argv):
     return parser.parse_args(argv)
 
 
+def get_buckets(infile):
+    if infile is None:
+        return []
+    with open(infile) as buf:
+        buckets = json.load(buf)
+    return buckets.keys()
+
+
 if __name__ == '__main__':
     if os.getenv('REQ_CACHE'):
         # for fast test iterations, enable caching GCS HTTP responses
         import requests_cache
         requests_cache.install_cache(os.getenv('REQ_CACHE'))
     OPTIONS = get_options(sys.argv[1:])
-    main(OPTIONS.jobs_dirs, OPTIONS.match, OPTIONS.outfile, OPTIONS.threads)
+    jobs_dirs = get_buckets(OPTIONS.buckets)
+    main(jobs_dirs, OPTIONS.match, OPTIONS.outfile, OPTIONS.threads)


### PR DESCRIPTION
I have documented the steps to setup a federated test job and incorporate results into the Kubernetes test history dashboard.  To simplify the modifications that must be made to test-history scripts, I have consolidated the list of Google Cloud Storage buckets into a single JSON file that is referenced by multiple scripts.