### PR TITLE
Updating the E2E name for federation e2e tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -496,7 +496,7 @@
             # ginkgo changes get made, but allows for testing them in a PR.
             export GINKGO_TOLERATE_FLAKES="y"
 
-            export E2E_NAME="federation-e2e-gce-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+            export E2E_NAME="fed-e2e-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
             export FAIL_ON_GCP_RESOURCE_LEAK="false"
             export NUM_NODES="3"
 


### PR DESCRIPTION
Fixing the e2e name to be smaller.
Cluster is failing to come up on jenkins due to errors:
```
Invalid value 'federation-e2e-gce-agent-pr-14-0-minion-federation-e2e-gce-agent-pr-14-0-http-alt'. Values must match the following regular expression: '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?'
```
We are now exceeding the 61 length limit on resource names.

Updated the e2e name to `fed-e2e-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}` from `federation-e2e-gce-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}`. The length should now be same as the GCE e2e test where e2e name is `e2e-gce-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}` which is of the same length and we know works.


cc @kubernetes/sig-cluster-federation 