### PR TITLE
Bump the remainder of the -slow- runs to 150m

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -144,7 +144,7 @@
                 export PROJECT="e2e-gce-gci-ci-1-2"
         - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-ci-slow-release-1.2
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
-            timeout: 60
+            timeout: 150  #  See #24072
             trigger-job: 'kubernetes-build-1.2'
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -263,7 +263,7 @@
                 export PROJECT="k8s-jkns-e2e-gce-reboot-1-2"
         - 'gce-slow-release-1.2':  # kubernetes-e2e-gce-slow-release-1.2
             description: 'Runs slow tests on GCE, sequentially on the release-1.2 branch.'
-            timeout: 60
+            timeout: 150  #  See #24072
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
@@ -303,7 +303,7 @@
                 export PROJECT="k8s-jkns-gce-reboot-1-3"
         - 'gce-slow-release-1.3':  # kubernetes-e2e-gce-slow-release-1.3
             description: 'Runs slow tests on GCE, sequentially on the release-1.3 branch.'
-            timeout: 60
+            timeout: 150  #  See #24072
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -188,7 +188,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
         - 'gke-slow-release-1.3':  # kubernetes-e2e-gke-slow-release-1.3
             description: 'Run slow E2E tests on GKE using the release-1.3 branch.'
-            timeout: 60
+            timeout: 150  #  See #24072
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-slow-1-3"
@@ -247,7 +247,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
         - 'gke-slow-release-1.2':  # kubernetes-e2e-gke-slow-release-1.2
             description: 'Run slow E2E tests on GKE using the release-1.2 branch.'
-            timeout: 60
+            timeout: 150  #  See #24072
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-slow-1-2"


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/24072

This extends it to release-1.3, and all release-1.2. It's not
exceeding timeouts on release-1.2, but it's getting close, and a GCE
twitch would put it over.