### PR TITLE
Revert "Move gke-large test to us-central1-b"

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -317,7 +317,7 @@
                 # TODO: Remove HPA and "master services" tests after enabling Heapster.
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Kubernetes\smaster\sservices\sis\sincluded\sin\scluster-info"
                 export GINKGO_PARALLEL="y"
-                export ZONE="us-central1-b"
+                export ZONE="us-east1-a"
                 export NUM_NODES=2000
                 export MACHINE_TYPE="n1-standard-1"
                 export ALLOWED_NOTREADY_NODES="10"


### PR DESCRIPTION
Moving back east for today.

Reverts kubernetes/test-infra#89