### PR TITLE
Fix crash with empty junit XML files.

### DIFF
--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -82,7 +82,7 @@ def build_details(build_dir):
 
     for future in junit_futures:
         junit = future.get_result()
-        if junit is None:
+        if not junit:
             continue
         failures.extend(parse_junit(junit, junit_futures[future]))
     failures.sort()

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -151,6 +151,13 @@ class BuildTest(main_test.TestBase):
         self.assertIn('TestUnschedulableNodes', response)
         self.assertIn('junit_01.xml', response)
 
+    def test_build_empty_junit(self):
+        # Sometimes junit files are actually empty (???)
+        write(self.BUILD_DIR + 'artifacts/junit_01.xml', '')
+        response = self.get_build_page()
+        print response
+        self.assertIn('No Test Failures', response)
+
     def test_build_pr_link(self):
         ''' The build page for a PR build links to the PR results.'''
         build_dir = '/%s/123/e2e/567/' % view_pr.PR_PREFIX


### PR DESCRIPTION
Since you like this rule :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/434)
<!-- Reviewable:end -->
