### PR TITLE
GKE tests need to run in us-central1

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -252,7 +252,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export ZONE="europe-west1-c"
         - 'gke-serial':
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300


### PR DESCRIPTION
Partial revert of #82

x-ref kubernetes/kubernetes#26361

cc @roberthbailey @dchen1107 @wonderfly @andyzheng0831 @adityakali @k8s-oncall