### PR TITLE
Workaround authn API mismatch in staging GKE vs head kubernetes.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -161,7 +161,7 @@
                 # We also paged SREs with max-nodes-per-pool=400 (5 concurrent MIGs)
                 # So setting max-nodes-per-pool=1000, to check if that helps.
                 export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
-                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'


### PR DESCRIPTION
Temporary workaround to unblock large cluster tests.