### PR TITLE
DO NOT MERGE Revert "Workaround authn API mismatch in staging GKE vs head kubernetes."

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -161,7 +161,7 @@
                 # We also paged SREs with max-nodes-per-pool=400 (5 concurrent MIGs)
                 # So setting max-nodes-per-pool=1000, to check if that helps.
                 export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
-                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'


### PR DESCRIPTION
Reverts kubernetes/test-infra#351

Once the fix has rolled out to GKE staging, we can revert large-cluster authentication to the way we want it to be.

cc @ixdy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/353)
<!-- Reviewable:end -->
