### PR TITLE
Switch back to n1-standard-8s for PR Jenkins.

### DIFF
--- a/jenkins/agent-ctl.sh
+++ b/jenkins/agent-ctl.sh
@@ -139,7 +139,7 @@ case "${KIND}" in
     # load 10-30, 10G ram
     DISK_SIZE='200GB'
     DISK_TYPE='pd-standard'
-    MACHINE_TYPE='n1-highcpu-16'
+    MACHINE_TYPE='n1-standard-8'
     ;;
   *)
     ;;


### PR DESCRIPTION
It was a failed experiment. `n1-highcpu-16`s were slower to build and test and also had strange issues such as https://github.com/kubernetes/kubernetes/issues/30407.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/416)
<!-- Reviewable:end -->
