### PR TITLE
Fix test-history crash on ill-formed junit-PRE-SETUP.xml files.

### DIFF
--- a/jenkins/test-history/gen_json.py
+++ b/jenkins/test-history/gen_json.py
@@ -125,7 +125,7 @@ class GCSClient(object):
 
         for child in root:
             name = child.attrib['name']
-            ctime = float(child.attrib['time'])
+            ctime = float(child.attrib['time'] or 0)
             failed = False
             skipped = False
             for param in child:
@@ -225,8 +225,12 @@ def mp_get_tests((job, build, timestamp)):
     """
     Inside a multiprocessing worker, get the tests for a given job and build.
     """
-    return job, build, timestamp, list(
-        WORKER_CLIENT.get_tests_from_build(job, build))
+    try:
+        return job, build, timestamp, list(
+            WORKER_CLIENT.get_tests_from_build(job, build))
+    except:
+        logging.exception('failed to get tests for %s/%s', job, build)
+        raise
 
 
 def get_existing_builds(jobs):

--- a/jenkins/test-history/gen_json_test.py
+++ b/jenkins/test-history/gen_json_test.py
@@ -141,6 +141,14 @@ class GCSClientTest(unittest.TestCase):
             ('Lazy', 0, False, True),
         ])
 
+    def test_get_tests_empty_time(self):
+        gets = dict(self.client.gets)
+        gets[self.client.ART_DIR + 'junit_01.xml'] = (
+            '<testsuite><testcase name="Empty" time="" /></testsuite>')
+        self.client.gets = gets
+        tests = list(self.client.get_tests_from_build('fake', '123'))
+        self.assertEqual(tests, [('Empty', 0.0, False, False)])
+
     def test_get_builds_normal_list(self):
         # normal case: lists a directory
         self.assertEqual(['123', '122'], self.client._get_builds('fake'))
@@ -169,6 +177,7 @@ class GCSClientTest(unittest.TestCase):
         have = {('fake', '123')}
         builds = list(self.client.get_daily_builds(lambda x: True, have))
         self.assertEqual(builds, [])
+
 
 class MainTest(unittest.TestCase):
     """End-to-end test of the main function's output."""


### PR DESCRIPTION
https://console.cloud.google.com/m/cloudstorage/b/kubernetes-jenkins/o/logs/kubernetes-e2e-aws-release-1.3/33/artifacts/junit-PRE-SETUP.xml