### PR TITLE
Add weekly merge rate, time to clear queue

### DIFF
--- a/queue-health/startup.sh
+++ b/queue-health/startup.sh
@@ -33,11 +33,11 @@ install-deps() {
 
 copy-to-old-location() {  # TODO(fejta): remove after pushing queue
   local old='gs://kubernetes-test-history/k8s-queue-health.png'
-  while ps ax | grep -v grep | grep "${GRAPHER}"; do
+  while ps ax | grep -v grep | grep "${GRAPH}"; do
     sleep 60
     gsutil cp "${GRAPH}" "${old}" || true
   done
-  echo "${GRAPHER} no longer running, stopping copy to ${old}"
+  echo "${GRAPH} no longer running, stopping copy to ${old}"
 }
 
 install-deps


### PR DESCRIPTION
* Example output: http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health-2.png
* Put open PRs and queue depth on the same chart (add count of open PRs to axis title)
* Put blocked timespans and merge rate on the same chart
* Calculate average merge rate for the week
* Calculate time required to clear the queue given current merge rate and current depth
* Refactor how we calculate weekly averages (mean of samples from the last 6 days)