### PR TITLE
Download the build log if it doesn't exist in the workspace.

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -7,6 +7,10 @@
                     mkdir -p _tmp
                     curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" > ./_tmp/upload-to-gcs.sh
                     chmod +x ./_tmp/upload-to-gcs.sh
+
+                    if [[ ! -e "${WORKSPACE}/build-log.txt" ]]; then
+                      curl -fsS --retry 3 "http://jenkins-master:8080/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" > "${WORKSPACE}/build-log.txt"
+                    fi
                 - conditional-step:
                     condition-kind: current-status
                     condition-worst: SUCCESS
@@ -33,15 +37,6 @@
                         - shell: 'JENKINS_BUILD_FINISHED=ABORTED ./_tmp/upload-to-gcs.sh'
             script-only-if-succeeded: False
             script-only-if-failed: False
-        # Use the plugin for the build log, since it isn't available on Jenkins slaves.
-        - google-cloud-storage:
-            credentials-id: kubernetes-jenkins
-            uploads:
-                - build-log:
-                    log-name: build-log.txt
-                    storage-location: gs://kubernetes-jenkins/logs/$JOB_NAME/$BUILD_NUMBER
-                    share-publicly: true
-                    upload-for-failed-jobs: true
 
 # Default log parser rules.
 - publisher:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -13,7 +13,6 @@
             {report-rc}
     publishers:
         - claim-build
-        - gcs-uploader
         - log-parser
         - email-ext:
             presend-script: $DEFAULT_PRESEND_SCRIPT
@@ -21,6 +20,7 @@
             fixed: true
             send-to:
                 - culprits
+        - gcs-uploader
     scm:
         - git:
             url: https://github.com/kubernetes/kubernetes

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -4,10 +4,10 @@
     publishers:
         - claim-build
         - junit-publisher
-        - gcs-uploader
         - log-parser
         - email-ext:
             recipients: '{recipients}'
+        - gcs-uploader
 
 # Common attributes/actions shared by all e2e jobs.
 - e2e_job_defaults: &e2e_job_defaults

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -21,10 +21,10 @@
     publishers:
         - claim-build
         - junit-publisher
-        - gcs-uploader
         - log-parser
         - email-ext:
             recipients: "gmarek@google.com"
+        - gcs-uploader
     triggers:
         - timed: '{cron-string}'
     wrappers:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -57,9 +57,9 @@
     publishers:
         - claim-build
         - email-ext
-        - gcs-uploader
         - junit-publisher
         - log-parser
+        - gcs-uploader
     triggers:
         - timed: '{cron-string}'
     wrappers:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -16,7 +16,6 @@
             {report-rc}
     publishers:
         - claim-build
-        - gcs-uploader
         - log-parser
         - email-ext
         - xunit:
@@ -35,6 +34,7 @@
                 - junit:
                     pattern: '_artifacts/**.xml'
                     deleteoutput: false
+        - gcs-uploader
     scm:
         - git:
             url: https://github.com/kubernetes/kubernetes

--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -24,10 +24,10 @@
              credentialsId: '1f361efb-5b85-4f61-91a7-4ec7fb2a5c23'
     publishers:
         - claim-build
-        - gcs-uploader
         - log-parser
         - email-ext:
             recipients: '{owner}'
+        - gcs-uploader
     scm:
         - git:
             url: 'https://github.com/{repoName}'
@@ -82,6 +82,7 @@
         - log-parser
         - email-ext:
             recipients: '{owner}'
+        - gcs-uploader
     scm:
         - git:
             url: 'https://github.com/{repoName}'

--- a/jenkins/job-configs/kubernetes-jenkins/test-linkchecker.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/test-linkchecker.yaml
@@ -13,9 +13,9 @@
             ./hack/verify-linkcheck.sh
     publishers:
         - claim-build
-        - gcs-uploader
         - email-ext:
             recipients: 'xuchao@google.com'
+        - gcs-uploader
     scm:
         - git:
             url: https://github.com/kubernetes/kubernetes


### PR DESCRIPTION
Companion to https://github.com/kubernetes/kubernetes/pull/26812. We lose the very end of the log, including anything wrong with the upload-to-gcs script, but I think this is the best we can do for now.