### PR TITLE
gke-large-cluster: move to us-central1-b, drop to 1500 nodes temporarily

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e.yaml
@@ -316,7 +316,7 @@
                                          --ginkgo.skip=\[Flaky\]"
                 export NUM_NODES=3
         - 'gke-large-cluster':
-            description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel on a large (1000 node) GKE cluster'
+            description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel on a large GKE cluster'
             timeout: 450
             emails: 'zml@google.com'
             cron-string: ''
@@ -327,18 +327,16 @@
                 export PROJECT="kubernetes-scale"
                 # TODO: Remove FAIL_ON_GCP_RESOURCE_LEAK when PROJECT changes back to gke-large-cluster-jenkins.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                # TODO: Remove HPA and "master services" tests after enabling Heapster.
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Kubernetes\smaster\sservices\sis\sincluded\sin\scluster-info"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export ZONE="us-east1-a"
-                export NUM_NODES=2000
-                export MACHINE_TYPE="n1-standard-1"
+                export ZONE="us-central1-b"
+                export NUM_NODES=1500
                 export ALLOWED_NOTREADY_NODES="10"
-                export CLUSTER_IP_RANGE="10.8.0.0/13"
+                export MACHINE_TYPE="n1-standard-2"
                 # We were asked (by MIG team) to not create more than 5 MIGs per zone.
                 # We also paged SREs with max-nodes-per-pool=400 (5 concurrent MIGs)
                 # So setting max-nodes-per-pool=1000, to check if that helps.
-                export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000 --no-enable-cloud-monitoring --disable-addons HorizontalPodAutoscaling"
+                export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
     jobs:
         - 'kubernetes-e2e-{suffix}'


### PR DESCRIPTION
Also re-enable Heapster and tests, since we'll have the quota for it there.