### PR TITLE
Add QA jobs for GCI

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -1,7 +1,13 @@
-# This file defines e2e jobs against Kuberentes HEAD and GCI HEAD, from master
-# and the latest three release branches, and the GCI milestones that they pin
-# to, e.g., GCI milestone 52 for Kubernetes `release-1.2`.
+# This file defines e2e jobs that run on GCE with GCI images on both the master
+# and nodes. These include two types of jobs:
+#  -  CI jobs, that run against Kubernetes HEAD and GCI HEAD, from master
+#     and the latest three release branches, and the GCI milestones that they
+#     pin to, e.g., GCI milestone 52 for Kubernetes `release-1.2`.
+#  -  QA jobs, that run against GCI HEAD of each active milestone, and the
+#     Kubernetes of the version built into the latest GCI image (on that
+#     milestone).
 
+# Template for CI jobs.
 - job-template:
     name: 'kubernetes-e2e-gce-gci-ci-{suffix}'
     node: '{jenkins_node}'
@@ -165,3 +171,128 @@
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
     jobs:
         - 'kubernetes-e2e-gce-gci-ci-{suffix}'
+
+# Template for QA jobs.
+- job-template:
+    name: 'kubernetes-e2e-gce-gci-qa-{suffix}'
+    node: '{jenkins_node}'
+    triggers:
+        - timed: '{cron-string}'
+    description: '{description} Test owner: {test-owner}.'
+    disabled: '{obj:disable_job}'
+    properties:
+        - build-discarder:
+            days-to-keep: 7
+    # Need the 8 essential kube-system pods ready before declaring cluster ready
+    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
+    provider-env: |
+        export KUBERNETES_PROVIDER="gce"
+        export E2E_MIN_STARTUP_PODS="8"
+        export KUBE_GCE_ZONE="us-central1-f"
+        export FAIL_ON_GCP_RESOURCE_LEAK="true"
+        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+        export JENKINS_USE_GCI_VERSION="y"  # Use GCI builtin k8s version.
+    builders:
+        - shell: |
+            {provider-env}
+            {job-env}
+            {post-env}
+            timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
+            if [[ ${{rc}} -ne 0 ]]; then
+                if [[ -x kubernetes/cluster/log-dump.sh && -d _artifacts ]]; then
+                    echo "Dumping logs for any remaining nodes"
+                    ./kubernetes/cluster/log-dump.sh _artifacts
+                fi
+            fi
+            {report-rc}
+    wrappers:
+        - ansicolor:
+            colormap: xterm
+        - e2e-credentials-binding
+        - timeout:
+            timeout: '{jenkins-timeout}'
+            fail: true
+        - timestamps
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
+    publishers:
+        - claim-build
+        - junit-publisher
+        - log-parser
+        - email-ext:
+            recipients: '{emails}'
+        - gcs-uploader
+        - description-setter:
+            regexp: KUBE_GCE_MASTER_IMAGE=(.*)
+        - groovy-postbuild:
+            script: |
+                def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
+                if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
+                if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
+    # Template defaults.
+    jenkins_node: 'e2e'
+    test-owner: 'wonderfly'
+    emails: 'gci-alerts+kubekins@google.com'
+
+- project:
+    name: kubernetes-e2e-gce-gci-qa
+    suffix:
+        - 'release-1.3':  # kubernetes-e2e-gce-gci-qa-release-1.3
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
+            timeout: 50
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-1-3"
+        - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-qa-slow-release-1.3
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
+            timeout: 150
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-slow-1-3"
+        - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-qa-serial-release-1.3
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
+            timeout: 300
+            trigger-job: 'kubernetes-build-1.3'
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-53"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-qa-serial-1-3"
+        - 'release-1.2':  # kubernetes-e2e-gce-gci-qa-release-1.2
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
+            timeout: 50  # See #21138
+            trigger-job: 'kubernetes-build-1.2'
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-52"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-1-2"
+        - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-qa-slow-release-1.2
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
+            timeout: 60
+            trigger-job: 'kubernetes-build-1.2'
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-52"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-slow-1-2"
+        - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-qa-serial-release-1.2
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
+            timeout: 300
+            trigger-job: 'kubernetes-build-1.2'
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-52"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-qa-serial-1-2"
+    jobs:
+        - 'kubernetes-e2e-gce-gci-qa-{suffix}'


### PR DESCRIPTION
We had continuous integration tests for GCI and Kuberetes, which ran e2e tests
against GCI HEAD and k8s HEAD. This CL adds release qualification (QA) jobs,
that run tests against GCI HEAD and **whatever version of k8s is built into the
image**. The purpose of these jobs is to qualify any GCI release candidates.

This depends on https://github.com/kubernetes/kubernetes/pull/29631

@spxtr, @fejta Can either of you review the yaml changes? I couldn't find a good way to merge the two templates so I decided to leave them (partially) duplicated. Let me know if you know a better way of doing it.

@Amey-D Can you review the GCI related logic?

cc/ @kubernetes/goog-image 