### PR TITLE
Try running 2k Node Load test with services

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -488,8 +488,7 @@
         export MASTER_SIZE="n1-standard-32"
         export NODE_SIZE="n1-standard-1"
         export NODE_DISK_SIZE="50GB"
-        # TODO: Get it back to 2000, after the experiment.
-        export NUM_NODES="1000"
+        export NUM_NODES="2000"
         export ALLOWED_NOTREADY_NODES="20"
         # Reduce logs verbosity
         export TEST_CLUSTER_LOG_LEVEL="--v=1"


### PR DESCRIPTION
@zml, @thockin 1k run was surprisingly smooth. Metrics were OK (~300ms), run took nearly 5h instead of previous 4h:20, but that's not terrible. Trying 2k now.