### PR TITLE
Move upgrade test timeouts from 5 hours to 10 hours

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -1052,7 +1052,7 @@
             suffix: '{provider}-{version-old}-{version-new}-upgrade-master'
             step: 'upgrade-master'
             description: 'Deploys a cluster at v{version-old}, upgrades the master to v{version-new}, and runs the v{version-old} tests.'
-            timeout: 300
+            timeout: 600
             job-env: |
                 export PROJECT="kube-gke-upg-{version-infix}-upg-mas"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
@@ -1067,7 +1067,7 @@
         - 'kubernetes-e2e-{suffix}':
             suffix: '{provider}-{version-old}-{version-new}-upgrade-cluster'
             description: 'Deploys a cluster at v{version-old}, upgrades the cluster to v{version-new}, and runs the v{version-old} tests.'
-            timeout: 300
+            timeout: 600
             job-env: |
                 export PROJECT="kube-gke-upg-{version-infix}-upg-clu"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
@@ -1082,7 +1082,7 @@
         - 'kubernetes-e2e-{suffix}':
             suffix: '{provider}-{version-old}-{version-new}-upgrade-cluster-new'
             description: 'Deploys a cluster at v{version-old}, upgrades the cluster to v{version-new}, and runs the v{version-new} tests.'
-            timeout: 300
+            timeout: 600
             job-env: |
                 export PROJECT="kube-gke-upg-{version-infix}-upg-clu-n"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"


### PR DESCRIPTION
Other options include:

1. only running tests that can be run in parallel (i.e. "smoke tests"); I don't  think this is sufficient, given problems we've seen in the past
1. running multiple suites for each, where we run some tests in parallel and others not (like we do with CI).  That would move our number of suites from 16 to ~40, which doesn't seem reasonable either