### PR TITLE
Fix hourly_maintenance.py error when dangling images exist.

### DIFF
--- a/jenkins/hourly_maintenance.py
+++ b/jenkins/hourly_maintenance.py
@@ -96,7 +96,7 @@ def RemoveImages(skip, ancient):
     dangling = subprocess.check_output([
         'docker', 'images', '-q', '-f', 'dangling=true'])
     if dangling:
-        err |= subprocess.call(['docker', 'rmi'] + dangling.split('\n'))
+        err |= subprocess.call(['docker', 'rmi'] + dangling.split())
 
     if err:
         print >>sys.stderr, 'RemoveImages failed'


### PR DESCRIPTION
Docker prints each dangling image with a trailing newline, which made us
attempt to delete the '' image, causing:

Error response from daemon: image name cannot be blank
Error: failed to remove images: []

Or, in Python:

    >>> '415c146af238\n'.split('\n')
    ['415c146af238', '']
    >>> '415c146af238\n'.split()
    ['415c146af238']