### PR TITLE
Disable e2e jobs for Trusty stable

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -870,9 +870,13 @@
     post-env: ''
     suffix:
         - 'release':
+            # Broken as it pins to the latest k8s release, which is broken by https://github.com/kubernetes/kubernetes/issues/25153
+            disable_job: true
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest Trusty stable build and the latest k8s 1.1 release.'
             timeout: 150
         - 'slow':
+            # Broken as it pins to the latest k8s release, which is broken by https://github.com/kubernetes/kubernetes/issues/25153
+            disable_job: true
             description: 'Run slow E2E tests on GCE with the latest Trusty stable build with the latest k8s 1.1 release.'
             timeout: 270
     jobs:


### PR DESCRIPTION
They pin to the latest release on the k8s `release-1.1` branch, which is broken by
https://github.com/kubernetes/kubernetes/issues/25153. Since there is no
immediate plan of a patch release on that old branch, these jobs will continue
to fail. I am not deleting the jobs as Trusty stable will eventualy pass 1.1 and
move to 1.2 then start passing again.

@spxtr Can you review
cc/ @kubernetes/goog-image 