### PR TITLE
Move the environment variable to the test job.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -72,7 +72,6 @@
               export PROJECT="k8s-jkns-e2e-gce-federation"
               export FEDERATION=true
               export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
-              export FEDERATIONS_DOMAIN_MAP="federation=k8s-federation.com"
               export KUBE_FASTBUILD=true
               export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
               export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -226,6 +226,7 @@
                 export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
                 export FEDERATION="true"
                 export DNS_ZONE_NAME="k8s-federation.com."
+                export FEDERATIONS_DOMAIN_MAP="federation=k8s-federation.com"
                 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
                 export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
                 export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case


### PR DESCRIPTION
Parameter substitution of federation domain map is now done while bootstrapping the nodes, so move the environment variable to the test job.

