### PR TITLE
Use gcs for queue-health storage, move to vm

### DIFF
--- a/queue-health/graph.py
+++ b/queue-health/graph.py
@@ -17,26 +17,41 @@
 from __future__ import division
 
 import collections
+import cStringIO
 import datetime
+import subprocess
+import sys
+import time
+import traceback
 
-dts = []
-prs = []
-queued = []
-instant_happiness = []
-daily_happiness = []
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 
-blocked_intervals = []
-daily_queue = collections.deque()
 
-with open('results.txt', 'r') as f:
+def render(history_lines, out_file):
+    """Read historical data and save to out_file as png."""
+    dts = []
+    prs = []
+    queued = []
+    instant_happiness = []
+    daily_happiness = []
+
+    blocked_intervals = []
+    daily_queue = collections.deque()
+
     last_blocked = None
     daily_sum = 0
-    for _ in xrange(60 * 24 * 21):
-        f.readline()
-    for line in f:
-        date, time, online, pr, queue, run, blocked = line.strip().split(' ')
+    for line in history_lines:
+        try:
+            date, time, online, pr, queue, run, blocked = line.strip().split(' ')
+        except ValueError:  # line does not fit expected criteria
+            continue
         pr, queue, run = int(pr), int(queue), int(run)
         dt = datetime.datetime.strptime('{} {}'.format(date, time), '%Y-%m-%d %H:%M:%S.%f')
+        if dt < datetime.datetime.now() - datetime.timedelta(days=30):
+            continue
         blocked = blocked == 'True'
         happy = online and not blocked
 
@@ -69,47 +84,75 @@ with open('results.txt', 'r') as f:
     if last_blocked is not None:
         blocked_intervals.append((last_blocked, dt))
 
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
+    fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True, figsize=(16, 8), dpi=100)
 
-fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True, figsize=(16, 8), dpi=100)
+    ax1.plot(dts, prs)
+    ax2.plot(dts, queued)
+    ax3.plot(dts, daily_happiness)
 
-ax1.plot(dts, prs)
-ax2.plot(dts, queued)
-ax3.plot(dts, daily_happiness)
+    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%m/%d/%Y'))
+    plt.gca().xaxis.set_major_locator(mdates.DayLocator())
 
-
-plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%m/%d/%Y'))
-plt.gca().xaxis.set_major_locator(mdates.DayLocator())
-
-ax1.set_ylabel('Pull Requests')
-ax2.set_ylabel('Submit Queue Size')
-ax3.set_ylabel('Merge Health Over Last Day')
+    ax1.set_ylabel('Pull Requests')
+    ax2.set_ylabel('Submit Queue Size')
+    ax3.set_ylabel('Merge Health Over Last Day')
 
 
-ax3.set_ylim([0.0, 1.0])
-ax3.set_xlim(left=datetime.datetime.now() - datetime.timedelta(days=14))
+    ax3.set_ylim([0.0, 1.0])
+    ax3.set_xlim(left=datetime.datetime.now() - datetime.timedelta(days=14))
 
-fig.autofmt_xdate()
+    fig.autofmt_xdate()
 
-for start, end in blocked_intervals:
-    for plot in [ax2, ax3]:
-        plot.axvspan(start, end, alpha=0.3, color='red', linewidth=0)
+    for start, end in blocked_intervals:
+        for plot in [ax2, ax3]:
+            plot.axvspan(start, end, alpha=0.3, color='red', linewidth=0)
 
 
-last_week = datetime.datetime.now() - datetime.timedelta(days=7)
-week_happy, week_points = 0, 0
-for dt, instant in zip(dts, instant_happiness):
-    if dt < last_week:
-        continue
-    if instant:
-        week_happy += 1
-    week_points += 1
+    last_week = datetime.datetime.now() - datetime.timedelta(days=7)
+    week_happy, week_points = 0, 0
+    for dt, instant in zip(dts, instant_happiness):
+        if dt < last_week:
+            continue
+        if instant:
+            week_happy += 1
+        week_points += 1
 
-if week_points > 0:
-    fig.text(.1, .08, "Health for the last week: %.0f%%" % (100.0 * week_happy / week_points))
+    if week_points > 0:
+        fig.text(.1, .08, 'Health for the last week: %.0f%%' % (100.0 * week_happy / week_points))
 
-plt.savefig('k8s-queue-health.png', bbox_inches='tight')
-# plt.show()
+    plt.savefig(out_file, bbox_inches='tight')
+
+
+def render_forever(history_uri, png_uri):
+    """Download results from history_uri, render to png and save to png_uri."""
+    buf = cStringIO.StringIO()
+    while True:
+        print >>sys.stderr, 'Truncate render buffer'
+        buf.seek(0)
+        buf.truncate()
+        print >>sys.stderr, 'Cat latest results from %s...' % history_uri
+        try:
+            history = subprocess.check_output(['gsutil', 'cat', history_uri])
+        except subprocess.CalledProcessError:
+            traceback.print_exc()
+            time.sleep(10)
+            continue
+
+        print >>sys.stderr, 'Render results to buffer...'
+        render(history.split('\n')[-60*24*21:], buf)  # Last 21 days
+
+        print >>sys.stderr, 'Copy buffer to %s...' % png_uri
+        proc = subprocess.Popen(
+            ['gsutil', '-q', '-h', 'Content-Type:image/png',
+             'cp', '-a', 'public-read', '-', png_uri],
+            stdin=subprocess.PIPE)
+        proc.communicate(buf.getvalue())
+        code = proc.wait()
+        if code:
+          print >>sys.stderr, 'Failed to copy rendering to %s: %d' % (png_uri, code)
+        time.sleep(60)
+
+
+
+if __name__ == '__main__':
+    render_forever(*sys.argv[1:])

--- a/queue-health/start-vm.sh
+++ b/queue-health/start-vm.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o xtrace
+set -o errexit
+
+NAME='queue-health'
+PROJECT='kubernetes-jenkins'
+STAGE_PATH="gs://kubernetes-test-history/sq/"
+
+echo "Copy files to ${STAGE_PATH}..."
+gsutil -m cp * "${STAGE_PATH}"
+
+echo "Check for previous version of ${NAME}..."
+PREVIOUS="$(gcloud compute instances list \
+  --filter="name=${NAME}" --project="${PROJECT}" || true)"
+if [[ -n "${PREVIOUS}" ]]; then
+  echo "Delete previous version of ${NAME}..."
+  gcloud -q compute instances delete "${NAME}" --project="${PROJECT}"
+fi
+
+echo "Create ${NAME}..."
+gcloud compute instances create \
+  "${NAME}" \
+  --boot-disk-size=50GB \
+  --description="Created by ${USER} to monitor submit-queue health on $(date)" \
+  --machine-type=n1-standard-1 \
+  --metadata=startup-script-url=gs://kubernetes-test-history/sq/startup.sh \
+  --project="${PROJECT}" \
+  --scopes=storage-rw

--- a/queue-health/startup.sh
+++ b/queue-health/startup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o verbose
+set -o errexit
+
+HISTORY='gs://kubernetes-test-history/sq/history.txt'
+GRAPH='gs://kubernetes-test-history/k8s-queue-health.png'
+
+POLLER='gs://kubernetes-test-history/sq/poller.py'
+GRAPHER='gs://kubernetes-test-history/sq/graph.py'
+
+install-deps() {
+  for i in {1..5}; do
+    sudo apt-get -y update || continue
+    sudo apt-get -y install python-matplotlib python-requests || continue
+    return 0
+  done
+  return 1
+}
+
+install-deps
+
+gsutil cat "${POLLER}" | python - "${HISTORY}" 2>&1 | tee /var/log/poller.log &
+gsutil cat "${GRAPHER}" | python - "${HISTORY}" "${GRAPH}" 2>&1 | tee /var/log/render.log
+wait


### PR DESCRIPTION
`start-vm.sh`: stages files, recreates the vm w/ a startup script and storage scope 
`startup.sh`: startup script that installs prerequisites and starts graph and poller programs
`poller.py`: poller program that downloads previous state, polls submit-queue to append new info and uploads state to gcs
`graph.py`: downloads the current state, renders it to a png file and saves to a public gcs object


Next step will be to create images for this, create a pod and move it into our utility cluster

cc @lavalamp 
