### PR TITLE
Create auto-deployment for Google Cloud SQL

### DIFF
--- a/github-stats/mysql/README.md
+++ b/github-stats/mysql/README.md
@@ -1,0 +1,27 @@
+Set-up Google Cloud SQL Proxy
+-----------------------------
+
+Create the database, from the console (recommended) or from command line:
+```
+gcloud sql instances create github-database
+```
+
+Create a new service account (with Editor role) and fetch its credentials, save it as "credential.json"
+https://cloud.google.com/storage/docs/authentication#service_accounts
+
+Create secret with the credentials:
+```
+kubectl create secret generic sqlproxy-credential-secret --from-file=credential.json
+```
+
+Create configmap to install ca-certificate and instances to listen to:
+```
+kubectl create configmap sqlproxy-config --from-literal=instances=${gcp_sql_project}:github-database=tcp:0.0.0.0:3306 --from-file=/etc/ssl/certs/ca-certificates.crt
+```
+
+Deployment
+---------
+As simple as:
+```
+kubectl apply -f sqlproxy.yaml
+```

--- a/github-stats/mysql/sqlproxy.yaml
+++ b/github-stats/mysql/sqlproxy.yaml
@@ -1,0 +1,62 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: github-sqlproxy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: github-sqlproxy
+    spec:
+      containers:
+      - image: b.gcr.io/cloudsql-docker/gce-proxy
+        name: github-sqlproxy
+        command:
+        - /cloud_sql_proxy
+        - -dir=/cloudsql
+        - -instances=$(INSTANCES)
+        - -credential_file=/credentials/credential.json
+        env:
+          - name: INSTANCES
+            valueFrom:
+              configMapKeyRef:
+                name: sqlproxy-config
+                key: instances
+        ports:
+        - name: sqlproxy-port
+          containerPort: 3306
+        volumeMounts:
+        - mountPath: /cloudsql
+          name: cloudsql
+        - mountPath: /credentials
+          name: credential
+        - mountPath: /etc/ssl/certs
+          name: config
+      volumes:
+      - name: cloudsql
+        emptyDir:
+      - name: credential
+        secret:
+          secretName: sqlproxy-credential-secret
+      - name: config
+        configMap:
+          name: sqlproxy-config
+          items:
+          - key: ca-certificates.crt
+            path: ca-certificates.crt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: github-stack
+  name: sqlproxy-service
+  namespace: default
+spec:
+  ports:
+  - name: sqlport
+    port: 3306
+    targetPort: sqlproxy-port
+  selector:
+    app: github-sqlproxy


### PR DESCRIPTION
This patch makes it very easy to deploy a Google Cloud SQL along with
the cloud-sql-proxy container.

It creates a new github-database in your gcloud project if you don't
have already one (you can make it manually before to override the
default). It also creates a docker container with the required
credentials to connect.

All you have to do is to download the credential file, put it there,
create the conf with sensible values, and run deployx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/317)
<!-- Reviewable:end -->
