### PR TITLE
Make Gubernator show commands to run individual failing tests.

### DIFF
--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -45,6 +45,15 @@ class HelperTest(unittest.TestCase):
     def test_slugify(self):
         self.assertEqual('k8s-test-foo', filters.do_slugify('[k8s] Test Foo'))
 
+    def test_testcmd_unit(self):
+        self.assertEqual(
+            filters.do_testcmd('k8s.io/kubernetes/pkg/api/errors TestErrorNew'),
+            'go test -v k8s.io/kubernetes/pkg/api/errors -run TestErrorNew$')
+
+    def test_testcmd_e2e(self):
+        self.assertEqual(filters.do_testcmd('[k8s.io] Proxy works'),
+            "go run hack/e2e.go -v -test --test_args='--ginkgo.focus=Proxy\\sworks$'" )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/gubernator/static/build.js
+++ b/gubernator/static/build.js
@@ -1,0 +1,13 @@
+// Given a DOM node, attempt to select it.
+function select(node) {
+	var sel = window.getSelection();
+	if (sel.toString() !== "") {
+		// User is already trying to do a drag-selection, don't prevent it.
+		return;
+	}
+	// Works in Chrome/Safari/FF/IE10+
+	var range = document.createRange();
+	range.selectNode(node);
+	sel.removeAllRanges();
+	sel.addRange(range);
+}

--- a/gubernator/static/style.css
+++ b/gubernator/static/style.css
@@ -25,14 +25,28 @@ body {
 #failures {
     padding: 0 0 0 10px;
 }
-pre.error {
+h3 {
+    margin: 0.67em 0 0 0;
+}
+pre {
     white-space: pre-wrap;
-    margin: 1em 0 1em 2em;
+}
+pre.error {
+    margin: .5em 0 1em 2em;
     padding: 10px;
     background-color: #eee;
     display: inline-block;
     border-radius: 10px;
     box-shadow: 5px 5px 2px 0 #aaa;
+}
+pre.cmd {
+    padding: 1em;     /* make the click target large */
+    margin: 0 0 0 0;  /* margin isn't clickable */
+    font-size: 9pt;
+    color: #777;
+}
+pre.cmd::before {
+    content: "Command: ";  /* This text isn't selectable */
 }
 span.time {
     font-weight: lighter;

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -5,6 +5,7 @@
 <link rel="icon" type="image/png" href="/static/favicon-green.png" />
 % endif
 <title>{{job}} #{{build}} Results</title>
+<script src="/static/build.js"></script>
 </head>
 <body>
 <div id="header" class="container">
@@ -26,7 +27,8 @@
 <div id="failures">
 <h2>Test Failures</h1>
 % for name, time, text in failures
-<a class="anchor" id="{{name|slugify}}" href="#{{name|slugify}}"><h3>{{name}} <span class="time">{{time|duration}}</span></h3></a>
+<a class="anchor" id="{{name|slugify}}" href="#{{name|slugify}}"><h3>{{name}}<span class="time"> {{time|duration}}</span></h3></a>
+<pre class="cmd" onclick="select(this)">{{name | testcmd}}</pre>
 % if text
 <pre class="error">
 {{text|linkify_stacktrace(commit)}}


### PR DESCRIPTION
Clicking on the command will select the whole thing, for easy copy-pasting.

![image](https://cloud.githubusercontent.com/assets/211868/15916300/249d8214-2da6-11e6-8363-aba5dd286f93.png)

Examples: [unit test failure](https://test-dot-k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-test-go/12737), [e2e test failure](https://test-dot-k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-e2e-gce/18156)
