### PR TITLE
Make gke-smoke config match gke-ci.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -363,6 +363,7 @@
             export KUBE_GKE_NETWORK=${{E2E_NAME}}
             export ZONE="us-central1-f"
             export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
+            export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
             # Get golang into our PATH so we can run e2e.go
             export PATH=${{PATH}}:/usr/local/go/bin


### PR DESCRIPTION
Set the container.use_client_certificate property to false (to make the client use Google Oauth2 credentials).