### PR TITLE
Make filtering compatible with more tests and add filters

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -97,11 +97,12 @@ def do_testcmd(name):
         test_args = ('--ginkgo.focus=%s$' % name_escaped)
         return "go run hack/e2e.go -v -test --test_args='%s'" % test_args
 
+
 def do_parse_pod_name(text):
     """Find the pod name from the failure and return the pod name."""
     p = re.search(r'(.*) pod (.*?) .*', text)
     if p:
-        return re.sub(r'(\'|\"|\\)', '', p.group(2))
+        return re.sub(r'[\'"\\:]', '', p.group(2))
     else:
         return ""
 

--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -38,7 +38,7 @@ def parse(lines, hilight_words, filters, objref_dict):
 
     # If the filter is on, look for it in the objref_dict
     for k in filters:
-        if k != "pod" and filters[k] and objref_dict[k]:
+        if k != "pod" and filters[k] and k in objref_dict:
             hilight_words.append(objref_dict[k])
 
     words_re = regex.combine_wordsRE(hilight_words)
@@ -66,3 +66,5 @@ def make_dict(data, pod_re):
                 objref_dict = re.sub(r'(\w+):', r'"\1": ', objref_dict)
                 objref_dict = objref_dict.replace('&#34;', '"')
                 return json.loads(objref_dict)
+    return {}
+    

--- a/gubernator/kubelet_parser_test.py
+++ b/gubernator/kubelet_parser_test.py
@@ -26,50 +26,48 @@ filters = {"UID": "", "pod": "", "Namespace": ""}
 
 
 class KubeletParserTest(unittest.TestCase):
-    def test_parse_error_re(self):
-        """Test for build-log.txt filtering by error_re"""
-        matched_lines, hilight_words = kubelet_parser.parse(
-            lines, ["error", "fatal", "failed", "build timed out"], filters, {})
-        self.assertEqual(matched_lines, [4])
-        self.assertEqual(
-            hilight_words, ["error", "fatal", "failed", "build timed out"])
+	def test_parse_error_re(self):
+		"""Test for build-log.txt filtering by error_re"""
+		matched_lines, hilight_words = kubelet_parser.parse(lines,
+			["error", "fatal", "failed", "build timed out"], filters, {})
+		self.assertEqual(matched_lines, [4])
+		self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
 
-    def test_parse_empty_lines(self):
-        """Test that it doesn't fail when files are empty"""
-        matched_lines, hilight_words = kubelet_parser.parse(
-            [], ["error", "fatal", "failed", "build timed out"], filters, {})
-        self.assertEqual(matched_lines, [])
-        self.assertEqual(
-            hilight_words, ["error", "fatal", "failed", "build timed out"])
+	def test_parse_empty_lines(self):
+		"""Test that it doesn't fail when files are empty"""
+		matched_lines, hilight_words = kubelet_parser.parse([],
+			["error", "fatal", "failed", "build timed out"], filters, {})
+		self.assertEqual(matched_lines, [])
+		self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
 
-    def test_parse_pod_RE(self):
-        """Test for initial pod filtering"""
-        filters["pod"] = "pod"
-        matched_lines, hilight_words = kubelet_parser.parse(
-            lines, ["pod"], filters, {"UID": "", "Namespace": ""})
-        self.assertEqual(matched_lines, [1])
-        self.assertEqual(hilight_words, ["pod"])
+	def test_parse_pod_RE(self):
+		"""Test for initial pod filtering"""
+		filters["pod"] = "pod"
+		matched_lines, hilight_words = kubelet_parser.parse(lines,
+			["pod"], filters,  {})
+		self.assertEqual(matched_lines, [1])
+		self.assertEqual(hilight_words, ["pod"])	
 
-    def test_parse_filters(self):
-        """Test for filters"""
-        filters["pod"] = "pod"
-        filters["UID"] = "on"
-        filters["Namespace"] = "on"
-        matched_lines, hilight_words = kubelet_parser.parse(
-            lines, ["pod"], filters, {"UID": "uid", "Namespace": "podName"})
-        self.assertEqual(matched_lines, [1, 2, 5, 6])
-        self.assertEqual(hilight_words, ["pod", "podName", "uid"])
+	def test_parse_filters(self):
+		"""Test for filters"""
+		filters["pod"] = "pod"
+		filters["UID"] = "on"
+		filters["Namespace"] = "on"
+		matched_lines, hilight_words = kubelet_parser.parse(lines,
+			["pod"], filters, {"UID":"uid", "Namespace":"podName"})
+		self.assertEqual(matched_lines, [1, 2, 5, 6])
+		self.assertEqual(hilight_words, ["pod", "podName", "uid"])	
 
-    def test_make_dict(self):
-        """Test make_dict works"""
-        objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"))
-        self.assertEqual(
-            objref_dict, {"UID": "uid", "Namespace": "podName", "Name": "abc"})
+	def test_make_dict(self):
+		"""Test make_dict works"""
+		objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"))
+		self.assertEqual(objref_dict, {"UID":"uid", "Namespace":"podName", "Name":"abc"})
 
-    def test_make_dict_fail(self):
-        """Test when objref line not in file"""
-        objref_dict = kubelet_parser.make_dict(["pod failed"], regex.wordRE("abc"))
-        self.assertEqual(objref_dict, None)
+	def test_make_dict_fail(self):
+		"""Test when objref line not in file"""
+		lines = ["pod failed"]
+		objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"))
+		self.assertEqual(objref_dict, {})
 
 if __name__ == '__main__':
     unittest.main()

--- a/gubernator/kubelet_parser_test.py
+++ b/gubernator/kubelet_parser_test.py
@@ -24,50 +24,48 @@ lines = ["line 0", "pod 2 3", "abcd podName", "line 3", "failed",
          "Event(api.ObjectReference{Namespace:\"podName\", Name:\"abc\", UID:\"uid\"}", "uid"]
 filters = {"UID": "", "pod": "", "Namespace": ""}
 
-
 class KubeletParserTest(unittest.TestCase):
-	def test_parse_error_re(self):
-		"""Test for build-log.txt filtering by error_re"""
-		matched_lines, hilight_words = kubelet_parser.parse(lines,
-			["error", "fatal", "failed", "build timed out"], filters, {})
-		self.assertEqual(matched_lines, [4])
-		self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
+    def test_parse_error_re(self):
+        """Test for build-log.txt filtering by error_re"""
+        matched_lines, hilight_words = kubelet_parser.parse(lines,
+            ["error", "fatal", "failed", "build timed out"], filters, {})
+        self.assertEqual(matched_lines, [4])
+        self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
 
-	def test_parse_empty_lines(self):
-		"""Test that it doesn't fail when files are empty"""
-		matched_lines, hilight_words = kubelet_parser.parse([],
-			["error", "fatal", "failed", "build timed out"], filters, {})
-		self.assertEqual(matched_lines, [])
-		self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
+    def test_parse_empty_lines(self):
+        """Test that it doesn't fail when files are empty"""
+        matched_lines, hilight_words = kubelet_parser.parse([],
+            ["error", "fatal", "failed", "build timed out"], filters, {})
+        self.assertEqual(matched_lines, [])
+        self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
 
-	def test_parse_pod_RE(self):
-		"""Test for initial pod filtering"""
-		filters["pod"] = "pod"
-		matched_lines, hilight_words = kubelet_parser.parse(lines,
-			["pod"], filters,  {})
-		self.assertEqual(matched_lines, [1])
-		self.assertEqual(hilight_words, ["pod"])	
+    def test_parse_pod_RE(self):
+        """Test for initial pod filtering"""
+        filters["pod"] = "pod"
+        matched_lines, hilight_words = kubelet_parser.parse(lines,
+            ["pod"], filters, {})
+        self.assertEqual(matched_lines, [1])
+        self.assertEqual(hilight_words, ["pod"])
 
-	def test_parse_filters(self):
-		"""Test for filters"""
-		filters["pod"] = "pod"
-		filters["UID"] = "on"
-		filters["Namespace"] = "on"
-		matched_lines, hilight_words = kubelet_parser.parse(lines,
-			["pod"], filters, {"UID":"uid", "Namespace":"podName"})
-		self.assertEqual(matched_lines, [1, 2, 5, 6])
-		self.assertEqual(hilight_words, ["pod", "podName", "uid"])	
+    def test_parse_filters(self):
+        """Test for filters"""
+        filters["pod"] = "pod"
+        filters["UID"] = "on"
+        filters["Namespace"] = "on"
+        matched_lines, hilight_words = kubelet_parser.parse(lines,
+            ["pod"], filters, {"UID":"uid", "Namespace":"podName", "ContainerID":""})
+        self.assertEqual(matched_lines, [1, 2, 5, 6])
+        self.assertEqual(hilight_words, ["pod", "podName", "uid"])
 
-	def test_make_dict(self):
-		"""Test make_dict works"""
-		objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"))
-		self.assertEqual(objref_dict, {"UID":"uid", "Namespace":"podName", "Name":"abc"})
+    def test_make_dict(self):
+        """Test make_dict works"""
+        objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"), {})
+        self.assertEqual(objref_dict, ({"UID":"uid", "Namespace":"podName", "Name":"abc"}, True))
 
-	def test_make_dict_fail(self):
-		"""Test when objref line not in file"""
-		lines = ["pod failed"]
-		objref_dict = kubelet_parser.make_dict(lines, regex.wordRE("abc"))
-		self.assertEqual(objref_dict, {})
+    def test_make_dict_fail(self):
+        """Test when objref line not in file"""
+        objref_dict = kubelet_parser.make_dict(["pod failed"], regex.wordRE("abc"), {})
+        self.assertEqual(objref_dict, ({}, False))
 
 if __name__ == '__main__':
     unittest.main()

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -75,13 +75,13 @@ def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l,
     lines = unicode(jinja2.escape(data)).split('\n')
 
     if filters is None:
-        filters = {'Namespace': '', 'UID': '', 'pod': ''}
+        filters = {'Namespace': '', 'UID': '', 'pod': '', 'ContainerID':''}
 
     hilight_words = ["error", "fatal", "failed", "build timed out"]
     if filters["pod"]:
         hilight_words = [filters["pod"]]
 
-    if not (filters["UID"] or filters["Namespace"]):
+    if not (filters["UID"] or filters["Namespace"] or filters["ContainerID"]):
         matched_lines = [n for n, line in enumerate(lines) if error_re.search(line)]
     else:
         matched_lines, hilight_words = kubelet_parser.parse(lines,

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -29,6 +29,17 @@ def hilight(line, hilight_words):
 
 
 def log_html(lines, matched_lines, hilight_words, skip_fmt):
+    """
+    Constructs the html for the filtered log
+    Given:
+        lines: list of all lines in the log
+        matched_lines: list of lines that have a filtered string in them
+        hilight_words: list of words to be bolded
+        skip_fmt: function producing string to replace the skipped lines
+    Returns:
+        output: list of a lines HTML code suitable for inclusion in a <pre>
+        tag, with "interesting" errors hilighted
+    """
     output = []
 
     matched_lines.append(len(lines))  # sentinel value

--- a/gubernator/log_parser_test.py
+++ b/gubernator/log_parser_test.py
@@ -23,7 +23,7 @@ import regex
 def digest(data, strip=True, filters=None,
            error_re=regex.error_re):
     if filters is None:
-        filters = {"UID": "", "pod": "", "Namespace": ""}
+        filters = {"UID":"", "pod":"", "Namespace":"", "ContainerID":""}
     digested = log_parser.digest(data.replace(' ', '\n'), error_re=error_re,
                                  skip_fmt=lambda l: 's%d' % l, filters=filters)
     if strip:
@@ -65,13 +65,11 @@ class LogParserTest(unittest.TestCase):
 
     def test_pod(self):
         self.assertEqual(digest(
-            'pod-blah', error_re=regex.wordRE("pod"),
-            filters={"pod": "pod", "UID": "", "Namespace": ""}, strip=False),
-            '<span class="hilight"><span class="keyword">'
-            'pod</span>-blah</span>')
+            'pod-blah', error_re=regex.wordRE("pod"), strip=False),
+            '<span class="hilight">pod-blah</span>')
         self.assertEqual(digest('0 1 2 3 4 5 pod 6 7 8 9 10',
             error_re=regex.wordRE("pod"),
-            filters={"pod": "pod", "UID": "", "Namespace": ""}),
+            filters={"pod": "pod", "UID": "", "Namespace": "", "ContainerID":""}),
             's2 ( 0 1 ) 2 3 4 5 pod 6 7 8 9')
 
 

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -408,12 +408,15 @@ class NodeLogHandler(RenderingHandler):
         # For other tests, give option to investigate across different folders
         if not apiserver_filename:
             all_logs = get_all_logs((build_dir, True))
+            apiserver_filename = find_log((build_dir, False, "kube-apiserver.log"))
             kubelet_filenames = find_log((build_dir, False, "kubelet.log"))
             for kubelet_log in kubelet_filenames:
                 objref_dict = parse_log_file(kubelet_log, pod_name, make_dict=True)
                 if objref_dict:
                     if log_files == []:
                         log_files = [kubelet_log]
+                        if apiserver_filename:
+                            log_files.extend(apiserver_filename)
                     for file in log_files:
                         filename = find_log_dirs((kubelet_log, file))
                         parsed_file = parse_log_file(file, pod_name, filters,

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -244,7 +244,7 @@ def parse_log_file(log_filename, pod, filters=None, make_dict=False, objref_dict
     """Based on make_dict, either returns the objref_dict or the parsed log file"""
     log = gcs_async.read(log_filename).get_result()
     if log is None:
-        return None, False if make_dict else None
+        return {}, False if make_dict else None
     pod_re = regex.wordRE(pod)
     if objref_dict is None:
         objref_dict = {}
@@ -450,8 +450,8 @@ class NodeLogHandler(RenderingHandler):
 
         apiserver_filename = find_log_junit((build_dir, junit, "kube-apiserver.log"))
         if apiserver_filename and pod_name:
-            all_logs, results, objref_dict, log_files = get_logs_junit((build_dir, log_files,
-                junit, pod_name, filters, objref_dict, apiserver_filename))
+            all_logs, results, objref_dict, log_files = get_logs_junit((log_files,
+                pod_name, filters, objref_dict, apiserver_filename))
         if not apiserver_filename:
             all_logs, results, objref_dict, log_files = get_logs(build_dir, log_files,
                 pod_name, filters, objref_dict)

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -231,13 +231,13 @@ class AppTest(TestBase):
 
     def test_nodelog_kubelet(self):
         """Test for a kubelet file."""
-        nodelog_url = self.BUILD_DIR + 'nodelog?logfiles=kubelet.log&pod=abc&junit=junit_01.xml'
+        nodelog_url = self.BUILD_DIR + 'nodelog?pod=abc&junit=junit_01.xml'
         init_build(self.BUILD_DIR)
         write(self.BUILD_DIR + 'artifacts/tmp-node-image/junit_01.xml', JUNIT_SUITE)
         write(self.BUILD_DIR + 'artifacts/tmp-node-image/kubelet.log',
             'abc\nEvent(api.ObjectReference{Name:"abc", UID:"podabc"})\n')
         response = app.get('/build' + nodelog_url)
-        self.assertIn("Event(api.ObjectReference{Name", response)
+        self.assertIn("Line wrapping on", response)
 
 
 class PRTest(TestBase):

--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -29,10 +29,13 @@ error_re = re.compile(
 def objref(line):
     return re.search(r'api\.ObjectReference(\{.*?&#34;\})', line)
 
+# Combine a list of words into one regex that match any of them
 def combine_wordsRE(words_list):
     return re.compile(r'\b(%s)\b' % '|'.join(words_list), re.IGNORECASE)
 
+# Match the file name of a log given a filepath to the log
 log_re = re.compile(r'[^/]+\.log$')
 
+# Match the container id given a line containing the pod name
 def containerID(line):
     return re.search(r'ContainerID:([0-9A-Fa-f]*)', line)

--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -27,9 +27,12 @@ error_re = re.compile(
 
 # Match the dictionary string in the given line
 def objref(line):
-    return re.search(r'Event\(api\.ObjectReference(\{.+\})', line)
+    return re.search(r'api\.ObjectReference(\{.*?&#34;\})', line)
 
 def combine_wordsRE(words_list):
-	return re.compile(r'\b(%s)\b' % '|'.join(words_list), re.IGNORECASE)
+    return re.compile(r'\b(%s)\b' % '|'.join(words_list), re.IGNORECASE)
 
 log_re = re.compile(r'[^/]+\.log$')
+
+def containerID(line):
+    return re.search(r'ContainerID:([0-9A-Fa-f]*)', line)

--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -29,6 +29,7 @@ error_re = re.compile(
 def objref(line):
     return re.search(r'Event\(api\.ObjectReference(\{.+\})', line)
 
-
 def combine_wordsRE(words_list):
-    return re.compile(r'\b(%s)\b' % '|'.join(words_list), re.IGNORECASE)
+	return re.compile(r'\b(%s)\b' % '|'.join(words_list), re.IGNORECASE)
+
+log_re = re.compile(r'[^/]+\.log$')

--- a/gubernator/regex_test.py
+++ b/gubernator/regex_test.py
@@ -49,9 +49,9 @@ class RegexTest(unittest.TestCase):
 
     def test_objref(self):
         for text, matches in [
-            ('Event(api.ObjectReference{Kind:\"Pod\"}) failed', True),
-            ('{Pod:\"abc\", Namespace:\"pod abc\"}', False),
-            ('Jan 1: Event(api.ObjectReference{Kind:\"Pod\", Podname:\"abc\"}) failed', True),
+            ('api.ObjectReference{Kind:&#34;Pod&#34;} failed', True),
+            ('{Pod:&#34;abc&#34;, Namespace:\"pod abc\"}', False),
+            ('Jan 1: Event(api.ObjectReference{Kind:&#34;Pod&#34;, Podname:&#34;abc&#34;}) failed', True),
         ]:
             self.assertEqual(bool(regex.objref(text)), matches,
                 'objref(%r) should be %r' % (text, matches))

--- a/gubernator/regex_test.py
+++ b/gubernator/regex_test.py
@@ -51,7 +51,8 @@ class RegexTest(unittest.TestCase):
         for text, matches in [
             ('api.ObjectReference{Kind:&#34;Pod&#34;} failed', True),
             ('{Pod:&#34;abc&#34;, Namespace:\"pod abc\"}', False),
-            ('Jan 1: Event(api.ObjectReference{Kind:&#34;Pod&#34;, Podname:&#34;abc&#34;}) failed', True),
+            ('Jan 1: Event(api.ObjectReference{Kind:&#34;Pod&#34;, Podname:&#34;abc&#34;}) failed'
+                , True),
         ]:
             self.assertEqual(bool(regex.objref(text)), matches,
                 'objref(%r) should be %r' % (text, matches))

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -33,7 +33,7 @@
 				<pre class="error">{{text|linkify_stacktrace(commit)}}<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span></pre>
 				% set pod_name = text|parse_pod_name
 				% if pod_name
-					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?logfiles=kubelet.log&pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>
+					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>
 				% endif
 			% else
 				<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span>

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -34,6 +34,8 @@
 				% set pod_name = text|parse_pod_name
 				% if pod_name
 					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>
+				% else
+					<p>Filter through <a href="/build{{build_dir}}/nodelog?junit={{filename|basename}}&wrap=on">log files</a>
 				% endif
 			% else
 				<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span>

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -15,21 +15,21 @@
 		<label><input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on</label>
 		% for folder, filenames in all_logs.items()|sort
 			<hr>
-			% set artifact = folder|dirname|basename
-			<h4> {{artifact}} </h4>
+			<h4> {{folder|basename or folder|dirname|basename}} </h4>
 			% for filename in filenames
-			% set log_name = filename|basename
-			<label><input type="checkbox" name="logfiles" value={{filename}} {% if filename in log_files %} checked {% endif %}> {{log_name}}</label> 
-			<a href="https://storage.googleapis.com{{filename}}">(Full Log)</a> <br>
+				% set log_name = filename|basename
+				<label><input type="checkbox" name="logfiles" value={{filename}} {% if filename in log_files %} checked {% endif %}> {{log_name}}</label>
+				<a href="https://storage.googleapis.com{{filename}}">(Full Log)</a> <br>
 			% endfor
 		% endfor
 		<hr>
-		<label><input type="checkbox" name="UID"{% if uid %} checked {% endif %}> Highlight Pod UID: <b>{{objref_dict["UID"]}}</b></label><br>
-		<label><input type="checkbox" name="Namespace"{% if namespace %} checked {% endif %}> Highlight Namespace: <b>{{objref_dict["Namespace"]}}</b></label>
+		<label><input type="checkbox" name="UID"{% if uid %} checked {% endif %}> Highlight Pod UID: <b>{% if objref_dict["UID"] %}{{objref_dict["UID"]}}<input type="hidden" name="poduid" value="{{objref_dict['UID']}}">{% else %}<input type="text" name="poduid">{% endif %}</b></label><br>
+		<label><input type="checkbox" name="Namespace"{% if namespace %} checked {% endif %}> Highlight Namespace: <b>{% if objref_dict["Namespace"] %}{{objref_dict["Namespace"]}}<input type="hidden" name="ns" value="{{objref_dict['Namespace']}}">{% else %}<input type="text" name="ns">{% endif %}</b></label><br>
+		<label><input type="checkbox" name="ContainerID"{% if containerID %} checked {% endif %}> Highlight ContainerID: <b>{% if objref_dict["ContainerID"] %}{{objref_dict["ContainerID"]}}<input type="hidden" name="cID" value="{{objref_dict['ContainerID']}}">{% else %}<input type="text" name="cID">{% endif %}</b></label>
 	</form>
-	% for file in log_files
+	% for file in log_files|sort
 		<h3>{{file}}</a></h3>
-		<pre {% if not wrap %} style="white-space:pre"{% endif %}> 
+		<pre {% if not wrap %} style="white-space:pre"{% endif %}>
 			{{logs[file] | safe}}
 		</pre>
 	% endfor

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -13,9 +13,10 @@
 		<input type="hidden" name="junit" value="{{junit}}">
 		<hr>
 		<label><input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on</label>
-		% for folder, filenames in all_logs.items()
+		% for folder, filenames in all_logs.items()|sort
 			<hr>
-			<h4> {{folder}} </h4>
+			% set artifact = folder|dirname|basename
+			<h4> {{artifact}} </h4>
 			% for filename in filenames
 			% set log_name = filename|basename
 			<label><input type="checkbox" name="logfiles" value={{filename}} {% if filename in log_files %} checked {% endif %}> {{log_name}}</label> 

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -7,21 +7,28 @@
 	<h1>{% if pr %}<a href="/pr/{{pr}}">PR #{{pr}}</a> {% endif %}<a href="/builds{{job_dir}}">{{job}}</a> <a href="/build{{build_dir}}">#{{build}}</a> {{log_file}}</h1>
 </div>
 <div id="failures">
+	<h3> Failed pod: {{pod}} </h3>
 	<form method="get" onchange="submit()">
 		<input type="hidden" name="pod" value="{{pod}}">
 		<input type="hidden" name="junit" value="{{junit}}">
 		<hr>
 		<label><input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on</label>
+		% for folder, filenames in all_logs.items()
+			<hr>
+			<h4> {{folder}} </h4>
+			% for filename in filenames
+			% set log_name = filename|basename
+			<label><input type="checkbox" name="logfiles" value={{filename}} {% if filename in log_files %} checked {% endif %}> {{log_name}}</label> 
+			<a href="https://storage.googleapis.com{{filename}}">(Full Log)</a> <br>
+			% endfor
+		% endfor
 		<hr>
-		<label><input type="checkbox" name="logfiles" value="kubelet.log" {% if "kubelet.log" in log_files %} checked {% endif %}> kubelet.log</label>
-		<label><input type="checkbox" name="logfiles" value="kube-apiserver.log" {% if "kube-apiserver.log" in log_files %} checked {% endif %}> kube-apiserver.log</label>
-		<hr>
-		<label><input type="checkbox" name="UID"{% if uid %} checked{% endif %}> Highlight Pod UID: <b>{{objref_dict["UID"]}}</b></label><br>
+		<label><input type="checkbox" name="UID"{% if uid %} checked {% endif %}> Highlight Pod UID: <b>{{objref_dict["UID"]}}</b></label><br>
 		<label><input type="checkbox" name="Namespace"{% if namespace %} checked {% endif %}> Highlight Namespace: <b>{{objref_dict["Namespace"]}}</b></label>
 	</form>
 	% for file in log_files
-		<h3><a href="https://storage.googleapis.com{{full_paths[file]}}">{{file}}</a></h3>
-		<pre {% if not wrap %} style="white-space:pre"{% endif %}>
+		<h3>{{file}}</a></h3>
+		<pre {% if not wrap %} style="white-space:pre"{% endif %}> 
 			{{logs[file] | safe}}
 		</pre>
 	% endfor

--- a/gubernator/templates/filtered_log.html
+++ b/gubernator/templates/filtered_log.html
@@ -7,9 +7,9 @@
 	<h1>{% if pr %}<a href="/pr/{{pr}}">PR #{{pr}}</a> {% endif %}<a href="/builds{{job_dir}}">{{job}}</a> <a href="/build{{build_dir}}">#{{build}}</a> {{log_file}}</h1>
 </div>
 <div id="failures">
-	<h3> Failed pod: {{pod}} </h3>
 	<form method="get" onchange="submit()">
-		<input type="hidden" name="pod" value="{{pod}}">
+		<h3> Failed pod: <input type="text" name="pod" value="{{pod}}" style="width: 300px;">
+		</h3>
 		<input type="hidden" name="junit" value="{{junit}}">
 		<hr>
 		<label><input type="checkbox" name="wrap"{% if wrap %} checked{% endif %}> Line wrapping on</label>
@@ -23,9 +23,9 @@
 			% endfor
 		% endfor
 		<hr>
-		<label><input type="checkbox" name="UID"{% if uid %} checked {% endif %}> Highlight Pod UID: <b>{% if objref_dict["UID"] %}{{objref_dict["UID"]}}<input type="hidden" name="poduid" value="{{objref_dict['UID']}}">{% else %}<input type="text" name="poduid">{% endif %}</b></label><br>
-		<label><input type="checkbox" name="Namespace"{% if namespace %} checked {% endif %}> Highlight Namespace: <b>{% if objref_dict["Namespace"] %}{{objref_dict["Namespace"]}}<input type="hidden" name="ns" value="{{objref_dict['Namespace']}}">{% else %}<input type="text" name="ns">{% endif %}</b></label><br>
-		<label><input type="checkbox" name="ContainerID"{% if containerID %} checked {% endif %}> Highlight ContainerID: <b>{% if objref_dict["ContainerID"] %}{{objref_dict["ContainerID"]}}<input type="hidden" name="cID" value="{{objref_dict['ContainerID']}}">{% else %}<input type="text" name="cID">{% endif %}</b></label>
+		<label><input type="checkbox" name="UID"{% if uid %} checked {% endif %}> Highlight Pod UID: <input type="text" name="poduid" value="{{objref_dict['UID']}}" style="width: 300px;"></label><br>
+		<label><input type="checkbox" name="Namespace"{% if namespace %} checked {% endif %}> Highlight Namespace: <input type="text" name="ns" value="{{objref_dict['Namespace']}}" style="width: 300px;"></label><br>
+		<label><input type="checkbox" name="ContainerID"{% if containerID %} checked {% endif %}> Highlight ContainerID: <input type="text" name="cID" value="{{objref_dict['ContainerID']}}" style="width: 300px;"></label>
 	</form>
 	% for file in log_files|sort
 		<h3>{{file}}</a></h3>


### PR DESCRIPTION
Initial implementation of making the filtering page accessible and useful for tests other than node e2e tests. If there is a folder containing the junit file that had the failed test, logs in that folder are shown (the case for node e2e test logs). Otherwise, all logs throughout folders in the artifacts directory can be filtered.

Make default filtered file for some failed tests kube-apiserver.log instead of kubelet.log.

@timstclair @rmmh 