### PR TITLE
Handle flakes in polling queue health

### DIFF
--- a/queue-health/graph.py
+++ b/queue-health/graph.py
@@ -115,10 +115,14 @@ def render(history_lines, out_file):
 
         if merged >= last_merge:
             did_merge = merged - last_merge
-        else:  # Might be negative in case of restart
+        elif online:  # Restarts reset the number to 0
             did_merge = merged
-        merge_sum += did_merge
-        last_merge = merged
+        else:
+            did_merge = 0
+
+        if online:  # Ignore offline status
+            merge_sum += did_merge
+            last_merge = merged
 
         daily_queue.append(happy)
         daily_merged.append(did_merge)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/220

Ignore the merge state when the queue is offline