### PR TITLE
Activate the stored service account before running any commands

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
@@ -4,4 +4,7 @@
         - credentials-binding:
             - file:
                 credential-id: 'gcp-service-account'
-                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'
+                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'  # TODO(ixdy): remove after all scripts are using GOOGLE_APPLICATION_CREDENTIALS instead
+            - file:
+                credential-id: 'gcp-service-account'
+                variable: 'GOOGLE_APPLICATION_CREDENTIALS'

--- a/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
@@ -1,4 +1,9 @@
 - builder:
+    name: activate-gce-service-account
+    builders:
+      - shell: 'gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"'
+
+- builder:
     name: ensure-upload-to-gcs-script
     git-basedir: ''
     builders:

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -262,6 +262,7 @@
         - ansicolor:
             colormap: xterm
     builders:
+        - activate-gce-service-account
         - ensure-upload-to-gcs-script:
             git-basedir: '{git-basedir}'
         - shell: JENKINS_BUILD_STARTED=true "${{WORKSPACE}}/_tmp/upload-to-gcs.sh"

--- a/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
@@ -30,6 +30,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - e2e-credentials-binding
         - timeout:
             timeout: '{jenkins-timeout}'
             fail: true
@@ -57,6 +58,7 @@
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}
@@ -118,6 +120,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - e2e-credentials-binding
         - timeout:
             timeout: 90
             fail: true
@@ -131,6 +134,7 @@
         export PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
     shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-docker-validation.properties'
     builders:
+        - activate-gce-service-account
         - shell: |
             #!/bin/bash
             set -e

--- a/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
@@ -19,4 +19,7 @@
                 variable: 'JENKINS_AWS_CREDENTIALS_FILE'
             - file:
                 credential-id: 'gcp-service-account'
-                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'
+                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'  # TODO(ixdy): remove after all scripts are using GOOGLE_APPLICATION_CREDENTIALS instead
+            - file:
+                credential-id: 'gcp-service-account'
+                variable: 'GOOGLE_APPLICATION_CREDENTIALS'

--- a/jenkins/job-configs/kubernetes-jenkins/fejta-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/fejta-e2e-gce.yaml
@@ -27,6 +27,7 @@
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     fejta-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/fejta/kubernetes/e2e2/hack/jenkins/dockerized-e2e-runner.sh")
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}

--- a/jenkins/job-configs/kubernetes-jenkins/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/global.yaml
@@ -1,3 +1,8 @@
+- builder:
+    name: activate-gce-service-account
+    builders:
+      - shell: 'gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"'
+
 - publisher:
     name: gcs-uploader
     publishers:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -6,6 +6,7 @@
         - build-discarder:
             num-to-keep: 200
     builders:
+        - activate-gce-service-account
         - shell: 'JENKINS_BUILD_STARTED=true bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh")'
         - shell: |
             {job-env}
@@ -37,6 +38,7 @@
         - pollscm:
             cron: 'H/2 * * * *'
     wrappers:
+        - e2e-credentials-binding
         - timeout:
             timeout: '{jenkins-timeout}'
             fail: true

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-djmm.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-djmm.yaml
@@ -6,6 +6,7 @@
         - build-discarder:
             num-to-keep: 20
     builders:
+        - activate-gce-service-account
         - shell: 'JENKINS_BUILD_STARTED=true bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh")'
         - shell: |
             {job-env}
@@ -31,6 +32,7 @@
         - pollscm:
             cron: 'H/2 * * * *'
     wrappers:
+        - e2e-credentials-binding
         - timeout:
             timeout: '{jenkins-timeout}'
             fail: true

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -34,6 +34,7 @@
         export AWS_SHARED_CREDENTIALS_FILE=/workspace/.aws/credentials
         export KUBE_SSH_USER=admin
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -31,6 +31,7 @@
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}
@@ -204,6 +205,7 @@
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
         export JENKINS_USE_GCI_VERSION="y"  # Use GCI builtin k8s version.
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -22,6 +22,7 @@
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -18,6 +18,7 @@
         export KUBERNETES_PROVIDER="gke"
         export ZONE="us-central1-f"
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -12,6 +12,7 @@
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -12,6 +12,7 @@
         export FAIL_ON_GCP_RESOURCE_LEAK="true"
         export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {job-env}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -4,6 +4,7 @@
     node: 'master'
     disabled: '{obj:disable_job}'
     builders:
+        - activate-gce-service-account
         - shell: |
             {provider-env}
             {soak-env}

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -8,6 +8,7 @@
             num-to-keep: 200
     node: unittest
     builders:
+        - activate-gce-service-account
         - shell: 'JENKINS_BUILD_STARTED=true bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh")'
         - shell: |
             export KUBE_FORCE_VERIFY_CHECKS='y'
@@ -51,6 +52,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - e2e-credentials-binding
         - timeout:
             timeout: '{jenkins-timeout}'
             fail: true

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
@@ -16,7 +16,10 @@
             browser: githubweb
             browser-url: https://github.com/kubernetes/test-infra
             skip-tag: true
+    wrappers:
+        - e2e-credentials-binding
     builders:
+        - activate-gce-service-account
         - shell: |
             cd jenkins/test-history
             ./gen_history

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-verify.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-verify.yaml
@@ -8,6 +8,7 @@
             num-to-keep: 200
     node: unittest
     builders:
+        - activate-gce-service-account
         - shell: 'JENKINS_BUILD_STARTED=true bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh")'
         - shell: |
             export KUBE_FORCE_VERIFY_CHECKS='y'
@@ -36,6 +37,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - e2e-credentials-binding
         - timeout:
             timeout: '{jenkins-timeout}'
             fail: true

--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -17,7 +17,8 @@
         - build-discarder:
             num-to-keep: 200
     builders:
-         - docker-build-publish:
+        - activate-gce-service-account
+        - docker-build-publish:
              repoName: '{repoName}'
              dockerfilePath: 'go/src/{gitbasedir}/{dockerfilePath}'
              tag: 'canary'
@@ -44,6 +45,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - e2e-credentials-binding
         - timeout:
             timeout: 30
             fail: true

--- a/jenkins/job-configs/kubernetes-jenkins/test-linkchecker.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/test-linkchecker.yaml
@@ -8,6 +8,7 @@
         - build-discarder:
             num-to-keep: 200
     builders:
+        - activate-gce-service-account
         - shell: |
             export PATH=${PATH}:/usr/local/go/bin
             ./hack/verify-linkcheck.sh
@@ -30,6 +31,7 @@
     wrappers:
         - ansicolor:
             colormap: xterm
+        - e2e-credentials-binding
         - timeout:
             timeout: 60
             fail: true


### PR DESCRIPTION
x-ref #266

This almost certainly breaks some things. In particular, I'm worried about the non-e2e jobs, which rely on projects which may not have ACL'd our kubekins service accounts.