### PR TITLE
Turn on delete-old in JJB.

### DIFF
--- a/jenkins/update-jobs.sh
+++ b/jenkins/update-jobs.sh
@@ -53,4 +53,4 @@ if ! docker inspect job-builder &> /dev/null; then
   fi
 fi
 
-docker exec job-builder jenkins-jobs update "${config_dir}"
+docker exec job-builder jenkins-jobs update --delete-old "${config_dir}"


### PR DESCRIPTION
If any jobs get accidentally deleted we'll have to grab them from a backup.