### PR TITLE
Use the merge queue's own opinion about whether it can merge

### DIFF
--- a/queue-health/poller.py
+++ b/queue-health/poller.py
@@ -24,11 +24,8 @@ def get_submit_queue_json(path):
     return requests.get('http://submit-queue.k8s.io/{}'.format(path)).json()
 
 def is_blocked():
-    ci = get_submit_queue_json('google-internal-ci')
-    for job in ci:
-        if ci[job]['Status'] != 'Stable':
-            return True
-    return False
+    ci = get_submit_queue_json('health')
+    return ci['MergePossibleNow'] != True
 
 def poll():
     prs = get_submit_queue_json('prs')


### PR DESCRIPTION
Example json:

{"TotalLoops":5,"NumStable":2,"NumStablePerJob":{"kubelet-gce-e2e-ci":5,"kubernetes-build":5,"kubernetes-e2e-gce":5,"kubernetes-e2e-gce-examples":5,"kubernetes-e2e-gce-scalability":5,"kubernetes-e2e-gce-serial":2,"kubernetes-e2e-gce-slow":5,"kubernetes-e2e-gke":5,"kubernetes-e2e-gke-serial":5,"kubernetes-e2e-gke-slow":5,"kubernetes-e2e-gke-staging":5,"kubernetes-e2e-gke-staging-parallel":5,"kubernetes-e2e-gke-subnet":5,"kubernetes-e2e-gke-test":5,"kubernetes-kubemark-5-gce":5,"kubernetes-kubemark-500-gce":5,"kubernetes-test-go":5},"MergePossibleNow":true}