### PR TITLE
Post-submit jenkins job with master running on container-vm

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -155,6 +155,18 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jenkins-cvm"
                 export KUBE_GCE_MASTER_IMAGE="container-v1-3-v20160517"
+        - 'gce-master-on-cvm':
+            cron-string: 'H * * * *' # run once an hour
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with the master on a ContainerVM image.'
+            test-owner: 'robertbailey & zml'
+            timeout: 50  # See #21138
+            job-env: |
+                # This list should match the list in kubernetes-pull-build-test-e2e-gce.
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jenkins-master-cvm"
+                export KUBE_OS_DISTRIBUTION="debian"
+                export KUBE_GCE_MASTER_IMAGE="container-vm-v20160321"
         - 'gce-proto':
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with protobuf communication.'


### PR DESCRIPTION
Configure a post-submit jenkins job that will test a Kubernetes cluster on GCE with the master node running on the debian-based container-vm base image.

ref: https://github.com/kubernetes/kubernetes/issues/25977

/cc @wonderfly @fejta 