### PR TITLE
Fix kubernetes-release-dev corruption

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -75,5 +75,6 @@
               export FEDERATIONS_DOMAIN_MAP="federation=k8s-federation.com"
               export KUBE_FASTBUILD=true
               export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
+              export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release
     jobs:
         - 'kubernetes-{build}'


### PR DESCRIPTION
Move federation job off of a mirror of gs://kubernetes-release-dev

The equal buckets should just work (rsync to itself should be fine,
etc.), but if not, I'll fix it upstream. c.f. https://github.com/kubernetes/kubernetes/pull/28172, https://github.com/kubernetes/kubernetes/pull/28233