### PR TITLE
Bumping the default logging down

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -106,6 +106,8 @@
             branch: 'master'
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak"
+                # Lower default logging to decrease master utilization.
+                export TEST_CLUSTER_LOG_LEVEL="--v=2"
             provider-env: |
                 export KUBERNETES_PROVIDER="gce"
                 export E2E_MIN_STARTUP_PODS="1"


### PR DESCRIPTION
The GCE soak test master has been pegged at >100% CPU for weeks, while GKE master has been at ~70%. After a while, the whole GCE soak suite starts timing out.

The only big difference I could note was the logging level. This is to bring the GCE log level to the same as the GKE log level to verify that this is the issue. If we want to continue to run at `--v=4`, we should consider updating GKE to do the same, and also increasing the master size to accommodate the extra load.

(Also I have no idea what I'm doing or if this is the right way to configure this :smile:)