### PR TITLE
Force CI 1.1 and 1.2 jobs to use the kubernetes-release bucket

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -141,6 +141,9 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-ci-slow-release-1.2
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 60
@@ -152,6 +155,9 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-slow-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-ci-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
@@ -162,5 +168,8 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     jobs:
         - 'kubernetes-e2e-gce-gci-ci-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -257,6 +257,9 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-reboot-release-1.2':  # kubernetes-e2e-gce-reboot-release-1.2
             description: 'Run [Feature:Reboot] tests on GCE on the release-1.2 branch.'
             timeout: 180
@@ -264,6 +267,9 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-e2e-gce-reboot-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-slow-release-1.2':  # kubernetes-e2e-gce-slow-release-1.2
             description: 'Runs slow tests on GCE, sequentially on the release-1.2 branch.'
             timeout: 60
@@ -273,6 +279,9 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce-slow-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-serial-release-1.2':  # kubernetes-e2e-gce-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.2 branch.'
             timeout: 300
@@ -281,6 +290,9 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -330,6 +342,9 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-ingress-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-ingress-release-1.3':  # kubernetes-e2e-gce-ingress-release-1.3
             description: 'Run [Feature:Ingress] tests on GCE on the release-1.3 branch.'
             timeout: 90
@@ -383,7 +398,10 @@
     runner: '{old-runner-1-1}'
     post-env: ''  # Empty expected
     provider-env: ''  # Empty expected
-    job-env: ''  # Empty expected
+    job-env: |
+        # build-1.1 is not using the kubernetes-release-dev bucket yet
+        export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+        export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     cron-string: 'H */6 * * *'
     suffix:
         - 'gce-release-1.1':  # kubernetes-e2e-gce-release-1.1

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -211,6 +211,9 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-gke-ingress-1-2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gke-ingress-release-1.3':  # kubernetes-e2e-gke-ingress-release-1.3
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.3 branch.'
             timeout: 90
@@ -237,6 +240,9 @@
                 export PROJECT="k8s-jkns-e2e-gke-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gke-serial-release-1.2':  # kubernetes-e2e-gke-serial-release-1.2
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.2 branch.'
             timeout: 300
@@ -245,6 +251,9 @@
                 export PROJECT="k8s-jkns-e2e-gke-serial-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gke-slow-release-1.2':  # kubernetes-e2e-gke-slow-release-1.2
             description: 'Run slow E2E tests on GKE using the release-1.2 branch.'
             timeout: 60
@@ -254,6 +263,9 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -352,7 +364,10 @@
     branch: 'release-1.1'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
-    job-env: ''  # Expected to be empty
+    job-env: |
+        # build-1.1 is not using the kubernetes-release-dev bucket yet
+        export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+        export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     post-env: ''  # Expected to be empty
     provider-env: ''  # Expected to be empty
     gke-suffix:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -164,6 +164,9 @@
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-2"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+                # build-1.2 is not using the kubernetes-release-dev bucket yet
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
             provider-env: |
                 export KUBERNETES_PROVIDER="gce"
                 export E2E_MIN_STARTUP_PODS="1"


### PR DESCRIPTION
The release-1.1 and release-1.2 Jenkins jobs only push to the gs://kubernetes-release bucket (1.3 and master mirror to gs://kubernetes-release-dev).

It seems that the e2e runner is only looking at kubernetes-release-dev, however, so it's not getting the latest 1.2 builds. (It's unclear if 1.1 is affected, too - it's not built anything in 2 weeks.)

The proper fix is to make the older release builder jobs mirror to kubernetes-release-dev as well, but it's late on a Friday before a 4-day weekend, so forcing the 1.1 and 1.2 e2e jobs to use the kubernetes-release bucket (instead of kubernetes-release-dev) seems safer.

cc @saad-ali @spxtr @fejta @zmerlynn 