### PR TITLE
Add JUnit parsing for node e2e jobs, allowing results to be missing

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -52,9 +52,9 @@
             unstable-on-warning: false
             fail-on-error: false
 
-# There is a junit JJB tag, but it doesn't handle the flaky-test-handler plugin.
+# There is a junit JJB tag, but it doesn't handle the flaky-test-handler plugin or allow empty results option.
 - publisher:
-    name: junit-publisher
+    name: junit-publisher-fully-specified
     publishers:
         - raw:
             xml: |
@@ -67,7 +67,13 @@
                         <hudson.plugins.claim.ClaimTestDataPublisher plugin="claim@2.7"/>
                     </testDataPublishers>
                     <healthScaleFactor>100.0</healthScaleFactor>
+                    <allowEmptyResults>{allow-empty-results}</allowEmptyResults>
                 </hudson.tasks.junit.JUnitResultArchiver>
+- publisher:
+    name: junit-publisher
+    publishers:
+        - junit-publisher-fully-specified:
+            allow-empty-results: false
 
 # Implements Docker Build and Publish Plugin
 # https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Build+and+Publish+plugin

--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -76,6 +76,8 @@
               {shell}
     publishers:
         - claim-build
+        - junit-publisher-fully-specified:
+                allow-empty-results: true
         - gcs-uploader
         - log-parser
         - email-ext:


### PR DESCRIPTION
Alternate version of #118, though I think this will actually work.

It's a little gross, but it'll be less gross whenever https://review.openstack.org/#/c/321305 gets merged.

cc @pwittrock @spxtr 

Note: PR Jenkins is already parsing JUnit for node e2e jobs.