### PR TITLE
Move e2e-g[ck]e-slow from us-central1-f to europe-west1-c

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -80,6 +80,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
+                export KUBE_GCE_ZONE="europe-west1-c"
                 export PROJECT="k8s-jkns-e2e-gce-slow"
         - 'gce-serial':
             description: 'Run [Serial], [Disruptive], tests on GCE.'
@@ -251,6 +252,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
+                export ZONE="europe-west1-c"
         - 'gke-serial':
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300


### PR DESCRIPTION
Arbitrarily chose the -slow builds, which actually aren't that slow.

Since both us-central1-f and europe-west1-c use Ivy Bridge processors, we shouldn't expect any change in behavior.

We also appear to be working well within default region quota limits for both of these builds.

Fixes kubernetes/kubernetes/issues/26361.

cc @roberthbailey @dchen1107 @wonderfly @andyzheng0831 @adityakali 