### PR TITLE
Revert "AWS: re-enable NPD"

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -64,9 +64,10 @@
             cron-string: '{sq-cron-string}'
             trigger-job: 'kubernetes-build'
             # See https://github.com/kubernetes/kubernetes/issues/30312 for why HPA is disabled.
+            # See https://github.com/kubernetes/node-problem-detector/issues/28 for why NPD is disabled.
             job-env: |
                 export E2E_NAME="e2e-aws-master"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-aws"
         - 'aws-release-1.3':  # kubernetes-e2e-aws-release-1.3


### PR DESCRIPTION
Reverts kubernetes/test-infra#392

See https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-e2e-aws/891 through
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-e2e-aws/900

cc @Random-Liu @justinsb 

will diagnose later. Disabling again for now.