### PR TITLE
Add QA tests for GCI master

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -245,7 +245,7 @@
             script: |
                 def gciImageMatcher = manager.getLogMatcher("KUBE_GCE_MASTER_IMAGE=(.*)")
                 if(gciImageMatcher?.matches()) manager.addShortText("<b>GCI Image: " + gciImageMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
-                def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
+                def k8sVersionMatcher = manager.getLogMatcher("Using\\sGCI\\sbuiltin\\sversion:\\s(.*)")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
     # Template defaults.
     jenkins_node: 'e2e'
@@ -255,68 +255,95 @@
 - project:
     name: kubernetes-e2e-gce-gci-qa
     suffix:
-        - 'release-1.3':  # kubernetes-e2e-gce-gci-qa-release-1.3
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
+        - 'master':  # kubernetes-e2e-gce-gci-qa-master
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images from the master branch, in parallel.'
+            timeout: 50
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-master"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+        - 'slow-master':  # kubernetes-e2e-gce-gci-qa-slow-master
+            description: 'Runs slow tests on GCE with GCI images from the master branch, sequentially.'
+            timeout: 150
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-slow-master"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+        - 'serial-master':  # kubernetes-e2e-gce-gci-qa-serial-master
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images from the master branch.'
+            timeout: 300
+            job-env: |
+                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-qa-serial-master"
+                export KUBE_MASTER_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+        - 'm53':  # kubernetes-e2e-gce-gci-qa-m53
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 53, in parallel.'
             timeout: 50
             job-env: |
                 export JENKINS_GCI_IMAGE_FAMILY="gci-53"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-qa-1-3"
+                export PROJECT="e2e-gce-gci-qa-m53"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-qa-slow-release-1.3
-            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
+        - 'slow-m53':  # kubernetes-e2e-gce-gci-qa-slow-m53
+            description: 'Runs slow tests on GCE with GCI images on milestone 53, sequentially.'
             timeout: 150
             job-env: |
                 export JENKINS_GCI_IMAGE_FAMILY="gci-53"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-qa-slow-1-3"
+                export PROJECT="e2e-gce-gci-qa-slow-m53"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-qa-serial-release-1.3
-            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
+        - 'serial-m53':  # kubernetes-e2e-gce-gci-qa-serial-m53
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 53.'
             timeout: 300
-            trigger-job: 'kubernetes-build-1.3'
             job-env: |
                 export JENKINS_GCI_IMAGE_FAMILY="gci-53"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-qa-serial-1-3"
+                export PROJECT="e2e-gce-gci-qa-serial-m53"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'release-1.2':  # kubernetes-e2e-gce-gci-qa-release-1.2
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
+        - 'm52':  # kubernetes-e2e-gce-gci-qa-m52
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 52, in parallel.'
             timeout: 50  # See #21138
-            trigger-job: 'kubernetes-build-1.2'
             job-env: |
                 export JENKINS_GCI_IMAGE_FAMILY="gci-52"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-qa-1-2"
+                export PROJECT="e2e-gce-gci-qa-m52"
                 export KUBE_OS_DISTRIBUTION="gci"
-        - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-qa-slow-release-1.2
-            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
+        - 'slow-m52':  # kubernetes-e2e-gce-gci-qa-slow-m52
+            description: 'Runs slow tests on GCE with GCI images on milestone 52, sequentially.'
             timeout: 60
-            trigger-job: 'kubernetes-build-1.2'
             job-env: |
                 export JENKINS_GCI_IMAGE_FAMILY="gci-52"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-qa-slow-1-2"
+                export PROJECT="e2e-gce-gci-qa-slow-m52"
                 export KUBE_OS_DISTRIBUTION="gci"
-        - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-qa-serial-release-1.2
-            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
+        - 'serial-m52':  # kubernetes-e2e-gce-gci-qa-serial-m52
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 52.'
             timeout: 300
-            trigger-job: 'kubernetes-build-1.2'
             job-env: |
                 export JENKINS_GCI_IMAGE_FAMILY="gci-52"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-qa-serial-1-2"
+                export PROJECT="e2e-gce-gci-qa-serial-m52"
                 export KUBE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-e2e-gce-gci-qa-{suffix}'


### PR DESCRIPTION
Kubernetes doesn't use GCI images from the master branch yet, but these QA tests
will make sure they are safe to make the switch when they can.

Also updated the trick of printing k8s version in Jenkins job history.

@adityakali Please review GCI related logic so that @spxtr can start reviewing the YAML changes.

cc/ @kubernetes/goog-image 