### PR TITLE
Enable cluster autoscaler scale down e2e tests for GKE

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -110,7 +110,7 @@
             timeout: 300
             job-env: |
                 export PROJECT="k8s-e2e-gke-autoscaling"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\] \
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] \
                                          --ginkgo.skip=\[Flaky\]"
                 export NUM_NODES=3
         - 'gke-large-cluster':  # kubernetes-e2e-gke-large-cluster


### PR DESCRIPTION
cc: @wojtek-t @piosz @fgrzadkowski @jszczepkowski 