### PR TITLE
AWS testing: Change to SQ testing, exclude builds from each other

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -5,6 +5,12 @@
     jenkins_node: 'e2e'
     disabled: '{obj:disable_job}'
     properties:
+        - build-blocker:
+            use-build-blocker: true
+            blocking-jobs:
+              - 'kubernetes-e2e-aws'
+              - 'kubernetes-e2e-aws-release-1.3'
+            queue-scanning: ALL
         - build-discarder:
             days-to-keep: 7
     triggers:
@@ -60,14 +66,19 @@
 
 - project:
     name: kubernetes-aws
-    test-owner: 'bburns'
-    emails: 'bburns@google.com'
-    cron-string: '@daily'
-    trigger-job: ''
+    test-owner: 'zmerlynn'
+    emails: 'zml@google.com'
     timeout: 240
+
+    # !!! NOTE: If you add a job here, add it to the build-blocker
+    # !!! config above as well. All of these are sharing the same AWS
+    # !!! credentials.
+
     aws-suffix:
         - 'aws':  # kubernetes-e2e-aws
             description: 'Run e2e tests on AWS using the latest successful Kubernetes build.'
+            cron-string: '{sq-cron-string}'
+            trigger-job: 'kubernetes-build'
             job-env: |
                 export E2E_NAME="e2e-aws-master"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
@@ -75,6 +86,8 @@
                 export PROJECT="k8s-jkns-e2e-aws"
         - 'aws-release-1.3':  # kubernetes-e2e-aws-release-1.3
             description: 'Run e2e tests on AWS using the latest successful 1.3 Kubernetes build.'
+            cron-string: '@daily'
+            trigger-job: 'kubernetes-build-1.3'
             job-env: |
                 export E2E_NAME="e2e-aws-1-3"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"


### PR DESCRIPTION
If we're going to claim support, we need to march this towards blocking.