### PR TITLE
Run critical e2e tests using GCI in addition to container-vm

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -65,6 +65,16 @@
                 export GINKGO_PARALLEL="y"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-e2e-gce"
+        - 'gce-gci':  # kubernetes-e2e-gce-gci
+            cron-string: '{sq-cron-string}'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI in parallel.'
+            timeout: 50  # See #21138
+            job-env: |
+                # This list should match the list in kubernetes-pull-build-test-e2e-gce.
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export KUBE_OS_DISTRIBUTION="gci"
+                export PROJECT="k8s-jkns-e2e-gce-gci"
         - 'gce-slow':  # kubernetes-e2e-gce-slow
             cron-string: '{sq-cron-string}'
             description: 'Runs slow tests on GCE, sequentially.'
@@ -76,6 +86,17 @@
                 export KUBE_GCE_ZONE="europe-west1-c"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-e2e-gce-slow"
+        - 'gce-gci-slow':  # kubernetes-e2e-gce-gci-slow
+            cron-string: '{sq-cron-string}'
+            description: 'Runs slow tests on GCE, sequentially.'
+            timeout: 150  #  See #24072
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export KUBE_GCE_ZONE="europe-west1-c"
+                export KUBE_OS_DISTRIBUTION="gci"
+                export PROJECT="k8s-jkns-e2e-gce-gci-slow"
         - 'gce-serial':  # kubernetes-e2e-gce-serial
             description: 'Run [Serial], [Disruptive], tests on GCE.'
             timeout: 300
@@ -84,6 +105,16 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="kubernetes-jkns-e2e-gce-serial"
+                export KUBE_OS_DISTRIBUTION="gci"
+        - 'gce-gci-serial':  # kubernetes-e2e-gce-gci-serial
+            description: 'Run [Serial], [Disruptive], tests on GCE.'
+            timeout: 300
+            job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="k8s-jkns-e2e-gce-gci-serial"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-reboot':  # kubernetes-e2e-gce-reboot
             description: 'Run [Feature:Reboot] tests on GCE.'
             timeout: 180
@@ -158,6 +189,34 @@
                 # Increase delete collection parallelism
                 export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-gci-scalability':  # kubernetes-e2e-gce-gci-scalability
+            description: 'Run the performance/scalability tests on GCE. A larger cluster is used.'
+            timeout: 120
+            cron-string: 'H H/12 * * *'
+            job-env: |
+                export E2E_NAME="e2e-scalability"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+                                         --gather-resource-usage=true \
+                                         --gather-metrics-at-teardown=true \
+                                         --gather-logs-sizes=true \
+                                         --output-print-type=json"
+                # Create a project k8s-jenkins-scalability-head and move this test there
+                export PROJECT="k8s-jenkins-gci-scalability"
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                # Override GCE defaults.
+                export MASTER_SIZE="n1-standard-4"
+                export NODE_SIZE="n1-standard-2"
+                export NODE_DISK_SIZE="50GB"
+                export NUM_NODES="100"
+                export ALLOWED_NOTREADY_NODES="1"
+                export REGISTER_MASTER="true"
+                # Reduce logs verbosity
+                export TEST_CLUSTER_LOG_LEVEL="--v=2"
+                # Increase resync period to simulate production
+                export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+                # Increase delete collection parallelism
+                export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-container-vm':  # kubernetes-e2e-gce-container-vm
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on a new ContainerVM image.'
@@ -220,6 +279,13 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Example\]"
                 export PROJECT="k8s-jkns-e2e-examples"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-gci-examples':  # kubernetes-e2e-gce-gci-examples
+            description: 'Run E2E examples test on GCE.'
+            timeout: 90
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Example\]"
+                export PROJECT="k8s-jkns-e2e-gci-examples"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-multizone':  # kubernetes-e2e-gce-multizone
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GCE, in parallel, and in a multi-zone cluster.'
             timeout: 150
@@ -252,6 +318,25 @@
                 export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
                 export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-gci-federation':  # kubernetes-e2e-gce-gci-federation
+            trigger-job: 'kubernetes-federation-build'
+            description: 'Run all federation e2e tests.'
+            timeout: 300
+            emails: 'quinton@google.com, colin.hom@coreos.com, madhusudancs@google.com'
+            test-owner: 'quinton'
+            job-env: |
+                export PROJECT="k8s-jkns-e2e-gce-gci-federatio"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
+                export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
+                export FEDERATION="true"
+                export DNS_ZONE_NAME="k8s-federation.com."
+                export FEDERATIONS_DOMAIN_MAP="federation=k8s-federation.com"
+                export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
+                export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
+                export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-kubenet':  # kubernetes-e2e-gce-kubenet
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GCE using kubenet as network provider'
             timeout: 120

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -189,34 +189,35 @@
                 # Increase delete collection parallelism
                 export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-gci-scalability':  # kubernetes-e2e-gce-gci-scalability
-            description: 'Run the performance/scalability tests on GCE. A larger cluster is used.'
-            timeout: 120
-            cron-string: 'H H/12 * * *'
-            job-env: |
-                export E2E_NAME="e2e-scalability"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
-                                         --gather-resource-usage=true \
-                                         --gather-metrics-at-teardown=true \
-                                         --gather-logs-sizes=true \
-                                         --output-print-type=json"
-                # Create a project k8s-jenkins-scalability-head and move this test there
-                export PROJECT="k8s-jenkins-gci-scalability"
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                # Override GCE defaults.
-                export MASTER_SIZE="n1-standard-4"
-                export NODE_SIZE="n1-standard-2"
-                export NODE_DISK_SIZE="50GB"
-                export NUM_NODES="100"
-                export ALLOWED_NOTREADY_NODES="1"
-                export REGISTER_MASTER="true"
-                # Reduce logs verbosity
-                export TEST_CLUSTER_LOG_LEVEL="--v=2"
-                # Increase resync period to simulate production
-                export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
-                # Increase delete collection parallelism
-                export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
-                export KUBE_OS_DISTRIBUTION="gci"
+        # TODO(vishh): Enable this test once quota has been increased on the test project.
+        # - 'gce-gci-scalability':  # kubernetes-e2e-gce-gci-scalability
+        #     description: 'Run the performance/scalability tests on GCE. A larger cluster is used.'
+        #     timeout: 120
+        #     cron-string: 'H H/12 * * *'
+        #     job-env: |
+        #         export E2E_NAME="e2e-scalability"
+        #         export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+        #                                  --gather-resource-usage=true \
+        #                                  --gather-metrics-at-teardown=true \
+        #                                  --gather-logs-sizes=true \
+        #                                  --output-print-type=json"
+        #         # Create a project k8s-jenkins-scalability-head and move this test there
+        #         export PROJECT="k8s-jenkins-gci-scalability"
+        #         export FAIL_ON_GCP_RESOURCE_LEAK="false"
+        #         # Override GCE defaults.
+        #         export MASTER_SIZE="n1-standard-4"
+        #         export NODE_SIZE="n1-standard-2"
+        #         export NODE_DISK_SIZE="50GB"
+        #         export NUM_NODES="100"
+        #         export ALLOWED_NOTREADY_NODES="1"
+        #         export REGISTER_MASTER="true"
+        #         # Reduce logs verbosity
+        #         export TEST_CLUSTER_LOG_LEVEL="--v=2"
+        #         # Increase resync period to simulate production
+        #         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+        #         # Increase delete collection parallelism
+        #         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+        #         export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-container-vm':  # kubernetes-e2e-gce-container-vm
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on a new ContainerVM image.'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -64,6 +64,16 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gke-gci':  # kubernetes-e2e-gke
+            cron-string: '{sq-cron-string}'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)'
+            timeout: 50  # See #21138
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="k8s-jkns-e2e-gke-gci-ci"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gke-slow':  # kubernetes-e2e-gke-slow
             cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
@@ -75,6 +85,17 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gke-slow"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gke-gci-slow':  # kubernetes-e2e-gke-gci-slow
+            cron-string: '{sq-cron-string}'
+            description: 'Run slow E2E tests on GKE using the latest successful build.'
+            timeout: 150  #  See #24072
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-e2e-gke-gci-slow"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gke-serial':  # kubernetes-e2e-gke-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
@@ -85,6 +106,16 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-e2e-serial"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gke-gci-serial':  # kubernetes-e2e-gke-gci-serial
+            description: 'Run [Serial], [Disruptive] tests on GKE.'
+            timeout: 300
+            job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="jenkins-gke-gci-e2e-serial"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gke-updown':  # kubernetes-e2e-gke-updown
             cron-string: '{sq-cron-string}'
             description: 'Brings a cluster up, checks networking, brings it down (against GKE test endpoint)'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -68,6 +68,31 @@
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - '5-gce-gci':
+            description: 'Run minimal Kubemark with GCI to make sure it is not broken.'
+            timeout: 60
+            cron-string: '{sq-cron-string}'
+            job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
+                export E2E_NAME="kubemark-5"
+                export PROJECT="k8s-jenkins-gci-kubemark"
+                export E2E_TEST="false"
+                export USE_KUBEMARK="true"
+                export KUBEMARK_TESTS="starting\s30\spods\sper\snode"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                # Override defaults to be independent from GCE defaults and set kubemark parameters
+                export NUM_NODES="1"
+                export MASTER_SIZE="n1-standard-1"
+                export NODE_SIZE="n1-standard-2"
+                export KUBE_GCE_ZONE="us-central1-f"
+                # TODO: This is to check if that helps with #26185.
+                # Revert it after migrating to etcd3.
+                export KUBEMARK_MASTER_SIZE="n1-standard-2"
+                export KUBEMARK_NUM_NODES="5"
+                # The kubemark scripts build a Docker image
+                export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export KUBE_OS_DISTRIBUTION="gci"
         - '100-gce':
             description: 'Run small-ish kubemark cluster to continuously run performance experiments'
             timeout: 240
@@ -142,6 +167,33 @@
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - '500-gce-gci':
+            description: 'Run Kubemark test on a fake 500 node cluster to test for regressions on bigger clusters'
+            timeout: 300
+            cron-string: '{sq-cron-string}'
+            job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
+                export E2E_NAME="kubemark-500"
+                export PROJECT="k8s-jenkins-block-kubemark-gci"
+                export E2E_TEST="false"
+                export USE_KUBEMARK="true"
+                export KUBEMARK_TESTS="\[Feature:Performance\]"
+                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
+                # Increase throughput in Kubemark master components.
+                export KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS="--kube-api-qps=100 --kube-api-burst=100"
+                # Increase throughput in Load test.
+                export LOAD_TEST_THROUGHPUT=50
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                # Override defaults to be independent from GCE defaults and set kubemark parameters
+                export NUM_NODES="6"
+                export MASTER_SIZE="n1-standard-4"
+                export NODE_SIZE="n1-standard-8"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export KUBEMARK_MASTER_SIZE="n1-standard-16"
+                export KUBEMARK_NUM_NODES="500"
+                # The kubemark scripts build a Docker image
+                export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-scale':
             description: 'Run Density test on Kubemark in very large cluster. Currently only scheduled to run every 12 hours so as not to waste too many resources.'
             # 12h - load tests take really, really, really long time.

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -119,6 +119,31 @@
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-gci':
+            deploy-description: |
+                Deploy GCI based Kubernetes to soak cluster using the latest successful
+                Kubernetes build every week.<br>
+                If a kubernetes-soak-continuous-e2e-gce-gci build is running,
+                this deployment build will be blocked and remain in the queue
+                until the test run is complete.<br>
+            e2e-description: |
+                Assumes Kubernetes soak cluster is already deployed.<br>
+                If a kubernetes-soak-weekly-deploy-gce-gci build is enqueued,
+                builds will be blocked and remain in the queue until the
+                deployment is complete.<br>
+            branch: 'master'
+            job-env: |
+                export PROJECT="k8s-jkns-gce-gci-soak"
+            # Need the 8 essential kube-system pods ready before declaring cluster ready
+            # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+            # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="8"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-2':
             deploy-description: Clone of kubernetes-soak-weekly-deploy-gce.
             e2e-description: Clone of kubernetes-soak-continuous-e2e-gce.
@@ -207,6 +232,39 @@
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
             job-env: |
                 export PROJECT="k8s-jkns-gke-soak"
+                # Need at least n1-standard-2 nodes to run kubelet_perf tests
+                export MACHINE_TYPE="n1-standard-2"
+                export E2E_OPT="--check_version_skew=false"
+        - 'gke-gci':
+            deploy-description: |
+                Deploy GCI based Kubernetes to a GKE soak cluster using the staging GKE
+                Kubernetes build every week.<br>
+                If a kubernetes-soak-continuous-e2e-gke-gci build is running, this
+                deployment build will be blocked and remain in the queue until
+                the test run is complete.<br>
+                Current Settings:<br>
+                - provider: GKE<br>
+                - apiary: staging<br>
+                - borg job: staging<br>
+                - client (kubectl): release/stable.txt<br>
+                - cluster (k8s): release/stable.txt<br>
+                - tests: release/stable.txt<br>
+            e2e-description: |
+                Assumes GCI based Kubernetes GKE soak cluster is already deployed.<br>
+                If a kubernetes-soak-weekly-deploy-gke-gci build is enqueued,
+                builds will be blocked and remain in the queue until the
+                deployment is complete.<br>
+            branch: 'master'
+            provider-env: |
+                export KUBERNETES_PROVIDER="gke"
+                export E2E_MIN_STARTUP_PODS="8"
+                export ZONE="us-central1-f"
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export KUBE_OS_DISTRIBUTION="gci"
+            job-env: |
+                export PROJECT="k8s-jkns-gke-gci-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests
                 export MACHINE_TYPE="n1-standard-2"
                 export E2E_OPT="--check_version_skew=false"


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/25276
New GCP projects have been created already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/420)
<!-- Reviewable:end -->
