### PR TITLE
Update recipients of GKE-Trusty job emails

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -370,8 +370,8 @@
 - project:
     name: kubernetes-e2e-gke-trusty
     trigger-job: 'kubernetes-build-1.2'
-    test-owner: 'wonderfly@google.com'
-    emails: 'wonderfly@google.com,qzheng@google.com'
+    test-owner: 'wonderfly'
+    emails: 'gci-alerts+kubekins@google.com'
     gke-suffix:
         - 'gke-trusty-test':  # kubernetes-e2e-gke-trusty-test
             description: 'Run E2E tests on GKE test endpoint.'


### PR DESCRIPTION
These jobs need a major update soon (from Trusty to GCI), but this PR only
targets to update the email recipients.

@adityakali Can you review?

cc/ @andyzheng0831 @kubernetes/goog-image 