### PR TITLE
Map in output directory when KUBE_RUN_FROM_OUTPUT is set

### DIFF
--- a/jenkins/credentials.md
+++ b/jenkins/credentials.md
@@ -59,7 +59,7 @@ In order to configure a service please do the following:
       - credentials-binding:
         - file:
             credential-id: 'my-id'  # This is what you selected previously
-            value: 'MY_VARIABLE'  # We are using KUBEKINS_SERVICE_ACCOUNT_FILE
+            value: 'MY_VARIABLE'  # We are using GOOGLE_APPLICATION_CREDENTIALS
     ```
 2. Add the wrapper to a job
   - Find the `job`/`project`/`job-template` of interest ([example job])

--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -29,10 +29,16 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
+KUBEKINS_E2E_IMAGE_TAG='v20160817'
+KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
+if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
+  KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")
+fi
+
 env \
+  -u GOOGLE_APPLICATION_CREDENTIALS \
   -u GOROOT \
   -u HOME \
-  -u KUBEKINS_SERVICE_ACCOUNT_FILE \
   -u PATH \
   -u PWD \
   -u WORKSPACE \
@@ -48,6 +54,12 @@ if [[ "${JENKINS_ENABLE_DOCKER_IN_DOCKER:-}" =~ ^[yY]$ ]]; then
     )
 fi
 
+if [[ "${KUBE_RUN_FROM_OUTPUT:-}" =~ ^[yY]$ ]]; then
+    docker_extra_args+=(\
+      -v "${WORKSPACE}/_output":/workspace/_output:ro \
+    )
+fi
+
 echo "Starting..."
 docker run --rm=true -i \
   -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
@@ -57,10 +69,11 @@ docker run --rm=true -i \
   ${JENKINS_AWS_SSH_PRIVATE_KEY_FILE:+-v "${JENKINS_AWS_SSH_PRIVATE_KEY_FILE}:/workspace/.ssh/kube_aws_rsa:ro"} \
   ${JENKINS_AWS_SSH_PUBLIC_KEY_FILE:+-v "${JENKINS_AWS_SSH_PUBLIC_KEY_FILE}:/workspace/.ssh/kube_aws_rsa.pub:ro"} \
   ${JENKINS_AWS_CREDENTIALS_FILE:+-v "${JENKINS_AWS_CREDENTIALS_FILE}:/workspace/.aws/credentials:ro"} \
-  ${KUBEKINS_SERVICE_ACCOUNT_FILE:+-v "${KUBEKINS_SERVICE_ACCOUNT_FILE}:/service-account.json:ro"} \
+  ${GOOGLE_APPLICATION_CREDENTIALS:+-v "${GOOGLE_APPLICATION_CREDENTIALS}:/service-account.json:ro"} \
   --env-file "${WORKSPACE}/env.list" \
   -e "HOME=/workspace" \
   -e "WORKSPACE=/workspace" \
-  ${KUBEKINS_SERVICE_ACCOUNT_FILE:+-e "KUBEKINS_SERVICE_ACCOUNT_FILE=/service-account.json"} \
+  ${GOOGLE_APPLICATION_CREDENTIALS:+-e "GOOGLE_APPLICATION_CREDENTIALS=/service-account.json"} \
+  ${GOOGLE_APPLICATION_CREDENTIALS:+-e "KUBEKINS_SERVICE_ACCOUNT_FILE=/service-account.json"} \
   "${docker_extra_args[@]:+${docker_extra_args[@]}}" \
-  gcr.io/google-containers/kubekins-e2e:v20160817
+  "gcr.io/google-containers/kubekins-e2e:${KUBEKINS_E2E_IMAGE_TAG}"

--- a/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
@@ -4,7 +4,4 @@
         - credentials-binding:
             - file:
                 credential-id: 'gcp-service-account'
-                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'  # TODO(ixdy): remove after all scripts are using GOOGLE_APPLICATION_CREDENTIALS instead
-            - file:
-                credential-id: 'gcp-service-account'
                 variable: 'GOOGLE_APPLICATION_CREDENTIALS'

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -375,7 +375,7 @@
             export PATH=${{PATH}}:/usr/local/go/bin
 
             if [[ -e "./hack/jenkins/.use_dockerized_e2e" ]]; then
-              timeout -k 15m 55m ./hack/jenkins/dockerized-e2e-runner.sh && rc=$? || rc=$?
+              timeout -k 15m 55m {runner} && rc=$? || rc=$?
             else
               timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
             fi
@@ -466,7 +466,7 @@
               export PATH=${{PATH}}:/usr/local/go/bin
 
               if [[ -e "./hack/jenkins/.use_dockerized_e2e" ]]; then
-                timeout -k 15m 55m ./hack/jenkins/dockerized-e2e-runner.sh && rc=$? || rc=$?
+                timeout -k 15m 55m {runner} && rc=$? || rc=$?
               else
                 timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
               fi
@@ -540,7 +540,7 @@
 
 
             if [[ -e "./hack/jenkins/.use_dockerized_e2e" ]]; then
-              timeout -k 15m 55m ./hack/jenkins/dockerized-e2e-runner.sh && rc=$? || rc=$?
+              timeout -k 15m 55m {runner} && rc=$? || rc=$?
             else
               timeout -k 15m 55m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
             fi
@@ -607,7 +607,7 @@
             export PATH=${{PATH}}:/usr/local/go/bin
 
             if [[ -e "./hack/jenkins/.use_dockerized_e2e" ]]; then
-              timeout -k 15m 45m ./hack/jenkins/dockerized-e2e-runner.sh && rc=$? || rc=$?
+              timeout -k 15m 45m {runner} && rc=$? || rc=$?
             else
               timeout -k 15m 45m ./hack/jenkins/e2e-runner.sh && rc=$? || rc=$?
             fi

--- a/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/credentials.yaml
@@ -19,7 +19,4 @@
                 variable: 'JENKINS_AWS_CREDENTIALS_FILE'
             - file:
                 credential-id: 'gcp-service-account'
-                variable: 'KUBEKINS_SERVICE_ACCOUNT_FILE'  # TODO(ixdy): remove after all scripts are using GOOGLE_APPLICATION_CREDENTIALS instead
-            - file:
-                credential-id: 'gcp-service-account'
                 variable: 'GOOGLE_APPLICATION_CREDENTIALS'


### PR DESCRIPTION
Necessary to support dockerized e2e on PR Jenkins.

I'm additionally retiring `KUBEKINS_SERVICE_ACCOUNT_FILE` in favor of `GOOGLE_APPLICATION_CREDENTIALS`.

This should not be merged until https://github.com/kubernetes/kubernetes/issues/31035 is merged and a new image is pushed.

A step along the way for https://github.com/kubernetes/test-infra/issues/318.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/419)
<!-- Reviewable:end -->
