### PR TITLE
Add collectd configs and scripts for GCP quotas and Jenkins metrics

### DIFF
--- a/monitoring/collectd/gcloud-quota
+++ b/monitoring/collectd/gcloud-quota
@@ -1,0 +1,36 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# collectd config to collect Google Compute quota usage and limits and report
+# them to Stackdriver.
+#
+# Paths have been hard-coded for Google's Jenkins setup, but they can
+# be adjusted as necessary.
+#
+# To enable:
+# 1. Copy gcloud-quota.sh into /opt/stackdriver/collectd/exec and chmod 755 the
+#    script
+# 2. Copy this config into /opt/stackdriver/collectd/etc/collectd.d
+# 3. Restart the stackdriver agent
+#
+# Metrics will appear in Stackdriver associated with the GCE instance where
+# this is installed.
+#
+# Metric names follow the naming pattern
+# "gcloud_quota:{PROJECT}:gauge:{METRIC}:value".
+
+LoadPlugin exec
+<Plugin exec>
+  Exec "jenkins:jenkins" "/opt/stackdriver/collectd/exec/gcloud-quota.sh"
+</Plugin>

--- a/monitoring/collectd/gcloud-quota.sh
+++ b/monitoring/collectd/gcloud-quota.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Collects Google Compute quota usage and limits and reports them to Stackdriver.
+# Paths have been hard-coded for Google's Jenkins setup, but they can be
+# adjusted as necessary.
+# See comments in gcloud-quota on how to enable.
+
+set -o errexit
+set -o nounset
+
+HOSTNAME="${COLLECTD_HOSTNAME:-localhost}"
+INTERVAL="${COLLECTD_INTERVAL:-60}"
+PLUGIN='gcloud_quota'
+GCLOUD=/usr/local/bin/gcloud
+HOME=/var/lib/jenkins
+
+while true; do
+    PROJECT=${PROJECT:-$("${GCLOUD}" compute project-info describe --format='value(name)')}
+    PREFIX="${HOSTNAME}/${PLUGIN}-${PROJECT}"
+
+    "${GCLOUD}" compute project-info describe --project="${PROJECT}" --format=json | jq -r ".quotas[] | @text \"\
+PUTVAL ${PREFIX}/gauge-\(.metric)_usage interval=${INTERVAL} N:\(.usage)
+PUTVAL ${PREFIX}/gauge-\(.metric)_limit interval=${INTERVAL} N:\(.limit)
+PUTVAL ${PREFIX}/percent-\(.metric) interval=${INTERVAL} N:\(.usage/.limit*100.0)\""
+
+    "${GCLOUD}" compute regions list --project="${PROJECT}" --format=json | jq -r ".[] | {region: .name, quota: .quotas[]} | @text \"\
+PUTVAL ${PREFIX}/gauge-\(.quota.metric)-\(.region)_usage interval=${INTERVAL} N:\(.quota.usage)
+PUTVAL ${PREFIX}/gauge-\(.quota.metric)-\(.region)_limit interval=${INTERVAL} N:\(.quota.limit)
+PUTVAL ${PREFIX}/percent-\(.quota.metric)-\(.region) interval=${INTERVAL} N:\(.quota.usage/.quota.limit*100.0)\""
+    sleep "${INTERVAL}"
+done

--- a/monitoring/collectd/jenkins
+++ b/monitoring/collectd/jenkins
@@ -41,5 +41,32 @@ LoadPlugin curl_json
     <Key "gauges/*/value">
       Type "gauge"
     </Key>
+    <Key "timers/*/max">
+      Type "duration"
+    </Key>
+    <Key "timers/*/mean">
+      Type "duration"
+    </Key>
+    <Key "timers/*/min">
+      Type "duration"
+    </Key>
+    <Key "timers/*/p50">
+      Type "duration"
+    </Key>
+    <Key "timers/*/p75">
+      Type "duration"
+    </Key>
+    <Key "timers/*/p95">
+      Type "duration"
+    </Key>
+    <Key "timers/*/p98">
+      Type "duration"
+    </Key>
+    <Key "timers/*/p99">
+      Type "duration"
+    </Key>
+    <Key "timers/*/p999">
+      Type "duration"
+    </Key>
   </URL>
 </Plugin>

--- a/monitoring/collectd/jenkins
+++ b/monitoring/collectd/jenkins
@@ -1,0 +1,45 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# collectd config to collect metrics from Jenkins and report to Stackdriver.
+#
+# To enable:
+# 1. Install the Jenkins Metrics plugin
+#    (https://wiki.jenkins-ci.org/display/JENKINS/Metrics+Plugin)
+# 2. Create a metrics access key by navigating to
+#    "Manage Jenkins > Configure System" and scrolling down to the "Metrics"
+#    section
+# 3. Replace {METRICS_KEY} below with that key
+# 4. Copy the modified config into /opt/stackdriver/collectd/etc/collectd.d
+# 5. Restart the stackdriver agent
+#
+# Note that collectd will spam the syslog with complaints about version metrics
+# being invalid; the repeated periods in some versions result in invalid gauge
+# values.
+#
+# Metrics will appear in Stackdriver associated with the GCE instance where
+# this is installed.
+#
+# Metric names follow the naming pattern
+# "curl_json:jenkins:gauge:{METRIC_NAME}.value-value:value".
+
+LoadPlugin curl_json
+<Plugin curl_json>
+  <URL "http://localhost:8080/metrics/{METRICS_KEY}/metrics">
+    Instance "jenkins"
+    <Key "gauges/*/value">
+      Type "gauge"
+    </Key>
+  </URL>
+</Plugin>


### PR DESCRIPTION
I'm not sure this is a fully viable long-term solution, but this is at least a start to getting some monitoring going. I've installed these on both the post-commit and PR Jenkins, which has already helped a bit in getting visibility into the systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/59)
<!-- Reviewable:end -->
