### PR TITLE
Redirect URLs with a trailing ) to a path without it.

### DIFF
--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -360,6 +360,15 @@ class PRBuildLogHandler(webapp2.RequestHandler):
         self.redirect('https://storage.googleapis.com/%s/%s' % (PR_PREFIX, path))
 
 
+class ParenRedirector(webapp2.RequestHandler):
+    '''
+    I don't know where these links are coming from, but many people hit 404s
+    trying to get pages with )s on the end. Try to help them along
+    '''
+    def get(self, path):
+        self.redirect(path)
+
+
 app = webapp2.WSGIApplication([
     (r'/', IndexHandler),
     (r'/jobs/(.*)$', JobListHandler),
@@ -368,4 +377,5 @@ app = webapp2.WSGIApplication([
     (r'/build/(.*)/([^/]+)/(\d+)/nodelog*', NodeLogHandler),
     (r'/pr/(\d+)', PRHandler),
     (r'/pr/(.*/build-log.txt)', PRBuildLogHandler),
+    (r'(.*)\)', ParenRedirector),  # this is a catch-all handler.
 ], debug=True)

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -268,3 +268,9 @@ class PRTest(unittest.TestCase, TestMixin):
         self.assertEqual(response.status_code, 302)
         self.assertIn('https://storage.googleapis.com', response.location)
         self.assertIn(path, response.location)
+
+    def test_paren_redirect(self):
+        path = '/abc/123/def'
+        response = app.get(path + ')')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, 'http://localhost' + path)


### PR DESCRIPTION
I don't know where these come from, the referers are all the
google.com/url redirector.