### PR TITLE
Use Google credentials in staging tests and release-1.3 tests.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -117,6 +117,7 @@
                 export GINKGO_PARALLEL="y"
                 export ZONE="us-central1-f"
                 export ADDITIONAL_ZONES="us-central1-a,us-central1-b"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
         - 'gke-autoscaling':  # kubernetes-e2e-gke-autoscaling
             description: 'Run all cluster autoscaler tests on GKE.'
             timeout: 300
@@ -176,6 +177,7 @@
                 export PROJECT="k8s-jkns-gke-serial-1-3"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
         - 'gke-slow-release-1.3':  # kubernetes-e2e-gke-slow-release-1.3
             description: 'Run slow E2E tests on GKE using the release-1.3 branch.'
             timeout: 60
@@ -185,6 +187,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
         - 'gke-reboot-release-1.3':  # kubernetes-e2e-gke-reboot-release-1.3
             description: 'Run [Feature:Reboot] tests on GKE on the release-1.3 branch.'
             timeout: 180
@@ -192,6 +195,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-reboot-1-3"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
         - 'gke-ingress-release-1.2':  # kubernetes-e2e-gke-ingress-release-1.2
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.2 branch.'
             timeout: 90
@@ -210,6 +214,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-gke-ingress-1-3"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
  
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
@@ -287,6 +292,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export E2E_OPT="--check_version_skew=false"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
         - 'gke-staging-parallel':  # kubernetes-e2e-gke-staging-parallel
             description: 'Run E2E tests on GKE staging endpoint in parallel.'
             timeout: 80
@@ -298,6 +304,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export E2E_OPT="--check_version_skew=false"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
         - 'gke-prod':  # kubernetes-e2e-gke-prod
             description: 'Run E2E tests on GKE prod endpoint.'
             timeout: 480


### PR DESCRIPTION
This will make these tests use google creds when running against a 1.3 server (so we're okay flipping staging back and forth between 1.2.* and 1.3.*).