### PR TITLE
Fix spacing around skipped lines again

### DIFF
--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -59,7 +59,7 @@ def log_html(lines, matched_lines, hilight_words, skip_fmt):
             skip_string = ('<span class="skip">'
                 '<a href="javascript:show_skipped(\'%s\')" onclick="this.style.display=\'none\'">'
                 '%s</a></span>'
-                '<span class="skipped" id=%s style="display:none;">') % (skip_id,
+                '<span class="skipped" id="%s" style="display:none;">') % (skip_id,
                 skip_fmt(skip_amount), skip_id)
             lines[previous_end] = "%s%s" % (skip_string, lines[previous_end])
             output.extend(lines[previous_end:match-CONTEXT])

--- a/gubernator/static/build.js
+++ b/gubernator/static/build.js
@@ -44,6 +44,6 @@ function fix_timestamps() {
 }
 
 function show_skipped(ID) {
-	document.getElementById(ID).style.display = "block"; 
+	document.getElementById(ID).style.display = "inline-block"; 
 }
 


### PR DESCRIPTION
Seems that this line was changed at some point, which caused the empty line after the expanded skipped lines to show up again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/411)
<!-- Reviewable:end -->
