### PR TITLE
Kill all references to CI builds of release-1.0 and release-1.1

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -80,8 +80,6 @@
         exit ${{rc}}
     runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/dockerized-e2e-runner.sh")
     legacy-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/e2e-runner.sh")
-    old-runner-1-1: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.1/hack/jenkins/e2e.sh")
-    old-runner-1-0: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.0/hack/jenkins/e2e.sh")
     post-env: |
         # Nothing should want Jenkins $HOME
         export HOME=${{WORKSPACE}}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -49,14 +49,6 @@
             branch: 'master'
             timeout: 50
             job-env: ''  # Empty expected
-        - 'build-1.0':
-            branch: 'release-1.0'
-            timeout: 30
-            job-env: ''  # Empty expected
-        - 'build-1.1':
-            branch: 'release-1.1'
-            timeout: 30
-            job-env: ''  # Empty expected
         - 'build-1.2':
             branch: 'release-1.2'
             timeout: 30

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -141,9 +141,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-ci-slow-release-1.2
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 60
@@ -155,9 +152,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-slow-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-ci-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
@@ -168,8 +162,5 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     jobs:
         - 'kubernetes-e2e-gce-gci-ci-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -376,24 +376,6 @@
         - 'kubernetes-e2e-{suffix}'
  
 - project:
-    name: kubernetes-e2e-gce-1.1
-    trigger-job: 'kubernetes-build-1.1'
-    test-owner: 'Build Cop'
-    branch: 'release-1.1'
-    jenkins_node: 'master'
-    runner: '{old-runner-1-1}'
-    post-env: ''  # Empty expected
-    provider-env: ''  # Empty expected
-    job-env: ''  # Empty expected
-    cron-string: 'H */6 * * *'
-    suffix:
-        - 'gce-release-1.1':  # kubernetes-e2e-gce-release-1.1
-            timeout: 175
-            description: 'Run E2E tests on GCE from the release-1.1 branch.'
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
-
-- project:
     name: kubernetes-e2e-gce-features
     trigger-job: 'kubernetes-build'
     suffix:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -258,9 +258,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-reboot-release-1.2':  # kubernetes-e2e-gce-reboot-release-1.2
             description: 'Run [Feature:Reboot] tests on GCE on the release-1.2 branch.'
             timeout: 180
@@ -268,9 +265,6 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-e2e-gce-reboot-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-slow-release-1.2':  # kubernetes-e2e-gce-slow-release-1.2
             description: 'Runs slow tests on GCE, sequentially on the release-1.2 branch.'
             timeout: 60
@@ -280,9 +274,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce-slow-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-serial-release-1.2':  # kubernetes-e2e-gce-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.2 branch.'
             timeout: 300
@@ -291,9 +282,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -343,9 +331,6 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-ingress-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gce-ingress-release-1.3':  # kubernetes-e2e-gce-ingress-release-1.3
             description: 'Run [Feature:Ingress] tests on GCE on the release-1.3 branch.'
             timeout: 90
@@ -399,10 +384,7 @@
     runner: '{old-runner-1-1}'
     post-env: ''  # Empty expected
     provider-env: ''  # Empty expected
-    job-env: |
-        # build-1.1 is not using the kubernetes-release-dev bucket yet
-        export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-        export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
+    job-env: ''  # Empty expected
     cron-string: 'H */6 * * *'
     suffix:
         - 'gce-release-1.1':  # kubernetes-e2e-gce-release-1.1

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -211,9 +211,6 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-gke-ingress-1-2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gke-ingress-release-1.3':  # kubernetes-e2e-gke-ingress-release-1.3
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.3 branch.'
             timeout: 90
@@ -240,9 +237,6 @@
                 export PROJECT="k8s-jkns-e2e-gke-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gke-serial-release-1.2':  # kubernetes-e2e-gke-serial-release-1.2
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.2 branch.'
             timeout: 300
@@ -251,9 +245,6 @@
                 export PROJECT="k8s-jkns-e2e-gke-serial-1-2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
         - 'gke-slow-release-1.2':  # kubernetes-e2e-gke-slow-release-1.2
             description: 'Run slow E2E tests on GKE using the release-1.2 branch.'
             timeout: 60
@@ -263,9 +254,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -364,10 +352,7 @@
     branch: 'release-1.1'
     jenkins_node: 'master'
     runner: '{old-runner-1-1}'
-    job-env: |
-        # build-1.1 is not using the kubernetes-release-dev bucket yet
-        export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-        export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
+    job-env: ''  # Expected to be empty
     post-env: ''  # Expected to be empty
     provider-env: ''  # Expected to be empty
     gke-suffix:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -346,25 +346,6 @@
         - 'kubernetes-e2e-{gke-suffix}'
 
 - project:
-    name: kubernetes-e2e-gke-1.1
-    trigger-job: 'kubernetes-build-1.1'
-    test-owner: 'Build Cop'
-    branch: 'release-1.1'
-    jenkins_node: 'master'
-    runner: '{old-runner-1-1}'
-    job-env: ''  # Expected to be empty
-    post-env: ''  # Expected to be empty
-    provider-env: ''  # Expected to be empty
-    gke-suffix:
-        - 'gke-1.1':  # kubernetes-e2e-gke-1.1
-            timeout: 150
-            description: 'Run E2E tests on GKE from the 1.1 release branch.'
-            cron-string: 'H */6 * * *'
-    jobs:
-        - 'kubernetes-e2e-{gke-suffix}'
-
-
-- project:
     name: kubernetes-e2e-gke-features
     trigger-job: 'kubernetes-build'
     gke-suffix:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -164,9 +164,6 @@
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-2"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                # build-1.2 is not using the kubernetes-release-dev bucket yet
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-release
             provider-env: |
                 export KUBERNETES_PROVIDER="gce"
                 export E2E_MIN_STARTUP_PODS="1"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -75,10 +75,5 @@
             # Every 3 hours
             cron-string: 'H H/3 * * *'
             timeout: 100
-        - 'go-release-1.1':
-            branch: 'release-1.1'
-            # Every 6 hours
-            cron-string: 'H H/12 * * *'
-            timeout: 60
     jobs:
         - 'kubernetes-test-{suffix}'


### PR DESCRIPTION
This eliminates any job that builds release-1.0 or release-1.1, and any job that tries to pull those releases from CI buckets.

This also reverts #256, since the combination of https://github.com/kubernetes/kubernetes/pull/28172, https://github.com/kubernetes/kubernetes/pull/28193 and https://github.com/kubernetes/kubernetes/pull/28792 are now present in `release-1.2` forward.