### PR TITLE
Don't check version skew for trusty jobs.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -361,6 +361,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export E2E_NAME="gke-e2e-test-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
+                export E2E_OPT="--check_version_skew=false"
         - 'gke-trusty-subnet':  # kubernetes-e2e-gke-trusty-subnet
             description: 'Run E2E tests on GKE test endpoint in a subnet.'
             timeout: 480
@@ -373,6 +374,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export E2E_NAME="gke-e2e-subnet-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
+                export E2E_OPT="--check_version_skew=false"
         - 'gke-trusty-staging':  # kubernetes-e2e-gke-trusty-staging
             description: 'Run E2E tests on GKE staging endpoint.'
             timeout: 480
@@ -383,6 +385,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export E2E_NAME="gke-e2e-staging-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
+                export E2E_OPT="--check_version_skew=false"
         - 'gke-trusty-staging-parallel':  # kubernetes-e2e-gke-trusty-staging-parallel
             description: 'Run E2E tests on GKE staging endpoint in parallel.'
             timeout: 80
@@ -395,6 +398,7 @@
                 export GINKGO_PARALLEL="y"
                 export E2E_NAME="gke-e2e-staging-pa-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
+                export E2E_OPT="--check_version_skew=false"
         - 'gke-trusty-prod':  # kubernetes-e2e-gke-trusty-prod
             # Failing constantly due to a known issue (tracked internally).
             disable_job: true
@@ -408,6 +412,7 @@
                 export KUBE_GCE_ZONE="asia-east1-b"
                 export E2E_NAME="gke-e2e-prod-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
+                export E2E_OPT="--check_version_skew=false"
         - 'gke-trusty-prod-parallel':  # kubernetes-e2e-gke-trusty-prod-parallel
             # Failing constantly due to a known issue (tracked internally).
             disable_job: true
@@ -423,6 +428,7 @@
                 export KUBE_GCE_ZONE="asia-east1-b"
                 export E2E_NAME="gke-e2e-prod-pa-trusty"
                 export KUBE_OS_DISTRIBUTION="trusty"
+                export E2E_OPT="--check_version_skew=false"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 


### PR DESCRIPTION
They also set JENKINS_USE_SERVER_VERSION, so client/server
skew is expected (client version will be branch head, same
as test files). cc @andyzheng0831 @wonderfly 