### PR TITLE
Link build results to testgrid (fixes #272).

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -187,6 +187,13 @@ def do_select(seq, pred):
     return filter(pred, seq)
 
 
+def do_tg_url(testgrid_query, test_name=''):
+    if test_name:
+        regex = '^Overall$|' + re.escape(test_name)
+        testgrid_query += '&include-filter-by-regex=%s' % urllib.quote(regex)
+    return 'https://k8s-testgrid.appspot.com/%s' % testgrid_query
+
+
 do_basename = os.path.basename
 do_dirname = os.path.dirname
 do_quote_plus = urllib.quote_plus

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -16,6 +16,7 @@
 
 import re
 import unittest
+import urllib
 
 import filters
 
@@ -100,6 +101,15 @@ class HelperTest(unittest.TestCase):
         expect({'status': {'ci': ['success', '', '']}, 'labels': ['lgtm']}, 'success check LGTM')
         expect({'attn': {'foo': 'Needs Rebase'}}, 'Needs Rebase', user='foo')
         expect({'attn': {'foo': 'Needs Rebase'}, 'labels': {'lgtm'}}, 'LGTM', user='foo')
+
+    def test_tg_url(self):
+        self.assertEqual(
+            filters.do_tg_url('a#b'),
+            'https://k8s-testgrid.appspot.com/a#b')
+        self.assertEqual(
+            filters.do_tg_url('a#b', '[low] test'),
+            'https://k8s-testgrid.appspot.com/a#b&include-filter-by-regex=%s' %
+            urllib.quote('^Overall$|\\[low\\]\\ test'))
 
 
 if __name__ == '__main__':

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -59,7 +59,7 @@ def log_html(lines, matched_lines, hilight_words, skip_fmt):
             skip_string = ('<span class="skip">'
                 '<a href="javascript:show_skipped(\'%s\')" onclick="this.style.display=\'none\'">'
                 '%s</a></span>'
-                '<span class="skipped" id=%s style="display:none; float: left;">') % (skip_id,
+                '<span class="skipped" id=%s style="display:none;">') % (skip_id,
                 skip_fmt(skip_amount), skip_id)
             lines[previous_end] = "%s%s" % (skip_string, lines[previous_end])
             output.extend(lines[previous_end:match-CONTEXT])

--- a/gubernator/pb_glance.py
+++ b/gubernator/pb_glance.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+A tiny, minimal protobuf2 parser that's able to extract enough information
+to be useful.
+'''
+
+import cStringIO as StringIO
+
+
+def parse_protobuf(data, schema=None):
+    '''
+    Do a simple parse of a protobuf2 given minimal type information.
+
+    Args:
+        data: a string containing the encoded protocol buffer.
+        schema: a dict containing information about each field number.
+            The keys are field numbers, and the values represent:
+                - str: the name of the field
+                - dict: schema to recursively decode an embedded message.
+                        May contain a 'name' key to name the field.
+    Returns:
+        dict: mapping from fields to values. The fields may be strings instead of
+            numbers if schema named them, and the value will *always* be
+            a list of values observed for that key.
+    '''
+    if schema is None:
+        schema = {}
+
+    buf = StringIO.StringIO(data)
+
+    def read_varint():
+        out = 0
+        shift = 0
+        c = 0x80
+        while c & 0x80:
+            c = ord(buf.read(1))
+            out = out | ((c & 0x7f) << shift)
+            shift += 7
+        return out
+
+    values = {}
+
+    while buf.tell() < len(data):
+        key = read_varint()
+        wire_type = key & 0b111
+        field_number = key >> 3
+        field_name = field_number
+        if wire_type == 0:
+            value = read_varint()
+        elif wire_type == 1:  # 64-bit
+            value = buf.read(8)
+        elif wire_type == 2:  # length-delim
+            length = read_varint()
+            value = buf.read(length)
+            if isinstance(schema.get(field_number), basestring):
+                field_name = schema[field_number]
+            elif field_number in schema:
+                # yes, I'm using dynamic features of a dynamic language.
+                # pylint: disable=redefined-variable-type
+                value = parse_protobuf(value, schema[field_number])
+                field_name = schema[field_number].get('name', field_name)
+        elif wire_type == 5:  # 32-bit
+            value = buf.read(4)
+        else:
+            raise ValueError('unhandled wire type %d' % wire_type)
+        values.setdefault(field_name, []).append(value)
+
+    return values

--- a/gubernator/pb_glance_test.py
+++ b/gubernator/pb_glance_test.py
@@ -1,0 +1,56 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pb_glance
+
+
+def tostr(data):
+    if isinstance(data, list):
+        return ''.join(c if isinstance(c, str) else chr(c) for c in data)
+    return data
+
+
+class PBGlanceTest(unittest.TestCase):
+    def expect(self, data, expected, types=None):
+        result = pb_glance.parse_protobuf(tostr(data), types)
+        self.assertEqual(result, expected)
+
+    def test_basic(self):
+        self.expect(
+            [0, 1,                  # varint
+             0, 0x96, 1,            # multi-byte varint
+             (1<<3)|1, 'abcdefgh',  # 64-bit
+             (2<<3)|2, 5, 'value',  # length-delimited (string)
+             (3<<3)|5, 'abcd',      # 32-bit
+            ],
+            {
+                0: [1, 150],
+                1: ['abcdefgh'],
+                2: ['value'],
+                3: ['abcd'],
+            })
+
+    def test_embedded(self):
+        self.expect([2, 2, 3<<3, 1], {0: [{3: [1]}]}, {0: {}})
+
+    def test_field_names(self):
+        self.expect([2, 2, 'hi'], {'greeting': ['hi']}, {0: 'greeting'})
+
+    def test_embedded_names(self):
+        self.expect(
+            [2, 4, (3<<3)|2, 2, 'hi'],
+            {'msg': [{'greeting': ['hi']}]},
+            {0: {'name': 'msg', 3: 'greeting'}})

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -25,6 +25,9 @@
 	<p>Build Result: {{finished['result'] if finished else 'Not Finished'}}
 	<p><a href="https://console.cloud.google.com/storage/browser{{build_dir}}">artifacts</a>
 	<a href="https://storage.googleapis.com{{build_dir}}/build-log.txt">build-log.txt</a>
+	% if testgrid_query
+		<p><a href="{{testgrid_query|tg_url}}">Testgrid history for this job</a>
+	% endif
 	</div>
 	<div id="failures">
 	% if failures
@@ -40,6 +43,9 @@
 					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>
 				% else
 					<p>Filter through <a href="/build{{build_dir}}/nodelog?junit={{filename|basename}}&wrap=on">log files</a>
+				% endif
+				% if testgrid_query
+					| View <a href="{{testgrid_query|tg_url(name)}}">test history</a> on testgrid
 				% endif
 			% else
 				<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span>

--- a/gubernator/testgrid.py
+++ b/gubernator/testgrid.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import cloudstorage as gcs
+
+import pb_glance
+
+
+CONFIG_PROTO_SCHEMA = {
+    1: {
+        'name': 'test_groups',
+        1: 'name',
+        2: 'query',
+        9: {},
+    },
+    2: {
+        'name': 'dashboards',
+        1: {
+            'name': 'dashboard_tab',
+            1: 'name',
+            2: 'test_group_name',
+            7: {},
+            8: {2: {}},
+            9: {},
+            11: {},
+            12: {},
+        },
+        2: 'name',
+    }
+}
+
+_testgrid_config = None
+
+
+def get_config():
+    '''
+    Load the testgrid config loaded from a proto stored on GCS.
+    It will be cached locally in memory for the life of this process.
+
+    Returns:
+        dict: {
+            'test_groups': [{'name': ..., 'query': ...}],
+            'dashboards': [{
+                'name': ...,
+                'dashboard_tab': [{'name': ..., 'test_group_name': ...}]
+            }]
+        }
+    '''
+    global _testgrid_config  # pylint: disable=global-statement
+    if not _testgrid_config:
+        data = gcs.open('/k8s-testgrid/config').read()
+        _testgrid_config = pb_glance.parse_protobuf(data, CONFIG_PROTO_SCHEMA)
+    return _testgrid_config
+
+
+def path_to_group_name(path):
+    '''
+    Args:
+        path: a job directory like "/kubernetes-jenkins/jobs/e2e-gce"
+    Returns:
+        test_group_name: the group name in the config, or None if not found
+    '''
+    path = path.strip('/')  # the config doesn't have leading/trailing slashes
+    try:
+        config = get_config()
+    except gcs.errors.Error:
+        logging.exception('unable to load testgrid config')
+        return None
+    for test_group in config.get('test_groups', []):
+        if path in test_group['query']:
+            return test_group['name'][0]
+
+
+def path_to_query(path):
+    '''
+    Convert a GCS job directory to the testgrid path for its results.
+
+    Args:
+        path: a job directory like "/kubernetes-jenkins/jobs/e2e-gce"
+    Returns:
+        query: the url for the job, like "k8s#gce", or "" if not found.
+    '''
+    group = path_to_group_name(path)
+    if not group:
+        return ''
+
+    # Tabs can appear on multiple dashboards. Favor selecting 'k8s' over others,
+    # otherwise pick a random tab.
+
+    options = {}
+    for dashboard in get_config().get('dashboards', []):
+        dashboard_name = dashboard['name'][0]
+        for tab in dashboard['dashboard_tab']:
+            if group in tab['test_group_name']:
+                query = '%s#%s' % (dashboard_name, tab['name'][0])
+                options[dashboard_name] = query
+    if 'k8s' in options:
+        return options['k8s']
+    elif len(options) > 1:
+        logging.warning('ambiguous testgrid options: %s', options)
+    elif len(options) == 0:
+        return ''
+    return options.values()[0]

--- a/gubernator/testgrid_test.py
+++ b/gubernator/testgrid_test.py
@@ -1,0 +1,117 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import testgrid
+
+import main_test
+import pb_glance_test
+import gcs_async_test
+
+
+def write_config():
+    tab = 'ajob'
+    path = 'kubernetes-jenkins/logs/somejob'
+    tab_len = 2 + len(tab) + 2 + 2
+    data = pb_glance_test.tostr(
+        [
+            (1<<3)|2, 2 + 2 + 2 + len(path),  # testgroup
+            (1<<3)|2, 2, 'tg',                # testgroup.name
+            (2<<3)|2, len(path), path,        # testgroup.query
+            (2<<3)|2, 2 + 3 + 2 + tab_len,        # dashboard
+            (2<<3)|2, 3, 'k8s',               # dashboard.name
+            (1<<3)|2, tab_len,                # dashboard.tab
+            (1<<3)|2, len(tab), tab,          # dashboard.tab.name
+            (2<<3)|2, len('tg'), 'tg',        # dashboard.tab.test_group_name
+        ]
+    )
+    gcs_async_test.write('/k8s-testgrid/config', data)
+
+
+class TestTestgrid(unittest.TestCase):
+    # pylint: disable=protected-access
+
+    def test_path_to_group(self):
+        testgrid._testgrid_config = {
+            'test_groups': [
+                {'query': []},
+                {'query': ['foo']},
+                {'query': ['bar/e'], 'name': ['blah']},
+            ]
+        }
+        self.assertEqual(testgrid.path_to_group_name('bar/e'), 'blah')
+        self.assertEqual(testgrid.path_to_group_name('/blah'), None)
+
+    def test_path_to_query(self):
+        testgrid._testgrid_config = {
+            'test_groups': [
+                {'query': ['gce-serial'], 'name': ['gce-serial']},
+                {'query': ['gce-soak'], 'name': ['gce-soak']},
+                {'query': ['gce-soak-1.3'], 'name': ['gce-soak-1.3']},
+                {'query': ['unusedgroup'], 'name': ['unused']},
+            ],
+            'dashboards': [
+                {
+                    'name': ['k8s'],
+                    'dashboard_tab': [
+                        {'test_group_name': ['gce-serial'], 'name': ['serial']},
+                    ]
+                },
+                {
+                    'name': ['gce'],
+                    'dashboard_tab': [
+                        {'test_group_name': ['gce-serial'], 'name': ['serial']},
+                        {'test_group_name': ['gce-soak'], 'name': ['soak']},
+                        {'test_group_name': ['gce-soak-1.3'], 'name': ['soak-1.3']},
+                    ]
+                },
+                {
+                    'name': ['1.3'],
+                    'dashboard_tab': [
+                        {'test_group_name': ['gce-soak-1.3'], 'name': ['soak']},
+                    ]
+                }
+            ]
+        }
+        def expect(path, out):
+            self.assertEqual(testgrid.path_to_query(path), out)
+
+        expect('/gce-serial/', 'k8s#serial')
+        expect('gce-soak', 'gce#soak')
+        expect('gce-soak-1.3', 'gce#soak-1.3')
+        expect('unusedgroup', '')
+        expect('notarealpath', '')
+
+
+class TestTestgridGCS(main_test.TestBase):
+    def test_write_config(self):
+        # pylint: disable=protected-access
+        self.init_stubs()
+        testgrid._testgrid_config = None
+        write_config()
+        path = 'kubernetes-jenkins/logs/somejob'
+        self.assertEqual(
+            testgrid.get_config(),
+            {
+                'test_groups': [{
+                    'name': ['tg'],
+                    'query': [path]
+                }],
+                'dashboards': [{
+                    'dashboard_tab': [{'name': ['ajob'], 'test_group_name': ['tg']}],
+                    'name': ['k8s']
+                }],
+            })
+        self.assertEqual(testgrid.path_to_query(path), 'k8s#ajob')

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -22,8 +22,8 @@ import defusedxml.ElementTree as ET
 import gcs_async
 from github import models
 import log_parser
+import testgrid
 import view_base
-
 
 
 def parse_junit(xml, filename):
@@ -102,6 +102,7 @@ class BuildHandler(view_base.BaseHandler):
     def get(self, prefix, job, build):
         self.check_bucket(prefix)
         job_dir = '/%s/%s/' % (prefix, job)
+        testgrid_query = testgrid.path_to_query(job_dir)
         build_dir = job_dir + build
         details = build_details(build_dir)
         if not details:
@@ -124,7 +125,8 @@ class BuildHandler(view_base.BaseHandler):
         self.render('build.html', dict(
             job_dir=job_dir, build_dir=build_dir, job=job, build=build,
             commit=commit, started=started, finished=finished,
-            failures=failures, build_log=build_log, pr=pr, pr_digest=pr_digest))
+            failures=failures, build_log=build_log, pr=pr, pr_digest=pr_digest,
+            testgrid_query=testgrid_query))
 
 
 class BuildListHandler(view_base.BaseHandler):

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -21,6 +21,7 @@ import view_build
 
 import main_test
 import gcs_async_test
+import testgrid_test
 import view_pr
 
 app = main_test.app
@@ -63,6 +64,7 @@ class BuildTest(main_test.TestBase):
     def setUp(self):
         self.init_stubs()
         init_build(self.BUILD_DIR)
+        testgrid_test.write_config()
 
     def get_build_page(self):
         return app.get('/build' + self.BUILD_DIR)
@@ -127,6 +129,13 @@ class BuildTest(main_test.TestBase):
         self.assertIn('No Test Failures', response)
         self.assertIn('ERROR</span>: test', response)
         self.assertNotIn('blah', response)
+
+    def test_build_testgrid_links(self):
+        response = self.get_build_page()
+        base = 'https://k8s-testgrid.appspot.com/k8s#ajob'
+        self.assertIn('a href="%s"' % base, response)
+        option = '&amp;include-filter-by-regex=%5EOverall%24%7CThird'
+        self.assertIn('a href="%s%s"' % (base, option), response)
 
     def test_build_failure_no_text(self):
         # Some failures don't have any associated text.

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -12,11 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
+
+import cloudstorage as gcs
 
 import view_build
 
 import main_test
+import gcs_async_test
+import view_pr
+
+app = main_test.app
+init_build = main_test.init_build
+write = gcs_async_test.write
 
 
 class ParseJunitTest(unittest.TestCase):
@@ -46,3 +55,115 @@ class ParseJunitTest(unittest.TestCase):
 
     def test_bad_xml(self):
         self.assertEqual(self.parse('''<body />'''), [])
+
+
+class BuildTest(main_test.TestBase):
+    BUILD_DIR = '/kubernetes-jenkins/logs/somejob/1234/'
+
+    def setUp(self):
+        self.init_stubs()
+        init_build(self.BUILD_DIR)
+
+    def get_build_page(self):
+        return app.get('/build' + self.BUILD_DIR)
+
+    def test_missing(self):
+        """Test that a missing build gives a 404."""
+        response = app.get('/build' + self.BUILD_DIR.replace('1234', '1235'),
+                           status=404)
+        self.assertIn('1235', response)
+
+    def test_missing_started(self):
+        """Test that a missing started.json still renders a proper page."""
+        build_dir = '/kubernetes-jenkins/logs/job-with-no-started/1234/'
+        init_build(build_dir, started=False)
+        response = app.get('/build' + build_dir)
+        self.assertIn('Build Result: SUCCESS', response)
+        self.assertIn('job-with-no-started', response)
+        self.assertNotIn('Started', response)  # no start timestamp
+        self.assertNotIn('github.com', response)  # no version => no src links
+
+    def test_missing_finished(self):
+        """Test that a missing finished.json still renders a proper page."""
+        build_dir = '/kubernetes-jenkins/logs/job-still-running/1234/'
+        init_build(build_dir, finished=False)
+        response = app.get('/build' + build_dir)
+        self.assertIn('Build Result: Not Finished', response)
+        self.assertIn('job-still-running', response)
+        self.assertIn('Started', response)
+
+    def test_build(self):
+        """Test that the build page works in the happy case."""
+        response = self.get_build_page()
+        self.assertIn('2014-07-28', response)  # started
+        self.assertIn('16m40s', response)      # build duration
+        self.assertIn('Third', response)       # test name
+        self.assertIn('1m36s', response)       # test duration
+        self.assertIn('Build Result: SUCCESS', response)
+        self.assertIn('Error Goes Here', response)
+        self.assertIn('test.go#L123">', response)  # stacktrace link works
+
+    def test_build_no_failures(self):
+        """Test that builds with no Junit artifacts work."""
+        gcs.delete(self.BUILD_DIR + 'artifacts/junit_01.xml')
+        response = self.get_build_page()
+        self.assertIn('No Test Failures', response)
+
+    def test_build_show_log(self):
+        """Test that builds that failed with no failures show the build log."""
+        gcs.delete(self.BUILD_DIR + 'artifacts/junit_01.xml')
+        write(self.BUILD_DIR + 'finished.json',
+              {'result': 'FAILURE', 'timestamp': 1406536800})
+
+        # Unable to fetch build-log.txt, still works.
+        response = self.get_build_page()
+        self.assertNotIn('Error lines', response)
+
+        self.testbed.init_memcache_stub()  # clear cached result
+        write(self.BUILD_DIR + 'build-log.txt',
+              u'ERROR: test \u039A\n\n\n\n\n\n\n\n\nblah'.encode('utf8'))
+        response = self.get_build_page()
+        self.assertIn('Error lines', response)
+        self.assertIn('No Test Failures', response)
+        self.assertIn('ERROR</span>: test', response)
+        self.assertNotIn('blah', response)
+
+    def test_build_failure_no_text(self):
+        # Some failures don't have any associated text.
+        write(self.BUILD_DIR + 'artifacts/junit_01.xml', '''
+            <testsuites>
+                <testsuite tests="1" failures="1" time="3.274" name="k8s.io/test/integration">
+                    <testcase classname="integration" name="TestUnschedulableNodes" time="0.210">
+                        <failure message="Failed" type=""/>
+                    </testcase>
+                </testsuite>
+            </testsuites>''')
+        response = self.get_build_page()
+        self.assertIn('TestUnschedulableNodes', response)
+        self.assertIn('junit_01.xml', response)
+
+    def test_build_pr_link(self):
+        ''' The build page for a PR build links to the PR results.'''
+        build_dir = '/%s/123/e2e/567/' % view_pr.PR_PREFIX
+        init_build(build_dir)
+        response = app.get('/build' + build_dir)
+        self.assertIn('PR #123', response)
+        self.assertIn('href="/pr/123"', response)
+
+    def test_cache(self):
+        """Test that caching works at some level."""
+        response = self.get_build_page()
+        gcs.delete(self.BUILD_DIR + 'started.json')
+        gcs.delete(self.BUILD_DIR + 'finished.json')
+        response2 = self.get_build_page()
+        self.assertEqual(str(response), str(response2))
+
+    def test_build_list(self):
+        """Test that the job page shows a list of builds."""
+        response = app.get('/builds' + os.path.dirname(self.BUILD_DIR[:-1]))
+        self.assertIn('/1234/">1234</a>', response)
+
+    def test_job_list(self):
+        """Test that the job list shows our job."""
+        response = app.get('/jobs/kubernetes-jenkins/logs')
+        self.assertIn('somejob/">somejob</a>', response)


### PR DESCRIPTION
This makes it easy to view historical failures for a job or test.

The neatest / grossest thing here is in `pb_glance.py` -- a tiny protobuf parser in 40 lines of code. See `pr_glance_test.py` for more usage information.