### PR TITLE
Make Gubernator show excerpts from log for mysterious failures.

### DIFF
--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import datetime
+import os
+import re
+
+import jinja2
+
+error_re = re.compile(r'\b(error|fatal|failed)\b', re.IGNORECASE)
+
+
+def hilight(line):
+    line = error_re.sub(r'<span class="keyword">\1</span>', line)
+    return '<span class="hilight">%s</span>' % line
+
+
+def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l):
+    """
+    Given a build log, return a chunk of HTML code suitable for
+    inclusion in a <pre> tag, with "interesting" errors hilighted.
+
+    This is similar to the output of `grep -C4` with an appropriate regex.
+    """
+    lines = unicode(jinja2.escape(data)).split('\n')
+    matched_lines = [n for n, line in enumerate(lines) if error_re.search(line)]
+    output = []
+    CONTEXT = 4
+
+    matched_lines.append(len(lines))  # sentinel value
+
+    last_match = None
+    for match in matched_lines:
+        if last_match is not None:
+            previous_end = min(match, last_match + CONTEXT + 1)
+            output.extend(lines[last_match + 1: previous_end])
+        else:
+            previous_end = 0
+        skip_amount = match - previous_end - CONTEXT
+        if skip_amount > 1:
+            output.append('<span class="skip">%s</span>' % skip_fmt(skip_amount))
+        elif skip_amount == 1:  # pointless say we skipped 1 line
+            output.append(lines[previous_end])
+        if match == len(lines):
+            break
+        output.extend(lines[max(previous_end, match - CONTEXT): match])
+        output.append(hilight(lines[match]))
+        last_match = match
+
+    return '\n'.join(output)
+
+if __name__ == '__main__':
+    import sys
+    for f in sys.argv[1:]:
+        print digest(open(f).read().decode('utf8'))

--- a/gubernator/log_parser_test.py
+++ b/gubernator/log_parser_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import unittest
+
+import log_parser
+
+
+class LogParserTest(unittest.TestCase):
+    def digest(self, data, strip=True):
+        digested = log_parser.digest(data.replace(' ', '\n'),
+                                     skip_fmt=lambda l: 's%d' % l)
+        if strip:
+            digested = re.sub(r'<[^>]*>', '', digested)
+        return digested.replace('\n', ' ')
+
+    def expect(self, data, expected):
+        self.assertEqual(self.digest(data), expected)
+
+    def test_empty(self):
+        self.expect('', '')
+        self.expect('no problems here!', '')
+
+    def test_escaping(self):
+        self.expect('error &c', 'error &amp;c')
+
+    def test_context(self):
+        self.expect('0 1 2 3 4 5 error 6 7 8 9 10',
+                    's2 2 3 4 5 error 6 7 8 9')
+
+    def test_multi_context(self):
+        self.expect('0 1 2 3 4 error-1 6 error-2 8 9 10 11 12',
+                    '0 1 2 3 4 error-1 6 error-2 8 9 10 11')
+
+    def test_skip_count(self):
+        self.expect('error 1 2 3 4 5 6 7 8 9 A error-2',
+                    'error 1 2 3 4 s2 7 8 9 A error-2')
+
+    def test_skip_at_least_two(self):
+        self.expect('error 1 2 3 4 5 6 7 8 error-2',
+                    'error 1 2 3 4 5 6 7 8 error-2')
+
+    def test_html(self):
+        self.assertEqual(self.digest('error-blah', strip=False), ''
+                         '<span class="hilight"><span class="keyword">'
+                         'error</span>-blah</span>')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gubernator/static/style.css
+++ b/gubernator/static/style.css
@@ -48,6 +48,15 @@ pre.cmd {
 pre.cmd::before {
     content: "Command: ";  /* This text isn't selectable */
 }
+span.hilight {
+    background-color: palegoldenrod;
+}
+span.keyword {
+    font-weight: bolder;
+}
+span.skip {
+    color: #999;
+}
 span.time {
     font-weight: lighter;
     font-family: monospace;

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -20,8 +20,8 @@
 <p><a href="https://console.cloud.google.com/storage/browser{{build_dir}}">artifacts</a>
 <a href="https://storage.googleapis.com{{build_dir}}/build-log.txt">build-log.txt</a>
 </div>
-% if failures
 <div id="failures">
+% if failures
 <h2>Test Failures</h2>
 % for name, time, text in failures
 <a class="anchor" id="{{name|slugify}}" href="#{{name|slugify}}"><h3>{{name}}<span class="time"> {{time|duration}}</span></h3></a>
@@ -34,5 +34,11 @@
 % endfor
 % else
 <h2>No Test Failures!</h2>
-</div>
+% if build_log
+<h3>Error lines from build-log.txt</h3>
+<pre>
+{{build_log | safe}}
+</pre>
 % endif
+% endif
+</div>


### PR DESCRIPTION
A "mysterious failure" is a build failure with no test failures.

The excerpts are chosen by looking for the words "error" and "fatal",
and showing the line and its surrounding context.

![image](https://cloud.githubusercontent.com/assets/211868/16165149/2752c512-3497-11e6-9ba6-f323e5e1c75b.png)
