### PR TITLE
Correctly escape grep command, use regex mode

### DIFF
--- a/jenkins/job-configs/jenkins-hourly-maintenance.yaml
+++ b/jenkins/job-configs/jenkins-hourly-maintenance.yaml
@@ -11,7 +11,7 @@
             # Try to avoid running at exactly :00 without worrying about a fancy solution
             [[ "$(date +%-M)" -gt 3 ]] || sleep 180
             # Select only exited or dead containers that weren't created this hour.
-            containers_to_remove=($(docker ps -a -f 'status=exited' -f 'status=dead' --format='{{.CreatedAt}}\t{{.ID}}' | grep -v ^$(date +'%Y-%m-%d %H') | cut -f2 || true))
+            containers_to_remove=($(docker ps -a -f 'status=exited' -f 'status=dead' --format='{{.CreatedAt}}\t{{.ID}}' | grep -v -E "^$(date +'%Y-%m-%d %H')" | cut -f2 || true))
             # Copied from http://blog.yohanliyanage.com/2015/05/docker-clean-up-after-yourself/
             docker rm -v "${containers_to_remove[@]:+${containers_to_remove[@]}}" || true
             docker rmi $(docker images -q -f 'dangling=true') || true


### PR DESCRIPTION
We aren't actually cleaning up dead containers due to a bug in my latest PR:

```
+ containers_to_remove=($(docker ps -a -f 'status=exited' -f 'status=dead' --format='{{.CreatedAt}}\t{{.ID}}' | grep -v ^$(date +'%Y-%m-%d %H') | cut -f2 || true))
++ docker ps -a -f status=exited -f status=dead '--format={{.CreatedAt}}\t{{.ID}}'
++ cut -f2
+++ date '+%Y-%m-%d %H'
++ grep -v '^2016-06-18' 00
grep: 00: No such file or directory
```

This why we are getting alerts about low disk, and this PR addresses the problem