### PR TITLE
Replace Trusty e2e jobs with GCI e2e jobs for OSS Kubernetes

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -650,23 +650,22 @@
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
-# NOTE: From here on all jobs use Trusty as the image for master and/or nodes.
-# Please add templates/groups/projects/jobs that use ContainerVm above/below
-# this section (search "End of Trusty jobs" for the ending separator).
+# NOTE: From here on all jobs use Google Container-VM Image (GCI,
+# https://cloud.google.com/compute/docs/containers/vm-image/) as the image for
+# master and/or nodes. Please add templates/groups/projects/jobs that use
+# ContainerVm above/below this section (search "End of GCI jobs" for the
+# ending separator).
 #
-# This section contains three types of jobs (all run e2e tests on GCE):
-#   * Jobs that use a "green" Trusty image to test k8s continuous builds (hence
-#     the "ci" in job names). We use these to guard k8s and Trusty
-#     compatibility.
-#   * Jobs that use a released k8s version to test Trusty's continuous builds
-#     (dev, beta and stable). We use these to qualify Trusty image releases.
-#   * Jobs that run tests against GKE endpoints with Trusty images. We use these
-#     to soak Trusty release candidate before pushing to GKE production.
+# This section contains two types of jobs (all run e2e tests on GCE):
+#   * Jobs that use a "green" GCI image to test k8s continuous builds (hence
+#     the "ci" in job names). We use these to guard k8s and GCI compatibility.
+#   * Jobs that use a released k8s version to test GCI's continuous builds
+#     (dev, beta and stable). We use these to qualify GCI image releases.
 
-# e2e test jobs that run on GCE with a "green" Trusty image and kubernetes'
+# e2e test jobs that run on GCE with a "green" GCI image and kubernetes'
 # continuous builds (currently only targeting `master` and `release-1.2`).
 - job-template:
-    name: 'kubernetes-e2e-gce-trusty-ci-{suffix}'
+    name: 'kubernetes-e2e-gce-gci-ci-{suffix}'
     <<: *e2e_job_defaults
     node: '{jenkins_node}'
     triggers:
@@ -681,88 +680,88 @@
             regexp: KUBE_GCE_MASTER_IMAGE=(.*)
         - groovy-postbuild:
             script: |
-                def trustyImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
-                if(trustyImageMatcher?.matches()) manager.addShortText("<b>Trusty Image: " + trustyImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
+                if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
                 def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
 
 - project:
-    name: kubernetes-e2e-gce-trusty-ci-master
+    name: kubernetes-e2e-gce-gci-ci-master
     trigger-job: 'kubernetes-build'
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
     provider-env: |
         {gce-provider-env}
-        export JENKINS_TRUSTY_IMAGE_TYPE="dev"
+        export JENKINS_GCI_IMAGE_TYPE="dev"
     suffix:
-        # TODO(wonderfly): For Trusty, we currently only run CI and slow tests.
-        # More test coverage under way.
+        # TODO(wonderfly): For GCI, we currently only run CI, slow and serial
+        # tests. More test coverage under way.
         - 'master':
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with Trusty images in parallel on the master branch.'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the master branch.'
             timeout: 30
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-trusty-ci-master"
+                export PROJECT="e2e-gce-gci-ci-master"
         - 'slow-master':
-            description: 'Runs slow tests on GCE with Trusty images, sequentially on the master branch.'
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the master branch.'
             timeout: 60
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-trusty-ci-master-slow"
+                export PROJECT="e2e-gce-gci-ci-master-slow"
         - 'serial-master':
-            description: 'Run [Serial], [Disruptive], tests on GCE, with Trusty images.'
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images.'
             timeout: 300
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-trusty-ci-serial"
+                export PROJECT="e2e-gce-gci-ci-serial"
     jobs:
-        - 'kubernetes-e2e-gce-trusty-ci-{suffix}'
+        - 'kubernetes-e2e-gce-gci-ci-{suffix}'
 
 - project:
-    name: kubernetes-e2e-gce-trusty-ci-1-2
+    name: kubernetes-e2e-gce-gci-ci-1-2
     trigger-job: 'kubernetes-build-1.2'
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
     provider-env: |
         {gce-provider-env}
         export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-        export JENKINS_TRUSTY_IMAGE_TYPE="dev"
+        export JENKINS_GCI_IMAGE_TYPE="dev"
     suffix:
-        # TODO(wonderfly): For Trusty, we currently only run CI and slow tests.
-        # More test coverage under way.
+        # TODO(wonderfly): For GCI, we currently only run CI, slow and serial
+        # tests. More test coverage under way.
         - 'release-1.2':
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with Trusty images in parallel on the release-1.2 branch.'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
             timeout: 30
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-trusty-ci-1-2"
+                export PROJECT="e2e-gce-gci-ci-1-2"
         - 'slow-release-1.2':
-            description: 'Runs slow tests on GCE with Trusty images, sequentially on the release-1.2 branch.'
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 60
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-trusty-ci-slow-1-2"
+                export PROJECT="e2e-gce-gci-ci-slow-1-2"
         - 'serial-release-1.2':
-            description: 'Run [Serial], [Disruptive], tests on GCE, with Trusty images, on the release-1.2 branch.'
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-trusty-ci-serial-1-2"
+                export PROJECT="e2e-gce-gci-ci-serial-1-2"
     jobs:
-        - 'kubernetes-e2e-gce-trusty-ci-{suffix}'
+        - 'kubernetes-e2e-gce-gci-ci-{suffix}'
 
 # Template for e2e test jobs that run on GCE with a released k8s version and
-# Trusty's continuous builds (dev and beta only).
+# GCI's continuous builds (dev and beta only).
 - job-template:
-    name: 'kubernetes-e2e-gce-trusty-{suffix}'
+    name: 'kubernetes-e2e-gce-gci-{suffix}'
     <<: *e2e_job_defaults
     node: '{jenkins_node}'
     triggers:
@@ -774,104 +773,103 @@
             regexp: KUBE_GCE_MASTER_IMAGE=(.*)
         - groovy-postbuild:
             script: |
-                def trustyImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
-                if(trustyImageMatcher?.matches()) manager.addShortText("<b>Trusty Image: " + trustyImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
+                if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
                 def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
 
 - project:
-    name: kubernetes-e2e-gce-trusty-dev
+    name: kubernetes-e2e-gce-gci-dev
     test-owner: 'wonderfly@google.com'
-    branch: 'release-1.2'
     emails: 'wonderfly@google.com,qzheng@google.com'
     provider-env: |
         {gce-provider-env}
         export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-        export JENKINS_TRUSTY_IMAGE_TYPE="dev"
+        export JENKINS_GCI_IMAGE_TYPE="dev"
     suffix:
         - 'dev-release':
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest Trusty build and the latest k8s 1.2 release.'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest GCI build and the latest k8s 1.2 release.'
             timeout: 30
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-trusty-dev"
+                export PROJECT="k8s-e2e-gce-gci-dev"
         - 'dev-slow':
-            description: 'Run slow E2E tests on GCE with the latest Trusty build with the latest k8s 1.2 release.'
+            description: 'Run slow E2E tests on GCE with the latest GCI build with the latest k8s 1.2 release.'
             timeout: 60
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-trusty-dev-slow"
+                export PROJECT="k8s-e2e-gce-gci-dev-slow"
         - 'dev-serial':
-            description: 'Run [Serial], [Disruptive], tests on GCE, with Trusty dev images and the latest k8s 1.2 release.'
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI dev images and the latest k8s 1.2 release.'
             timeout: 300
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-trusty-dev-serial"
+                export PROJECT="e2e-gce-gci-dev-serial"
     jobs:
-        - 'kubernetes-e2e-gce-trusty-{suffix}'
+        - 'kubernetes-e2e-gce-gci-{suffix}'
 
 - project:
-    name: kubernetes-e2e-gce-trusty-beta
+    name: kubernetes-e2e-gce-gci-beta
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
     provider-env: |
         {gce-provider-env}
         export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-        export JENKINS_TRUSTY_IMAGE_TYPE="beta"
+        export JENKINS_GCI_IMAGE_TYPE="beta"
     suffix:
         - 'beta-release':
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest Trusty beta build and the latest k8s 1.2 release.'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest GCI beta build and the latest k8s 1.2 release.'
             timeout: 30
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-trusty-beta"
+                export PROJECT="k8s-e2e-gce-gci-beta"
         - 'beta-slow':
-            description: 'Run slow E2E tests on GCE with the latest Trusty beta build with the latest k8s 1.2 release.'
+            description: 'Run slow E2E tests on GCE with the latest GCI beta build with the latest k8s 1.2 release.'
             timeout: 60
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-trusty-beta-slow"
+                export PROJECT="k8s-e2e-gce-gci-beta-slow"
         - 'beta-serial':
-            description: 'Run [Serial], [Disruptive], tests on GCE, with Trusty beta images and the latest k8s 1.2 release.'
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI beta images and the latest k8s 1.2 release.'
             timeout: 300
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-trusty-beta-serial"
+                export PROJECT="e2e-gce-gci-beta-serial"
     jobs:
-        - 'kubernetes-e2e-gce-trusty-{suffix}'
+        - 'kubernetes-e2e-gce-gci-{suffix}'
 
 # Template for e2e test jobs that run on GCE with a released k8s version and
-# Trusty's continuous builds (stable only works with k8s 1.1).
+# GCI's continuous builds (GCI stable only works with k8s 1.1).
 - job-template:
-    name: 'kubernetes-e2e-gce-trusty-stable-{suffix}'
+    name: 'kubernetes-e2e-gce-gci-stable-{suffix}'
     <<: *e2e_job_defaults
     node: '{jenkins_node}'
     triggers:
-        # Trusty stable images are built once per day.
+        # GCI stable images are built once per day.
         - timed: '@daily'
     publishers:
         - e2e-publishers:
             recipients: '{emails}'
         - description-setter:
-            # In 1.1, only nodes run Trusty.
+            # In 1.1, only nodes run GCI.
             regexp: KUBE_GCE_MINION_IMAGE=(.*)
         - groovy-postbuild:
             script: |
-                def trustyImageMatcher = manager.getLogMatcher("KUBE_GCE_MINION_IMAGE=(.*)")
-                if(trustyImageMatcher?.matches()) manager.addShortText("<b>Trusty Image: " + trustyImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MINION_IMAGE=(.*)")
+                if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
                 def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
 
 - project:
-    name: kubernetes-e2e-gce-trusty-stable
+    name: kubernetes-e2e-gce-gci-stable
     test-owner: 'wonderfly@google.com'
     branch: 'release-1.1'
     emails: 'wonderfly@google.com,qzheng@google.com'
@@ -890,7 +888,9 @@
             description: 'Run slow E2E tests on GCE with the latest Trusty stable build with the latest k8s 1.1 release.'
             timeout: 270
     jobs:
-        - 'kubernetes-e2e-gce-trusty-stable-{suffix}'
+        - 'kubernetes-e2e-gce-gci-stable-{suffix}'
+
+# End of GCI jobs
 
 # Jobs that run e2e tests on GKE with Trusty as node image on the release-1.2
 # branch. Note that the variable "E2E_NAME" in all following jobs are set to
@@ -977,7 +977,6 @@
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
-# End of Trusty jobs
 
 - job-group:
     name: 'kubernetes-e2e-{provider}-{version-old}-{version-new}'


### PR DESCRIPTION
We are not intersted in Trusty any more now that GCI(Google Container-VM Image)
is out. Turning them down. Note that we can't replace the GKE pinned jobs yet as
they pin to the 1.2 branch and the `--image-type` flag support is not
cherry-picked to 1.2. See https://github.com/kubernetes/kubernetes/pull/25156.

@spxtr @andyzheng0831 Can you review?

cc/ @kubernetes/goog-image 