### PR TITLE
Fix gc-feature test

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -50,7 +50,7 @@
             job-env: |
                 # Start the gc in controller plane
                 export ENABLE_GARBAGE_COLLECTOR="true"
-                export E2E_NAME="garbagecollector-feature"
+                export E2E_NAME="gc-feature"
                 export PROJECT="k8s-jenkins-garbagecollector"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -52,20 +52,6 @@
                 export ENABLE_GARBAGE_COLLECTOR="true"
                 export E2E_NAME="gc-feature"
                 export PROJECT="k8s-jenkins-garbagecollector"
-                export E2E_TEST="false"
-                export USE_KUBEMARK="true"
-                export KUBEMARK_TESTS="\[Feature:GarbageCollector\]"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
-                export CREATE_SERVICES="true"
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                # Override defaults to be independent from GCE defaults and set kubemark parameters
-                export NUM_NODES="3"
-                export MASTER_SIZE="n1-standard-2"
-                export NODE_SIZE="n1-standard-4"
-                export KUBE_GCE_ZONE="us-central1-f"
-                export KUBEMARK_MASTER_SIZE="n1-standard-4"
-                export KUBEMARK_NUM_NODES="100"
-                # The kubemark scripts build a Docker image
-                export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:GarbageCollector\]"
     jobs:
         - 'kubernetes-garbagecollector-{suffix}'


### PR DESCRIPTION
1. shorten E2E_NAME to fix the GCE cannot create firewall bug
2. stop using kubemark in this gc-feature tests, as the tests don't check scalability.
@ixdy @lavalamp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/412)
<!-- Reviewable:end -->
