### PR TITLE
Update the GCI image family used for daily builds

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
@@ -86,6 +86,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-docker-validation-gci"
-                export JENKINS_GCI_IMAGE_FAMILY="gci-preview-test"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-canary-test"
     jobs:
         - 'continuous-docker-validation-{os-distro}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -76,8 +76,9 @@
             timeout: 50
             trigger-job: 'kubernetes-build'
             job-env: |
-                # This should become 54 once it's available.
-                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                # The master branch will always uses GCI images built from its
+                # tip of tree, categorized in family `gci-canary`.
+                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master"
@@ -86,7 +87,7 @@
             timeout: 150  #  See #24072
             trigger-job: 'kubernetes-build'
             job-env: |
-                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
@@ -96,7 +97,7 @@
             timeout: 300
             trigger-job: 'kubernetes-build'
             job-env: |
-                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -76,7 +76,7 @@
             timeout: 50
             trigger-job: 'kubernetes-build'
             job-env: |
-                # The master branch will always uses GCI images built from its
+                # The master branch will always use GCI images built from its
                 # tip of tree, categorized in family `gci-canary`.
                 export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"


### PR DESCRIPTION
This depends on https://github.com/kubernetes/kubernetes/pull/28917

Jobs that test against the master branch should use GCI daily builds, which are in
family `gci-canary`. The Docker continuous validation job uses test images from
daily builds, hence `gci-canary-test`.

Hopefully this will the last time we have to update image families. :)

@Amey-D @spxtr Can you review?

@Random-Liu Heads up.

cc/ @kubernetes/goog-image 