### PR TITLE
Fix bad command when [k8s.io] is included multiple times.

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -72,7 +72,7 @@ def do_testcmd(name):
             return name
         return 'go test -v %s -run %s$' % (pkg, name)
     else:
-        name = name.replace('[k8s.io] ', '')
+        name = re.sub(r'^\[k8s\.io\] ', '', name)
         name_escaped = re.escape(name).replace('\\ ', '\\s')
 
         test_args = ('--ginkgo.focus=%s$' % name_escaped)

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -51,8 +51,9 @@ class HelperTest(unittest.TestCase):
             'go test -v k8s.io/kubernetes/pkg/api/errors -run TestErrorNew$')
 
     def test_testcmd_e2e(self):
-        self.assertEqual(filters.do_testcmd('[k8s.io] Proxy works'),
-            "go run hack/e2e.go -v -test --test_args='--ginkgo.focus=Proxy\\sworks$'" )
+        self.assertEqual(filters.do_testcmd('[k8s.io] Proxy [k8s.io] works'),
+            "go run hack/e2e.go -v -test --test_args='--ginkgo.focus="
+            "Proxy\\s\\[k8s\\.io\\]\\sworks$'" )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tests like `[k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner should create and delete persistent volumes` should probably be renamed.