### PR TITLE
Change E2E_MIN_STARTUP_PODS to 8 for GCE/GKE/AWS environments

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -19,9 +19,12 @@
         - email-ext:
             recipients: '{emails}'
         - gcs-uploader
+    # Need the 8 essential kube-system pods ready before declaring cluster ready
+    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
     provider-env: |
         export KUBERNETES_PROVIDER="aws"
-        export E2E_MIN_STARTUP_PODS="1"
+        export E2E_MIN_STARTUP_PODS="8"
         export KUBE_AWS_ZONE="us-west-2a"
         export MASTER_SIZE="m3.medium"
         export NODE_SIZE="m3.medium"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -18,9 +18,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
+    # Need the 8 essential kube-system pods ready before declaring cluster ready
+    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
     provider-env: |
         export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="1"
+        export E2E_MIN_STARTUP_PODS="8"
         export KUBE_GCE_ZONE="us-central1-f"
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -12,9 +12,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
+    # Need the 8 essential kube-system pods ready before declaring cluster ready
+    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
     provider-env: |
         export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="1"
+        export E2E_MIN_STARTUP_PODS="8"
         export KUBE_GCE_ZONE="us-central1-f"
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -7,8 +7,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
+    # Need the 8 essential kube-system pods ready before declaring cluster ready
+    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
     provider-env: |
         export KUBERNETES_PROVIDER="gke"
+        export E2E_MIN_STARTUP_PODS="8"
         export ZONE="us-central1-f"
         export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
         export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -106,9 +106,12 @@
             branch: 'master'
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak"
+            # Need the 8 essential kube-system pods ready before declaring cluster ready
+            # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+            # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
             provider-env: |
                 export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="1"
+                export E2E_MIN_STARTUP_PODS="8"
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
@@ -121,7 +124,7 @@
                 export PROJECT="k8s-jkns-gce-soak-2"
             provider-env: |
                 export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="1"
+                export E2E_MIN_STARTUP_PODS="8"
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
@@ -139,7 +142,7 @@
                 deployment is complete.<br>
             provider-env: |
                 export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="1"
+                export E2E_MIN_STARTUP_PODS="8"
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
@@ -189,6 +192,7 @@
             branch: 'master'
             provider-env: |
                 export KUBERNETES_PROVIDER="gke"
+                export E2E_MIN_STARTUP_PODS="8"
                 export ZONE="us-central1-f"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"


### PR DESCRIPTION
Test flake caused due to window of time between initial kube-system pods and the addon pods start running. Only 6 pods were found and they were all running. We need to wait for a minimum of 8 pods to be ready before we declare the cluster ready.

Fixes https://github.com/kubernetes/kubernetes/issues/26180
