### PR TITLE
Move GKE large back to us-east1-a

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -152,7 +152,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|should\stest\skube-proxy \
                                          --system-pods-startup-timeout=240m"
                 export GINKGO_PARALLEL="y"
-                export ZONE="us-central1-b"
+                export ZONE="us-east1-a"
                 export NUM_NODES=2000
                 export MACHINE_TYPE="n1-standard-1"
                 export HEAPSTER_MACHINE_TYPE="n1-standard-4"


### PR DESCRIPTION
We were asked to move it back temporarily to us-east1-a, for debugging purposes.