### PR TITLE
Delete provider-env, job-env from global.yaml

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -127,34 +127,10 @@
         fi
         echo "Exiting with code: ${{rc}}"
         exit ${{rc}}
-    branch: 'master'
-    job-env: ''
     runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/dockerized-e2e-runner.sh")
     legacy-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh")
     old-runner-1-1: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.1/hack/jenkins/e2e.sh")
     old-runner-1-0: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.0/hack/jenkins/e2e.sh")
-    provider-env: ''
-    gce-provider-env: |
-        export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="1"
-        export KUBE_GCE_ZONE="us-central1-f"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
-    gke-provider-env: |
-        export KUBERNETES_PROVIDER="gke"
-        export ZONE="us-central1-f"
-        # By default, GKE tests run against the GKE test endpoint using CI Cloud SDK.
-        # Release jobs (e.g. prod, staging, and test) override these two variables.
-        export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
-        export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-    aws-provider-env: |
-        export KUBERNETES_PROVIDER="aws"
-        export E2E_MIN_STARTUP_PODS="1"
-        export KUBE_AWS_ZONE="us-west-2a"
-        export MASTER_SIZE="m3.medium"
-        export NODE_SIZE="m3.medium"
-        export NUM_NODES="3"
     post-env: |
         # Nothing should want Jenkins $HOME
         export HOME=${{WORKSPACE}}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -48,15 +48,19 @@
         - 'build':
             branch: 'master'
             timeout: 50
+            job-env: ''  # Empty expected
         - 'build-1.0':
             branch: 'release-1.0'
             timeout: 30
+            job-env: ''  # Empty expected
         - 'build-1.1':
             branch: 'release-1.1'
             timeout: 30
+            job-env: ''  # Empty expected
         - 'build-1.2':
             branch: 'release-1.2'
             timeout: 30
+            job-env: ''  # Empty expected
         - 'federation-build':
             branch: 'master'
             timeout: 50

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -19,6 +19,20 @@
         - email-ext:
             recipients: '{emails}'
         - gcs-uploader
+    provider-env: |
+        export KUBERNETES_PROVIDER="aws"
+        export E2E_MIN_STARTUP_PODS="1"
+        export KUBE_AWS_ZONE="us-west-2a"
+        export MASTER_SIZE="m3.medium"
+        export NODE_SIZE="m3.medium"
+        export NUM_NODES="3"
+        export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+        export GINKGO_PARALLEL="y"
+        export PROJECT="k8s-jkns-e2e-aws"
+        export AWS_CONFIG_FILE='/var/lib/jenkins/.aws/credentials'
+        export AWS_SSH_KEY='/var/lib/jenkins/.ssh/kube_aws_rsa'
+        export KUBE_SSH_USER='admin'
+        export AWS_SHARED_CREDENTIALS_FILE='/var/lib/jenkins/.aws/credentials'  # Needed to create PD from e2e test
     builders:
         - shell: |
             {provider-env}
@@ -52,16 +66,6 @@
     timeout: 240
     jenkins_node: 'master'
     runner: '{legacy-runner}'
-    provider-env: |
-        {aws-provider-env}
-        export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-        export GINKGO_PARALLEL="y"
-        export PROJECT="k8s-jkns-e2e-aws"
-        export AWS_CONFIG_FILE='/var/lib/jenkins/.aws/credentials'
-        export AWS_SSH_KEY='/var/lib/jenkins/.ssh/kube_aws_rsa'
-        export KUBE_SSH_USER='admin'
-        # This is needed to be able to create PD from the e2e test
-        export AWS_SHARED_CREDENTIALS_FILE='/var/lib/jenkins/.aws/credentials'
     aws-suffix:
         - 'aws':  # kubernetes-e2e-aws
             description: 'Run e2e tests on AWS using the latest successful Kubernetes build.'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -18,6 +18,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
+    provider-env: |
+        export KUBERNETES_PROVIDER="gce"
+        export E2E_MIN_STARTUP_PODS="1"
+        export KUBE_GCE_ZONE="us-central1-f"
+        export FAIL_ON_GCP_RESOURCE_LEAK="true"
+        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
         - shell: |
             {provider-env}
@@ -76,9 +82,6 @@
     trigger-job: 'kubernetes-build'
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
-    provider-env: |
-        {gce-provider-env}
-        export JENKINS_GCI_IMAGE_TYPE="dev"
     suffix:
         # TODO(wonderfly): For GCI, we currently only run CI, slow and serial
         # tests. More test coverage under way.
@@ -86,6 +89,7 @@
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the master branch.'
             timeout: 30
             job-env: |
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master"
@@ -93,6 +97,7 @@
             description: 'Runs slow tests on GCE with GCI images, sequentially on the master branch.'
             timeout: 60
             job-env: |
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -101,6 +106,7 @@
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images.'
             timeout: 300
             job-env: |
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
@@ -112,10 +118,6 @@
     trigger-job: 'kubernetes-build-1.2'
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
-    provider-env: |
-        {gce-provider-env}
-        export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-        export JENKINS_GCI_IMAGE_TYPE="dev"
     suffix:
         # TODO(wonderfly): For GCI, we currently only run CI, slow and serial
         # tests. More test coverage under way.
@@ -123,6 +125,8 @@
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
             timeout: 30
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-2"
@@ -130,6 +134,8 @@
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 60
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -138,6 +144,8 @@
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
@@ -168,15 +176,13 @@
     name: kubernetes-e2e-gce-gci-dev
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
-    provider-env: |
-        {gce-provider-env}
-        export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-        export JENKINS_GCI_IMAGE_TYPE="dev"
     suffix:
         - 'dev-release':  # kubernetes-e2e-gce-gci-dev-release
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest GCI build and the latest k8s 1.2 release.'
             timeout: 30
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-e2e-gce-gci-dev"
@@ -184,6 +190,8 @@
             description: 'Run slow E2E tests on GCE with the latest GCI build with the latest k8s 1.2 release.'
             timeout: 60
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -192,6 +200,8 @@
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI dev images and the latest k8s 1.2 release.'
             timeout: 300
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="dev"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-dev-serial"
@@ -202,15 +212,13 @@
     name: kubernetes-e2e-gce-gci-beta
     test-owner: 'wonderfly@google.com'
     emails: 'wonderfly@google.com,qzheng@google.com'
-    provider-env: |
-        {gce-provider-env}
-        export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-        export JENKINS_GCI_IMAGE_TYPE="beta"
     suffix:
         - 'beta-release':  # kubernetes-e2e-gce-gci-beta-release
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest GCI beta build and the latest k8s 1.2 release.'
             timeout: 30
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="beta"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-e2e-gce-gci-beta"
@@ -218,6 +226,8 @@
             description: 'Run slow E2E tests on GCE with the latest GCI beta build with the latest k8s 1.2 release.'
             timeout: 60
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="beta"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -226,6 +236,8 @@
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI beta images and the latest k8s 1.2 release.'
             timeout: 300
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
+                export JENKINS_GCI_IMAGE_TYPE="beta"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-beta-serial"
@@ -261,7 +273,9 @@
     emails: 'wonderfly@google.com,qzheng@google.com'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
-    post-env: ''
+    job-env: ''  # Empty expected
+    post-env: ''  # Empty expected
+    provider-env: ''  # Empty expected
     suffix:
         - 'release':  # kubernetes-e2e-gce-gci-stable-release
             # Broken as it pins to the latest k8s release, which is broken by https://github.com/kubernetes/kubernetes/issues/25153

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -12,6 +12,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
+    provider-env: |
+        export KUBERNETES_PROVIDER="gce"
+        export E2E_MIN_STARTUP_PODS="1"
+        export KUBE_GCE_ZONE="us-central1-f"
+        export FAIL_ON_GCP_RESOURCE_LEAK="true"
+        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
         - shell: |
             {provider-env}
@@ -47,7 +53,6 @@
     name: kubernetes-e2e-gce-master
     trigger-job: 'kubernetes-build'
     test-owner: 'Build Cop'
-    provider-env: '{gce-provider-env}'
     suffix:
         - 'gce':  # kubernetes-e2e-gce
             cron-string: '{sq-cron-string}'
@@ -236,14 +241,12 @@
     name: kubernetes-e2e-gce-1-2
     trigger-job: 'kubernetes-build-1.2'
     test-owner: 'Build Cop'
-    provider-env: |
-        {gce-provider-env}
-        export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
     suffix:
         - 'gce-release-1.2':  # kubernetes-e2e-gce-release-1.2
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.2 branch.'
             timeout: 50  # See #21138
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce-1-2"
@@ -251,12 +254,14 @@
             description: 'Run [Feature:Reboot] tests on GCE on the release-1.2 branch.'
             timeout: 180
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-e2e-gce-reboot-1-2"
         - 'gce-slow-release-1.2':  # kubernetes-e2e-gce-slow-release-1.2
             description: 'Runs slow tests on GCE, sequentially on the release-1.2 branch.'
             timeout: 60
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -265,6 +270,7 @@
             description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.2 branch.'
             timeout: 300
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
@@ -274,6 +280,7 @@
             emails: 'beeps@google.com'
             test-owner: 'beeps'
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-ingress-1-2"
                 # TODO: Enable this when we've split 1.2 tests into another project.
@@ -284,6 +291,7 @@
             # Run on Saturday 8 am
             cron-string: 'H 8 * * 6'
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export E2E_NAME="e2e-scalability-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
                                          --gather-resource-usage=true \
@@ -319,12 +327,14 @@
     branch: 'release-1.1'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
-    post-env: ''
+    post-env: ''  # Empty expected
+    provider-env: ''  # Empty expected
+    job-env: ''  # Empty expected
     cron-string: 'H */6 * * *'
     suffix:
         - 'gce-release-1.1':  # kubernetes-e2e-gce-release-1.1
             timeout: 175
-            description: 'Run E2E tests on GCE from the current release branch.'
+            description: 'Run E2E tests on GCE from the release-1.1 branch.'
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -332,18 +342,17 @@
     name: kubernetes-e2e-gce-features
     trigger-job: 'kubernetes-build'
     suffix:
-        - 'gce-ingress':  # kubernetes-e2e-gce-
+        - 'gce-ingress':  # kubernetes-e2e-gce-ingress
             description: 'Run [Feature:Ingress] tests on GCE.'
             timeout: 90
             emails: 'beeps@google.com'
             test-owner: 'beeps'
-            provider-env: '{gce-provider-env}'
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-ingress"
                 # TODO: Enable this when we've split 1.2 tests into another project.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
-        - 'gce-flannel':  # kubernetes-e2e-gce-
+        - 'gce-flannel':  # kubernetes-e2e-gce-flannel
             description: 'Run E2E tests on GCE using Flannel and the latest successful build. This suite is quarantined in a dedicated project because Flannel integration is experimental.'
             disable_job: true  # Issue #24520
             # We don't really care to enforce a timeout for flannel tests. Any performance issues will show up in the other GCE builders.
@@ -351,7 +360,6 @@
             timeout: 120
             emails: 'beeps@google.com'
             test-owner: 'beeps'
-            provider-env: '{gce-provider-env}'
             job-env: |
                 # XXX Not a unique project
                 export E2E_NAME="e2e-flannel"
@@ -364,22 +372,19 @@
             timeout: 90
             emails: 'mixia@google.com'
             test-owner: 'mixia'
-            provider-env: '{gce-provider-env}'
             job-env: |
                 export PROJECT="kubernetes-es-logging"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Elasticsearch\]"
                 export KUBE_LOGGING_DESTINATION="elasticsearch"
-        - 'gce-petset':
+        - 'gce-petset':  # kubernetes-e2e-gce-petset
             description: 'Run [Feature:PetSet] tests on GCE.'
             timeout: 90
             emails: 'beeps@google.com'
             test-owner: 'beeps'
-            provider-env: '{gce-provider-env}'
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:PetSet\]"
                 export PROJECT="kubernetes-petset"
-                # TODO: Enable once we've fixed #23032
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"  # TODO: Enable once we've fixed #23032
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -394,7 +399,6 @@
     timeout: 1440
     branch: 'master'
     suffix: 'gce-enormous-cluster'  # kubernetes-e2e-gce-enormous-cluster
-    provider-env: '{gce-provider-env}'
     job-env: |
         # XXX Not a unique project
         export E2E_NAME="e2e-enormous-cluster"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -7,6 +7,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
+    provider-env: |
+        export KUBERNETES_PROVIDER="gke"
+        export ZONE="us-central1-f"
+        export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
+        export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
+        export FAIL_ON_GCP_RESOURCE_LEAK="true"
     builders:
         - shell: |
             {provider-env}
@@ -47,7 +53,6 @@
     name: kubernetes-e2e-gke-master
     trigger-job: 'kubernetes-build'
     test-owner: 'Build Cop'
-    provider-env: '{gke-provider-env}'
     gke-suffix:
         - 'gke':  # kubernetes-e2e-gke
             cron-string: '{sq-cron-string}'
@@ -145,14 +150,12 @@
     name: kubernetes-e2e-gke-1-2
     trigger-job: 'kubernetes-build-1.2'
     test-owner: 'Build Cop'
-    provider-env: |
-        {gke-provider-env}
-        export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
     gke-suffix:
         - 'gke-release-1.2':  # kubernetes-e2e-gke-release-1.2
             description: 'Run E2E tests on GKE from the release-1.2 branch.'
             timeout: 50  # See #21138
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -160,6 +163,7 @@
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.2 branch.'
             timeout: 300
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-serial-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
@@ -167,6 +171,7 @@
             description: 'Run slow E2E tests on GKE using the release-1.2 branch.'
             timeout: 60
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-slow-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
@@ -177,20 +182,17 @@
             emails: 'beeps@google.com'
             test-owner: 'beeps'
             job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-gke-ingress-1-2"
-                # TODO: Enable this when we've split 1.2 tests into another project.
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"  # TODO(spxtr): Enable after 1.2 in another projet
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
 - project:
     name: kubernetes-e2e-gke-version-pinned
-    # TODO(spxtr) This should float with the current release, or something.
-    trigger-job: 'kubernetes-build-1.2'
+    trigger-job: 'kubernetes-build-1.2'  # TODO(spxtr) float with current release.
     test-owner: 'GKE on-call'
-    provider-env: |
-        {gke-provider-env}
     gke-suffix:
         - 'gke-pre-release':  # kubernetes-e2e-gke-pre-release
             description: 'Run E2E tests on GKE test endpoint against the latest prerelease (alpha/beta).'
@@ -229,9 +231,9 @@
             timeout: 80
             job-env: |
                 export PROJECT="k8s-e2e-gke-staging-parallel"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
         - 'gke-prod':  # kubernetes-e2e-gke-prod
@@ -239,18 +241,18 @@
             timeout: 480
             job-env: |
                 export PROJECT="k8s-jkns-e2e-gke-prod"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export ZONE="asia-east1-b"
         - 'gke-prod-parallel':  # kubernetes-e2e-gke-prod-parallel
             description: 'Run E2E tests on GKE prod endpoint in parallel.'
             timeout: 80
             job-env: |
                 export PROJECT="k8s-e2e-gke-prod-parallel"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export ZONE="asia-east1-b"
@@ -264,7 +266,9 @@
     branch: 'release-1.1'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
-    post-env: ''
+    job-env: ''  # Expected to be empty
+    post-env: ''  # Expected to be empty
+    provider-env: ''  # Expected to be empty
     gke-suffix:
         - 'gke-1.1':  # kubernetes-e2e-gke-1.1
             timeout: 150
@@ -283,7 +287,6 @@
             timeout: 90
             emails: 'beeps@google.com'
             test-owner: 'beeps'
-            provider-env: '{gke-provider-env}'
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-gke-ingress"
@@ -301,8 +304,6 @@
     name: kubernetes-e2e-gke-trusty
     trigger-job: 'kubernetes-build-1.2'
     test-owner: 'wonderfly@google.com'
-    provider-env: |
-        {gke-provider-env}
     emails: 'wonderfly@google.com,qzheng@google.com'
     gke-suffix:
         - 'gke-trusty-test':  # kubernetes-e2e-gke-trusty-test
@@ -331,9 +332,9 @@
             timeout: 480
             job-env: |
                 export PROJECT="e2e-gke-trusty-staging"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export E2E_NAME="gke-e2e-staging-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
         - 'gke-trusty-staging-parallel':  # kubernetes-e2e-gke-trusty-staging-parallel
@@ -341,9 +342,9 @@
             timeout: 80
             job-env: |
                 export PROJECT="e2e-gke-trusty-staging-p"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export E2E_NAME="gke-e2e-staging-pa-trusty"
@@ -355,6 +356,7 @@
             timeout: 480
             job-env: |
                 export PROJECT="kubekins-e2e-gke-trusty-prod"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_GCE_ZONE="asia-east1-b"
@@ -367,6 +369,7 @@
             timeout: 80
             job-env: |
                 export PROJECT="e2e-gke-trusty-prod-p"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
@@ -431,7 +434,6 @@
 - project:
     name: kubernetes-e2e-upgrades-gke
     provider: 'gke'
-    provider-env: '{gke-provider-env}'
     jobs:
         - 'kubernetes-e2e-{provider}-{version-old}-{version-new}':  # kubernetes-e2e-gke-1.0-1.2
             version-old: '1.0'
@@ -506,7 +508,6 @@
 - project:
     name: 'kubernetes-e2e-kubectl-skew-gke'
     provider: 'gke'
-    provider-env: '{gke-provider-env}'
     jobs:
         - 'kubernetes-e2e-{provider}-{version-cluster}-{version-client}-kubectl-skew':
             version-cluster: '1.2'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -5,6 +5,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
+    provider-env: |
+        export KUBERNETES_PROVIDER="gce"
+        export E2E_MIN_STARTUP_PODS="1"
+        export KUBE_GCE_ZONE="us-central1-f"
+        export FAIL_ON_GCP_RESOURCE_LEAK="true"
+        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
         - shell: |
             {provider-env}
@@ -40,7 +46,6 @@
 
 - project:
     name: kubernetes-kubemark
-    provider-env: '{gce-provider-env}'
     suffix:
         - '5-gce':
             description: 'Run minimal Kubemark to make sure it is not broken.'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -1,15 +1,25 @@
-- job-template:
-    name: 'kubernetes-soak-weekly-deploy-{suffix}'
-    description: '{deploy-description} Test owner: {test-owner}'
+- soak_defaults: &soak_defaults
+    name: soak_defaults
+    branch: 'master'
     node: 'master'
     builders:
         - shell: |
             {provider-env}
-            {soak-deploy}
+            {soak-env}
             {job-env}
             {post-env}
-            timeout -k {kill-timeout}m 90m {legacy-runner} && rc=$? || rc=$?
+            timeout -k {kill-timeout}m {run-timeout}m {legacy-runner} && rc=$? || rc=$?
             {report-rc}
+
+- job-template:
+    name: 'kubernetes-soak-weekly-deploy-{suffix}'
+    <<: *soak_defaults
+    description: '{deploy-description} Test owner: {test-owner}'
+    run-timeout: 90
+    soak-env: |
+        export FAIL_ON_GCP_RESOURCE_LEAK="false"
+        export E2E_TEST="false"
+        export E2E_DOWN="false"
     properties:
         - build-blocker:
             use-build-blocker: true
@@ -35,17 +45,23 @@
 
 - job-template:
     name: 'kubernetes-soak-continuous-e2e-{suffix}'
+    <<: *soak_defaults
     description: '{e2e-description} Test Owner: {test-owner}'
     workspace: '/var/lib/jenkins/jobs/kubernetes-soak-weekly-deploy-{suffix}/workspace'
-    node: 'master'
-    builders:
-        - shell: |
-            {provider-env}
-            {soak-continuous}
-            {job-env}
-            {post-env}
-            timeout -k {kill-timeout}m 360m {legacy-runner} && rc=$? || rc=$?
-            {report-rc}
+    run-timeout: 360
+    soak-env: |
+        export JENKINS_USE_EXISTING_BINARIES="y"
+        export FAIL_ON_GCP_RESOURCE_LEAK="false"
+        export E2E_UP="false"
+        export E2E_DOWN="false"
+        # Clear out any orphaned namespaces in case previous run was interrupted.
+        export E2E_CLEAN_START="true"
+        # TODO: Remove when we figure out #22166 and other docker potential slowness.
+        export DOCKER_TEST_LOG_LEVEL="--log-level=warn"
+        # We should be testing the reliability of a long-running cluster. The
+        # [Disruptive] tests kill/restart components or nodes in the cluster,
+        # defeating the purpose of a soak cluster. (#15722)
+        export GINKGO_TEST_ARGS="--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
     properties:
         - build-blocker:
             use-build-blocker: true
@@ -73,23 +89,6 @@
 - project:
     name: soak
     test-owner: 'Build Cop'
-    soak-deploy: |
-        export FAIL_ON_GCP_RESOURCE_LEAK="false"
-        export E2E_TEST="false"
-        export E2E_DOWN="false"
-    soak-continuous: |
-        export JENKINS_USE_EXISTING_BINARIES="y"
-        export FAIL_ON_GCP_RESOURCE_LEAK="false"
-        export E2E_UP="false"
-        export E2E_DOWN="false"
-        # Clear out any orphaned namespaces in case previous run was interrupted.
-        export E2E_CLEAN_START="true"
-        # TODO: Remove when we figure out #22166 and other docker potential slowness.
-        export DOCKER_TEST_LOG_LEVEL="--log-level=warn"
-        # We should be testing the reliability of a long-running cluster. The
-        # [Disruptive] tests kill/restart components or nodes in the cluster,
-        # defeating the purpose of a soak cluster. (#15722)
-        export GINKGO_TEST_ARGS="--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
     suffix:
         - 'gce':
             deploy-description: |
@@ -104,17 +103,27 @@
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
             branch: 'master'
-            provider-env: '{gce-provider-env}'
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak"
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="1"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
         - 'gce-2':
             deploy-description: Clone of kubernetes-soak-weekly-deploy-gce.
             e2e-description: Clone of kubernetes-soak-continuous-e2e-gce.
             branch: 'master'
-            provider-env: '{gce-provider-env}'
             job-env: |
                 export HAIRPIN_MODE="hairpin-veth"
                 export PROJECT="k8s-jkns-gce-soak-2"
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="1"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
         - 'gce-1.2':
             deploy-description: |
                 Deploy Kubernetes to soak cluster using the latest successful
@@ -127,10 +136,15 @@
                 If a kubernetes-soak-weekly-deploy-gce-1.2 build is enqueued,
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
-            provider-env: '{gce-provider-env}'
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-2"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="1"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
         - 'gke':
             deploy-description: |
                 Deploy Kubernetes to a GKE soak cluster using the staging GKE
@@ -151,7 +165,12 @@
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
             branch: 'master'
-            provider-env: '{gke-provider-env}'
+            provider-env: |
+                export KUBERNETES_PROVIDER="gke"
+                export ZONE="us-central1-f"
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
             job-env: |
                 export PROJECT="k8s-jkns-gke-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests


### PR DESCRIPTION
Migrated provider-env to the various yaml files.
Removed the default value of '' in job-env.

Corrected the value of `CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER` for `trusty-prod` jobs.