### PR TITLE
metadata-cache: add logging and health checks

### DIFF
--- a/jenkins/metadata-cache/README.md
+++ b/jenkins/metadata-cache/README.md
@@ -23,12 +23,21 @@ The utility is composed of the following pieces:
 
 ## Instructions
 
+### Prerequisites
+
+You must first run
+```sh
+gcloud config set project $PROJECT
+gcloud config set compute/zone $ZONE
+```
+with appropriate values before any of the `remote_*` commands will work.
+
 ### Quick setup
 
 This is the ultimate lazy version, which does everything for you:
 
 ```sh
-# Create a new instance
+# Create a new instance (only necessary if VM doesn't exist yet)
 jenkins/metadata-cache/metadata-cache-control.sh remote_create $INSTANCE
 # Update that instance
 jenkins/metadata-cache/metadata-cache-control.sh remote_update $INSTANCE


### PR DESCRIPTION
Log version on startup/exit and exception backtrace on crashes.

Also add /healthz handler, and check this endpoint in control script.

Fixes #134. Also hopefully helps us figure out what keeps causing this to die.