### PR TITLE
Really move to us-central1-b, enable Heapster tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -119,30 +119,28 @@
                                          --ginkgo.skip=\[Flaky\]"
                 export NUM_NODES=3
         - 'gke-large-cluster':  # kubernetes-e2e-gke-large-cluster
-            description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel on a large (1000 node) GKE cluster'
+            description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel on a large GKE cluster'
             timeout: 450
             emails: 'zml@google.com'
             cron-string: ''
             trigger-job: ''
-            # TODO(zmerlynn) change back to PROJECT="gke-large-cluster-jenkins", re-enable Heapster
             job-env: |
                 export E2E_NAME="gke-large-cluster"
                 export PROJECT="kubernetes-scale"
                 # TODO: Remove FAIL_ON_GCP_RESOURCE_LEAK when PROJECT changes back to gke-large-cluster-jenkins.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # TODO: Remove HPA and "master services" tests after enabling Heapster.
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Kubernetes\smaster\sservices\sis\sincluded\sin\scluster-info"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export ZONE="us-east1-a"
+                export ZONE="us-central1-b"
                 export NUM_NODES=2000
                 export MACHINE_TYPE="n1-standard-1"
-                export ALLOWED_NOTREADY_NODES="10"
-                export CLUSTER_IP_RANGE="10.8.0.0/13"
+                export HEAPSTER_MACHINE_TYPE="n1-standard-4"
+                export ALLOWED_NOTREADY_NODES="20"
                 # We were asked (by MIG team) to not create more than 5 MIGs per zone.
                 # We also paged SREs with max-nodes-per-pool=400 (5 concurrent MIGs)
                 # So setting max-nodes-per-pool=1000, to check if that helps.
-                export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000 --no-enable-cloud-monitoring --disable-addons HorizontalPodAutoscaling"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
+                export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 


### PR DESCRIPTION
Relies on https://github.com/kubernetes/kubernetes/pull/27395 (and I'll wait for that to finish building)