### PR TITLE
Update Jenkins Job Builder image

### DIFF
--- a/jenkins/diff-job-config-patch.sh
+++ b/jenkins/diff-job-config-patch.sh
@@ -32,7 +32,7 @@ set -o nounset
 set -o pipefail
 
 readonly JOB_CONFIGS_ROOT="jenkins/job-configs"
-readonly JOB_BUILDER_IMAGE="gcr.io/google_containers/kubekins-job-builder:4"
+readonly JOB_BUILDER_IMAGE="gcr.io/google_containers/kubekins-job-builder:5"
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd)
 REPO_DIR=${REPO_DIR:-"${REPO_ROOT}"}

--- a/jenkins/job-builder-image/Makefile
+++ b/jenkins/job-builder-image/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 4
+TAG = 5
 
 all:
 	docker build -t gcr.io/google_containers/kubekins-job-builder:$(TAG) .

--- a/jenkins/update-jobs.sh
+++ b/jenkins/update-jobs.sh
@@ -24,7 +24,7 @@ else
   exit 1
 fi
 
-IMAGE="gcr.io/google_containers/kubekins-job-builder:4"
+IMAGE="gcr.io/google_containers/kubekins-job-builder:5"
 
 # If we're on an old image then stop it and remove it.
 if docker inspect job-builder &> /dev/null; then


### PR DESCRIPTION
Most of my JJB changes have been merged, so we can start to remove raw XML in another PR. (https://review.openstack.org/#/c/321313/ is still pending.)

The only real expected changes are to the git configuration; in particular, the node e2e class of jobs should actually be configured correctly now.

Diff at https://gist.github.com/ixdy/87029ead91d323f27dd5b1aa9340793f.