### PR TITLE
Fix bug where ContainerID not found in objref_dict

### DIFF
--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -69,7 +69,7 @@ def make_dict(data, pod_re, objref_dict):
             pod_in_file = True
             objref = regex.objref(line)
             containerID = regex.containerID(line)
-            if containerID and not objref_dict["ContainerID"]:
+            if containerID and not objref_dict.get("ContainerID"):
                 objref_dict["ContainerID"] = containerID.group(1)
             if objref:
                 objref_dict_re = objref.group(1)


### PR DESCRIPTION
Fix bug for: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/30242/kubernetes-pull-build-test-e2e-gce/52484/nodelog?pod=e2e-tests-container-probe-d3qvr/liveness-exec&junit=junit_25.xml&wrap=on

@timstclair 