### PR TITLE
Create deployment for nginx/influxdb/grafana

### DIFF
--- a/grafana-stack/README.md
+++ b/grafana-stack/README.md
@@ -1,0 +1,35 @@
+The goal of this directory is to set-up the following monitoring stack:
+- InfluxDB as the Time-series Database
+- Grafana as the front-end/display
+- Nginx is use as a proxy (mostly to fix CORS issue)
+
+Step-by-step
+============
+
+First time-only
+---------------
+Create the passwords:
+```
+kubectl create secret generic grafana --from-literal=rootpassword="${grafana_passwoord}"
+kubectl create secret generic influxdb --from-literal=rootpassword="${influxdb_passwoord}"
+```
+
+Create the persistent disks (make sure `gcloud` points to your instance):
+```
+gcloud compute disks create grafana-database --size 10GiB
+gcloud compute disks create influxdb-database --size 100GiB --type pd-ssd
+```
+
+Deploying
+---------
+Deploying is simple:
+```
+kubectl apply -f grafana.yaml -f influxdb.yaml -f nginx.yaml
+```
+
+Adding data-source
+------------------
+Probably a first time only:
+```
+./datasource.sh ${nginx_ip} ${grafana_password} ${influxdb_password}
+```

--- a/grafana-stack/datasource.sh
+++ b/grafana-stack/datasource.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 server_hostname grafana_admin_password influxdb_root_password" >&2
+  exit 64
+fi
+
+server_hostname=$1
+grafana_admin_password=$2
+influxdb_root_password=$3
+
+curl -s --fail "http://admin:${grafana_admin_password}@${server_hostname}/api/datasources/name/github" ||
+env - server_hostname="${server_hostname}" influxdb_root_password="${influxdb_root_password}" envsubst <<EOF |
+{
+  "name": "github",
+  "type": "influxdb",
+  "access": "direct",
+  "url": "http://${server_hostname}/influxdb/",
+  "user": "root",
+  "password": "${influxdb_root_password}",
+  "database": "github",
+  "isDefault": true
+}
+EOF
+curl \
+  -X POST --fail \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  "http://admin:${grafana_admin_password}@${server_hostname}/api/datasources" \
+  --data-binary @-

--- a/grafana-stack/grafana.yaml
+++ b/grafana-stack/grafana.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        command:
+        image: grafana/grafana:3.1.1
+        ports:
+        - name: grafana-port
+          containerPort: 3000
+        volumeMounts:
+        - mountPath: /var/lib/grafana
+          name: database-volume
+        env:
+          - name: GF_SECURITY_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: grafana
+                key: rootpassword
+      volumes:
+      - name: database-volume
+        persistentVolumeClaim:
+          claimName: grafana-database-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: grafana
+  name: grafana-service
+  namespace: default
+spec:
+  ports:
+  - name: grafana
+    port: 3000
+    targetPort: grafana-port
+  selector:
+    app: grafana
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app: grafana-stack
+  name: grafana-database
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    pdName: grafana-database
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: grafana-database-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/grafana-stack/influxdb.yaml
+++ b/grafana-stack/influxdb.yaml
@@ -1,0 +1,216 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: influxdb
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: influxdb
+    spec:
+      containers:
+      - name: influxdb
+        command:
+        image: tutum/influxdb:0.13
+        env:
+        - name: ADMIN_USER
+          value: root
+        - name: INFLUXDB_INIT_PWD
+          valueFrom:
+            secretKeyRef:
+              name: influxdb
+              key: rootpassword
+        - name: PRE_CREATE_DB
+          value: github
+        ports:
+        - name: influxdb-port
+          containerPort: 8086
+        volumeMounts:
+        - mountPath: /opt/influxdb/shared/data/db
+          name: database-volume
+        - mountPath: /config
+          name: influx-config
+      volumes:
+      - name: database-volume
+        persistentVolumeClaim:
+          claimName: influxdb-database-claim
+      - name: influx-config
+        configMap:
+          name: influxdb
+          items:
+          - key: influxdb.toml
+            path: config.toml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: influxdb
+  name: influxdb-service
+spec:
+  ports:
+  - name: influxdb
+    port: 8086
+    targetPort: influxdb-port
+  selector:
+    app: influxdb
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    app: grafana-stack
+  name: influxdb-database
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    pdName: influxdb-database
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: influxdb-database-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: influxdb
+  labels:
+    app: grafana-stack
+data:
+  influxdb.toml: |
+    reporting-disabled = false
+    bind-address = ":8088"
+    hostname = ""
+    join = ""
+
+    [meta]
+      dir = "/root/.influxdb/meta"
+      retention-autocreate = true
+      logging-enabled = true
+      pprof-enabled = false
+      lease-duration = "1m0s"
+
+    [data]
+      dir = "/root/.influxdb/data"
+      engine = "tsm1"
+      wal-dir = "/root/.influxdb/wal"
+      wal-logging-enabled = true
+      query-log-enabled = true
+      cache-max-memory-size = 524288000
+      cache-snapshot-memory-size = 26214400
+      cache-snapshot-write-cold-duration = "1h0m0s"
+      compact-full-write-cold-duration = "24h0m0s"
+      max-points-per-block = 0
+      data-logging-enabled = true
+
+    [cluster]
+      force-remote-mapping = false
+      write-timeout = "5s"
+      shard-writer-timeout = "5s"
+      max-remote-write-connections = 3
+      shard-mapper-timeout = "5s"
+      max-concurrent-queries = 0
+      query-timeout = "0"
+      max-select-point = 0
+      max-select-series = 0
+      max-select-buckets = 0
+
+    [retention]
+      enabled = true
+      check-interval = "30m0s"
+
+    [shard-precreation]
+      enabled = true
+      check-interval = "10m0s"
+      advance-period = "30m0s"
+
+    [admin]
+      enabled = true
+      bind-address = ":8083"
+      https-enabled = false
+      https-certificate = "/etc/ssl/influxdb.pem"
+      Version = ""
+
+    [monitor]
+      store-enabled = true
+      store-database = "_internal"
+      store-interval = "10s"
+
+    [subscriber]
+      enabled = true
+
+    [http]
+      enabled = true
+      bind-address = ":8086"
+      auth-enabled = true
+      log-enabled = true
+      write-tracing = false
+      pprof-enabled = false
+      https-enabled = false
+      https-certificate = "/etc/ssl/influxdb.pem"
+      max-row-limit = 10000
+
+    [[graphite]]
+      enabled = false
+      bind-address = ":2003"
+      database = "graphite"
+      protocol = "tcp"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "1s"
+      consistency-level = "one"
+      separator = "."
+      udp-read-buffer = 0
+
+    [collectd]
+      enabled = false
+      bind-address = ":25826"
+      database = "collectd"
+      retention-policy = ""
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "10s"
+      read-buffer = 0
+      typesdb = "/usr/share/collectd/types.db"
+
+    [opentsdb]
+      enabled = false
+      bind-address = ":4242"
+      database = "opentsdb"
+      retention-policy = ""
+      consistency-level = "one"
+      tls-enabled = false
+      certificate = "/etc/ssl/influxdb.pem"
+      batch-size = 1000
+      batch-pending = 5
+      batch-timeout = "1s"
+      log-point-errors = true
+
+    [[udp]]
+      enabled = false
+      bind-address = ":8089"
+      database = "udp"
+      retention-policy = ""
+      batch-size = 5000
+      batch-pending = 10
+      read-buffer = 0
+      batch-timeout = "1s"
+      precision = ""
+      udp-payload-size = 0
+
+    [continuous_queries]
+      log-enabled = true
+      enabled = true
+      run-interval = "1s"

--- a/grafana-stack/nginx.yaml
+++ b/grafana-stack/nginx.yaml
@@ -1,0 +1,86 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: grafana-nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grafana-nginx
+    spec:
+      containers:
+      - image: nginx:1.10.1
+        name: grafana-nginx
+        command: ['nginx', '-g', 'daemon off;']
+        ports:
+        - name: nginx-port
+          containerPort: 8080
+        volumeMounts:
+        - mountPath: /etc/nginx
+          name: nginx-config
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: grafana-stack
+  name: nginx-service
+  namespace: default
+spec:
+  ports:
+  - name: nginx
+    port: 80
+    targetPort: nginx-port
+  selector:
+    app: grafana-nginx
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx
+  labels:
+    app: grafana-stack
+data:
+  nginx.conf: |
+    user  nginx;
+    worker_processes  1;
+
+    error_log  /var/log/nginx/error.log warn;
+    pid        /var/run/nginx.pid;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        server {
+            listen 8080;
+            location / {
+                proxy_pass http://grafana-service:3000/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+            }
+            location /influxdb/ {
+                proxy_pass http://influxdb-service:8086/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+            }
+        }
+    }


### PR DESCRIPTION
Create a deploy script to deploy an nginx server that reverse-proxies
influxdb and grafana to serve graphs.

Everything should be done automatically for easy set-up.

The goal is to use this grafana-stack for many different tools. It's easy to have public (with committed configuration) dashboard for:
- Github statistics and metrics
- Build time
- Submit-queue health and statistics