### PR TITLE
Clean up leaked VMs from node e2e tests

### DIFF
--- a/jenkins/clean_project.py
+++ b/jenkins/clean_project.py
@@ -57,8 +57,8 @@ def DeleteInstances(project, zones, delete):
   return err
 
 
-def main(project, hours, filt, delete):
-  age = datetime.datetime.now() - datetime.timedelta(hours=int(hours))
+def main(project, days, hours, filt, delete):
+  age = datetime.datetime.now() - datetime.timedelta(days=days, hours=hours)
   zones = Instances(project, age, filt)
   if zones:
     sys.exit(DeleteInstances(project, zones, delete))
@@ -69,10 +69,21 @@ if __name__ == '__main__':
       description='Delete old instances from a project')
   parser.add_argument('--project', help='Project to clean', required=True)
   parser.add_argument(
-      '--hours', type=float, help='Clean items more than --hours old', required=True)
+      '--days', type=int,
+      help='Clean items more than --days old (added to --hours)')
+  parser.add_argument(
+      '--hours', type=float,
+      help='Clean items more than --hours old (added to --days)')
   parser.add_argument(
       '--delete', action='store_true', help='Really delete things when set')
   parser.add_argument(
-      '--filter', default='name:tmp*', help='Filter down to these instances')
+      '--filter', default="name~'tmp.*' AND NOT tags.items:do-not-delete",
+      help='Filter down to these instances')
   args = parser.parse_args()
-  main(args.project, args.hours, args.filter, args.delete)
+
+  # We want to allow --days=0 and --hours=0, so check against Noneness instead.
+  if args.days is None and args.hours is None:
+    print >>sys.stderr, 'must specify --days and/or --hours'
+    sys.exit(1)
+
+  main(args.project, args.days or 0, args.hours or 0, args.filter, args.delete)

--- a/jenkins/clean_project.py
+++ b/jenkins/clean_project.py
@@ -57,8 +57,8 @@ def DeleteInstances(project, zones, delete):
   return err
 
 
-def main(project, days, filt, delete):
-  age = datetime.datetime.now() - datetime.timedelta(days=int(days))
+def main(project, hours, filt, delete):
+  age = datetime.datetime.now() - datetime.timedelta(hours=int(hours))
   zones = Instances(project, age, filt)
   if zones:
     sys.exit(DeleteInstances(project, zones, delete))
@@ -69,10 +69,10 @@ if __name__ == '__main__':
       description='Delete old instances from a project')
   parser.add_argument('--project', help='Project to clean', required=True)
   parser.add_argument(
-      '--days', type=float, help='Clean items more than --days old', required=True)
+      '--hours', type=float, help='Clean items more than --hours old', required=True)
   parser.add_argument(
       '--delete', action='store_true', help='Really delete things when set')
   parser.add_argument(
       '--filter', default='name:tmp*', help='Filter down to these instances')
   args = parser.parse_args()
-  main(args.project, args.days, args.filter, args.delete)
+  main(args.project, args.hours, args.filter, args.delete)

--- a/jenkins/job-configs/cloud-resource-cleanup.yaml
+++ b/jenkins/job-configs/cloud-resource-cleanup.yaml
@@ -1,0 +1,25 @@
+- job-template:
+    name: 'google-cloud-resource-cleanup'
+    description: 'Clean up leaked cloud resources. Test owner: test-infra maintainers.'
+    properties:
+        - build-discarder:
+            days-to-keep: 14
+    scm:
+    - git:
+        url: https://github.com/kubernetes/test-infra
+        branches:
+        - master
+        browser: githubweb
+        browser-url: https://github.com/kubernetes/test-infra
+        skip-tag: true
+    triggers:
+        - timed: 'H H/3 * * *'
+    builders:
+        - activate-gce-service-account
+        - shell:
+            ./jenkins/clean_project.py --project="{node-e2e-project}" --hours=3 --delete
+    wrappers:
+        - e2e-credentials-binding
+        - timeout:
+            timeout: 15
+            fail: true

--- a/jenkins/job-configs/kubernetes-jenkins-pull/cloud-resource-cleanup.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/cloud-resource-cleanup.yaml
@@ -1,0 +1,5 @@
+- project:
+    name: resource-cleanup
+    node-e2e-project: 'k8s-jkns-pr-node-e2e'
+    jobs:
+        - 'google-cloud-resource-cleanup'

--- a/jenkins/job-configs/kubernetes-jenkins/cloud-resource-cleanup.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/cloud-resource-cleanup.yaml
@@ -1,0 +1,5 @@
+- project:
+    name: resource-cleanup
+    node-e2e-project: 'k8s-jkns-ci-node-e2e'
+    jobs:
+        - 'google-cloud-resource-cleanup'


### PR DESCRIPTION
Somewhat mitigate https://github.com/kubernetes/kubernetes/issues/25629 and https://github.com/kubernetes/kubernetes/issues/25639. I'm not sure if running this daily is actually going to save us at the current leak rate, but once we get things under control it should be reasonable.

We probably don't need *all* of the filters, but I'm pretty paranoid after yesterday.

(We can probably be even safer if we start using a different zone for the node e2e tests.)

cc @bprashanth @pwittrock 