### PR TITLE
Keep fewer build logs

### DIFF
--- a/jenkins/job-configs/jenkins-daily-maintenance.yaml
+++ b/jenkins/job-configs/jenkins-daily-maintenance.yaml
@@ -2,7 +2,7 @@
     name: 'jenkins-daily-maintenance'
     description: 'Run gcloud components update and clean Docker images. Test owner: spxtr.'
     logrotate:
-        numToKeep: 200
+        daysToKeep: 30
     builders:
         - shell: |
             sudo chown -R jenkins:jenkins /usr/local/share/google
@@ -21,7 +21,7 @@
     name: 'jenkins-daily-maintenance-all'
     description: 'Run jenkins-daily-maintenance on all nodes. Test owner: spxtr.'
     logrotate:
-        numToKeep: 200
+        daysToKeep: 30
     builders:
         # Run jenkins-daily-maintenance on all nodes.
         - raw:

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
@@ -2,7 +2,7 @@
     name: kubernetes-update-jenkins-jobs
     description: 'Update Jenkins jobs based on configs in https://github.com/kubernetes/test-infra/tree/master/jenkins/job-configs. Test owner: spxtr.'
     logrotate:
-        daysToKeep: 7
+        daysToKeep: 3
     node: master
     triggers:
         - timed: 'H/15 * * * *'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
@@ -1,6 +1,8 @@
 - job:
     name: kubernetes-test-summary
     description: 'Create a daily test summary and upload to GCS. Test owner: spxtr.'
+    logrotate:
+        daysToKeep: 3
     triggers:
         # Run hourly
         - timed: 'H * * * *'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
@@ -2,7 +2,7 @@
     name: kubernetes-update-jenkins-jobs
     description: 'Update Jenkins jobs based on configs in https://github.com/kubernetes/test-infra/tree/master/jenkins/job-configs. Test owner: spxtr.'
     logrotate:
-        daysToKeep: 7
+        daysToKeep: 3
     triggers:
         - timed: 'H/15 * * * *'
     builders:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrades.yaml
@@ -9,6 +9,8 @@
     name: 'kubernetes-upgrade-{provider}-{version-old}-{version-new}'
     disabled: false
     description: 'Upgrade multijob from {version-old} to {version-new}. Test owner: ihmccreery.'
+    logrotate:
+        daysToKeep: 7
     project-type: multijob
     triggers:
         - timed: '@hourly'


### PR DESCRIPTION
Worst offenders on kubernetes-jenkins right now:
```
    530 kubernetes-e2e-gce
    567 kubernetes-e2e-gke
    592 kubernetes-kubemark-5-gce
    645 kubernetes-upgrade-gce-1.1-1.3
    674 kubernetes-update-jenkins-jobs
    737 kubernetes-upgrade-gke-1.1-1.3
   1391 kubernetes-upgrade-gce-1.2-1.3
   1511 kubernetes-upgrade-gce-1.0-1.2
```