### PR TITLE
Always download Jenkins build log

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
@@ -28,7 +28,7 @@
                 - ensure-upload-to-gcs-script:
                     git-basedir: '{git-basedir}'
                 - shell: |
-                    if [[ ! -e "${{WORKSPACE}}/build-log.txt" ]]; then
+                    if [[ "${{NODE_NAME:-}}" != 'master' ]]; then
                       curl -fsS --retry 3 "http://pull-jenkins-master:8080/job/${{JOB_NAME}}/${{BUILD_NUMBER}}/consoleText" > "${{WORKSPACE}}/build-log.txt"
                     fi
                 - conditional-step:

--- a/jenkins/job-configs/kubernetes-jenkins/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/global.yaml
@@ -8,7 +8,7 @@
                     curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" > ./_tmp/upload-to-gcs.sh
                     chmod +x ./_tmp/upload-to-gcs.sh
 
-                    if [[ ! -e "${WORKSPACE}/build-log.txt" ]]; then
+                    if [[ "${NODE_NAME:-}" != 'master' ]]; then
                       curl -fsS --retry 3 "http://jenkins-master:8080/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" > "${WORKSPACE}/build-log.txt"
                     fi
                 - conditional-step:


### PR DESCRIPTION
I'm not sure why we didn't just do this by default. @spxtr do you remember?

This should fix the soak test stale log issue, at least.