### PR TITLE
test-history: urlencode links

### DIFF
--- a/jenkins/test-history/templates/index.html
+++ b/jenkins/test-history/templates/index.html
@@ -26,7 +26,7 @@
                 <tr>
                     <td class="numeric">{{ job.passed }}</td>
                     <td class="numeric">{% if job.latest_failure is none %}{{ job.failed }}{% else %}<a title="Latest Failure" href="{{ job.latest_failure }}">{{ job.failed }}</a>{% endif %}</td>
-                    <td style="white-space: nowrap">{% if job.tests > 0 %}<a href="suite-{{ job.name }}.html">{{ job.name }}</a>{% else %}{{ job.name }}{% endif %}</td>
+                    <td style="white-space: nowrap">{% if job.tests > 0 %}<a href="suite-{{ job.name | urlencode }}.html">{{ job.name }}</a>{% else %}{{ job.name }}{% endif %}</td>
                     <td class="numeric">{{ job.tests }}</td>
                     <td class="numeric">{{ job.stable }}</td>
                     <td class="numeric">{{ job.unstable }}</td>


### PR DESCRIPTION
This fixes e.g. the rktnetes link that tried to use `rktnetes:...` as a
schema.

If you click through the rktnetes or azure links on the main page right now, they're broken without this change.

I verified that changing this locally resulted in the expected `%3A` encoding.