### PR TITLE
run scalability tests with GC

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -78,6 +78,7 @@
             description: 'Run [Serial], [Disruptive], tests on GCE.'
             timeout: 300
             job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="kubernetes-jkns-e2e-gce-serial"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -77,6 +77,7 @@
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
             job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -43,19 +43,19 @@
 - project:
     name: kubernetes-garbage-collector
     suffix:
-        - '100-gce':  # kubernetes-garbagecollector-100-gce
-            description: 'Run the garbage collector with high workload'
+        - 'feature':  # kubernetes-garbagecollector-feature
+            description: 'Run the garbage collector specific tests'
             timeout: 600
             cron-string: 'H H/6 * * *'
             job-env: |
                 # Start the gc in controller plane
                 export ENABLE_GARBAGE_COLLECTOR="true"
-                export E2E_NAME="garbagecollector-100"
+                export E2E_NAME="garbagecollector-feature"
                 export PROJECT="k8s-jenkins-garbagecollector"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"
                 export KUBEMARK_TESTS="\[Feature:GarbageCollector\]"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
                 export CREATE_SERVICES="true"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # Override defaults to be independent from GCE defaults and set kubemark parameters

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -48,12 +48,13 @@
             timeout: 60
             cron-string: '{sq-cron-string}'
             job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
                 export E2E_NAME="kubemark-5"
                 export PROJECT="k8s-jenkins-kubemark"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"
                 export KUBEMARK_TESTS="starting\s30\spods\sper\snode"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # Override defaults to be independent from GCE defaults and set kubemark parameters
                 export NUM_NODES="1"
@@ -71,12 +72,13 @@
             timeout: 240
             cron-string: 'H H/6 * * *'
             job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
                 export E2E_NAME="kubemark-100"
                 export PROJECT="k8s-jenkins-kubemark"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"
                 export KUBEMARK_TESTS="\[Feature:Performance\]"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
                 export CREATE_SERVICES="true"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # Override defaults to be independent from GCE defaults and set kubemark parameters
@@ -93,12 +95,13 @@
             timeout: 160
             cron-string: 'H 20 * * 6'
             job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
                 export E2E_NAME="kubemark-100pods"
                 export PROJECT="k8s-jenkins-kubemark"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"
                 export KUBEMARK_TESTS="\[Feature:HighDensityPerformance\]"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # Override defaults to be independent from GCE defaults and set kubemark parameters
                 export NUM_NODES="3"
@@ -114,12 +117,13 @@
             timeout: 300
             cron-string: '{sq-cron-string}'
             job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
                 export E2E_NAME="kubemark-500"
                 export PROJECT="k8s-jenkins-blocking-kubemark"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"
                 export KUBEMARK_TESTS="\[Feature:Performance\]"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
                 # Increase throughput in Kubemark master components.
                 export KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS="--kube-api-qps=100 --kube-api-burst=100"
                 # Increase throughput in Load test.
@@ -140,13 +144,14 @@
             timeout: 720
             cron-string: 'H H/12 * * *'
             job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
                 # XXX Not a unique project
                 export E2E_NAME="kubemark-2000"
                 export PROJECT="kubernetes-scale"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"
                 export KUBEMARK_TESTS="\[Feature:Performance\]"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --kube-api-content-type=application/vnd.kubernetes.protobuf"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true --kube-api-content-type=application/vnd.kubernetes.protobuf"
                 # Increase throughput in Kubemark master components.
                 export KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS="--kube-api-qps=100 --kube-api-burst=100"
                 # Increase throughput in Load test.


### PR DESCRIPTION
Add back #369, since  kubernetes/kubernetes#30401 is merged now.

This change is needed even if we turned on GC by default, because changes in this PR tell the scalability e2e tests to rely on GC.

@lavalamp @ixdy could you help merge this one? Thanks.