### PR TITLE
Smaller, more isolated agents, image family, no metadata-cache

### DIFF
--- a/jenkins/attach_agent.py
+++ b/jenkins/attach_agent.py
@@ -24,10 +24,9 @@ EXCLUSIVE = True
 SHARED = False
 
 INFO = {
-    'bespoke': ('bespoke', 1, EXCLUSIVE),
-    'heavy': ('build unittest', 2, EXCLUSIVE),
-    'light': ('node e2e', 20, EXCLUSIVE),
-    'pr': ('pull', 6, SHARED),
+    'heavy': ('build unittest', 1, EXCLUSIVE),
+    'light': ('node e2e', 10, EXCLUSIVE),
+    'pr': ('pull', 1, SHARED),
 }
 
 


### PR DESCRIPTION
Reduce the size of our agents: 

* 8 cores per instance
* 10 light executors, single cpu-intensive executors
* Create agents based off an agent image
* Disable metadata cache on agents
* Share ssh keys between all agents