### PR TITLE
Make existing e2e tests to use container-vm explicitly

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -327,7 +327,6 @@
             export KUBE_RUN_FROM_OUTPUT=y
             export KUBE_FASTBUILD=true
             export KUBE_GCS_UPDATE_LATEST=n
-
             ./hack/jenkins/build.sh
 
             version=$(source build/util.sh && echo $(kube::release::semantic_version))
@@ -360,6 +359,8 @@
             export E2E_DOWN="true"
             export E2E_OPT="--check_version_skew=false"
 
+            # Force to use container-vm.
+            export KUBE_NODE_OS_DISTRIBUTION="debian"
             # Skip gcloud update checking
             export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 
@@ -446,6 +447,8 @@
               # NUM_NODES should match kubernetes-e2e-gce.
               export NUM_NODES="3"
 
+              # Force to use container-vm.
+              export KUBE_NODE_OS_DISTRIBUTION="debian"
               # Assume we're upping, testing, and downing a cluster
               export E2E_UP="true"
               export E2E_TEST="true"
@@ -517,6 +520,8 @@
             export FAIL_ON_GCP_RESOURCE_LEAK="false"
             export NUM_NODES="3"
 
+            # Force to use container-vm.
+            export KUBE_NODE_OS_DISTRIBUTION="debian"
             # Assume we're upping, testing, and downing a cluster
             export E2E_UP="true"
             export E2E_TEST="true"
@@ -593,6 +598,8 @@
             export KUBE_GCE_NETWORK=${{E2E_NAME}}
             export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
 
+            # Force to use container-vm.
+            export KUBE_NODE_OS_DISTRIBUTION="debian"
             # Skip gcloud update checking
             export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -63,6 +63,7 @@
                 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-e2e-gce"
         - 'gce-slow':  # kubernetes-e2e-gce-slow
             cron-string: '{sq-cron-string}'
@@ -73,6 +74,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export KUBE_GCE_ZONE="europe-west1-c"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-e2e-gce-slow"
         - 'gce-serial':  # kubernetes-e2e-gce-serial
             description: 'Run [Serial], [Disruptive], tests on GCE.'
@@ -87,6 +89,7 @@
             timeout: 180
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-e2e-gce-ci-reboot"
         - 'gce-autoscaling':  # kubernetes-e2e-gce-autoscaling
             description: 'Run autoscaling E2E tests on GCE.'
@@ -102,6 +105,7 @@
                 export KUBE_AUTOSCALER_MIN_NODES=3
                 export KUBE_AUTOSCALER_MAX_NODES=5
                 export KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
         - 'gce-autoscaling-migs':  # kubernetes-e2e-gce-autoscaling-migs
             description: 'Run autoscaling E2E tests on GCE with multiple MIGs.'
@@ -116,6 +120,7 @@
                 export KUBE_AUTOSCALER_MIN_NODES=3
                 export KUBE_AUTOSCALER_MAX_NODES=5
                 export KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
         - 'gce-flaky':  # kubernetes-e2e-gce-flaky
             description: 'Run the flaky tests on GCE, sequentially.'
@@ -124,6 +129,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
                                          --ginkgo.skip=\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-flaky"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-scalability':  # kubernetes-e2e-gce-scalability
             description: 'Run the performance/scalability tests on GCE. A larger cluster is used.'
             timeout: 120
@@ -151,6 +157,7 @@
                 export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
                 # Increase delete collection parallelism
                 export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-container-vm':  # kubernetes-e2e-gce-container-vm
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on a new ContainerVM image.'
@@ -161,6 +168,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jenkins-cvm"
                 export KUBE_GCE_NODE_IMAGE="container-v1-3-v20160604"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-master-on-cvm':  # kubernetes-e2e-gce-master-on-cvm
             cron-string: 'H * * * *' # run once an hour
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with the master on a ContainerVM image.'
@@ -174,6 +182,7 @@
                 export KUBE_MASTER_OS_DISTRIBUTION="debian"
                 export KUBE_GCE_MASTER_IMAGE="container-v1-3-v20160604"
                 export KUBE_GCE_NODE_IMAGE="container-v1-3-v20160604"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-etcd3':  # kubernetes-e2e-gce-etcd3
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with etcd3 underneath.'
@@ -188,6 +197,7 @@
                 export PROJECT="k8s-jkns-e2e-etcd3"
                 # Use etcd3 as storage backend.
                 export STORAGE_BACKEND="etcd3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-proto':  # kubernetes-e2e-gce-proto
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with protobuf communication.'
@@ -202,12 +212,14 @@
                 export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
                 # Use protobufs to communicate with apiserver.
                 export TEST_CLUSTER_API_CONTENT_TYPE="--kube-api-content-type=application/vnd.kubernetes.protobuf"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-examples':  # kubernetes-e2e-gce-examples
             description: 'Run E2E examples test on GCE.'
             timeout: 90
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Example\]"
                 export PROJECT="k8s-jkns-e2e-examples"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-multizone':  # kubernetes-e2e-gce-multizone
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GCE, in parallel, and in a multi-zone cluster.'
             timeout: 150
@@ -220,6 +232,7 @@
                 export MULTIZONE="true"
                 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the nodes reside.  Master is in the first one.
                 export KUBE_GCE_ZONE="us-central1-a" # Where the master resides - hangover due to legacy scripts.
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-federation':  # kubernetes-e2e-gce-federation
             trigger-job: 'kubernetes-federation-build'
             description: 'Run all federation e2e tests.'
@@ -238,6 +251,7 @@
                 export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
                 export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
                 export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-kubenet':  # kubernetes-e2e-gce-kubenet
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GCE using kubenet as network provider'
             timeout: 120
@@ -248,6 +262,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export NETWORK_PROVIDER="kubenet"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -264,6 +279,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-reboot-release-1.2':  # kubernetes-e2e-gce-reboot-release-1.2
             description: 'Run [Feature:Reboot] tests on GCE on the release-1.2 branch.'
             timeout: 180
@@ -271,6 +287,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-e2e-gce-reboot-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-slow-release-1.2':  # kubernetes-e2e-gce-slow-release-1.2
             description: 'Runs slow tests on GCE, sequentially on the release-1.2 branch.'
             timeout: 150  #  See #24072
@@ -280,6 +297,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gce-slow-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-serial-release-1.2':  # kubernetes-e2e-gce-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.2 branch.'
             timeout: 300
@@ -288,6 +306,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -304,6 +323,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-gce-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-reboot-release-1.3':  # kubernetes-e2e-gce-reboot-release-1.3
             description: 'Run [Feature:Reboot] tests on GCE on the release-1.3 branch.'
             timeout: 180
@@ -311,6 +331,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-gce-reboot-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-slow-release-1.3':  # kubernetes-e2e-gce-slow-release-1.3
             description: 'Runs slow tests on GCE, sequentially on the release-1.3 branch.'
             timeout: 150  #  See #24072
@@ -320,6 +341,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-gce-slow-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-serial-release-1.3':  # kubernetes-e2e-gce-serial-release-1.3
             description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.3 branch.'
             timeout: 300
@@ -328,6 +350,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-gce-serial-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-ingress-release-1.2':  # kubernetes-e2e-gce-ingress-release-1.2
             description: 'Run [Feature:Ingress] tests on GCE on the release-1.2 branch.'
             timeout: 90
@@ -337,6 +360,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-ingress-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-ingress-release-1.3':  # kubernetes-e2e-gce-ingress-release-1.3
             description: 'Run [Feature:Ingress] tests on GCE on the release-1.3 branch.'
             timeout: 90
@@ -346,6 +370,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="kubernetes-ingress-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-scalability-release-1.3':  # kubernetes-e2e-gce-scalability-release-1.3
             timeout: 120
             description: 'Run scalability E2E tests on GCE from the release-1.3 branch.'
@@ -378,6 +403,7 @@
                 export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
                 # Increase delete collection parallelism
                 export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -395,6 +421,7 @@
                 export PROJECT="kubernetes-ingress"
                 # TODO: Enable this when we've split 1.2 tests into another project.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-flannel':  # kubernetes-e2e-gce-flannel
             description: 'Run E2E tests on GCE using Flannel and the latest successful build. This suite is quarantined in a dedicated project because Flannel integration is experimental.'
             disable_job: true  # Issue #24520
@@ -410,6 +437,7 @@
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # Override GCE defaults.
                 export NETWORK_PROVIDER="flannel"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-es-logging':  # kubernetes-e2e-gce-es-logging
             description: 'Run [Feature:Elasticsearch] tests on GCE using the latest successful build.'
             timeout: 90
@@ -419,6 +447,7 @@
                 export PROJECT="kubernetes-es-logging"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Elasticsearch\]"
                 export KUBE_LOGGING_DESTINATION="elasticsearch"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-petset':  # kubernetes-e2e-gce-petset
             description: 'Run [Feature:PetSet] tests on GCE.'
             timeout: 90
@@ -428,6 +457,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:PetSet\]"
                 export PROJECT="kubernetes-petset"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"  # TODO: Enable once we've fixed #23032
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -468,5 +498,6 @@
         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
         # Increase delete collection parallelism
         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+        export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -63,6 +63,7 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-slow':  # kubernetes-e2e-gke-slow
             cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
@@ -73,6 +74,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gke-slow"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-serial':  # kubernetes-e2e-gke-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
@@ -82,6 +84,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-e2e-serial"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-updown':  # kubernetes-e2e-gke-updown
             cron-string: '{sq-cron-string}'
             description: 'Brings a cluster up, checks networking, brings it down (against GKE test endpoint)'
@@ -91,6 +94,7 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]"
                 export PROJECT="kubernetes-e2e-gke-updown"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-reboot':  # kubernetes-e2e-gke-reboot
             description: 'Run [Feature:Reboot] tests on GKE using the latest successful build.'
             timeout: 180
@@ -98,6 +102,7 @@
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci-reboot"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-flaky':  # kubernetes-e2e-gke-flaky
             description: |
                 Run flaky e2e tests using the following config:<br>
@@ -113,6 +118,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
                                          --ginkgo.skip=\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci-flaky"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-multizone':  # kubernetes-e2e-gke-multizone
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel, and in a multi-zone cluster.'
             timeout: 150
@@ -123,6 +129,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-multizone"
                 export ZONE="us-central1-f"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-autoscaling':  # kubernetes-e2e-gke-autoscaling
             description: 'Run all cluster autoscaler tests on GKE.'
             timeout: 300
@@ -132,6 +139,7 @@
                                          --ginkgo.skip=\[Flaky\]"
                 export NUM_NODES=3
                 export PROJECT="k8s-e2e-gke-autoscaling"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-large-cluster':  # kubernetes-e2e-gke-large-cluster
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel on a large GKE cluster'
             timeout: 450
@@ -159,6 +167,7 @@
                 export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -175,6 +184,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-serial-release-1.3':  # kubernetes-e2e-gke-serial-release-1.3
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.3 branch.'
             timeout: 300
@@ -183,6 +193,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-serial-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-slow-release-1.3':  # kubernetes-e2e-gke-slow-release-1.3
             description: 'Run slow E2E tests on GKE using the release-1.3 branch.'
             timeout: 150  #  See #24072
@@ -192,6 +203,7 @@
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-slow-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-reboot-release-1.3':  # kubernetes-e2e-gke-reboot-release-1.3
             description: 'Run [Feature:Reboot] tests on GKE on the release-1.3 branch.'
             timeout: 180
@@ -199,6 +211,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-reboot-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-ingress-release-1.2':  # kubernetes-e2e-gke-ingress-release-1.2
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.2 branch.'
             timeout: 90
@@ -208,6 +221,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="kubernetes-gke-ingress-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-ingress-release-1.3':  # kubernetes-e2e-gke-ingress-release-1.3
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.3 branch.'
             timeout: 90
@@ -217,6 +231,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="kubernetes-gke-ingress-1-3"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
 
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
@@ -234,6 +249,7 @@
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-serial-release-1.2':  # kubernetes-e2e-gke-serial-release-1.2
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.2 branch.'
             timeout: 300
@@ -242,6 +258,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-serial-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-slow-release-1.2':  # kubernetes-e2e-gke-slow-release-1.2
             description: 'Run slow E2E tests on GKE using the release-1.2 branch.'
             timeout: 150  #  See #24072
@@ -251,6 +268,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-slow-1-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -266,6 +284,7 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_PUBLISHED_VERSION="release/latest"
                 export PROJECT="k8s-jkns-e2e-gke-prerel"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-test':  # kubernetes-e2e-gke-test
             description: 'Run E2E tests on GKE test endpoint.'
             timeout: 480
@@ -274,6 +293,7 @@
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-test"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-subnet':  # kubernetes-e2e-gke-subnet
             description: 'Run E2E tests on GKE test endpoint in a subnet.'
             timeout: 480
@@ -285,6 +305,7 @@
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-subnet"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-staging':  # kubernetes-e2e-gke-staging
             description: 'Run E2E tests on GKE staging endpoint.'
             timeout: 480
@@ -294,6 +315,7 @@
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-staging"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-staging-parallel':  # kubernetes-e2e-gke-staging-parallel
             description: 'Run E2E tests on GKE staging endpoint in parallel.'
             timeout: 80
@@ -305,6 +327,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-e2e-gke-staging-parallel"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-prod':  # kubernetes-e2e-gke-prod
             description: 'Run E2E tests on GKE prod endpoint.'
             timeout: 480
@@ -315,6 +338,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-prod"
                 export ZONE="us-central1-b"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-prod-parallel':  # kubernetes-e2e-gke-prod-parallel
             description: 'Run E2E tests on GKE prod endpoint in parallel.'
             timeout: 80
@@ -327,6 +351,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-e2e-gke-prod-parallel"
                 export ZONE="us-central1-b"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-prod-smoke':  # kubernetes-e2e-gke-prod-smoke
             description: 'Run smoke tests on GKE prod day 1 zone (asia-east1-b).'
             timeout: 80
@@ -339,6 +364,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-e2e-gke-prod-smoke"
                 export ZONE="asia-east1-b"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -356,6 +382,7 @@
                 export PROJECT="kubernetes-gke-ingress"
                 # TODO: Enable this when we've split 1.2 tests into another project.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -380,6 +407,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_OS_DISTRIBUTION="trusty"
                 export PROJECT="kubekins-e2e-gke-trusty-test"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-trusty-subnet':  # kubernetes-e2e-gke-trusty-subnet
             description: 'Run E2E tests on GKE test endpoint in a subnet.'
             timeout: 480
@@ -393,6 +421,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_OS_DISTRIBUTION="trusty"
                 export PROJECT="k8s-e2e-gke-trusty-subnet"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-trusty-staging':  # kubernetes-e2e-gke-trusty-staging
             description: 'Run E2E tests on GKE staging endpoint.'
             timeout: 480
@@ -404,6 +433,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_OS_DISTRIBUTION="trusty"
                 export PROJECT="e2e-gke-trusty-staging"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-trusty-staging-parallel':  # kubernetes-e2e-gke-trusty-staging-parallel
             description: 'Run E2E tests on GKE staging endpoint in parallel.'
             timeout: 80
@@ -417,6 +447,7 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_OS_DISTRIBUTION="trusty"
                 export PROJECT="e2e-gke-trusty-staging-p"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-trusty-prod':  # kubernetes-e2e-gke-trusty-prod
             # Failing constantly due to a known issue (tracked internally).
             disable_job: true
@@ -431,6 +462,7 @@
                 export KUBE_GCE_ZONE="asia-east1-b"
                 export KUBE_OS_DISTRIBUTION="trusty"
                 export PROJECT="kubekins-e2e-gke-trusty-prod"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-trusty-prod-parallel':  # kubernetes-e2e-gke-trusty-prod-parallel
             # Failing constantly due to a known issue (tracked internally).
             disable_job: true
@@ -447,6 +479,7 @@
                 export KUBE_GCE_ZONE="asia-east1-b"
                 export KUBE_OS_DISTRIBUTION="trusty"
                 export PROJECT="e2e-gke-trusty-prod-p"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -466,6 +499,7 @@
                 export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gke-upg-{version-infix}-upg-mas"
                 # Set legacy skip list, only when testing old version
                 # TODO remove when we no longer care about v1.1
@@ -481,6 +515,7 @@
                 export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gke-upg-{version-infix}-upg-clu"
                 # Set legacy skip list, only when testing old version
                 # TODO remove when we no longer care about v1.1
@@ -497,6 +532,7 @@
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
                 export JENKINS_USE_SKEW_TESTS="true"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gke-upg-{version-infix}-upg-clu-n"
                 {version-env}
 
@@ -584,6 +620,7 @@
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-client}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-cluster}"
                 export PROJECT="kube-gke-upg-{version-infix}-ctl-skew"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
 
 - project:
     name: 'kubernetes-e2e-kubectl-skew-gke'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -53,5 +53,6 @@
                 export E2E_NAME="gc-feature"
                 export PROJECT="k8s-jenkins-garbagecollector"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:GarbageCollector\]"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-garbagecollector-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -67,6 +67,7 @@
                 export KUBEMARK_NUM_NODES="5"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - '100-gce':
             description: 'Run small-ish kubemark cluster to continuously run performance experiments'
             timeout: 240
@@ -90,6 +91,7 @@
                 export KUBEMARK_NUM_NODES="100"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'high-density-100-gce':
             description: 'Run Kubemark high-density (100 pods/node) test on a fake 100 node cluster.'
             timeout: 160
@@ -112,6 +114,7 @@
                 export KUBEMARK_NUM_NODES="100"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - '500-gce':
             description: 'Run Kubemark test on a fake 500 node cluster to test for regressions on bigger clusters'
             timeout: 300
@@ -138,6 +141,7 @@
                 export KUBEMARK_NUM_NODES="500"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-scale':
             description: 'Run Density test on Kubemark in very large cluster. Currently only scheduled to run every 12 hours so as not to waste too many resources.'
             # 12h - load tests take really, really, really long time.
@@ -173,5 +177,6 @@
                 # export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-kubemark-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -118,6 +118,7 @@
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-2':
             deploy-description: Clone of kubernetes-soak-weekly-deploy-gce.
             e2e-description: Clone of kubernetes-soak-continuous-e2e-gce.
@@ -131,6 +132,7 @@
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-1.3':
             deploy-description: |
                 Deploy Kubernetes to soak cluster using the latest successful
@@ -149,6 +151,7 @@
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-3"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
@@ -173,6 +176,7 @@
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke':
             deploy-description: |
                 Deploy Kubernetes to a GKE soak cluster using the staging GKE
@@ -200,6 +204,7 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
             job-env: |
                 export PROJECT="k8s-jkns-gke-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests


### PR DESCRIPTION
This is required to prepare for the switch to gci as default.
For https://github.com/kubernetes/kubernetes/issues/25276

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/417)
<!-- Reviewable:end -->
