### PR TITLE
Switch gci jobs to use new image and runner

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Save environment variables in $WORKSPACE/env.list and then run the Jenkins e2e
+# test runner inside the kubekins-test Docker image.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export REPO_DIR=${REPO_DIR:-$(pwd)}
+export HOST_ARTIFACTS_DIR=${WORKSPACE}/_artifacts
+mkdir -p "${HOST_ARTIFACTS_DIR}"
+
+# TODO(ixdy): remove when all jobs are setting these vars using Jenkins credentials
+: ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
+: ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
+
+env \
+  -u HOME \
+  -u KUBEKINS_SERVICE_ACCOUNT_FILE \
+  -u PATH \
+  -u PWD \
+  -u WORKSPACE \
+  -u GOROOT \
+  >${WORKSPACE}/env.list
+
+docker_extra_args=()
+if [[ "${JENKINS_ENABLE_DOCKER_IN_DOCKER:-}" =~ ^[yY]$ ]]; then
+    docker_extra_args+=(\
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
+      -e "REPO_DIR=${REPO_DIR}" \
+      -e "HOST_ARTIFACTS_DIR=${HOST_ARTIFACTS_DIR}" \
+    )
+fi
+
+echo "Starting..."
+docker run --rm=true -i \
+  -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
+  -v /etc/localtime:/etc/localtime:ro \
+  ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:+-v "${JENKINS_GCE_SSH_PRIVATE_KEY_FILE}:/workspace/.ssh/google_compute_engine:ro"} \
+  ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:+-v "${JENKINS_GCE_SSH_PUBLIC_KEY_FILE}:/workspace/.ssh/google_compute_engine.pub:ro"} \
+  ${JENKINS_AWS_SSH_PRIVATE_KEY_FILE:+-v "${JENKINS_AWS_SSH_PRIVATE_KEY_FILE}:/workspace/.ssh/kube_aws_rsa:ro"} \
+  ${JENKINS_AWS_SSH_PUBLIC_KEY_FILE:+-v "${JENKINS_AWS_SSH_PUBLIC_KEY_FILE}:/workspace/.ssh/kube_aws_rsa.pub:ro"} \
+  ${JENKINS_AWS_CREDENTIALS_FILE:+-v "${JENKINS_AWS_CREDENTIALS_FILE}:/workspace/.aws/credentials:ro"} \
+  ${KUBEKINS_SERVICE_ACCOUNT_FILE:+-v "${KUBEKINS_SERVICE_ACCOUNT_FILE}:/service-account.json:ro"} \
+  --env-file "${WORKSPACE}/env.list" \
+  -e "HOME=/workspace" \
+  -e "WORKSPACE=/workspace" \
+  ${KUBEKINS_SERVICE_ACCOUNT_FILE:+-e "KUBEKINS_SERVICE_ACCOUNT_FILE=/service-account.json"} \
+  "${docker_extra_args[@]:+${docker_extra_args[@]}}" \
+  gcr.io/google-containers/kubekins-e2e:v20160810

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -35,7 +35,7 @@
             {provider-env}
             {job-env}
             {post-env}
-            timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
+            timeout -k {kill-timeout}m {timeout}m {gci-runner} && rc=$? || rc=$?
             {report-rc}
     wrappers:
         - ansicolor:
@@ -64,6 +64,7 @@
                 def k8sVersionMatcher = manager.getLogMatcher("Using\\spublished\\sversion\\s(.*)\\s\\(from.*")
                 if(k8sVersionMatcher?.matches()) manager.addShortText("<br><b>Kubernetes version: " + k8sVersionMatcher.group(1) + "</b>", "grey", "white", "0px", "white")
     # Template defaults.
+    gci-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/test-infra/master/jenkins/dockerized-e2e-runner.sh")  # TODO(fejta): migrate all dockerized-e2e-runner.sh references here
     jenkins_node: 'e2e'
     test-owner: 'wonderfly'
     emails: 'gci-alerts+kubekins@google.com'


### PR DESCRIPTION
Updating just the gci jobs to use the new runner/image to unblock gci testing for https://github.com/kubernetes/test-infra/issues/368

Validated it works with both the master and 1.2 jobs: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/fejta-e2e-release-1.2/1/