### PR TITLE
Stop exporting GCE_SERVICE_ACCOUNT

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -101,7 +101,6 @@
         export INSTANCE_PREFIX="${{E2E_NAME:-jenkins-e2e}}"
         export KUBE_GCE_NETWORK="${{E2E_NAME:-jenkins-e2e}}"
         export KUBE_GCE_INSTANCE_PREFIX="${{E2E_NAME:-jenkins-e2e}}"
-        export GCE_SERVICE_ACCOUNT=$(gcloud auth list 2> /dev/null | grep active | cut -f3 -d' ')
 
         # GKE variables
         export CLUSTER_NAME="${{E2E_NAME:-jenkins-e2e}}"

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -389,7 +389,6 @@
               export INSTANCE_PREFIX=${{E2E_NAME}}
               export KUBE_GCE_NETWORK=${{E2E_NAME}}
               export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
-              export GCE_SERVICE_ACCOUNT=$(gcloud auth list 2> /dev/null | grep active | cut -f3 -d' ')
 
               # Get golang into our PATH so we can run e2e.go
               export PATH=${{PATH}}:/usr/local/go/bin


### PR DESCRIPTION
After https://github.com/kubernetes/kubernetes/pull/28802 is working stop exporting `GCE_SERVICE_ACCOUNT` in our test jobs.

Please just review/lgtm and do not merge.