### PR TITLE
Reverse logic to special-case only on release-1.0 and release-1.1

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -268,61 +268,61 @@
             export KUBE_RUN_FROM_OUTPUT=y
             export KUBE_FASTBUILD=true
             ./hack/jenkins/build.sh
-            if [[ "${{ghprbTargetBranch:-}}" == "master" || "${{ghprbTargetBranch:-}}" == "release-1.2" || "${{ghprbTargetBranch:-}}" == "release-1.3" ]]; then
-              # Nothing should want Jenkins $HOME
-              export HOME=${{WORKSPACE}}
-
-              export KUBERNETES_PROVIDER="gke"
-              export E2E_MIN_STARTUP_PODS="1"
-              export FAIL_ON_GCP_RESOURCE_LEAK="true"
-
-              # Experimental flake detection-- harmlessly does nothing until
-              # ginkgo changes get made, but allows for testing them in a PR.
-              export GINKGO_TOLERATE_FLAKES="y"
-
-              export E2E_NAME="e2e-gke-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
-              export GINKGO_PARALLEL="y"
-              # Just run a smoke test.
-              export GINKGO_TEST_ARGS="--ginkgo.focus=Guestbook"
-              export FAIL_ON_GCP_RESOURCE_LEAK="false"
-              export PROJECT="k8s-jkns-pr-gke"
-              # Since we're only running one test, just use two nodes.
-              export NUM_NODES="2"
-
-              # Assume we're upping, testing, and downing a cluster
-              export E2E_UP="true"
-              export E2E_TEST="true"
-              export E2E_DOWN="true"
-              export E2E_OPT="--check_version_skew=false"
-
-              # Skip gcloud update checking
-              export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
-
-              # GKE variables
-              export CLUSTER_NAME=${{E2E_NAME}}
-              export KUBE_GKE_NETWORK=${{E2E_NAME}}
-              export ZONE="us-central1-f"
-
-              # Get golang into our PATH so we can run e2e.go
-              export PATH=${{PATH}}:/usr/local/go/bin
-
-              timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
-              if [[ ${{rc}} -ne 0 ]]; then
-                if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-                  echo "Dumping logs for any remaining nodes"
-                  ./cluster/log-dump.sh _artifacts
-                fi
-              fi
-              if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
-                echo "Build timed out" >&2
-              elif [[ ${{rc}} -ne 0 ]]; then
-                echo "Build failed" >&2
-              fi
-              echo "Exiting with code: ${{rc}}"
-              exit ${{rc}}
-            else
+            if [[ "${{ghprbTargetBranch:-}}" == "release-1.0" || "${{ghprbTargetBranch:-}}" == "release-1.1" ]]; then
               echo "PR GKE job disabled for legacy branches."
+              exit
             fi
+            # Nothing should want Jenkins $HOME
+            export HOME=${{WORKSPACE}}
+
+            export KUBERNETES_PROVIDER="gke"
+            export E2E_MIN_STARTUP_PODS="1"
+            export FAIL_ON_GCP_RESOURCE_LEAK="true"
+
+            # Experimental flake detection-- harmlessly does nothing until
+            # ginkgo changes get made, but allows for testing them in a PR.
+            export GINKGO_TOLERATE_FLAKES="y"
+
+            export E2E_NAME="e2e-gke-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+            export GINKGO_PARALLEL="y"
+            # Just run a smoke test.
+            export GINKGO_TEST_ARGS="--ginkgo.focus=Guestbook"
+            export FAIL_ON_GCP_RESOURCE_LEAK="false"
+            export PROJECT="k8s-jkns-pr-gke"
+            # Since we're only running one test, just use two nodes.
+            export NUM_NODES="2"
+
+            # Assume we're upping, testing, and downing a cluster
+            export E2E_UP="true"
+            export E2E_TEST="true"
+            export E2E_DOWN="true"
+            export E2E_OPT="--check_version_skew=false"
+
+            # Skip gcloud update checking
+            export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
+            # GKE variables
+            export CLUSTER_NAME=${{E2E_NAME}}
+            export KUBE_GKE_NETWORK=${{E2E_NAME}}
+            export ZONE="us-central1-f"
+
+            # Get golang into our PATH so we can run e2e.go
+            export PATH=${{PATH}}:/usr/local/go/bin
+
+            timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+            if [[ ${{rc}} -ne 0 ]]; then
+              if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+                echo "Dumping logs for any remaining nodes"
+                ./cluster/log-dump.sh _artifacts
+              fi
+            fi
+            if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
+              echo "Build timed out" >&2
+            elif [[ ${{rc}} -ne 0 ]]; then
+              echo "Build failed" >&2
+            fi
+            echo "Exiting with code: ${{rc}}"
+            exit ${{rc}}
 
       - build-test-e2e-gce: # kubernetes-pull-build-test-e2e-gce
           status-context: GCE e2e
@@ -355,7 +355,9 @@
             export KUBE_RUN_FROM_OUTPUT=y
             export KUBE_FASTBUILD=true
             ./hack/jenkins/build.sh
-            if [[ "${{ghprbTargetBranch:-}}" == "master" || "${{ghprbTargetBranch:-}}" == "release-1.2" || "${{ghprbTargetBranch:-}}" == "release-1.3" ]]; then
+            if [[ "${{ghprbTargetBranch:-}}" == "release-1.0" || "${{ghprbTargetBranch:-}}" == "release-1.1" ]]; then
+              ./hack/jenkins/e2e.sh
+            else
               # Nothing should want Jenkins $HOME
               export HOME=${{WORKSPACE}}
 
@@ -408,8 +410,6 @@
               fi
               echo "Exiting with code: ${{rc}}"
               exit ${{rc}}
-            else
-              ./hack/jenkins/e2e.sh
             fi
     jobs:
         - '{git-project}-pull-{suffix}'


### PR DESCRIPTION
I recently noticed that we failed to run on `release-1.3.0` because it didn't match the list of known branches.

At this point, "the other list" is shorter, so use it instead.

cc @david-mcmahon 