### PR TITLE
Don't start more than 5 MIGs in large GKE suite

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -288,7 +288,9 @@
                 export MACHINE_TYPE="n1-standard-1"
                 export ALLOWED_NOTREADY_NODES="10"
                 export CLUSTER_IP_RANGE="10.8.0.0/13"
-                export GKE_CREATE_FLAGS="--max-nodes-per-pool=100 --no-enable-cloud-monitoring --disable-addons HorizontalPodAutoscaling"
+                # We were asked (by MIG team) to not create more than 5 MIGs per zone.
+                # So setting max-nodes-per-pool=400, to have 5 MIGs.
+                export GKE_CREATE_FLAGS="--max-nodes-per-pool=400 --no-enable-cloud-monitoring --disable-addons HorizontalPodAutoscaling"
                 export KUBE_GKE_NETWORK="gke-large-cluster"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
     jobs:


### PR DESCRIPTION
We were asked to not start more than 5 MIGs concurrently (by MIG team).
So reflecting this in our Jenkins config.

@zmerlynn - FYI