### PR TITLE
Add "fail" to the highlighted word list.

### DIFF
--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -87,7 +87,7 @@ def digest(data, skip_fmt=lambda l: '... skipping %d lines ...' % l,
     if filters is None:
         filters = {'Namespace': '', 'UID': '', 'pod': '', 'ContainerID':''}
 
-    hilight_words = ["error", "fatal", "failed", "build timed out"]
+    hilight_words = ["error", "fatal", "fail", "failed", "build timed out"]
     if filters["pod"]:
         hilight_words = [filters["pod"]]
 

--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -23,7 +23,7 @@ def wordRE(word):
 
 # Match lines with error messages
 error_re = re.compile(
-    r'\b(error|fatal|failed|build timed out)\b', re.IGNORECASE)
+    r'\b(error|fatal|fail|failed|build timed out)\b', re.IGNORECASE)
 
 # Match the dictionary string in the given line
 def objref(line):

--- a/gubernator/regex_test.py
+++ b/gubernator/regex_test.py
@@ -42,6 +42,7 @@ class RegexTest(unittest.TestCase):
             ('misc. fatality', False),
             ('there was a FaTaL error', True),
             ('we failed to read logs', True),
+            ('FAIL k8s.io/kubernetes/pkg/client/record', True),
         ]:
             self.assertEqual(bool(regex.error_re.search(text)), matches,
                 'error_re.search(%r) should be %r' % (text, matches))


### PR DESCRIPTION
This catches Go unit test failure lines.