### PR TITLE
Use dockerized e2e in PR Jenkins when special file exists

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -373,7 +373,11 @@
             # Get golang into our PATH so we can run e2e.go
             export PATH=${{PATH}}:/usr/local/go/bin
 
-            timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+            if [[ -e "./hack/jenkins/.use_dockerized_e2e" ]]; then
+              timeout -k 15m 55m ./hack/jenkins/dockerized-e2e-runner.sh && rc=$? || rc=$?
+            else
+              timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+            fi
             if [[ ${{rc}} -ne 0 ]]; then
               if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
                 echo "Dumping logs for any remaining nodes"
@@ -458,7 +462,11 @@
               # Get golang into our PATH so we can run e2e.go
               export PATH=${{PATH}}:/usr/local/go/bin
 
-              timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+              if [[ -e "./hack/jenkins/.use_dockerized_e2e" ]]; then
+                timeout -k 15m 55m ./hack/jenkins/dockerized-e2e-runner.sh && rc=$? || rc=$?
+              else
+                timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+              fi
               if [[ ${{rc}} -ne 0 ]]; then
                 if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
                   echo "Dumping logs for any remaining nodes"
@@ -527,7 +535,11 @@
             export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
             export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 
-            timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+            if [[ -e "./hack/jenkins/.use_dockerized_e2e" ]]; then
+              timeout -k 15m 55m ./hack/jenkins/dockerized-e2e-runner.sh && rc=$? || rc=$?
+            else
+              timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
+            fi
             if [[ ${{rc}} -ne 0 ]]; then
               if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
                 echo "Dumping logs for any remaining nodes"


### PR DESCRIPTION
It probably just works, but I'd like to test it first before I break the world. It'll use the existing method unless `./hack/jenkins/.use_dockerized_e2e` exists.

After we verify that it works, we can remove this conditional.

A step towards fixing #318.