### PR TITLE
Revert to storing jsons in etcd

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -153,7 +153,8 @@
                 export KUBE_GCE_ZONE="us-central1-f"
                 # Use protobufs
                 export TEST_CLUSTER_API_CONTENT_TYPE="--kube-api-content-type=application/vnd.kubernetes.protobuf"
-                export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
+                # TODO: Uncomment when we make the final decision to store protobufs in etcd.
+                # export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
     jobs:


### PR DESCRIPTION
We still didn't make the final decision whether to enable storing protobufs by default in etcd for 1.3.
So I'm reverting this from the 2000-node kubemark for now.