### PR TITLE
Use git-basedir to correctly find upload-to-gcs.sh for PR node e2e

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
@@ -1,55 +1,58 @@
 - builder:
     name: ensure-upload-to-gcs-script
+    git-basedir: ''
     builders:
       - shell: |
-          _script_tmp_path="${WORKSPACE}/_tmp/upload-to-gcs.sh"
-          _script_repo_path='hack/jenkins/upload-to-gcs.sh'
-          mkdir -p "${WORKSPACE}/_tmp"
-          if [[ "${ghprbTargetBranch:-}" == 'master' && -x "${_script_repo_path}" ]]; then
+          _script_tmp_path="${{WORKSPACE}}/_tmp/upload-to-gcs.sh"
+          _script_repo_path="${{WORKSPACE}}/{git-basedir}/hack/jenkins/upload-to-gcs.sh"
+          mkdir -p "${{WORKSPACE}}/_tmp"
+          if [[ "${{ghprbTargetBranch:-}}" == 'master' && -x "${{_script_repo_path}}" ]]; then
             # Force using the checked-out version if we're testing the master branch
-            ln -sf "${WORKSPACE}/${_script_repo_path}" "${_script_tmp_path}"
+            ln -sf "${{WORKSPACE}}/${{_script_repo_path}}" "${{_script_tmp_path}}"
           fi
           # Download only if necessary; if this is called multiple times,
           # we only want to download this script the first time.
-          if [[ ! -x "${_script_tmp_path}" ]]; then
-            rm -f "${_script_tmp_path}"
-            curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/${_script_repo_path}" > "${_script_tmp_path}"
-            chmod +x "${_script_tmp_path}"
+          if [[ ! -x "${{_script_tmp_path}}" ]]; then
+            rm -f "${{_script_tmp_path}}"
+            curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/${{_script_repo_path}}" > "${{_script_tmp_path}}"
+            chmod +x "${{_script_tmp_path}}"
           fi
 
 - publisher:
     name: gcs-uploader
+    git-basedir: ''
     publishers:
         - postbuildscript:
             builders:
-                - ensure-upload-to-gcs-script
+                - ensure-upload-to-gcs-script:
+                    git-basedir: '{git-basedir}'
                 - shell: |
-                    if [[ ! -e "${WORKSPACE}/build-log.txt" ]]; then
-                      curl -fsS --retry 3 "http://pull-jenkins-master:8080/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" > "${WORKSPACE}/build-log.txt"
+                    if [[ ! -e "${{WORKSPACE}}/build-log.txt" ]]; then
+                      curl -fsS --retry 3 "http://pull-jenkins-master:8080/job/${{JOB_NAME}}/${{BUILD_NUMBER}}/consoleText" > "${{WORKSPACE}}/build-log.txt"
                     fi
                 - conditional-step:
                     condition-kind: current-status
                     condition-worst: SUCCESS
                     condition-best: SUCCESS
                     steps:
-                        - shell: 'JENKINS_BUILD_FINISHED=SUCCESS "${WORKSPACE}/_tmp/upload-to-gcs.sh"'
+                        - shell: 'JENKINS_BUILD_FINISHED=SUCCESS "${{WORKSPACE}}/_tmp/upload-to-gcs.sh"'
                 - conditional-step:
                     condition-kind: current-status
                     condition-worst: UNSTABLE
                     condition-best: UNSTABLE
                     steps:
-                        - shell: 'JENKINS_BUILD_FINISHED=UNSTABLE "${WORKSPACE}/_tmp/upload-to-gcs.sh"'
+                        - shell: 'JENKINS_BUILD_FINISHED=UNSTABLE "${{WORKSPACE}}/_tmp/upload-to-gcs.sh"'
                 - conditional-step:
                     condition-kind: current-status
                     condition-worst: FAILURE
                     condition-best: FAILURE
                     steps:
-                        - shell: 'JENKINS_BUILD_FINISHED=FAILURE "${WORKSPACE}/_tmp/upload-to-gcs.sh"'
+                        - shell: 'JENKINS_BUILD_FINISHED=FAILURE "${{WORKSPACE}}/_tmp/upload-to-gcs.sh"'
                 - conditional-step:
                     condition-kind: current-status
                     condition-worst: ABORTED
                     condition-best: ABORTED
                     steps:
-                        - shell: 'JENKINS_BUILD_FINISHED=ABORTED "${WORKSPACE}/_tmp/upload-to-gcs.sh"'
+                        - shell: 'JENKINS_BUILD_FINISHED=ABORTED "${{WORKSPACE}}/_tmp/upload-to-gcs.sh"'
             script-only-if-succeeded: False
             script-only-if-failed: False

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -260,7 +260,8 @@
         - ansicolor:
             colormap: xterm
     builders:
-        - ensure-upload-to-gcs-script
+        - ensure-upload-to-gcs-script:
+            git-basedir: '{git-basedir}'
         - shell: JENKINS_BUILD_STARTED=true "${{WORKSPACE}}/_tmp/upload-to-gcs.sh"
         - shell: |
               if [[ -n '{git-basedir}' ]]; then cd '{git-basedir}'; fi
@@ -283,7 +284,8 @@
                     skip-if-no-test-files: '{skip-if-no-test-files}'
                     pattern: '_artifacts/**.xml'
                     deleteoutput: false
-        - gcs-uploader
+        - gcs-uploader:
+            git-basedir: '{git-basedir}'
 
 - project:
     name: kubernetes-pull


### PR DESCRIPTION
Yak-shaving for https://github.com/kubernetes/kubernetes/pull/29584.

We're supposed to use the PR version of `upload-to-gcs.sh`, but because node e2e uses a git basedir, we were using the version from master HEAD. 