### PR TITLE
Only sample merge rate when PRs are queued

### DIFF
--- a/queue-health/graph/graph.py
+++ b/queue-health/graph/graph.py
@@ -121,13 +121,16 @@ def render(history_lines, out_file):
             did_merge = 0
 
         if online:  # Ignore offline status
-            merge_sum += did_merge
             last_merge = merged
 
         daily_queue.append(happy)
-        daily_merged.append(did_merge)
         if len(daily_queue) > 60*24:
             happy_sum -= daily_queue.popleft()
+
+        if queue or did_merge:  # Only add samples when things are in the queue.
+            merge_sum += did_merge
+            daily_merged.append(did_merge)
+        if len(daily_merged) > 60*24:
             merge_sum -= daily_merged.popleft()
 
         if not start_offline and not online:

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Override with production targets
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph:v20160701
+        image: gcr.io/google-containers/queue-health-graph:v20160703
         env:
         - name: GRAPH
           value: "gs://kubernetes-test-history/k8s-queue-health.svg"

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Override with production targets
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph:v20160703
+        image: gcr.io/google-containers/queue-health-graph:v20160711
         env:
         - name: GRAPH
           value: "gs://kubernetes-test-history/k8s-queue-health.svg"

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Override with production targets
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph:v20160711
+        image: gcr.io/google-containers/queue-health-graph:v20160714
         env:
         - name: GRAPH
           value: "gs://kubernetes-test-history/k8s-queue-health.svg"


### PR DESCRIPTION
Instead of penalizing the merge queue when it is empty just drop these samples instead.

http://storage.googleapis.com/kubernetes-test-history/sq-test/k8s-queue-health.svg