### PR TITLE
Exporting KUBE_MASTER_OS_DISTRIBUTION for 1.3+ and KUBE_OS_DISTRIBUTION for 1.2 for GCI tests.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -89,6 +89,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'slow-master': # kubernetes-e2e-gce-gci-ci-slow-master
             description: 'Runs slow tests on GCE with GCI images, sequentially on the master branch.'
             timeout: 150  #  See #24072
@@ -100,6 +101,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master-slow"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'serial-master': # kubernetes-e2e-gce-gci-ci-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images.'
             timeout: 300
@@ -110,6 +112,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
             timeout: 50
@@ -121,6 +124,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-3"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-ci-slow-release-1.3
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
             timeout: 150
@@ -133,6 +137,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-slow-1-3"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-ci-serial-release-1.3
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
             timeout: 300
@@ -144,6 +149,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-3"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'release-1.2':  # kubernetes-e2e-gce-gci-ci-release-1.2
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
             timeout: 50  # See #21138
@@ -258,6 +264,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-1-3"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-qa-slow-release-1.3
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
             timeout: 150
@@ -268,6 +275,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-1-3"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-qa-serial-release-1.3
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
             timeout: 300
@@ -278,6 +286,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-1-3"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'release-1.2':  # kubernetes-e2e-gce-gci-qa-release-1.2
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
             timeout: 50  # See #21138

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -88,6 +88,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'slow-master': # kubernetes-e2e-gce-gci-ci-slow-master
             description: 'Runs slow tests on GCE with GCI images, sequentially on the master branch.'
             timeout: 150  #  See #24072
@@ -98,6 +99,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master-slow"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'serial-master': # kubernetes-e2e-gce-gci-ci-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images.'
             timeout: 300
@@ -107,6 +109,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
             timeout: 50
@@ -117,6 +120,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-3"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-ci-slow-release-1.3
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
             timeout: 150
@@ -128,6 +132,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-slow-1-3"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-ci-serial-release-1.3
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
             timeout: 300
@@ -138,6 +143,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-3"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'release-1.2':  # kubernetes-e2e-gce-gci-ci-release-1.2
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
             timeout: 50  # See #21138
@@ -148,6 +154,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-2"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-ci-slow-release-1.2
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 150  #  See #24072
@@ -159,6 +166,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-slow-1-2"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-ci-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
@@ -169,6 +177,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
+                export KUBE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-e2e-gce-gci-ci-{suffix}'
 
@@ -248,6 +257,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-1-3"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-qa-slow-release-1.3
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
             timeout: 150
@@ -257,6 +267,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-1-3"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-qa-serial-release-1.3
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
             timeout: 300
@@ -266,6 +277,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-1-3"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
         - 'release-1.2':  # kubernetes-e2e-gce-gci-qa-release-1.2
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
             timeout: 50  # See #21138
@@ -275,6 +287,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-1-2"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-qa-slow-release-1.2
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 60
@@ -285,6 +298,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-1-2"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-qa-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
@@ -294,5 +308,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-1-2"
+                export KUBE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-e2e-gce-gci-qa-{suffix}'


### PR DESCRIPTION
@wonderfly @spxtr 