### PR TITLE
Refactor objref dictionary, consolidate filtering into one page

### DIFF
--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -25,10 +25,10 @@ import regex
 
 def parse(lines, hilight_words, filters, objref_dict):
     """
-    Given filters returns indeces of wanted lines from the kubelet log
+    Given filters returns indeces of wanted lines from log
 
     Args:
-        lines: array of kubelet log lines
+        lines: array of log lines
         hilight_words: array of words that need to be bolded
         filters: dictionary of which filters to apply
     Returns:
@@ -55,8 +55,8 @@ def parse(lines, hilight_words, filters, objref_dict):
 
 def make_dict(data, pod_re):
     """
-    Given the kubelet log file and the failed pod name, returns a dictionary
-    containing the namespace and UID associated with the pod.
+    Given the log file and the failed pod name, returns a dictionary
+    containing the namespace, UID, and other information associated with the pod.
 
     This dictionary is lifted from the line with the ObjectReference
     """

--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -31,18 +31,18 @@ def parse(lines, hilight_words, filters, objref_dict):
         lines: array of log lines
         hilight_words: array of words that need to be bolded
         filters: dictionary of which filters to apply
+        objref_dict: a dictionary where the keys are possible filters 
+        and the values are the words to be hilighted 
     Returns:
         matched_lines: ordered array of indeces of lines to display
         hilight_words: updated hilight_words
     """
     matched_lines = []
     
-    if filters["uid"] and objref_dict["UID"]:
-        uid = objref_dict["UID"]
-        hilight_words.append(uid)
-    if filters["namespace"] and objref_dict["Namespace"]:
-        namespace = objref_dict["Namespace"]
-        hilight_words.append(namespace)
+    # If the filter is on, look for it in the objref_dict
+    for k in filters:
+        if k != "pod" and filters[k] and objref_dict[k]:
+            hilight_words.append(objref_dict[k])
 
     words_re = regex.combine_wordsRE(hilight_words)
 

--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -51,7 +51,6 @@ def parse(lines, error_re, hilight_words, filters, objref_dict):
         if words_re.search(line):
             matched_lines.append(n)
 
-
     return matched_lines, hilight_words
 
 

--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -40,9 +40,17 @@ def parse(lines, error_re, hilight_words, filters):
     uid = ""
     namespace = ""
 
+    if filters["uid"] and uid == "":
+        uid = objref_dict["UID"]
+        hilight_words.append(uid)
+    if filters["namespace"] and namespace == "":
+        namespace = objref_dict["Namespace"]
+        hilight_words.append(namespace)
+
     for n, line in enumerate(lines):
         if error_re.search(line):
             matched_lines.append(n)
+
 
 
 

--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -23,7 +23,7 @@ import jinja2
 
 import regex
 
-def parse(lines, error_re, hilight_words, filters):
+def parse(lines, error_re, hilight_words, filters, objref_dict):
     """
     Given filters returns indeces of wanted lines from the kubelet log
 
@@ -37,21 +37,21 @@ def parse(lines, error_re, hilight_words, filters):
         hilight_words: updated hilight_words
     """
     matched_lines = []
-    uid = ""
-    namespace = ""
-
-    if filters["uid"] and uid == "":
+    
+    if filters["uid"] and objref_dict["UID"]:
         uid = objref_dict["UID"]
         hilight_words.append(uid)
-    if filters["namespace"] and namespace == "":
+    if filters["namespace"] and objref_dict["Namespace"]:
         namespace = objref_dict["Namespace"]
         hilight_words.append(namespace)
 
+    words_re = re.compile(r'\b(%s)\b' % '|'.join(hilight_words), re.IGNORECASE)     
+
     for n, line in enumerate(lines):
-        if error_re.search(line):
+        if words_re.search(line):
             matched_lines.append(n)
 
 
-
-
     return matched_lines, hilight_words
+
+

--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -45,7 +45,7 @@ def parse(lines, error_re, hilight_words, filters, objref_dict):
         namespace = objref_dict["Namespace"]
         hilight_words.append(namespace)
 
-    words_re = re.compile(r'\b(%s)\b' % '|'.join(hilight_words), re.IGNORECASE)     
+    words_re = regex.combine_wordsRE(hilight_words)
 
     for n, line in enumerate(lines):
         if words_re.search(line):

--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -44,29 +44,6 @@ def parse(lines, error_re, hilight_words, filters):
         if error_re.search(line):
             matched_lines.append(n)
 
-            # If the line is the ObjectReference line, make a dictionary
-            objref = regex.objref(line)
-            if objref and objref.group(1) != "":
-                objref_dict = objref.group(1)        
-                keys = regex.keys_re.findall(objref_dict)
-                
-                for k in keys:
-                    objref_dict = regex.key_to_string(k, objref_dict)
 
-                # Convert string into dictionary
-                objref_dict = ast.literal_eval(regex.fix_quotes(objref_dict))
-
-                if uid == "" and filters["uid"] and objref_dict["UID"]:
-                    uid = objref_dict["UID"]
-                    hilight_words.append(uid)
-                if namespace == "" and filters["namespace"] and objref_dict["Namespace"]:
-                    namespace = objref_dict["Namespace"]
-                    hilight_words.append(namespace)
-
-        if uid != "" and matched_lines[-1] != n:
-            uid_re = regex.wordRE(uid)
-            if uid_re.search(line):
-                matched_lines.append(n)
-        matched_lines.sort()
 
     return matched_lines, hilight_words

--- a/gubernator/kubelet_parser_test.py
+++ b/gubernator/kubelet_parser_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import kubelet_parser
+import regex
+
+
+lines = ["line 0", "pod 2 3", "abcd podName", "line 3", "failed",
+"Event(api.ObjectReference{Namespace:\"podName\", Name:\"abc\", UID:\"uid\"}", "uid"]
+filters = {"uid":"", "pod":"", "namespace":""}
+
+class KubeletParserTest(unittest.TestCase):
+	def test_parse_error_re(self):
+		"""Test for build-log.txt filtering by error_re"""
+		matched_lines, hilight_words = kubelet_parser.parse(lines,
+			["error", "fatal", "failed", "build timed out"], filters, {})
+		self.assertEqual(matched_lines, [4])
+		self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
+
+
+	def test_parse_empty_lines(self):
+		"""Test that it doesn't fail when files are empty"""
+		matched_lines, hilight_words = kubelet_parser.parse([],
+			["error", "fatal", "failed", "build timed out"], filters, {})
+		self.assertEqual(matched_lines, [])
+		self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])		
+
+
+	def test_parse_pod_RE(self):
+		"""Test for initial pod filtering"""
+		filters["pod"] = "pod"
+		matched_lines, hilight_words = kubelet_parser.parse(lines,
+			["pod"], filters,  {"UID":"", "Namespace":""})
+		self.assertEqual(matched_lines, [1])
+		self.assertEqual(hilight_words, ["pod"])	
+
+
+	def test_parse_filters(self):
+		"""Test for filters"""
+		filters["pod"] = "pod"
+		filters["uid"] = "on"
+		filters["namespace"] = "on"
+		matched_lines, hilight_words = kubelet_parser.parse(lines,
+			["pod"], filters, {"UID":"uid", "Namespace":"podName"})
+		self.assertEqual(matched_lines, [1, 2, 5, 6])
+		self.assertEqual(hilight_words, ["pod", "uid", "podName"])	
+
+
+	def test_make_dict(self):
+		"""Test make_dict works"""
+		objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"))
+		self.assertEqual(objref_dict, {"UID":"uid", "Namespace":"podName", "Name":"abc"})
+
+
+	def test_make_dict_fail(self):
+		"""Test when objref line not in file"""
+		lines = ["pod failed"]
+		objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"))
+		self.assertEqual(objref_dict, None)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gubernator/kubelet_parser_test.py
+++ b/gubernator/kubelet_parser_test.py
@@ -22,7 +22,7 @@ import regex
 
 lines = ["line 0", "pod 2 3", "abcd podName", "line 3", "failed",
 "Event(api.ObjectReference{Namespace:\"podName\", Name:\"abc\", UID:\"uid\"}", "uid"]
-filters = {"uid":"", "pod":"", "namespace":""}
+filters = {"UID":"", "pod":"", "Namespace":""}
 
 class KubeletParserTest(unittest.TestCase):
 	def test_parse_error_re(self):
@@ -53,12 +53,12 @@ class KubeletParserTest(unittest.TestCase):
 	def test_parse_filters(self):
 		"""Test for filters"""
 		filters["pod"] = "pod"
-		filters["uid"] = "on"
-		filters["namespace"] = "on"
+		filters["UID"] = "on"
+		filters["Namespace"] = "on"
 		matched_lines, hilight_words = kubelet_parser.parse(lines,
 			["pod"], filters, {"UID":"uid", "Namespace":"podName"})
 		self.assertEqual(matched_lines, [1, 2, 5, 6])
-		self.assertEqual(hilight_words, ["pod", "uid", "podName"])	
+		self.assertEqual(hilight_words, ["pod", "podName", "uid"])	
 
 
 	def test_make_dict(self):

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -26,7 +26,7 @@ import regex
     
 def hilight(line, hilight_words):
     # Join all the words that need to be bolded into one regex
-    words_re = re.compile(r'\b(%s)\b' % '|'.join(hilight_words), re.IGNORECASE)     
+    words_re = regex.combine_wordsRE(hilight_words)
     line = words_re.sub(r'<span class="keyword">\1</span>', line)
     return '<span class="hilight">%s</span>' % line
 
@@ -78,6 +78,12 @@ def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l, objref_dict
 
 
 def make_dict(data, pod_re):
+    """
+    Given the kubelet log file and the failed pod name, returns a dictionary
+    containing the namespace and UID associated with the pod.
+
+    This dictionary is lifted from the line with the ObjectReference
+    """
     lines = unicode(jinja2.escape(data)).split('\n')
     for line in lines:
         if pod_re.search(line):

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -94,8 +94,6 @@ def make_dict(data, pod_re):
                 return objref_dict
 
 
-
-
 if __name__ == '__main__':
     import sys
     for f in sys.argv[1:]:

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -32,7 +32,7 @@ def hilight(line, hilight_words):
 
 
 def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l, objref_dict={},
-    filters={"uid":"", "pod":"", "namespace":""}, error_re=regex.error_re):
+    filters={"UID":"", "pod":"", "Namespace":""}, error_re=regex.error_re):
     """
     Given a build log, return a chunk of HTML code suitable for
     inclusion in a <pre> tag, with "interesting" errors hilighted.
@@ -45,7 +45,7 @@ def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l, objref_dict
     if filters["pod"]:
         hilight_words = [filters["pod"]]
 
-    if not (filters["uid"] or filters["namespace"]):
+    if not (filters["UID"] or filters["Namespace"]):
         matched_lines = [n for n, line in enumerate(lines) if error_re.search(line)]
     else:
         matched_lines, hilight_words = kubelet_parser.parse(lines,

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -48,7 +48,7 @@ def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l, objref_dict
     if not (filters["uid"] or filters["namespace"]):
         matched_lines = [n for n, line in enumerate(lines) if error_re.search(line)]
     else:
-        matched_lines, hilight_words = kubelet_parser.parse(lines, error_re, 
+        matched_lines, hilight_words = kubelet_parser.parse(lines,
             hilight_words, filters, objref_dict)
 
     output = []
@@ -75,29 +75,6 @@ def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l, objref_dict
         last_match = match
 
     return '\n'.join(output)
-
-
-def make_dict(data, pod_re):
-    """
-    Given the kubelet log file and the failed pod name, returns a dictionary
-    containing the namespace and UID associated with the pod.
-
-    This dictionary is lifted from the line with the ObjectReference
-    """
-    lines = unicode(jinja2.escape(data)).split('\n')
-    for line in lines:
-        if pod_re.search(line):
-            objref = regex.objref(line)
-            if objref and objref.group(1) != "":
-                objref_dict = objref.group(1)        
-                keys = regex.keys_re.findall(objref_dict)
-                
-                for k in keys:
-                    objref_dict = regex.key_to_string(k, objref_dict)
-
-                # Convert string into dictionary
-                objref_dict = ast.literal_eval(regex.fix_quotes(objref_dict))
-                return objref_dict
 
 
 if __name__ == '__main__':

--- a/gubernator/log_parser_test.py
+++ b/gubernator/log_parser_test.py
@@ -21,7 +21,7 @@ import log_parser
 import regex
 
 class LogParserTest(unittest.TestCase):
-    def digest(self, data, strip=True, filters={"uid":"", "pod":"", "namespace":""},
+    def digest(self, data, strip=True, filters={"UID":"", "pod":"", "Namespace":""},
         error_re=regex.error_re):
         digested = log_parser.digest(data.replace(' ', '\n'), error_re=error_re, 
                                      skip_fmt=lambda l: 's%d' % l, filters=filters)
@@ -63,12 +63,12 @@ class LogParserTest(unittest.TestCase):
     def test_pod(self):
         self.assertEqual(self.digest('pod-blah', 
             error_re=regex.wordRE("pod"),
-            filters={"pod":"pod", "uid":"", "namespace":""}, strip=False), ''
+            filters={"pod":"pod", "UID":"", "Namespace":""}, strip=False), ''
                          '<span class="hilight"><span class="keyword">'
                          'pod</span>-blah</span>')
         self.assertEqual(self.digest('0 1 2 3 4 5 pod 6 7 8 9 10', 
-            error_re=regex.wordRE("pod"), filters={"pod":"pod", "uid":"", 
-            "namespace":""}), 's2 2 3 4 5 pod 6 7 8 9')
+            error_re=regex.wordRE("pod"), filters={"pod":"pod", "UID":"", 
+            "Namespace":""}), 's2 2 3 4 5 pod 6 7 8 9')
         
 
 if __name__ == '__main__':

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -350,8 +350,8 @@ class NodeLogHandler(RenderingHandler):
         self.render('filtered_log.html', dict(
             job_dir=job_dir, build_dir=build_dir, log=result, job=job,
             build=build, full_path=filename, log_file=log_file,
-            pod=pod_name, junit=junit, uid=uid,
-            namespace=namespace, wrap=wrap))
+            pod=pod_name, junit=junit, uid=uid, namespace=namespace,
+            wrap=wrap, objref_dict=objref_dict))
 
 
 class JobListHandler(RenderingHandler):

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -342,7 +342,7 @@ class NodeLogHandler(RenderingHandler):
             result = parse_log_file(filename, pod_name, filters, objref_dict=objref_dict)
 
         if filename is None or result is None:
-            self.render('node_404.html', {"build_dir": build_dir,
+            self.render('node_404.html', {"build_dir": build_dir, "log_file": log_file,
                 "pod_name":pod_name, "junit":junit})
             self.response.set_status(404)
             return

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -338,7 +338,7 @@ class NodeLogHandler(RenderingHandler):
         uid = bool(self.request.get("UID"))
         namespace = bool(self.request.get("Namespace"))
         wrap = bool(self.request.get("wrap"))
-        filters = {"uid":uid, "pod":pod_name, "namespace":namespace}
+        filters = {"UID":uid, "pod":pod_name, "Namespace":namespace}
 
         # default to filtering kubelet log if user unchecks both checkboxes
         if log_files == []:

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -32,6 +32,7 @@ import cloudstorage as gcs
 import gcs_async
 import filters
 import log_parser
+import kubelet_parser
 import pull_request
 import regex
 
@@ -207,7 +208,7 @@ def parse_log_file(log_filename, pod, filters=None, make_dict=False, objref_dict
     pod_re = regex.wordRE(pod)
 
     if make_dict:
-        return log_parser.make_dict(log.decode('utf8','replace'), pod_re)
+        return kubelet_parser.make_dict(log.decode('utf8','replace'), pod_re)
     else:
         return log_parser.digest(log.decode('utf8','replace'), 
         error_re=pod_re, filters=filters, objref_dict=objref_dict)

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -333,7 +333,6 @@ class NodeLogHandler(RenderingHandler):
                 "pod_name":pod_name, "junit":junit})
             self.response.set_status(404)
             return
-
         self.render('filtered_log.html', dict(
             job_dir=job_dir, build_dir=build_dir, log=result, job=job,
             build=build, full_path=filename, log_file=log_file,

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -326,6 +326,7 @@ class NodeLogHandler(RenderingHandler):
         junit = self.request.get("junit")
         uid = bool(self.request.get("UID"))
         namespace = bool(self.request.get("Namespace"))
+        wrap = bool(self.request.get("wrap"))
         filters = {"uid":uid, "pod":pod_name, "namespace":namespace}
         filename = find_log((build_dir, junit, log_file))
 
@@ -350,7 +351,7 @@ class NodeLogHandler(RenderingHandler):
             job_dir=job_dir, build_dir=build_dir, log=result, job=job,
             build=build, full_path=filename, log_file=log_file,
             pod=pod_name, junit=junit, uid=uid,
-            namespace=namespace))
+            namespace=namespace, wrap=wrap))
 
 
 class JobListHandler(RenderingHandler):

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -243,7 +243,7 @@ class AppTest(unittest.TestCase, TestMixin):
         nodelog_url = self.BUILD_DIR + 'nodelog?logfile=kubelet.log&pod=abc&junit=junit_01.xml'
         init_build(self.BUILD_DIR)
         write(self.BUILD_DIR + 'artifacts/tmp-node-image/junit_01.xml', JUNIT_SUITE)
-        write(self.BUILD_DIR + 'artifacts/tmp-node-image/kubelet.log', 'abc\nEvent(api.ObjectReference{Name:&#34;abc&#34;, UID:&#34;podabc&#34;})\n')
+        write(self.BUILD_DIR + 'artifacts/tmp-node-image/kubelet.log', 'abc\nEvent(api.ObjectReference{Name:"abc", UID:"podabc"})\n')
         response = app.get('/build' + nodelog_url)
         self.assertRegexpMatches(str(response), re.compile(r'Lines from.*kubelet.log'))
 

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -240,12 +240,13 @@ class AppTest(unittest.TestCase, TestMixin):
 
     def test_nodelog_kubelet(self):
         """Test for a kubelet file."""
-        nodelog_url = self.BUILD_DIR + 'nodelog?logfile=kubelet.log&pod=abc&junit=junit_01.xml'
+        nodelog_url = self.BUILD_DIR + 'nodelog?logfiles=kubelet.log&pod=abc&junit=junit_01.xml'
         init_build(self.BUILD_DIR)
         write(self.BUILD_DIR + 'artifacts/tmp-node-image/junit_01.xml', JUNIT_SUITE)
         write(self.BUILD_DIR + 'artifacts/tmp-node-image/kubelet.log', 'abc\nEvent(api.ObjectReference{Name:"abc", UID:"podabc"})\n')
         response = app.get('/build' + nodelog_url)
-        self.assertRegexpMatches(str(response), re.compile(r'Lines from.*kubelet.log'))
+        print response
+        self.assertIn("Event(api.ObjectReference{Name", response)
 
 
 class PRTest(unittest.TestCase, TestMixin):

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -245,7 +245,6 @@ class AppTest(unittest.TestCase, TestMixin):
         write(self.BUILD_DIR + 'artifacts/tmp-node-image/junit_01.xml', JUNIT_SUITE)
         write(self.BUILD_DIR + 'artifacts/tmp-node-image/kubelet.log', 'abc\nEvent(api.ObjectReference{Name:"abc", UID:"podabc"})\n')
         response = app.get('/build' + nodelog_url)
-        print response
         self.assertIn("Event(api.ObjectReference{Name", response)
 
 

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -236,7 +236,7 @@ class AppTest(unittest.TestCase, TestMixin):
         """Test that a missing kubelet log gives a 404."""
         build_dir = self.BUILD_DIR + 'nodelog?pod=abc'
         response = app.get('/build' + build_dir, status=404)
-        self.assertIn('Missing kubelet.log', response)
+        self.assertIn('Unable to find', response)
 
     def test_nodelog_kubelet(self):
         """Test for a kubelet file."""

--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -38,3 +38,6 @@ def key_to_string(k, objref_dict):
 # Replace &#34; with \"
 def fix_quotes(objref_dict):
 	return re.sub(r'&#34;', '\"', objref_dict)
+
+def combine_wordsRE(words_list):
+	return re.compile(r'\b(%s)\b' % '|'.join(words_list), re.IGNORECASE)

--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -16,6 +16,7 @@
 
 import re
 
+
 # Match a specific word
 def wordRE(word):
 	return re.compile(r'\b(%s)\b' % word, re.IGNORECASE)

--- a/gubernator/static/style.css
+++ b/gubernator/static/style.css
@@ -32,6 +32,9 @@ h3 {
 pre {
     white-space: pre-wrap;
 }
+pre.nowrap{
+    white-space: pre;
+}
 pre.error {
     margin: .5em 0 1em 2em;
     padding: 10px;

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -35,9 +35,7 @@
 				</pre>
 				% set pod_name = text|parse_pod_name
 				% if pod_name
-					<p>Find <tt>{{pod_name}}</tt> mentions in
-					<a href="/build{{build_dir}}/nodelog?logfile=kubelet.log&pod={{pod_name}}&junit={{filename|basename}}">kubelet.log</a>,
-					<a href="/build{{build_dir}}/nodelog?logfile=kube-apiserver.log&pod={{pod_name}}&junit={{filename|basename}}">kube-apiserver.log</a>.</h4>
+					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?logfiles=kube-apiserver.log&logfiles=kubelet.log&pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>
 				% endif
 			% else
 				<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span>

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -35,7 +35,7 @@
 				</pre>
 				% set pod_name = text|parse_pod_name
 				% if pod_name
-					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?logfiles=kube-apiserver.log&logfiles=kubelet.log&pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>
+					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?logfiles=kubelet.log&pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>
 				% endif
 			% else
 				<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span>

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -15,8 +15,8 @@
 		<hr>
 		<input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on
 		<hr>
-		<label><input type="checkbox" name="UID"{% if uid %} checked{% endif %}> Highlight Pod UID</label><br>
-		<label><input type="checkbox" name="Namespace"{% if namespace %} checked{% endif %}> Highlight Namespace</label>
+		<label><input type="checkbox" name="UID"{% if uid %} checked{% endif %}> Highlight Pod UID: <b>{{objref_dict["UID"]}}</b></label><br>
+		<label><input type="checkbox" name="Namespace"{% if namespace %} checked{% endif %}> Highlight Namespace: <b>{{objref_dict["Namespace"]}}</b></label>
 	</form>
 	% if log
 		{% if wrap %}<pre>{% else %}<pre class="nowrap">{% endif %}

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -7,13 +7,15 @@
 	<h1>{% if pr %}<a href="/pr/{{pr}}">PR #{{pr}}</a> {% endif %}<a href="/builds{{job_dir}}">{{job}}</a> <a href="/build{{build_dir}}">#{{build}}</a> {{log_file}}</h1>
 </div>
 <div id="failures">
-	<h3>Lines from <a href="https://storage.googleapis.com{{full_path}}">{{log_file}}</a> containing pod {{pod}}</h3>
 	<form method="get" onchange="submit()">
 		<input type="hidden" name="logfile" value="{{log_file}}">
 		<input type="hidden" name="pod" value="{{pod}}">
 		<input type="hidden" name="junit" value="{{junit}}">
 		<hr>
 		<input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on
+		<hr>
+		<label><input type="checkbox" name="logfiles" value="kubelet.log" {% if "kubelet.log" in log_files %} checked{% endif %}> kubelet.log</label>
+		<label><input type="checkbox" name="logfiles" value="kube-apiserver.log" {% if "kube-apiserver.log" in log_files %} checked{% endif %}> kube-apiserver.log</label>
 		<hr>
 		<label><input type="checkbox" name="UID"{% if uid %} checked{% endif %}> Highlight Pod UID: <b>{{objref_dict["UID"]}}</b></label><br>
 		<label><input type="checkbox" name="Namespace"{% if namespace %} checked{% endif %}> Highlight Namespace: <b>{{objref_dict["Namespace"]}}</b></label>

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -19,8 +19,11 @@
 		<label><input type="checkbox" name="Namespace"{% if namespace %} checked{% endif %}> Highlight Namespace: <b>{{objref_dict["Namespace"]}}</b></label>
 	</form>
 	% if log
-		{% if wrap %}<pre>{% else %}<pre class="nowrap">{% endif %}
-		{{log | safe}}
+	% for file in log_files
+		<h3>{{file}}</h3>
+		<pre {% if not wrap %} style="white-space:pre"{% endif %}>
+			{{logs[file] | safe}}
 		</pre>
+	% endfor
 	% endif
 </div>

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -12,11 +12,14 @@
 		<input type="hidden" name="logfile" value="{{log_file}}">
 		<input type="hidden" name="pod" value="{{pod}}">
 		<input type="hidden" name="junit" value="{{junit}}">
+		<hr>
+		<input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on
+		<hr>
 		<label><input type="checkbox" name="UID"{% if uid %} checked{% endif %}> Highlight Pod UID</label><br>
 		<label><input type="checkbox" name="Namespace"{% if namespace %} checked{% endif %}> Highlight Namespace</label>
 	</form>
 	% if log
-		<pre>
+		{% if wrap %}<pre>{% else %}<pre class="nowrap">{% endif %}
 		{{log | safe}}
 		</pre>
 	% endif

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -8,24 +8,21 @@
 </div>
 <div id="failures">
 	<form method="get" onchange="submit()">
-		<input type="hidden" name="logfile" value="{{log_file}}">
 		<input type="hidden" name="pod" value="{{pod}}">
 		<input type="hidden" name="junit" value="{{junit}}">
 		<hr>
-		<input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on
+		<label><input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on</label>
 		<hr>
-		<label><input type="checkbox" name="logfiles" value="kubelet.log" {% if "kubelet.log" in log_files %} checked{% endif %}> kubelet.log</label>
-		<label><input type="checkbox" name="logfiles" value="kube-apiserver.log" {% if "kube-apiserver.log" in log_files %} checked{% endif %}> kube-apiserver.log</label>
+		<label><input type="checkbox" name="logfiles" value="kubelet.log" {% if "kubelet.log" in log_files %} checked {% endif %}> kubelet.log</label>
+		<label><input type="checkbox" name="logfiles" value="kube-apiserver.log" {% if "kube-apiserver.log" in log_files %} checked {% endif %}> kube-apiserver.log</label>
 		<hr>
 		<label><input type="checkbox" name="UID"{% if uid %} checked{% endif %}> Highlight Pod UID: <b>{{objref_dict["UID"]}}</b></label><br>
-		<label><input type="checkbox" name="Namespace"{% if namespace %} checked{% endif %}> Highlight Namespace: <b>{{objref_dict["Namespace"]}}</b></label>
+		<label><input type="checkbox" name="Namespace"{% if namespace %} checked {% endif %}> Highlight Namespace: <b>{{objref_dict["Namespace"]}}</b></label>
 	</form>
-	% if log
 	% for file in log_files
-		<h3>{{file}}</h3>
+		<h3><a href="https://storage.googleapis.com{{full_paths[file]}}">{{file}}</a></h3>
 		<pre {% if not wrap %} style="white-space:pre"{% endif %}>
 			{{logs[file] | safe}}
 		</pre>
 	% endfor
-	% endif
 </div>

--- a/gubernator/templates/node_404.html
+++ b/gubernator/templates/node_404.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<title>Missing {{log_file}} file</title>
-Unable to find {{log_file}} file from <a href="https://console.cloud.google.com/storage/browser{{build_dir}}">gs:/{{build_dir}}</a> for {{pod_name}}
+<title>Missing {% for log_file in log_files %} {{log_file}} file {% endfor %} </title>
+Unable to find {% for log_file in log_files %} {{log_file}} {% endfor %} file from <a href="https://console.cloud.google.com/storage/browser{{build_dir}}">gs:/{{build_dir}}</a> for {{pod_name}}

--- a/gubernator/templates/node_404.html
+++ b/gubernator/templates/node_404.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<title>Missing kubelet.log file</title>
-Unable to find kubelet.log file from <a href="https://console.cloud.google.com/storage/browser{{build_dir}}">gs:/{{build_dir}}</a> for {{pod_name}}
+<title>Missing {{log_file}} file</title>
+Unable to find {{log_file}} file from <a href="https://console.cloud.google.com/storage/browser{{build_dir}}">gs:/{{build_dir}}</a> for {{pod_name}}


### PR DESCRIPTION
Fixed bug where UID/Namespace was not actually found throughout log files.
Added line wrapping as option.

The dictionary from objref is found first in the kubelet log and then is used when parsing the kubelet or kube-api server log. I am planning on making one page for all logs/filtering so there won't be separate links for kubelet.log and kube-apiserver.log. Hopefully some of this refactoring will make sense more then. 
@timstclair  @rmmh 
