### PR TITLE
Add pull e2e gce job.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -7,7 +7,7 @@
         - github:
             url: https://github.com/kubernetes/kubernetes
         - throttle:
-            max-total: 0  # Unlimited
+            max-total: '{max-total}'
             max-per-node: 2
             option: project
         - raw:
@@ -42,7 +42,7 @@
         - github-pull-request:
             # This is the Jenkins GHPRB plugin ID, not the actual github token.
             auth-id: 'f8e31bc1-9abb-460a-a2ca-9c4aae3ca4e8'
-            trigger-phrase: '(?is).*@k8s-bot\s+unit\s+test\s+this.*'
+            trigger-phrase: '(?is).*@k8s-bot\s+{trigger-phrase}\s+this.*'
             cron: 'H/2 * * * *'
             status-context: Jenkins {status-context}
             status-url: 'http://pr-test.k8s.io/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/'
@@ -183,6 +183,9 @@
             white-list-target-branches:
                 - master
                 - release-.*
+            success-comment: '{success-comment}'
+            failure-comment: '{failure-comment}'
+            error-comment: '{error-comment}'
     wrappers:
         - workspace-cleanup:
             dirmatch: true
@@ -220,17 +223,114 @@
     suffix:
       - test-unit-integration: # kubernetes-pull-test-unit-integration
           status-context: unit/integration
-          skip-if-no-test-files: false
+          max-total: 0 # Unlimited
+          skip-if-no-test-files: false  # We expect JUnit output from this job.
+          success-comment: ''
+          failure-comment: ''
+          error-comment: ''
+          trigger-phrase: 'unit\s+test'
           cmd: |
             export KUBE_VERIFY_GIT_BRANCH="${{ghprbTargetBranch}}"
             ./hack/jenkins/gotest-dockerized.sh
       - verify-all: # kubernetes-pull-verify-all
           status-context: verification
-          skip-if-no-test-files: true
+          max-total: 0 # Unlimited
+          skip-if-no-test-files: true  # We do not expect JUnit output from this job.
+          success-comment: ''
+          failure-comment: ''
+          error-comment: ''
+          trigger-phrase: 'verify'
           cmd: |
             export KUBE_VERIFY_GIT_BRANCH="${{ghprbTargetBranch}}"
             export KUBE_TEST_SCRIPT="./hack/jenkins/verify-dockerized.sh"
             ./hack/jenkins/gotest-dockerized.sh
+      - build-test-e2e-gce: # kubernetes-pull-build-test-e2e-gce
+          status-context: GCE e2e
+          max-total: 12
+          skip-if-no-test-files: false  # We expect JUnit output from this job.
+          success-comment: |
+            GCE e2e build/test **passed** for commit ${{ghprbActualCommit}}.
+            * [Build Log](http://pr-test.k8s.io/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/build-log.txt)
+            * [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/artifacts/)
+            * [Internal Jenkins Results](${{JOB_URL}}/${{BUILD_NUMBER}})
+          failure-comment: |
+            GCE e2e build/test **failed** for commit ${{ghprbActualCommit}}.
+            * [Build Log](http://pr-test.k8s.io/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/build-log.txt)
+            * [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/artifacts/)
+            * [Internal Jenkins Results](${{JOB_URL}}/${{BUILD_NUMBER}})
+
+            Please reference the [list of currently known flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open) when examining this failure. If you request a re-test, you must reference the issue describing the flake.
+          error-comment: |
+            GCE e2e build/test **errored** for commit ${{ghprbActualCommit}}.
+            * [Build Log](http://pr-test.k8s.io/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/build-log.txt)
+            * [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/artifacts/)
+            * [Internal Jenkins Results](${{JOB_URL}}/${{BUILD_NUMBER}})
+
+            Please reference the [list of currently known flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open) when examining this failure. If you request a re-test, you must reference the issue describing the flake.
+          trigger-phrase: 'e2e\s+test'
+          cmd: |
+            export KUBE_SKIP_PUSH_GCS=y
+            export KUBE_RUN_FROM_OUTPUT=y
+            ./hack/jenkins/build.sh
+            if [[ "${{ghprbTargetBranch:-}}" == "master" || "${{ghprbTargetBranch:-}}" == "release-1.2" || "${{ghprbTargetBranch:-}}" == "release-1.3" ]]; then
+              # Nothing should want Jenkins $HOME
+              export HOME=${{WORKSPACE}}
+
+              export KUBERNETES_PROVIDER="gce"
+              export E2E_MIN_STARTUP_PODS="1"
+              export KUBE_GCE_ZONE="us-central1-f"
+              export FAIL_ON_GCP_RESOURCE_LEAK="true"
+
+              # XXX Not a unique project
+              export E2E_NAME="e2e-gce-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+              export GINKGO_PARALLEL="y"
+              # This list should match the list in kubernetes-e2e-gce.
+              export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+              export FAIL_ON_GCP_RESOURCE_LEAK="false"
+              export PROJECT="kubernetes-jenkins-pull"
+              # Override GCE defaults
+              export NUM_NODES="6"
+
+              # Assume we're upping, testing, and downing a cluster
+              export E2E_UP="${{E2E_UP:-true}}"
+              export E2E_TEST="${{E2E_TEST:-true}}"
+              export E2E_DOWN="${{E2E_DOWN:-true}}"
+
+              # Skip gcloud update checking
+              export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
+              # AWS variables
+              export KUBE_AWS_INSTANCE_PREFIX=${{E2E_NAME:-'jenkins-e2e'}}
+
+              # GCE variables
+              export INSTANCE_PREFIX=${{E2E_NAME:-'jenkins-e2e'}}
+              export KUBE_GCE_NETWORK=${{E2E_NAME:-'jenkins-e2e'}}
+              export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME:-'jenkins-e2e'}}
+              export GCE_SERVICE_ACCOUNT=$(gcloud auth list 2> /dev/null | grep active | cut -f3 -d' ')
+
+              # GKE variables
+              export CLUSTER_NAME=${{E2E_NAME:-'jenkins-e2e'}}
+              export KUBE_GKE_NETWORK=${{E2E_NAME:-'jenkins-e2e'}}
+
+              # Get golang into our PATH so we can run e2e.go
+              export PATH=${{PATH}}:/usr/local/go/bin
+
+              timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+              if [[ ${{rc}} -ne 0 ]]; then
+                if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+                  echo "Dumping logs for any remaining nodes"
+                  ./cluster/log-dump.sh _artifacts
+                fi
+              fi
+              if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
+                echo "Build timed out" >&2
+              elif [[ ${{rc}} -ne 0 ]]; then
+                echo "Build failed" >&2
+              fi
+              echo "Exiting with code: ${{rc}}"
+              exit ${{rc}}
+            else
+              ./hack/jenkins/e2e.sh
+            fi
     jobs:
         - 'kubernetes-pull-{suffix}'
-


### PR DESCRIPTION
Instead of using the post-build workspace cleanup, I added the bit at the start that checks for `_output` and deletes it if present.