### PR TITLE
Bind kubernetes-test-history to master

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
@@ -4,6 +4,7 @@
     properties:
         - build-discarder:
             days-to-keep: 3
+    node: master
     triggers:
         # Run hourly
         - timed: 'H * * * *'


### PR DESCRIPTION
Otherwise this job never runs if we tell the master to only run jobs bound to it (as all the others are already configured this way)