### PR TITLE
Fix serial job config to check update every 30 minutes and run at least every 2 hours.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -94,7 +94,7 @@
             basedir: 'go/src/{gitbasedir}'
     triggers:
         - pollscm:
-            cron: 'H/5 * * * *'
+            cron: '{scm-cron-string}'
         - timed: '{cron-string}'
     wrappers:
         - ansicolor:
@@ -111,6 +111,8 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+
+    scm-cron-string: 'H/5 * * * *'
 
 - project:
     name: node-docker-canary-build
@@ -155,7 +157,8 @@
             owner: 'pwittroc@google.com'
             shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-ci.properties'
         - 'kubelet-serial':
-            cron-string: '* H * * * *'
+            scm-cron-string: 'H/30 * * * *'
+            cron-string: 'H H/2 * * *'
             repoName: 'kubernetes/kubernetes'
             gitbasedir: 'k8s.io/kubernetes'
             owner: 'lantaol@google.com'


### PR DESCRIPTION
Current node e2e serial job is not configured correctly, now we can only manually trigger build.

This PR fixed the jenkins job config to make the test check update every 30 minutes and run at least every 2 hours.

/cc @coufon 