### PR TITLE
Moving graph/poll invocation to the deployment file

### DIFF
--- a/queue-health/graph/Dockerfile
+++ b/queue-health/graph/Dockerfile
@@ -19,13 +19,10 @@ MAINTAINER Erick Fejta <fejta@google.com>
 RUN apt-get update \
     && apt-get install -y \
          python-matplotlib
-# Install grapher and set default variables
-ENV GRAPH='gs://kubernetes-test-history/sq-test/k8s-queue-health.svg' \
-    HISTORY='gs://kubernetes-test-history/sq-test/history.txt' \
-    SERVICE=
+
+# Install grapher
 COPY graph.py /
 
 # When not running inside GCE ensure you copy over credentials:
 # cp ~/.boto /tmp/foo/ && chmod 644 /tmp/foo/.boto
 # docker run -v /tmp/foo:/boto -e BOTO_CONFIG=/boto/.boto derived-image
-CMD python /graph.py "${HISTORY}" "${GRAPH}" "${SERVICE}"

--- a/queue-health/graph/graph.py
+++ b/queue-health/graph/graph.py
@@ -33,6 +33,8 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy
 
+from pprint import pprint
+
 def parse_line(
         date, time, online, pr, queue,
         run, blocked, merge_count=0):  # merge_count may be missing
@@ -350,4 +352,7 @@ def render_forever(history_uri, img_uri, service_account=None):
 
 
 if __name__ == '__main__':
+    # log all arguments.
+    pprint(sys.argv)
+
     render_forever(*sys.argv[1:])

--- a/queue-health/graph/graph.py
+++ b/queue-health/graph/graph.py
@@ -21,6 +21,7 @@ import cStringIO
 import datetime
 import gzip
 import os
+import pprint
 import subprocess
 import sys
 import time
@@ -32,8 +33,6 @@ import matplotlib.dates as mdates
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy
-
-from pprint import pprint
 
 def parse_line(
         date, time, online, pr, queue,
@@ -353,6 +352,7 @@ def render_forever(history_uri, img_uri, service_account=None):
 
 if __name__ == '__main__':
     # log all arguments.
-    pprint(sys.argv)
+    pp = pprint.PrettyPrinter(stream=sys.stderr)
+    pp.pprint(sys.argv)
 
     render_forever(*sys.argv[1:])

--- a/queue-health/poll/Dockerfile
+++ b/queue-health/poll/Dockerfile
@@ -16,11 +16,8 @@ FROM gcr.io/google-containers/queue-health-base:v20160627
 MAINTAINER Erick Fejta <fejta@google.com>
 
 # Install poller and set default variables
-ENV HISTORY='gs://kubernetes-test-history/sq-test/history.txt' \
-    SERVICE=
 COPY poller.py /
 
 # When not running inside GCE ensure you copy over credentials:
 # cp ~/.boto /tmp/foo/ && chmod 644 /tmp/foo/.boto
 # docker run -v /tmp/foo:/boto -e BOTO_CONFIG=/boto/.boto derived-image
-CMD python /poller.py "${HISTORY}" "${SERVICE}"

--- a/queue-health/poll/poller.py
+++ b/queue-health/poll/poller.py
@@ -22,7 +22,7 @@ import time
 import traceback
 
 import requests
-
+from pprint import pprint
 
 def get_submit_queue_json(path):
     for n in range(3):
@@ -118,4 +118,7 @@ def poll_forever(uri, service_account=None):
 
 
 if __name__ == '__main__':
+    # log all arguments.
+    pprint(sys.argv)
+
     poll_forever(*sys.argv[1:])

--- a/queue-health/poll/poller.py
+++ b/queue-health/poll/poller.py
@@ -16,13 +16,13 @@
 
 import cStringIO
 import datetime
+import pprint
 import subprocess
 import sys
 import time
 import traceback
 
 import requests
-from pprint import pprint
 
 def get_submit_queue_json(path):
     for n in range(3):
@@ -119,6 +119,7 @@ def poll_forever(uri, service_account=None):
 
 if __name__ == '__main__':
     # log all arguments.
-    pprint(sys.argv)
+    pp = pprint.PrettyPrinter(stream=sys.stderr)
+    pp.pprint(sys.argv)
 
     poll_forever(*sys.argv[1:])

--- a/queue-health/queue-health-graph-dev.yaml
+++ b/queue-health/queue-health-graph-dev.yaml
@@ -12,13 +12,12 @@ spec:
       containers:
       - name: grapher
         image: gcr.io/google-containers/queue-health-graph
-        env:
-        - name: GRAPH  # Test svg uri
-          value: "gs://kubernetes-test-history/sq-test/k8s-queue-health.svg"
-        - name: HISTORY  # prod history uri
-          value: "gs://kubernetes-test-history/sq/history.txt"
-        - name: SERVICE
-          value: '/creds/service-account.json'
+        command:
+        - python
+        - /graph.py
+        - "gs://kubernetes-test-history/sq/history.txt"
+        - "gs://kubernetes-test-history/sq-test/k8s-queue-health.svg"
+        - '/creds/service-account.json'
         volumeMounts:
         - name: service-account
           mountPath: /creds

--- a/queue-health/queue-health-graph-dev.yaml
+++ b/queue-health/queue-health-graph-dev.yaml
@@ -15,9 +15,9 @@ spec:
         command:
         - python
         - /graph.py
-        - "gs://kubernetes-test-history/sq/history.txt"
-        - "gs://kubernetes-test-history/sq-test/k8s-queue-health.svg"
-        - '/creds/service-account.json'
+        - gs://kubernetes-test-history/sq/history.txt
+        - gs://kubernetes-test-history/sq-test/k8s-queue-health.svg
+        - /creds/service-account.json
         volumeMounts:
         - name: service-account
           mountPath: /creds

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -12,24 +12,23 @@ spec:
       containers:
       - name: grapher
         image: gcr.io/google-containers/queue-health-graph:v20160725
-        env:
-        - name: GRAPH
-          value: "gs://kubernetes-test-history/k8s-queue-health.svg"
-        - name: HISTORY
-          value: "gs://kubernetes-test-history/sq/history.txt"
-        - name: SERVICE
-          value: '/creds/service-account.json'
+        command:
+        - python
+        - /graph.py
+        - "gs://kubernetes-test-history/sq/history.txt"
+        - "gs://kubernetes-test-history/k8s-queue-health.svg"
+        - '/creds/service-account.json'
         volumeMounts:
         - name: service-account
           mountPath: /creds
           readOnly: true
       - name: poller
         image: gcr.io/google-containers/queue-health-poll:v20160725
-        env:
-        - name: HISTORY
-          value: "gs://kubernetes-test-history/sq/history.txt"
-        - name: SERVICE
-          value: '/creds/service-account.json'
+        command:
+        - python
+        - /poller.py
+        - "gs://kubernetes-test-history/sq/history.txt"
+        - '/creds/service-account.json'
         volumeMounts:
         - name: service-account
           mountPath: /creds

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -15,9 +15,9 @@ spec:
         command:
         - python
         - /graph.py
-        - "gs://kubernetes-test-history/sq/history.txt"
-        - "gs://kubernetes-test-history/k8s-queue-health.svg"
-        - '/creds/service-account.json'
+        - gs://kubernetes-test-history/sq/history.txt
+        - gs://kubernetes-test-history/k8s-queue-health.svg
+        - /creds/service-account.json
         volumeMounts:
         - name: service-account
           mountPath: /creds
@@ -27,8 +27,8 @@ spec:
         command:
         - python
         - /poller.py
-        - "gs://kubernetes-test-history/sq/history.txt"
-        - '/creds/service-account.json'
+        - gs://kubernetes-test-history/sq/history.txt
+        - /creds/service-account.json
         volumeMounts:
         - name: service-account
           mountPath: /creds

--- a/queue-health/queue-health.yaml
+++ b/queue-health/queue-health.yaml
@@ -12,18 +12,23 @@ spec:
       containers:
       - name: grapher
         image: gcr.io/google-containers/queue-health-graph
-        env:
-        - name: SERVICE
-          value: '/creds/service-account.json'
+        command:
+        - python
+        - /graph.py
+        - "gs://kubernetes-test-history/sq-test/history.txt"
+        - "gs://kubernetes-test-history/sq-test/k8s-queue-health.svg"
+        - '/creds/service-account.json'
         volumeMounts:
         - name: service-account
           mountPath: /creds
           readOnly: true
       - name: poller
         image: gcr.io/google-containers/queue-health-poll
-        env:
-        - name: SERVICE
-          value: '/creds/service-account.json'
+        command:
+        - python
+        - /poller.py
+        - "gs://kubernetes-test-history/sq-test/history.txt"
+        - '/creds/service-account.json'
         volumeMounts:
         - name: service-account
           mountPath: /creds

--- a/queue-health/queue-health.yaml
+++ b/queue-health/queue-health.yaml
@@ -15,9 +15,9 @@ spec:
         command:
         - python
         - /graph.py
-        - "gs://kubernetes-test-history/sq-test/history.txt"
-        - "gs://kubernetes-test-history/sq-test/k8s-queue-health.svg"
-        - '/creds/service-account.json'
+        - gs://kubernetes-test-history/sq-test/history.txt
+        - gs://kubernetes-test-history/sq-test/k8s-queue-health.svg
+        - /creds/service-account.json
         volumeMounts:
         - name: service-account
           mountPath: /creds
@@ -27,8 +27,8 @@ spec:
         command:
         - python
         - /poller.py
-        - "gs://kubernetes-test-history/sq-test/history.txt"
-        - '/creds/service-account.json'
+        - gs://kubernetes-test-history/sq-test/history.txt
+        - /creds/service-account.json
         volumeMounts:
         - name: service-account
           mountPath: /creds


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/issues/306
The first step towards parameterizing history and graph generation by submit-queue.
Moving the execution logic to within the deployment file as opposed to the docker containers.

This should let us easily add a command-line option to specify which submit-queue we query, when we run one deployment per submit-queue instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/390)
<!-- Reviewable:end -->
