### PR TITLE
Pass the test-infra repo into the job-builder image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache: pip
 services:
     - docker
 before_install:
-    - docker pull gcr.io/google_containers/kubekins-job-builder:3
+    - docker pull gcr.io/google_containers/kubekins-job-builder:4
 install:
 # Based on https://github.com/travis-ci/travis-ci/issues/738#issuecomment-11179888
     - wget -nv https://storage.googleapis.com/appengine-sdks/featured/${GAE_ZIP}

--- a/jenkins/diff-job-config-patch.sh
+++ b/jenkins/diff-job-config-patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #
@@ -15,9 +15,8 @@
 # limitations under the License.
 
 # Uses the kubekins-job-builder Docker image to compute the differences in
-# the Jenkins job config XML, comparing the current git branch against upstream
-# master. The filename containing the diff is printed at the end, assuming
-# everything parsed successfully.
+# the Jenkins job config XML, comparing the current git branch against master.
+# The diff is printed at the end, assuming everything parsed successfully.
 
 # Note: anecdotal evidence suggests this doesn't work correctly on OS X.
 # If you find that there is no diff being generated, you may want to try setting
@@ -33,7 +32,7 @@ set -o nounset
 set -o pipefail
 
 readonly JOB_CONFIGS_ROOT="jenkins/job-configs"
-readonly JOB_BUILDER_IMAGE='gcr.io/google_containers/kubekins-job-builder:3'
+readonly JOB_BUILDER_IMAGE="gcr.io/google_containers/kubekins-job-builder:4"
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd)
 REPO_DIR=${REPO_DIR:-"${REPO_ROOT}"}
@@ -55,10 +54,14 @@ readonly common_commands="\
     '${JOB_CONFIGS_ROOT}:${JOB_CONFIGS_ROOT}/kubernetes-jenkins-pull' \
     -o /output/kubernetes-jenkins-pull"
 
+# We don't want to modify the local source in any way, so mount it read-only
+# and checkout the master branch in a separate directory.
 docker run --rm=true -i \
+  -v "${REPO_DIR}:/test-infra:ro" \
   -v "${docker_volume_output_dir}/upstream:/output" \
   "${JOB_BUILDER_IMAGE}" \
-  bash -c "git checkout master && git pull && ${common_commands}"
+  bash -c "git clone -b master --single-branch /test-infra /workspace && \
+    cd /workspace && ${common_commands}"
 
 docker run --rm=true -i \
   -v "${docker_volume_output_dir}/patch:/output" \

--- a/jenkins/job-builder-image/Dockerfile
+++ b/jenkins/job-builder-image/Dockerfile
@@ -42,6 +42,5 @@ RUN git clone https://git.openstack.org/openstack-infra/jenkins-job-builder \
 # JJB configuration lives in /etc/jenkins_jobs/jenkins_jobs.ini
 RUN mkdir -p /etc/jenkins_jobs
 
-WORKDIR /
-RUN git clone https://github.com/kubernetes/test-infra
-WORKDIR test-infra
+RUN mkdir /test-infra
+WORKDIR /test-infra

--- a/jenkins/job-builder-image/Makefile
+++ b/jenkins/job-builder-image/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 3
+TAG = 4
 
 all:
 	docker build -t gcr.io/google_containers/kubekins-job-builder:$(TAG) .

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
@@ -6,11 +6,17 @@
     node: master
     triggers:
         - timed: 'H/15 * * * *'
+    scm:
+        - git:
+            url: https://github.com/kubernetes/test-infra
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            skip-tag: true
     builders:
         - shell: |
-            curl -fsS https://raw.githubusercontent.com/kubernetes/test-infra/master/jenkins/update-jobs.sh > update-jobs.sh
-            chmod +x update-jobs.sh
-            ./update-jobs.sh "jenkins/job-configs:jenkins/job-configs/kubernetes-jenkins-pull"
+            ./jenkins/update-jobs.sh "jenkins/job-configs:jenkins/job-configs/kubernetes-jenkins-pull"
     publishers:
       - email-ext:
           recipients: spxtr@google.com

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
@@ -3,13 +3,20 @@
     description: 'Update Jenkins jobs based on configs in https://github.com/kubernetes/test-infra/tree/master/jenkins/job-configs. Test owner: spxtr.'
     logrotate:
         daysToKeep: 3
+    node: master
     triggers:
         - timed: 'H/15 * * * *'
+    scm:
+        - git:
+            url: https://github.com/kubernetes/test-infra
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            skip-tag: true
     builders:
         - shell: |
-            curl -fsS https://raw.githubusercontent.com/kubernetes/test-infra/master/jenkins/update-jobs.sh > update-jobs.sh
-            chmod +x update-jobs.sh
-            ./update-jobs.sh "jenkins/job-configs:jenkins/job-configs/kubernetes-jenkins"
+            ./jenkins/update-jobs.sh "jenkins/job-configs:jenkins/job-configs/kubernetes-jenkins"
     publishers:
       - email-ext:
           recipients: spxtr@google.com


### PR DESCRIPTION
So that we don't need to keep it in the container and constantly do git pulls. I'm not sure how this'll work on travis. Lets find out!

It copies the repo to a safe spot before checking out master so that we don't bork our local copy.

*edit*: sweet, it worked