### PR TITLE
Bind service account credentials to jobs

### DIFF
--- a/jenkins/credentials.md
+++ b/jenkins/credentials.md
@@ -1,0 +1,79 @@
+In order to configure a service please do the following:
+
+## Acquire the service account credentials
+
+1. Navigate to the [service accounts] for the project that owns the service
+   account (kubernetes-jenkins)
+  - Go to Google cloud console
+  - Open the burger on top left
+  - Select the `IAM & Admin` item
+  - Select `Service accounts` on the left sidebar
+2. Create the service account if it does not already exist.
+  - Give it a name: `kubekins`
+  - Note the service account id: `kubekins@kubernetes-jenkins.iam.gserviceaccount.com`
+  - Check the box to create/furnish a new key
+  - Select the `json` type
+3. Download the private key for this account
+  - Should already have happened if you just created the account
+  - Otherwise click the burger on the right
+  - Select the `create key` item
+  - Select the `json` type
+  - Note the location of this file on your computer
+
+## Add the credentials to jenkins
+
+1. Navigate to the global credentials in jenkins at `/credential-store/domain/_/`
+  - Go to jenkins
+  - `log in`
+  - Select `Credentials` on the left sidebar
+  - Select `Global credentials (unrestricted)`
+2. Upload the credentials
+  - Click `Add credentials` on the left sidebar
+  - Select `Secret file` in the `Kind` dropdown list.
+  - Set the `scope` to include `Global` and/or `all child items`
+  - Set the file to the private key you downloaded previously.
+  - Set the description to something that will help you find this later.
+  - Click the `Advanced` button to show the `ID` field
+  - Set the `ID` to something and note this for later.
+3. Note the `ID` of these credentials
+  - This is the value you selected in the previous step.
+  - Alternatively click the secret file with the matching description
+  - Click `Update` on the left sidebar.
+  - Click `Advanced` to show the `ID`.
+  - Remember the `ID` value for these credentials.
+
+## Add the credentials to the job configuration
+
+1. Add the credentials to a wrapper via the `credentials-binding` plugin.
+  - Open the [credentials.yaml] file
+  - Add/find a wrapper with a credentials-binding wrapper.
+  - Add a new file item to this wrapper where:
+    - `credential-id` is the `ID` of the credential from the previous step.
+    - `variable` is the environment variable containing the path of to this
+      file.
+    -  Example:
+    ```
+    wrapper:
+      name: foo-wrapper  # Remember this
+      wrappers:
+      - credentials-binding:
+        - file:
+            credential-id: 'my-id'  # This is what you selected previously
+            value: 'MY_VARIABLE'  # We are using KUBEKINS_SERVICE_ACCOUNT_FILE
+    ```
+2. Add the wrapper to a job
+  - Find the `job`/`project`/`job-template` of interest ([example job])
+  - Ensure the item of interest includes the wrapper defined in the previous
+    step:
+    - Example:
+    ```
+    job:
+      name: 'hello'
+      wrappers:
+        - foo-wrapper  # this is from above
+    ```
+
+
+[credentials.yaml]: https://github.com/kubernetes/test-infra/blob/master/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
+[example job]: https://github.com/kubernetes/test-infra/blob/master/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml#L40
+[service accounts]: https://console.developers.google.com/iam-admin/serviceaccounts/project

--- a/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
@@ -1,0 +1,7 @@
+- wrapper:
+    name: e2e-credentials-binding  # TODO(fejta): make this match non-pull
+    wrappers:
+        - credentials-binding:
+            - file:
+                credential-id: 'kubekins@kubernetes-jenkins.iam.gserviceaccount.com'
+                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -197,6 +197,7 @@
             failure-comment: '{failure-comment}'
             error-comment: '{error-comment}'
     wrappers:
+        - e2e-credentials-binding
         - inject:
             properties-content: |
                 GOROOT=/usr/local/go

--- a/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
@@ -17,3 +17,6 @@
             - file:
                 credential-id: '00711c20-7f9e-409d-81f1-80401fac2dfb'
                 variable: 'JENKINS_AWS_CREDENTIALS_FILE'
+            - file:
+                credential-id: 'kubekins@kubernetes-jenkins.iam.gserviceaccount.com'
+                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'

--- a/jenkins/list-owners.sh
+++ b/jenkins/list-owners.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Account test projects need
+ACCOUNT='kubekins@kubernetes-jenkins.iam.gserviceaccount.com'
+# Path we store jenkins job configs
+CONFIGS="$(dirname $0)/job-configs"
+# List of projects in our job configs
+PROJECTS="$(grep -h -r -o -E 'PROJECT=".+"' "${CONFIGS}" | sort | uniq | cut -d '"' -f 2)"
+
+(for project in ${PROJECTS}; do
+  # Check each project to see if it has the service account
+  echo -n "${project}: " >&2
+  gcloud projects get-iam-policy "${project}" | grep "${ACCOUNT}" >/dev/null \
+  && echo 'configured' >&2 \
+  && continue  # We are done if it is there
+  # Otherwise list owners of the account
+  echo 'listing owners...' >&2
+  gcloud projects get-iam-policy "${project}" \
+    --format='json(bindings)' | jq -r ".bindings[] | select(.role == \"roles/owner\") | .members[] "
+done) | sort | uniq -c | sort -h

--- a/jenkins/update-projects.sh
+++ b/jenkins/update-projects.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Store list of problematic problems
+if [[ -f problems.txt ]]; then
+  rm problems.txt
+fi
+touch problems.txt
+# Account test projects need
+ACCOUNT='kubekins@kubernetes-jenkins.iam.gserviceaccount.com'
+# Path we store jenkins job configs
+CONFIGS="$(dirname $0)/job-configs"
+# List of projects in our job configs
+PROJECTS="$(grep -h -r -o -E 'PROJECT=".+"' "${CONFIGS}" | sort | uniq | cut -d '"' -f 2)"
+for project in ${PROJECTS}; do
+  # Check if account is present and skip if so
+  echo -n "${project}: " >&2
+  if gcloud projects get-iam-policy "${project}" | grep "${ACCOUNT}" >/dev/null; then
+    echo 'configured' >&2
+    continue
+  fi
+  # Try to add the policy and note on stdout if the add fails
+  echo 'updating...' >&2
+  gcloud -q projects add-iam-policy-binding \
+    "$project" \
+    --member="serviceAccount:${ACCOUNT}" \
+    --role='roles/editor' \
+  && echo "${project} updated" >&2 \
+  || echo "${project} not updated" | tee -a problems.txt
+done
+# Check the number of projects that failed to update
+echo "There are $(wc -l problems.txt) projects left to update..."


### PR DESCRIPTION
Related to https://github.com/kubernetes/kubernetes/pull/28634

Bind service account credentials for a service account to `KUBEKINS_SERVICE_ACCOUNT_FILE`

Instructions at https://github.com/fejta/test-infra/blob/cache/jenkins/credentials.md