### PR TITLE
Rework GCI e2e jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
@@ -1,0 +1,91 @@
+# Template for continuous Docker validation tests. See
+# https://github.com/kubernetes/kubernetes/issues/25215 for details of what the
+# job does.
+
+# A custom publisher that prints out critical software versions (OS, K8s, and
+# Docker) in the build history page.
+- publisher:
+    name: version-printer
+    publishers:
+        - groovy-postbuild:
+            script: |
+                def masterImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
+                if(masterImageMatcher?.matches()) manager.addShortText("<b>Master Image: " + masterImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
+                if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def dockerVersionMatcher = manager.getLogMatcher("KUBE_GCI_DOCKER_VERSION=(.*)")
+                if(dockerVersionMatcher?.matches()) manager.addShortText("<b>Docker Version: " + dockerVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+
+
+# Template for the continuous Docker validation jobs.
+- job-template:
+    name: 'continuous-docker-validation-{os-distro}'
+    node: '{jenkins_node}'
+    triggers:
+        - timed: '@daily'
+    description: '{description} Test owner: {test-owner}.'
+    disabled: '{obj:disable_job}'
+    properties:
+        - build-discarder:
+            days-to-keep: 7
+    # Need the 8 essential kube-system pods ready before declaring cluster ready
+    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
+    provider-env: |
+        export KUBERNETES_PROVIDER="gce"
+        export E2E_MIN_STARTUP_PODS="8"
+        export KUBE_GCE_ZONE="us-central1-f"
+        export FAIL_ON_GCP_RESOURCE_LEAK="true"
+        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - timeout:
+            timeout: '{jenkins-timeout}'
+            fail: true
+        - timestamps
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
+    publishers:
+        - claim-build
+        - junit-publisher
+        - log-parser
+        - email-ext:
+            recipients: '{emails}'
+        - gcs-uploader
+        - description-setter:
+            regexp: KUBE_GCE_MASTER_IMAGE=(.*)
+        - version-printer
+    builders:
+        - shell: |
+            {provider-env}
+            {job-env}
+            {post-env}
+            timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
+            if [[ ${{rc}} -ne 0 ]]; then
+                if [[ -x kubernetes/cluster/log-dump.sh && -d _artifacts ]]; then
+                    echo "Dumping logs for any remaining nodes"
+                    ./kubernetes/cluster/log-dump.sh _artifacts
+                fi
+            fi
+            {report-rc}
+
+    # Template defaults. Can be overriden in job definitions.
+    jenkins_node: 'e2e'
+    test-owner: 'dchen1107'
+    emails: 'dawnchen@google.com'
+
+- project:
+    name: continuous-docker-validation
+    os-distro:
+        - 'gci': # continuous-docker-validation-gci
+            description: 'Runs the default e2e tests with the latest Kubernetes green build, latest GCI build, and latest Docker (pre)release.'
+            timeout: 50
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-docker-validation-gci"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-preview-test"
+    jobs:
+        - 'continuous-docker-validation-{os-distro}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -1,19 +1,16 @@
-# Common publishers shared by all e2e jobs.
-- publisher:
-    name: e2e-publishers
-    publishers:
-        - claim-build
-        - junit-publisher
-        - log-parser
-        - email-ext:
-            recipients: '{recipients}'
-        - gcs-uploader
+# This file defines e2e jobs against Kuberentes HEAD and GCI HEAD, from master
+# and the latest three release branches, and the GCI milestones that they pin
+# to, e.g., GCI milestone 52 for Kubernetes `release-1.2`.
 
-# Common attributes/actions shared by all e2e jobs.
-- e2e_job_defaults: &e2e_job_defaults
-    name: e2e_job_defaults
+- job-template:
+    name: 'kubernetes-e2e-gce-gci-ci-{suffix}'
+    node: '{jenkins_node}'
+    triggers:
+        - reverse:
+            jobs: '{trigger-job}'
+            result: success
+        - timed: '{cron-string}'
     description: '{description} Test owner: {test-owner}.'
-    jenkins_node: 'e2e'
     disabled: '{obj:disable_job}'
     properties:
         - build-discarder:
@@ -50,27 +47,13 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
-
-# This section contains two types of jobs (all run e2e tests on GCE):
-#   * Jobs that use a "green" GCI image to test k8s continuous builds (hence
-#     the "ci" in job names). We use these to guard k8s and GCI compatibility.
-#   * Jobs that use a released k8s version to test GCI's continuous builds
-#     (dev, beta and stable). We use these to qualify GCI image releases.
-
-# e2e test jobs that run on GCE with a "green" GCI image and kubernetes'
-# continuous builds (currently only targeting `master` and `release-1.2`).
-- job-template:
-    name: 'kubernetes-e2e-gce-gci-ci-{suffix}'
-    <<: *e2e_job_defaults
-    node: '{jenkins_node}'
-    triggers:
-        - reverse:
-            jobs: '{trigger-job}'
-            result: success
-        - timed: '{cron-string}'
     publishers:
-        - e2e-publishers:
+        - claim-build
+        - junit-publisher
+        - log-parser
+        - email-ext:
             recipients: '{emails}'
+        - gcs-uploader
         - description-setter:
             regexp: KUBE_GCE_MASTER_IMAGE=(.*)
         - groovy-postbuild:
@@ -79,66 +62,91 @@
                 if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
                 def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+    # Template defaults.
+    jenkins_node: 'e2e'
+    test-owner: 'wonderfly'
+    emails: 'wonderfly@google.com,qzheng@google.com,lakitu-dev@google.com'
 
 - project:
-    name: kubernetes-e2e-gce-gci-ci-master
-    trigger-job: 'kubernetes-build'
-    test-owner: 'wonderfly@google.com'
-    emails: 'wonderfly@google.com,qzheng@google.com'
+    name: kubernetes-e2e-gce-gci-ci
     suffix:
-        # TODO(wonderfly): For GCI, we currently only run CI, slow and serial
-        # tests. More test coverage under way.
-        - 'master':
+        - 'master': # kubernetes-e2e-gce-gci-ci-master
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the master branch.'
-            timeout: 30
+            timeout: 50
+            trigger-job: 'kubernetes-build'
             job-env: |
-                export JENKINS_GCI_IMAGE_TYPE="dev"
+                # This should become 54 once it's available.
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master"
-        - 'slow-master':
+        - 'slow-master': # kubernetes-e2e-gce-gci-ci-slow-master
             description: 'Runs slow tests on GCE with GCI images, sequentially on the master branch.'
-            timeout: 60
+            timeout: 150  #  See #24072
+            trigger-job: 'kubernetes-build'
             job-env: |
-                export JENKINS_GCI_IMAGE_TYPE="dev"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master-slow"
-        - 'serial-master':
+        - 'serial-master': # kubernetes-e2e-gce-gci-ci-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images.'
             timeout: 300
+            trigger-job: 'kubernetes-build'
             job-env: |
-                export JENKINS_GCI_IMAGE_TYPE="dev"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
-    jobs:
-        - 'kubernetes-e2e-gce-gci-ci-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gce-gci-ci-1-2
-    trigger-job: 'kubernetes-build-1.2'
-    test-owner: 'wonderfly@google.com'
-    emails: 'wonderfly@google.com,qzheng@google.com'
-    suffix:
-        # TODO(wonderfly): For GCI, we currently only run CI, slow and serial
-        # tests. More test coverage under way.
+        - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
+            timeout: 50
+            trigger-job: 'kubernetes-build-1.3'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-1-3"
+        - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-ci-slow-release-1.3
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
+            timeout: 150
+            trigger-job: 'kubernetes-build-1.3'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-slow-1-3"
+        - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-ci-serial-release-1.3
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
+            timeout: 300
+            trigger-job: 'kubernetes-build-1.3'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-ci-serial-1-3"
         - 'release-1.2':  # kubernetes-e2e-gce-gci-ci-release-1.2
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
-            timeout: 30
+            timeout: 50  # See #21138
+            trigger-job: 'kubernetes-build-1.2'
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="dev"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-52"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-2"
         - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-ci-slow-release-1.2
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 60
+            trigger-job: 'kubernetes-build-1.2'
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="dev"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-52"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -146,189 +154,12 @@
         - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-ci-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
+            trigger-job: 'kubernetes-build-1.2'
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="dev"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-52"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
     jobs:
         - 'kubernetes-e2e-gce-gci-ci-{suffix}'
-
-# Template for e2e test jobs that run on GCE with a released k8s version and
-# GCI's continuous builds (dev and beta only).
-- job-template:
-    name: 'kubernetes-e2e-gce-gci-{suffix}'
-    <<: *e2e_job_defaults
-    node: '{jenkins_node}'
-    triggers:
-        - timed: 'H H/8 * * *'
-    publishers:
-        - e2e-publishers:
-            recipients: '{emails}'
-        - description-setter:
-            regexp: KUBE_GCE_MASTER_IMAGE=(.*)
-        - groovy-postbuild:
-            script: |
-                def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
-                if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
-                if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-
-- project:
-    name: kubernetes-e2e-gce-gci-dev
-    test-owner: 'wonderfly@google.com'
-    emails: 'wonderfly@google.com,qzheng@google.com'
-    suffix:
-        - 'dev-release':  # kubernetes-e2e-gce-gci-dev-release
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest GCI build and the latest k8s 1.2 release.'
-            timeout: 30
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="dev"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-gci-dev"
-        - 'dev-slow':  # kubernetes-e2e-gce-gci-dev-slow
-            description: 'Run slow E2E tests on GCE with the latest GCI build with the latest k8s 1.2 release.'
-            timeout: 60
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="dev"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-gci-dev-slow"
-        - 'dev-serial':  # kubernetes-e2e-gce-gci-dev-serial
-            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI dev images and the latest k8s 1.2 release.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="dev"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-dev-serial"
-    jobs:
-        - 'kubernetes-e2e-gce-gci-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gce-gci-beta
-    test-owner: 'wonderfly@google.com'
-    emails: 'wonderfly@google.com,qzheng@google.com'
-    suffix:
-        - 'beta-release':  # kubernetes-e2e-gce-gci-beta-release
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest GCI beta build and the latest k8s 1.2 release.'
-            timeout: 30
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="beta"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-gci-beta"
-        - 'beta-slow':  # kubernetes-e2e-gce-gci-beta-slow
-            description: 'Run slow E2E tests on GCE with the latest GCI beta build with the latest k8s 1.2 release.'
-            timeout: 60
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="beta"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-e2e-gce-gci-beta-slow"
-        - 'beta-serial':  # kubernetes-e2e-gce-gci-beta-serial
-            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI beta images and the latest k8s 1.2 release.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="release/stable-1.2"
-                export JENKINS_GCI_IMAGE_TYPE="beta"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-beta-serial"
-    jobs:
-        - 'kubernetes-e2e-gce-gci-{suffix}'
-
-# Template for e2e test jobs that run on GCE with a released k8s version and
-# GCI's continuous builds (GCI stable only works with k8s 1.1).
-- job-template:
-    name: 'kubernetes-e2e-gce-gci-stable-{suffix}'
-    <<: *e2e_job_defaults
-    node: '{jenkins_node}'
-    triggers:
-        # GCI stable images are built once per day.
-        - timed: '@daily'
-    publishers:
-        - e2e-publishers:
-            recipients: '{emails}'
-        - description-setter:
-            # In 1.1, only nodes run GCI.
-            regexp: KUBE_GCE_MINION_IMAGE=(.*)
-        - groovy-postbuild:
-            script: |
-                def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MINION_IMAGE=(.*)")
-                if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
-                if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-
-- project:
-    name: kubernetes-e2e-gce-gci-stable
-    test-owner: 'wonderfly@google.com'
-    branch: 'release-1.1'
-    emails: 'wonderfly@google.com,qzheng@google.com'
-    jenkins_node: 'master'
-    runner: '{old-runner-1-1}'
-    job-env: ''  # Empty expected
-    post-env: ''  # Empty expected
-    provider-env: ''  # Empty expected
-    suffix:
-        - 'release':  # kubernetes-e2e-gce-gci-stable-release
-            # Broken as it pins to the latest k8s release, which is broken by https://github.com/kubernetes/kubernetes/issues/25153
-            disable_job: true
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with the latest Trusty stable build and the latest k8s 1.1 release.'
-            timeout: 150
-        - 'slow':  # kubernetes-e2e-gce-gci-stable-slow
-            # Broken as it pins to the latest k8s release, which is broken by https://github.com/kubernetes/kubernetes/issues/25153
-            disable_job: true
-            description: 'Run slow E2E tests on GCE with the latest Trusty stable build with the latest k8s 1.1 release.'
-            timeout: 270
-    jobs:
-        - 'kubernetes-e2e-gce-gci-stable-{suffix}'
-
-# Template for Docker continuous validation tests, running on GCI. See
-# https://github.com/kubernetes/kubernetes/issues/25215 for details of what the
-# job does.
-- job-template:
-    <<: *e2e_job_defaults
-    name: 'continuous-docker-validation{suffix}'
-    test-owner: 'dawnchen@google.com'
-    node: '{jenkins_node}'
-    triggers:
-        - timed: '@daily'
-    publishers:
-        - e2e-publishers:
-            recipients: 'wonderfly@google.com,dawnchen@google.com'
-        - description-setter:
-            regexp: KUBE_GCI_DOCKER_VERSION=(.*)
-        - groovy-postbuild:
-            script: |
-                def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
-                if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
-                if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-                def dockerVersionMatcher = manager.getLogMatcher("KUBE_GCI_DOCKER_VERSION=(.*)")
-                if(dockerVersionMatcher?.matches()) manager.addShortText("<b>Docker Version: " + dockerVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-    timeout: 30
-    job-env: |
-        export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-        export GINKGO_PARALLEL="y"
-        export PROJECT="k8s-docker-validation"
-        export JENKINS_GCI_IMAGE_TYPE="preview-test"
-
-- project:
-    name: continuous-docker-validation
-    suffix:
-        - '':
-            description: 'Runs the default e2e tests with the latest Kubernetes green build, latest GCI daily build, and latest Docker (pre)release.'
-    jobs:
-        - 'continuous-docker-validation{suffix}'
-
-# End of GCI jobs


### PR DESCRIPTION
This is based on our new plan to run CI tests against every active k8s branch to
ensure that GCI will always be able to cut a release whenever k8s cuts a patch
release. Theoretically we should cover master, 1.3, 1.2 and 1.1, but since only
nodes could run on GCI back in 1.1, and 1.1 jobs used the old e2e runner, which
is hard to update now, I am skipping the 1.1 branch.

@adityakali @fejta Can you review? This depends on https://github.com/kubernetes/kubernetes/pull/27083

cc/ @kubernetes/goog-image @spxtr 