### PR TITLE
Choose correct basedir, org and branch

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/fejta-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/fejta-e2e-gce.yaml
@@ -10,13 +10,13 @@
     # Need the 8 essential kube-system pods ready before declaring cluster ready
     # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
     # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-    provider-env: gce-provider-env
+    provider-env: gce
     fejta-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/fejta/test-infra/e2e/jenkins/dockerized-e2e-runner.sh")
     builders:
         - activate-gce-service-account
         - shell: |
-            export KUBEKINS_PROVIDER_ENV="{provider-env}".bashrc
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {fejta-runner} && rc=$? || rc=$?
             if [[ ${{rc}} -ne 0 ]]; then
@@ -29,12 +29,12 @@
     scm:
         - git:
             branches:
-                - master
+                - e2e
             browser: githubweb
-            browser-url: https://github.com/kubernetes/test-infra
-            git-basedir: go/src/k8s.io/test-infra
+            browser-url: https://github.com/fejta/test-infra
+            basedir: go/src/k8s.io/test-infra
             skip-tag: true
-            url: https://github.com/kubernetes/test-infra
+            url: https://github.com/fejta/test-infra
             wipe-workspace: false
     wrappers:
         - ansicolor:


### PR DESCRIPTION
http://docs.openstack.org/infra/jenkins-job-builder/scm.html shows that it is `basedir` not `git-basedir`

Also for this test job I want to use the `e2e` branch on fejta/test-infra

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/423)
<!-- Reviewable:end -->
