### PR TITLE
Add a 15m timeout to the hourly and daily maintenance jobs

### DIFF
--- a/jenkins/job-configs/jenkins-daily-maintenance.yaml
+++ b/jenkins/job-configs/jenkins-daily-maintenance.yaml
@@ -11,6 +11,10 @@
             gcloud components update
             gcloud components update alpha
             gcloud components update beta
+    wrappers:
+        - timeout:
+            timeout: 15
+            fail: true
 
 - job:
     name: 'jenkins-daily-maintenance-all'

--- a/jenkins/job-configs/jenkins-hourly-maintenance.yaml
+++ b/jenkins/job-configs/jenkins-hourly-maintenance.yaml
@@ -16,6 +16,10 @@
             docker rm -v "${containers_to_remove[@]:+${containers_to_remove[@]}}" || true
             docker rmi $(docker images -q -f 'dangling=true') || true
             docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes
+    wrappers:
+        - timeout:
+            timeout: 15
+            fail: true
 
 - job:
     name: 'jenkins-hourly-maintenance-all'


### PR DESCRIPTION
These jobs occasionally hang (probably due to docker getting stuck), and then we don't do any cleanup for days or weeks until we notice they aren't running. They normally complete in a few seconds.