### PR TITLE
Use --env-file for provider-env and job-env

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -71,6 +71,8 @@ docker run --rm=true -i \
   ${JENKINS_AWS_CREDENTIALS_FILE:+-v "${JENKINS_AWS_CREDENTIALS_FILE}:/workspace/.aws/credentials:ro"} \
   ${GOOGLE_APPLICATION_CREDENTIALS:+-v "${GOOGLE_APPLICATION_CREDENTIALS}:/service-account.json:ro"} \
   --env-file "${WORKSPACE}/env.list" \
+  --env-file "go/src/k8s.io/test-infra/job-configs/${KUBEKINS_PROVIDER_ENV}" \
+  --env-file "go/src/k8s.io/test-infra/job-configs/${KUBEKINS_JOB_ENV}" \
   -e "HOME=/workspace" \
   -e "WORKSPACE=/workspace" \
   ${GOOGLE_APPLICATION_CREDENTIALS:+-e "GOOGLE_APPLICATION_CREDENTIALS=/service-account.json"} \

--- a/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
@@ -19,7 +19,7 @@
 # Template for the continuous e2e Docker validation jobs.
 - job-template:
     name: 'continuous-e2e-docker-validation-{os-distro}'
-    node: '{jenkins_node}' 
+    node: '{jenkins_node}'
     description: '{description} Test owner: {test-owner}.'
     disabled: '{obj:disable_job}'
     properties:
@@ -27,6 +27,16 @@
             days-to-keep: 7
     triggers:
         - timed: '@daily'
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -48,20 +58,12 @@
         - description-setter:
             regexp: KUBE_GCE_MASTER_IMAGE=(.*)
         - e2e-version-printer
-    # Need the 8 essential kube-system pods ready before declaring cluster ready
-    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-    provider-env: |
-        export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="8"
-        export KUBE_GCE_ZONE="us-central1-f"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+    provider-env: gce
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
@@ -151,6 +153,7 @@
 
 - project:
     name: continuous-docker-validation
+    job-name: 'continuous-e2e-docker-validation-{os-distro}'
     jobs:
         - 'continuous-e2e-docker-validation-{os-distro}':
             os-distro: 'gci'

--- a/jenkins/job-configs/kubernetes-jenkins/fejta-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/fejta-e2e-gce.yaml
@@ -16,7 +16,7 @@
         - activate-gce-service-account
         - shell: |
             export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
-            export KUBEKINS_JOB_ENV="{name}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {fejta-runner} && rc=$? || rc=$?
             if [[ ${{rc}} -ne 0 ]]; then
@@ -55,6 +55,7 @@
 
 - project:
     name: fejta-e2e-gce-master
+    job-name: 'fejta-e2e-{suffix}'
     test-owner: 'fejta'
     suffix:
     - 'gce':  # fejta-e2e-gce

--- a/jenkins/job-configs/kubernetes-jenkins/kops-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kops-build.yaml
@@ -8,7 +8,7 @@
     builders:
         - activate-gce-service-account
         - shell: |
-            {job-env}
+            {build-env}
             timeout -k {kill-timeout}m {timeout}m ./docker/build-squash-push.sh && rc=$? || rc=$?
             {report-rc}
     publishers:
@@ -52,7 +52,7 @@
         - 'build':
             branch: 'master'
             timeout: 20
-            job-env: |
+            build-env: |
               export BUILD_LINK="latest"
               export BUILD_PUSH_TAG="yes"
     jobs:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -9,7 +9,7 @@
         - activate-gce-service-account
         - shell: 'JENKINS_BUILD_STARTED=true bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh")'
         - shell: |
-            {job-env}
+            {build-env}
             timeout -k {kill-timeout}m {timeout}m ./hack/jenkins/build.sh && rc=$? || rc=$?
             {report-rc}
     publishers:
@@ -53,19 +53,19 @@
         - 'build':
             branch: 'master'
             timeout: 50
-            job-env: ''  # Empty expected
+            build-env: ''  # Empty expected
         - 'build-1.2':
             branch: 'release-1.2'
             timeout: 30
-            job-env: ''  # Empty expected
+            build-env: ''  # Empty expected
         - 'build-1.3':
             branch: 'release-1.3'
             timeout: 50
-            job-env: ''  # Empty expected
+            build-env: ''  # Empty expected
         - 'federation-build':
             branch: 'master'
             timeout: 50
-            job-env: |
+            build-env: |
               export PROJECT="k8s-jkns-e2e-gce-federation"
               export FEDERATION=true
               export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-djmm.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-djmm.yaml
@@ -9,7 +9,7 @@
         - activate-gce-service-account
         - shell: 'JENKINS_BUILD_STARTED=true bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh")'
         - shell: |
-            {job-env}
+            {build-env}
             timeout -k {kill-timeout}m {timeout}m ./hack/jenkins/build.sh && rc=$? || rc=$?
             {report-rc}
     publishers:
@@ -47,13 +47,13 @@
         - 'build':
             branch: 'master'
             timeout: 50
-            job-env: |
+            build-env: |
               export RELEASE_INFRA_PUSH=true
               export SET_NOMOCK_FLAG=false
         - 'federation-build':
             branch: 'master'
             timeout: 50
-            job-env: |
+            build-env: |
               export RELEASE_INFRA_PUSH=true
               export SET_NOMOCK_FLAG=false
               export PROJECT="k8s-jkns-e2e-gce-federation"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -19,28 +19,25 @@
         - email-ext:
             recipients: '{emails}'
         - gcs-uploader
-    # Need the 8 essential kube-system pods ready before declaring cluster ready
-    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-    provider-env: |
-        export KUBERNETES_PROVIDER="aws"
-        export E2E_MIN_STARTUP_PODS="8"
-        export KUBE_AWS_ZONE="us-west-2a"
-        export MASTER_SIZE="m3.medium"
-        export NODE_SIZE="m3.medium"
-        export NUM_NODES="3"
-        export AWS_CONFIG_FILE=/workspace/.aws/credentials
-        # This is needed to be able to create PD from the e2e test
-        export AWS_SHARED_CREDENTIALS_FILE=/workspace/.aws/credentials
-        export KUBE_SSH_USER=admin
+    provider-env: aws
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -80,5 +77,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-aws"
+    job-name: 'kubernetes-e2e-{aws-suffix}'
     jobs:
         - 'kubernetes-e2e-{aws-suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -21,23 +21,25 @@
     properties:
         - build-discarder:
             days-to-keep: 7
-    # Need the 8 essential kube-system pods ready before declaring cluster ready
-    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-    provider-env: |
-        export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="8"
-        export KUBE_GCE_ZONE="us-central1-f"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+    provider-env: gce
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -180,6 +182,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
                 export KUBE_OS_DISTRIBUTION="gci"
+    job-name: 'kubernetes-e2e-gce-gci-ci-{suffix}'
     jobs:
         - 'kubernetes-e2e-gce-gci-ci-{suffix}'
 
@@ -194,24 +197,26 @@
     properties:
         - build-discarder:
             days-to-keep: 7
-    # Need the 8 essential kube-system pods ready before declaring cluster ready
-    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-    provider-env: |
-        export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="8"
-        export KUBE_GCE_ZONE="us-central1-f"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
-        export JENKINS_USE_GCI_VERSION="y"  # Use GCI builtin k8s version.
+    provider-env: gce
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
+            export JENKINS_USE_GCI_VERSION="y"  # Use GCI builtin k8s version.
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -339,5 +344,6 @@
                 export PROJECT="e2e-gce-gci-qa-serial-m52"
                 export KUBE_OS_DISTRIBUTION="gci"
                 export KUBE_ENABLE_RESCHEDULER=true
+    job-name: 'kubernetes-e2e-gce-gci-qa-{suffix}'
     jobs:
         - 'kubernetes-e2e-gce-gci-qa-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -12,23 +12,25 @@
     properties:
         - build-discarder:
             days-to-keep: 7
-    # Need the 8 essential kube-system pods ready before declaring cluster ready
-    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-    provider-env: |
-        export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="8"
-        export KUBE_GCE_ZONE="us-central1-f"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+    provider-env: gce
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -350,6 +352,7 @@
                 export GINKGO_PARALLEL="y"
                 export NETWORK_PROVIDER="kubenet"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{suffix}'
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -394,6 +397,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{suffix}'
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -491,6 +495,7 @@
                 # Increase delete collection parallelism
                 export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{suffix}'
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -545,6 +550,7 @@
                 export PROJECT="kubernetes-petset"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"  # TODO: Enable once we've fixed #23032
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{suffix}'
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
@@ -586,5 +592,6 @@
         # Increase delete collection parallelism
         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
         export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{suffix}'
     jobs:
         - 'kubernetes-e2e-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -7,24 +7,25 @@
     properties:
         - build-discarder:
             days-to-keep: 7
-    # Need the 8 essential kube-system pods ready before declaring cluster ready
-    # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-    # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-    provider-env: |
-        export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
-        export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
-        export E2E_MIN_STARTUP_PODS="8"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export KUBERNETES_PROVIDER="gke"
-        export ZONE="us-central1-f"
+    provider-env: gke
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     wrappers:
         - ansicolor:
             colormap: xterm
@@ -201,6 +202,7 @@
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -266,6 +268,7 @@
                 export PROJECT="kubernetes-gke-ingress-1-3"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
 
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -302,6 +305,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-slow-1-2"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -398,6 +402,7 @@
                 export PROJECT="k8s-e2e-gke-prod-smoke"
                 export ZONE="asia-east1-b"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -416,6 +421,7 @@
                 # TODO: Enable this when we've split 1.2 tests into another project.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -513,6 +519,7 @@
                 export KUBE_OS_DISTRIBUTION="trusty"
                 export PROJECT="e2e-gke-trusty-prod-p"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -520,6 +527,7 @@
     name: 'kubernetes-e2e-{provider}-{version-old}-{version-new}'
     trigger-job: 'kubernetes-build'
     test-owner: 'ihmccreery'
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}':
             gke-suffix: '{provider}-{version-old}-{version-new}-upgrade-master'
@@ -641,6 +649,7 @@
     name: 'kubernetes-e2e-{provider}-{version-cluster}-{version-client}-kubectl-skew'
     trigger-job: 'kubernetes-build'
     test-owner: 'ihmccreery'
+    job-name: 'kubernetes-e2e-{gke-suffix}'
     jobs:
         - 'kubernetes-e2e-{gke-suffix}':
             gke-suffix: '{provider}-{version-cluster}-{version-client}-kubectl-skew'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -5,17 +5,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
-    provider-env: |
-        export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="1"
-        export KUBE_GCE_ZONE="us-central1-f"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+    provider-env: gce
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
@@ -26,6 +21,16 @@
         - email-ext:
             recipients: "xuchao@google.com"
         - gcs-uploader
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     triggers:
         - timed: '{cron-string}'
     wrappers:
@@ -54,5 +59,6 @@
                 export PROJECT="k8s-jenkins-garbagecollector"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:GarbageCollector\]"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-garbagecollector-{suffix}'
     jobs:
         - 'kubernetes-garbagecollector-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -5,17 +5,12 @@
     properties:
         - build-discarder:
             days-to-keep: 7
-    provider-env: |
-        export KUBERNETES_PROVIDER="gce"
-        export E2E_MIN_STARTUP_PODS="1"
-        export KUBE_GCE_ZONE="us-central1-f"
-        export FAIL_ON_GCP_RESOURCE_LEAK="true"
-        export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+    provider-env: gce
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
-            {job-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {post-env}
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}
@@ -26,6 +21,16 @@
         - email-ext:
             recipients: "gmarek@google.com"
         - gcs-uploader
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
     triggers:
         - timed: '{cron-string}'
     wrappers:
@@ -230,5 +235,6 @@
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+    job-name: 'kubernetes-kubemark-{suffix}'
     jobs:
         - 'kubernetes-kubemark-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -6,12 +6,22 @@
     builders:
         - activate-gce-service-account
         - shell: |
-            {provider-env}
+            export KUBEKINS_PROVIDER_ENV="{provider-env}.env"
+            export KUBEKINS_JOB_ENV="{job-name}.env"
             {soak-env}
-            {job-env}
             {post-env}
             timeout -k {kill-timeout}m {run-timeout}m {legacy-runner} && rc=$? || rc=$?
             {report-rc}
+    scm:
+        - git:
+            branches:
+                - master
+            browser: githubweb
+            browser-url: https://github.com/kubernetes/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/kubernetes/test-infra
+            wipe-workspace: false
 
 - job-template:
     name: 'kubernetes-soak-weekly-deploy-{suffix}'
@@ -109,16 +119,7 @@
             branch: 'master'
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak"
-            # Need the 8 essential kube-system pods ready before declaring cluster ready
-            # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-            # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-            provider-env: |
-                export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="8"
-                export KUBE_GCE_ZONE="us-central1-f"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+            provider-env: gce
         - 'gce-gci':
             deploy-description: |
                 Deploy GCI based Kubernetes to soak cluster using the latest successful
@@ -134,16 +135,7 @@
             branch: 'master'
             job-env: |
                 export PROJECT="k8s-jkns-gce-gci-soak"
-            # Need the 8 essential kube-system pods ready before declaring cluster ready
-            # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-            # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-            provider-env: |
-                export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="8"
-                export KUBE_GCE_ZONE="us-central1-f"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
-                export KUBE_OS_DISTRIBUTION="gci"
+            provider-env: gce
         - 'gce-2':
             deploy-description: Clone of kubernetes-soak-weekly-deploy-gce.
             e2e-description: Clone of kubernetes-soak-continuous-e2e-gce.
@@ -151,13 +143,8 @@
             job-env: |
                 export HAIRPIN_MODE="hairpin-veth"
                 export PROJECT="k8s-jkns-gce-soak-2"
-            provider-env: |
-                export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="8"
-                export KUBE_GCE_ZONE="us-central1-f"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+            provider-env: gce
         - 'gce-1.3':
             deploy-description: |
                 Deploy Kubernetes to soak cluster using the latest successful
@@ -170,16 +157,11 @@
                 If a kubernetes-soak-weekly-deploy-gce-1.3 build is enqueued,
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
-            provider-env: |
-                export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="8"
-                export KUBE_GCE_ZONE="us-central1-f"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
             job-env: |
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-gce-soak-1-3"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+            provider-env: gce
         - 'gce-1.2':
             deploy-description: |
                 Deploy Kubernetes to soak cluster using the latest successful
@@ -195,13 +177,8 @@
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-2"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-            provider-env: |
-                export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="1"
-                export KUBE_GCE_ZONE="us-central1-f"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+            provider-env: gce
         - 'gke':
             deploy-description: |
                 Deploy Kubernetes to a GKE soak cluster using the staging GKE
@@ -222,18 +199,12 @@
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
             branch: 'master'
-            provider-env: |
-                export KUBERNETES_PROVIDER="gke"
-                export E2E_MIN_STARTUP_PODS="8"
-                export ZONE="us-central1-f"
-                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+            provider-env: gke
             job-env: |
                 export PROJECT="k8s-jkns-gke-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests
                 export MACHINE_TYPE="n1-standard-2"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export E2E_OPT="--check_version_skew=false"
         - 'gke-gci':
             deploy-description: |
@@ -255,19 +226,15 @@
                 builds will be blocked and remain in the queue until the
                 deployment is complete.<br>
             branch: 'master'
-            provider-env: |
-                export KUBERNETES_PROVIDER="gke"
-                export E2E_MIN_STARTUP_PODS="8"
-                export ZONE="us-central1-f"
-                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
-                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export KUBE_OS_DISTRIBUTION="gci"
+            provider-env: gke
             job-env: |
+                export KUBE_OS_DISTRIBUTION="gci"
                 export PROJECT="k8s-jkns-gke-gci-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests
                 export MACHINE_TYPE="n1-standard-2"
                 export E2E_OPT="--check_version_skew=false"
     jobs:
-        - 'kubernetes-soak-weekly-deploy-{suffix}'
-        - 'kubernetes-soak-continuous-e2e-{suffix}'
+        - 'kubernetes-soak-weekly-deploy-{suffix}':
+            job-name: 'kubernetes-soak-weekly-deploy-{suffix}'
+        - 'kubernetes-soak-continuous-e2e-{suffix}':
+            job-name: 'kubernetes-soak-continuous-e2e-{suffix}'

--- a/jenkins/job_config_parser.py
+++ b/jenkins/job_config_parser.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python
+
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Delete this code as soon as possible and/or convert to yaml linter.
+
+This is a hacky file designed to extract job-env from jobs in JJB.
+"""
+
+
+import os
+import pprint
+import re
+import sys
+
+import yaml
+
+
+class Context(dict):
+  """A stack of contexts.
+
+  empty = Context({})
+  a = Context(empty, {'a': 1})
+  b = Context(a, {'b': 2})
+  c = Context(b, {'c': 3})
+  context = Context(c)
+  assert context['a'] == a['a']
+  b['a'] = 5
+  assert context['a'] == 5
+  """
+
+  def __init__(self, base, *a, **kw):
+    super(Context, self).__init__(*a, **kw)
+    self.base = base
+
+  def __getitem__(self, item):
+    if super(Context, self).__contains__(item):
+      return super(Context, self).__getitem__(item)
+    return self.base[item]
+
+  def __contains__(self, item):
+    if super(Context, self).__contains__(item):
+      return True
+    if self.base is not None:
+      return item in self.base
+    return False
+
+
+# Make sure provider-env is one of these values
+PROVIDERS = [
+    'aws',
+    'gce',
+    'gke',
+]
+
+
+def CheckContext(name, context):
+  # Each job must specify a provider-env
+  if 'provider-env' not in context:
+    raise ValueError('missing provider-env', name, context)
+  if context['provider-env'] not in PROVIDERS:
+    raise ValueError('bad provider', name, context['provider-env'])
+
+  # Each job must have test-infra in its workspace
+  if 'scm' not in context:
+    raise ValueError('Workspace must export kubernetes/test-infra', name)
+  infra = False
+  for scm in context['scm']:
+    if scm.get('git')['url'].endswith('/test-infra'):
+      # Basedir must be the the following:
+      if not scm['git']['basedir'] == 'go/src/k8s.io/test-infra':
+        raise ValueError('bad test-infra basedir', name, scm)
+      infra |= True
+  if not infra:
+    raise ValueError('Workspace must export kubernetes/test-infra', name, context['scm'])
+
+  # Must shell out the following lines:
+  expected = {
+      'provider': 'export KUBEKINS_PROVIDER_ENV="{provider-env}.env"\n',
+      'job': 'export KUBEKINS_JOB_ENV="{job-name}.env"\n',
+      #'runner': '{runner}',
+  }
+  # Must not shell out these lines
+  unexpected = {
+      'provider-env': '{provider-env}\n',
+      'job-env': '{job-env}\n',
+  }
+  found = set()
+  bad_found = set()
+  for builder in context['builders']:
+    if not isinstance(builder, dict):
+      continue
+    value = builder.get('shell', '')
+    for key, check in expected.items():
+      if key in found:
+        continue
+      if check in value:
+        found.add(key)
+    for key, check in unexpected.items():
+      if key in bad_found:
+        continue
+      if check in value:
+        bad_found.add(key)
+
+  missing = set(expected) - found
+  if missing:
+    raise ValueError(name, [expected[m] for m in missing])
+  if bad_found:
+    raise ValueError(name, [unexpected[b] for b in bad_found])
+
+
+def ConvertJob(context, out_path):
+  """Extract job-env from a context, including any {replacements}."""
+  name = context['name']
+
+  # Ensure job-env is set or else it already has a .env file
+  path = os.path.join(out_path, '%s.env' % name)
+  if 'job-env' not in context:
+    if not os.path.isfile(path):
+      raise ValueError(name, path)
+    print >>sys.stderr, '  CONFIGURED:', path
+    return
+
+  # Check the sanity of the context
+  CheckContext(name, context)
+
+  # Replace job-env variables as necessary.
+  print >>sys.stderr, '  ', path
+  for resolved in Resolve(context, 'job-env'):
+    parsed = []
+    # Put each variable on a single line
+    # Aka convert this:
+    #   export FOO="spam \
+    #               eggs"
+    # to this:
+    #   export FOO="spam eggs"
+    for env in re.sub(r'\\\n\s*', '', resolved['job-env']).split('\n'):
+      # Ensure everything starts with export or is a comment
+      if env and not (env.startswith('export') or env.startswith('#')):
+        raise ValueError(env)
+      # Convert export FOO="bar" to FOO=bar
+      parsed.append(env.replace('"','').replace('export ',''))
+    for p in parsed:
+      print >>sys.stderr, '  ', p
+    with open(path, 'w') as fp:
+      fp.write('\n'.join(parsed))
+    print >>sys.stderr, '  WROTE: %s (delete job-env)' % path
+
+
+class JJBObject(dict):
+  def __init__(self, kind, name, values):
+    super(JJBObject, self).__init__(values)
+    self.kind = kind
+    self.name = name
+
+
+def KindList(items):
+  """A list of kinds (project, job-template) with a name field.
+
+  The following yaml:
+  - project:
+      name: foo
+  - project:
+      name: bar
+  - job-template:
+      name: hello
+  Should result in:
+    [JJObject('project', 'foo', {'name': 'foo'}),
+     JJObject('project', 'bar', {'name': 'bar'}),
+     JJObject('job-template', 'hello', {'name': 'hello'}]
+  """
+  for item in items:
+    if not isinstance(item, dict):
+      raise ValueError('jbb objects are dicts', item)
+    if len(item) != 1:
+      raise ValueError('jjb objects have one item', item)
+    kind = item.keys()[0]
+    value = item[kind]
+    if 'name' not in value:
+      raise ValueError('missing name key', item)
+    yield JJBObject(kind, value['name'], value)
+
+
+def NameList(kind, items):
+  """A list of names of objects (jobs) of the same kind.
+
+  The following yaml:
+    - 'kubernetes-e2e-{suffix}'
+    - 'kubernetes-e2e-{gke-suffix}':
+        argle: bargle
+    - 'boring':
+        spam: eggs
+
+  Should result in:
+    JJObject(kind, 'kubernetes-e2e-{suffix}', {})
+    JJObject(kind, 'kubernetes-e2e-{gke-suffix}', {'argle': 'bargle'})
+    JJObject(kind, 'boring', {'spam': 'eggs'})
+  """
+  for item in items:
+    if isinstance(item, basestring):
+      yield JJBObject(kind, item, {})
+      continue
+
+    if not isinstance(item, dict):
+      raise ValueError('jbb objects are dicts', item)
+    if len(item) != 1:
+      raise ValueError('jjb objects have one item', item)
+    name = item.keys()[0]
+    value = item[name]
+    yield JJBObject(kind, name, value or {})
+
+
+def Jobs(item, context, jjb_objects):
+  context = Context(context, item)
+  # job-template, resolve the name and yield the resulting context
+  if item.kind not in ['project', 'job-group']:
+    for resolved in Resolve(context, 'name'):
+      yield resolved
+    return
+
+  # We need to expand the jobs for project or job-group
+  if 'jobs' not in item:
+    raise ValueError('Empty', item.kind, item.name)
+  jobs = item['jobs']
+  # Lookup each job name, expanding as necessary
+  for ref in NameList('unknown', jobs):
+    if ref.name not in jjb_objects:
+      raise ValueError('Cannot find %s in %s' % (ref.name, item.name))
+    obj = jjb_objects[ref.name]  # Real object
+    for resolved in Jobs(obj, Context(context, ref), jjb_objects):
+      yield resolved
+
+
+def Resolve(context, key):
+  """Resolve any {variables} in the context, yielding the result.
+
+  context = Context({}, {
+      'target': 'this is {really} {annoying}',
+      'really': 'super duper',
+      'annoying': 'fun and exciting'})
+  assert (
+      Resolve(context, 'target')['target'] ==
+      'this is really super duper fun and exciting')
+  """
+  replacements = re.findall(r'{([^}]+)}', context[key])
+  if not replacements:
+    yield context  # Nothing to do, yay!
+    return
+
+  # Replace the first {variable} in context[key] with context[variable]
+  repl = replacements[0]
+  val = context[repl]
+  if isinstance(val, basestring):
+    val = [val]
+  for val in NameList('unknown', val):
+    val[key] = context[key].replace('{%s}' % repl, val.name)
+    for resolved in Resolve(Context(context, val), key):
+      yield resolved
+
+# Some files have a mix of e2e and other jobs
+# Skip specific jobs in these files
+SKIP_JOBS = [
+    'continuous-node-e2e-docker-validation-gci',
+]
+
+
+def ParseFile(path, out_path):
+  """Extract every job's job-env in path to out_path/<job-name>.env"""
+  print 'Processing %s...' % path
+  with open(path) as fp:
+    buf = fp.read()
+
+  root = yaml.safe_load(buf)
+  jjb_objects = {}
+  projects = {}
+  for obj in KindList(root):
+    if obj.name in jjb_objects:
+      raise ValueError('Duplicate name', name)
+    jjb_objects[obj.name] = obj
+    if obj.kind == 'project':
+      projects[obj.name] = obj
+
+  for name in projects:
+    project = projects[name]
+    context = {}
+    for resolved in Jobs(project, context, jjb_objects):
+      if resolved['name'] in SKIP_JOBS:
+        print >>sys.stderr, 'Skipping %s...' % resolved['name']
+        continue
+      print project.name, resolved['name']
+      ConvertJob(resolved, out_path)
+
+
+# Many files do not use {runner}/{job-env}
+SKIP = [
+    'cloud-resource-cleanup.yaml',  # job not defined in file
+    'kops-build.yaml',  # no job-env
+    'kubernetes-build.yaml',  # no job-env
+    'kubernetes-djmm.yaml',  # no job-env
+    'kubernetes-test-go.yaml',  # no job-env
+    'kubernetes-verify.yaml',  # no job-env
+    'node-e2e.yaml',  # doesn't use job-env
+]
+
+
+def main(
+    in_path='./jenkins/job-configs/kubernetes-jenkins',
+    out_path='./job-configs'):
+  if not os.path.isdir(out_path):
+    raise ValueError('not a directory', out_path)
+  if os.path.isdir(in_path):
+    for dirpath, _, names in os.walk(in_path):
+      for name in names:
+        if name in SKIP:
+          print >>sys.stderr, 'Skipping %s' % name
+          continue
+        ParseFile(os.path.join(dirpath, name), out_path)
+    return
+  ParseFile(in_path, out_path)
+
+
+
+if __name__ == '__main__':
+  main(*sys.argv[1:])

--- a/job-configs/aws.env
+++ b/job-configs/aws.env
@@ -1,0 +1,13 @@
+AWS_CONFIG_FILE=/workspace/.aws/credentials
+# This is needed to be able to create PD from the e2e test
+AWS_SHARED_CREDENTIALS_FILE=/workspace/.aws/credentials
+# Need the 8 essential kube-system pods ready before declaring cluster ready
+# etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+# kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
+E2E_MIN_STARTUP_PODS=8
+KUBE_AWS_ZONE=us-west-2a
+KUBERNETES_PROVIDER=aws
+KUBE_SSH_USER=admin
+MASTER_SIZE=m3.medium
+NODE_SIZE=m3.medium
+NUM_NODES=3

--- a/job-configs/continuous-e2e-docker-validation-gci.env
+++ b/job-configs/continuous-e2e-docker-validation-gci.env
@@ -1,0 +1,4 @@
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-docker-validation-gci
+JENKINS_GCI_IMAGE_FAMILY=gci-canary-test

--- a/job-configs/fejta-e2e-gce.env
+++ b/job-configs/fejta-e2e-gce.env
@@ -1,0 +1,3 @@
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=fejta-prod

--- a/job-configs/gce.env
+++ b/job-configs/gce.env
@@ -1,0 +1,8 @@
+CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
+# Need the 8 essential kube-system pods ready before declaring cluster ready
+# etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+# kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
+E2E_MIN_STARTUP_PODS=8
+FAIL_ON_GCP_RESOURCE_LEAK=true
+KUBE_GCE_ZONE=us-central1-f
+KUBERNETES_PROVIDER=gce

--- a/job-configs/gke.env
+++ b/job-configs/gke.env
@@ -1,0 +1,9 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://test-container.sandbox.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/ci/staging
+# Need the 8 essential kube-system pods ready before declaring cluster ready
+# etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+# kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
+E2E_MIN_STARTUP_PODS=8
+FAIL_ON_GCP_RESOURCE_LEAK=true
+KUBERNETES_PROVIDER=gke
+ZONE=us-central1-f

--- a/job-configs/kubernetes-e2e-aws-release-1.3.env
+++ b/job-configs/kubernetes-e2e-aws-release-1.3.env
@@ -1,0 +1,5 @@
+E2E_NAME=e2e-aws-1-3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-aws

--- a/job-configs/kubernetes-e2e-aws.env
+++ b/job-configs/kubernetes-e2e-aws.env
@@ -1,0 +1,4 @@
+E2E_NAME=e2e-aws-master
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-aws

--- a/job-configs/kubernetes-e2e-gce-autoscaling-migs.env
+++ b/job-configs/kubernetes-e2e-gce-autoscaling-migs.env
@@ -1,0 +1,11 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
+PROJECT=k8s-jnks-e2e-gce-autoscl-migs
+# Override GCE default for cluster size autoscaling purposes.
+KUBE_ENABLE_CLUSTER_AUTOSCALER=true
+NUM_NODES=3
+MAX_INSTANCES_PER_MIG=2
+KUBE_AUTOSCALER_MIN_NODES=3
+KUBE_AUTOSCALER_MAX_NODES=5
+KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+KUBE_ADMISSION_CONTROL=NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota

--- a/job-configs/kubernetes-e2e-gce-autoscaling.env
+++ b/job-configs/kubernetes-e2e-gce-autoscaling.env
@@ -1,0 +1,11 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\]
+PROJECT=k8s-jnks-e2e-gce-autoscaling
+# Override GCE default for cluster size autoscaling purposes.
+ENABLE_CUSTOM_METRICS=true
+KUBE_ENABLE_CLUSTER_AUTOSCALER=true
+NUM_NODES=3
+KUBE_AUTOSCALER_MIN_NODES=3
+KUBE_AUTOSCALER_MAX_NODES=5
+KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+KUBE_ADMISSION_CONTROL=NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota

--- a/job-configs/kubernetes-e2e-gce-container-vm.env
+++ b/job-configs/kubernetes-e2e-gce-container-vm.env
@@ -1,0 +1,6 @@
+# This list should match the list in kubernetes-pull-build-test-e2e-gce.
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jenkins-cvm
+KUBE_GCE_NODE_IMAGE=container-v1-3-v20160604
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-enormous-cluster.env
+++ b/job-configs/kubernetes-e2e-gce-enormous-cluster.env
@@ -1,0 +1,26 @@
+# XXX Not a unique project
+E2E_NAME=e2e-enormous-cluster
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf
+PROJECT=kubernetes-scale
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override GCE defaults.
+# Temporarily switch of Heapster, as this will not schedule anywhere.
+# TODO: Think of a solution to enable it.
+KUBE_ENABLE_CLUSTER_MONITORING=none
+CLUSTER_IP_RANGE=10.224.0.0/13
+# TODO: Move to us-central1-c once we have permission for it.
+KUBE_GCE_ZONE=us-east1-a
+MASTER_SIZE=n1-standard-32
+NODE_SIZE=n1-standard-1
+NODE_DISK_SIZE=50GB
+NUM_NODES=2000
+ALLOWED_NOTREADY_NODES=20
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=1
+MAX_INSTANCES_PER_MIG=1000
+CREATE_SERVICES=true
+# Increase resync period to simulate production
+TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+# Increase delete collection parallelism
+TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-es-logging.env
+++ b/job-configs/kubernetes-e2e-gce-es-logging.env
@@ -1,0 +1,4 @@
+PROJECT=kubernetes-es-logging
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Elasticsearch\]
+KUBE_LOGGING_DESTINATION=elasticsearch
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-etcd3.env
+++ b/job-configs/kubernetes-e2e-gce-etcd3.env
@@ -1,0 +1,7 @@
+# This list should match the list in kubernetes-pull-build-test-e2e-gce.
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kube-api-content-type=application/vnd.kubernetes.protobuf
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-etcd3
+# Use etcd3 as storage backend.
+STORAGE_BACKEND=etcd3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-examples.env
+++ b/job-configs/kubernetes-e2e-gce-examples.env
@@ -1,0 +1,3 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Example\]
+PROJECT=k8s-jkns-e2e-examples
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-federation.env
+++ b/job-configs/kubernetes-e2e-gce-federation.env
@@ -1,0 +1,12 @@
+PROJECT=k8s-jkns-e2e-gce-federation
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\]
+GINKGO_PARALLEL=n # We don't have namespaces yet in federation apiserver, so we need to serialize
+FEDERATION=true
+DNS_ZONE_NAME=k8s-federation.com.
+FEDERATIONS_DOMAIN_MAP=federation=k8s-federation.com
+E2E_ZONES=us-central1-a us-central1-b us-central1-f # Where the clusters will be created. Federation components are now deployed to the last one.
+FEDERATION_PUSH_REPO_BASE=gcr.io/k8s-jkns-e2e-gce-federation
+KUBE_GCE_ZONE=us-central1-f #TODO(colhom): This should be generalized out to plural case
+KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
+KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-flaky.env
+++ b/job-configs/kubernetes-e2e-gce-flaky.env
@@ -1,0 +1,3 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
+PROJECT=k8s-jkns-e2e-gce-flaky
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-flannel.env
+++ b/job-configs/kubernetes-e2e-gce-flannel.env
@@ -1,0 +1,7 @@
+# XXX Not a unique project
+E2E_NAME=e2e-flannel
+PROJECT=kubernetes-flannel
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override GCE defaults.
+NETWORK_PROVIDER=flannel
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-gci-ci-master.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-master.env
@@ -1,0 +1,8 @@
+# The master branch will always use GCI images built from its
+# tip of tree, categorized in family `gci-canary`.
+JENKINS_GCI_IMAGE_FAMILY=gci-canary
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-ci-master
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-ci-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-release-1.2.env
@@ -1,0 +1,6 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+JENKINS_GCI_IMAGE_FAMILY=gci-52
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-ci-1-2
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-ci-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-release-1.3.env
@@ -1,0 +1,7 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+JENKINS_GCI_IMAGE_FAMILY=gci-53
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-ci-1-3
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-ci-serial-master.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-serial-master.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-canary
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=e2e-gce-gci-ci-serial
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gce-gci-ci-serial-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-serial-release-1.2.env
@@ -1,0 +1,5 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+JENKINS_GCI_IMAGE_FAMILY=gci-52
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=e2e-gce-gci-ci-serial-1-2
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-ci-serial-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-serial-release-1.3.env
@@ -1,0 +1,6 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+JENKINS_GCI_IMAGE_FAMILY=gci-53
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=e2e-gce-gci-ci-serial-1-3
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-ci-slow-master.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-slow-master.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-canary
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-ci-master-slow
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-ci-slow-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-slow-release-1.2.env
@@ -1,0 +1,6 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+JENKINS_GCI_IMAGE_FAMILY=gci-52
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-ci-slow-1-2
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-ci-slow-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-gci-ci-slow-release-1.3.env
@@ -1,0 +1,7 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+JENKINS_GCI_IMAGE_FAMILY=gci-53
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-ci-slow-1-3
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-examples.env
+++ b/job-configs/kubernetes-e2e-gce-gci-examples.env
@@ -1,0 +1,3 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Example\]
+PROJECT=k8s-jkns-e2e-gci-examples
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-federation.env
+++ b/job-configs/kubernetes-e2e-gce-gci-federation.env
@@ -1,0 +1,12 @@
+PROJECT=k8s-jkns-e2e-gce-gci-federatio
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\]
+GINKGO_PARALLEL=n # We don't have namespaces yet in federation apiserver, so we need to serialize
+FEDERATION=true
+DNS_ZONE_NAME=k8s-federation.com.
+FEDERATIONS_DOMAIN_MAP=federation=k8s-federation.com
+E2E_ZONES=us-central1-a us-central1-b us-central1-f # Where the clusters will be created. Federation components are now deployed to the last one.
+FEDERATION_PUSH_REPO_BASE=gcr.io/k8s-jkns-e2e-gce-gci-federatio
+KUBE_GCE_ZONE=us-central1-f #TODO(colhom): This should be generalized out to plural case
+KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
+KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-qa-m52.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-m52.env
@@ -1,0 +1,5 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-52
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-qa-m52
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-qa-m53.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-m53.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-53
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-qa-m53
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-qa-master.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-master.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-canary
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-qa-master
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-qa-serial-m52.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-serial-m52.env
@@ -1,0 +1,5 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-52
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=e2e-gce-gci-qa-serial-m52
+KUBE_OS_DISTRIBUTION=gci
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gce-gci-qa-serial-m53.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-serial-m53.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-53
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=e2e-gce-gci-qa-serial-m53
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gce-gci-qa-serial-master.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-serial-master.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-canary
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=e2e-gce-gci-qa-serial-master
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gce-gci-qa-slow-m52.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-slow-m52.env
@@ -1,0 +1,5 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-52
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-qa-slow-m52
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-qa-slow-m53.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-slow-m53.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-53
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-qa-slow-m53
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-qa-slow-master.env
+++ b/job-configs/kubernetes-e2e-gce-gci-qa-slow-master.env
@@ -1,0 +1,6 @@
+JENKINS_GCI_IMAGE_FAMILY=gci-canary
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=e2e-gce-gci-qa-slow-master
+KUBE_MASTER_OS_DISTRIBUTION=gci
+KUBE_NODE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-scalability.env
+++ b/job-configs/kubernetes-e2e-gce-gci-scalability.env
@@ -1,0 +1,19 @@
+E2E_NAME=e2e-scalability
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
+# Create a project k8s-jenkins-scalability-head and move this test there
+PROJECT=k8s-jenkins-gci-scalability
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override GCE defaults.
+MASTER_SIZE=n1-standard-4
+NODE_SIZE=n1-standard-2
+NODE_DISK_SIZE=50GB
+NUM_NODES=100
+ALLOWED_NOTREADY_NODES=1
+REGISTER_MASTER=true
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=2
+# Increase resync period to simulate production
+TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+# Increase delete collection parallelism
+TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gce-gci-serial.env
+++ b/job-configs/kubernetes-e2e-gce-gci-serial.env
@@ -1,0 +1,5 @@
+ENABLE_GARBAGE_COLLECTOR=true
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=k8s-jkns-e2e-gce-gci-serial
+KUBE_OS_DISTRIBUTION=gci
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gce-gci-slow.env
+++ b/job-configs/kubernetes-e2e-gce-gci-slow.env
@@ -1,0 +1,5 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+KUBE_GCE_ZONE=europe-west1-c
+KUBE_OS_DISTRIBUTION=gci
+PROJECT=k8s-jkns-e2e-gce-gci-slow

--- a/job-configs/kubernetes-e2e-gce-gci.env
+++ b/job-configs/kubernetes-e2e-gce-gci.env
@@ -1,0 +1,5 @@
+# This list should match the list in kubernetes-pull-build-test-e2e-gce.
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+KUBE_OS_DISTRIBUTION=gci
+PROJECT=k8s-jkns-e2e-gce-gci

--- a/job-configs/kubernetes-e2e-gce-ingress-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-ingress-release-1.2.env
@@ -1,0 +1,4 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+PROJECT=kubernetes-ingress-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-ingress-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-ingress-release-1.3.env
@@ -1,0 +1,4 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+PROJECT=kubernetes-ingress-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-ingress.env
+++ b/job-configs/kubernetes-e2e-gce-ingress.env
@@ -1,0 +1,5 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+PROJECT=kubernetes-ingress
+# TODO: Enable this when we've split 1.2 tests into another project.
+FAIL_ON_GCP_RESOURCE_LEAK=false
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-kubenet.env
+++ b/job-configs/kubernetes-e2e-gce-kubenet.env
@@ -1,0 +1,5 @@
+PROJECT=k8s-jkns-e2e-gce-kubenet
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+NETWORK_PROVIDER=kubenet
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-master-on-cvm.env
+++ b/job-configs/kubernetes-e2e-gce-master-on-cvm.env
@@ -1,0 +1,8 @@
+# This list should match the list in kubernetes-pull-build-test-e2e-gce.
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jenkins-master-cvm
+KUBE_MASTER_OS_DISTRIBUTION=debian
+KUBE_GCE_MASTER_IMAGE=container-v1-3-v20160604
+KUBE_GCE_NODE_IMAGE=container-v1-3-v20160604
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-multizone.env
+++ b/job-configs/kubernetes-e2e-gce-multizone.env
@@ -1,0 +1,7 @@
+PROJECT=k8s-jkns-e2e-gce-ubelite
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+MULTIZONE=true
+E2E_ZONES=us-central1-a us-central1-b us-central1-f # Where the nodes reside.  Master is in the first one.
+KUBE_GCE_ZONE=us-central1-a # Where the master resides - hangover due to legacy scripts.
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-petset.env
+++ b/job-configs/kubernetes-e2e-gce-petset.env
@@ -1,0 +1,4 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:PetSet\]
+PROJECT=kubernetes-petset
+FAIL_ON_GCP_RESOURCE_LEAK=false  # TODO: Enable once we've fixed #23032
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-proto.env
+++ b/job-configs/kubernetes-e2e-gce-proto.env
@@ -1,0 +1,9 @@
+# This list should match the list in kubernetes-pull-build-test-e2e-gce.
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kube-api-content-type=application/vnd.kubernetes.protobuf
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-protobuf
+# Store protobufs in database.
+TEST_CLUSTER_STORAGE_CONTENT_TYPE=--storage-media-type=application/vnd.kubernetes.protobuf
+# Use protobufs to communicate with apiserver.
+TEST_CLUSTER_API_CONTENT_TYPE=--kube-api-content-type=application/vnd.kubernetes.protobuf
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-reboot-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-reboot-release-1.2.env
@@ -1,0 +1,4 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
+PROJECT=k8s-jkns-e2e-gce-reboot-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-reboot-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-reboot-release-1.3.env
@@ -1,0 +1,4 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
+PROJECT=k8s-jkns-gce-reboot-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-reboot.env
+++ b/job-configs/kubernetes-e2e-gce-reboot.env
@@ -1,0 +1,3 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-jkns-e2e-gce-ci-reboot

--- a/job-configs/kubernetes-e2e-gce-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-release-1.2.env
@@ -1,0 +1,5 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-gce-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-release-1.3.env
@@ -1,0 +1,5 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-gce-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-scalability-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-scalability-release-1.3.env
@@ -1,0 +1,23 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+E2E_NAME=e2e-scalability-1-3
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
+# Use the 1.1 project for now, since it has quota.
+# TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+PROJECT=k8s-e2e-gce-scalability-1-1
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override GCE defaults.
+KUBE_GCE_ZONE=us-east1-b
+MASTER_SIZE=n1-standard-4
+NODE_SIZE=n1-standard-1
+NODE_DISK_SIZE=50GB
+NUM_NODES=100
+REGISTER_MASTER=true
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=2
+# TODO: Remove when we figure out the reason for occasional failures #19048
+KUBELET_TEST_LOG_LEVEL=--v=4
+# Increase resync period to simulate production
+TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+# Increase delete collection parallelism
+TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-scalability.env
+++ b/job-configs/kubernetes-e2e-gce-scalability.env
@@ -1,0 +1,19 @@
+E2E_NAME=e2e-scalability
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
+# Create a project k8s-jenkins-scalability-head and move this test there
+PROJECT=google.com:k8s-jenkins-scalability
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override GCE defaults.
+MASTER_SIZE=n1-standard-4
+NODE_SIZE=n1-standard-2
+NODE_DISK_SIZE=50GB
+NUM_NODES=100
+ALLOWED_NOTREADY_NODES=1
+REGISTER_MASTER=true
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=2
+# Increase resync period to simulate production
+TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+# Increase delete collection parallelism
+TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-serial-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-serial-release-1.2.env
@@ -1,0 +1,4 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=k8s-jkns-e2e-gce-serial-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-serial-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-serial-release-1.3.env
@@ -1,0 +1,4 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=k8s-jkns-gce-serial-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-serial.env
+++ b/job-configs/kubernetes-e2e-gce-serial.env
@@ -1,0 +1,5 @@
+ENABLE_GARBAGE_COLLECTOR=true
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=kubernetes-jkns-e2e-gce-serial
+KUBE_OS_DISTRIBUTION=gci
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gce-slow-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gce-slow-release-1.2.env
@@ -1,0 +1,5 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-gce-slow-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-slow-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gce-slow-release-1.3.env
@@ -1,0 +1,5 @@
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-gce-slow-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gce-slow.env
+++ b/job-configs/kubernetes-e2e-gce-slow.env
@@ -1,0 +1,5 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+KUBE_GCE_ZONE=europe-west1-c
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-jkns-e2e-gce-slow

--- a/job-configs/kubernetes-e2e-gce.env
+++ b/job-configs/kubernetes-e2e-gce.env
@@ -1,0 +1,7 @@
+# This is the *only* job that should publish the last green version.
+E2E_PUBLISH_GREEN_VERSION=true
+# This list should match the list in kubernetes-pull-build-test-e2e-gce.
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-jkns-e2e-gce

--- a/job-configs/kubernetes-e2e-gke-1.0-1.2-upgrade-cluster-new.env
+++ b/job-configs/kubernetes-e2e-gke-1.0-1.2-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.2
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.0
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-0-1-2-upg-clu-n
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.0-1.2-upgrade-cluster.env
+++ b/job-configs/kubernetes-e2e-gke-1.0-1.2-upgrade-cluster.env
@@ -1,0 +1,20 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.2
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.0
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-0-1-2-upg-clu
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+# XXX This is a hack to run only the tests we care about, without importing all of
+# the skip list vars from the v1.0 e2e.sh.
+GINKGO_TEST_ARGS=--ginkgo.skip=Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster
+
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.0-1.2-upgrade-master.env
+++ b/job-configs/kubernetes-e2e-gke-1.0-1.2-upgrade-master.env
@@ -1,0 +1,20 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.2
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.0
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-0-1-2-upg-mas
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+# XXX This is a hack to run only the tests we care about, without importing all of
+# the skip list vars from the v1.0 e2e.sh.
+GINKGO_TEST_ARGS=--ginkgo.skip=Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster
+
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.1-1.2-upgrade-cluster-new.env
+++ b/job-configs/kubernetes-e2e-gke-1.1-1.2-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.2
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.1
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-1-1-2-upg-clu-n
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.1-1.2-upgrade-cluster.env
+++ b/job-configs/kubernetes-e2e-gke-1.1-1.2-upgrade-cluster.env
@@ -1,0 +1,20 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.2
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.1
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-1-1-2-upg-clu
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+# XXX This is a hack to run only the tests we care about, without importing all of
+# the skip list vars from the v1.1 e2e.sh.
+GINKGO_TEST_ARGS=--ginkgo.skip=Autoscaling\sSuite|resource\susage\stracking|Nodes|Etcd\sFailure|MasterCerts|experimental\sresource\susage\stracking|ServiceLoadBalancer|Shell|Daemon\sset|Deployment|Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster
+
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.1-1.2-upgrade-master.env
+++ b/job-configs/kubernetes-e2e-gke-1.1-1.2-upgrade-master.env
@@ -1,0 +1,20 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.2
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.1
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-1-1-2-upg-mas
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+# XXX This is a hack to run only the tests we care about, without importing all of
+# the skip list vars from the v1.1 e2e.sh.
+GINKGO_TEST_ARGS=--ginkgo.skip=Autoscaling\sSuite|resource\susage\stracking|Nodes|Etcd\sFailure|MasterCerts|experimental\sresource\susage\stracking|ServiceLoadBalancer|Shell|Daemon\sset|Deployment|Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster
+
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.1-1.3-upgrade-cluster-new.env
+++ b/job-configs/kubernetes-e2e-gke-1.1-1.3-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.3
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.1
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-1-1-3-upg-clu-n
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.1-1.3-upgrade-cluster.env
+++ b/job-configs/kubernetes-e2e-gke-1.1-1.3-upgrade-cluster.env
@@ -1,0 +1,20 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.3
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.1
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-1-1-3-upg-clu
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+# XXX This is a hack to run only the tests we care about, without importing all of
+# the skip list vars from the v1.1 e2e.sh.
+GINKGO_TEST_ARGS=--ginkgo.skip=Autoscaling\sSuite|resource\susage\stracking|Nodes|Etcd\sFailure|MasterCerts|experimental\sresource\susage\stracking|ServiceLoadBalancer|Shell|Daemon\sset|Deployment|Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster
+
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.1-1.3-upgrade-master.env
+++ b/job-configs/kubernetes-e2e-gke-1.1-1.3-upgrade-master.env
@@ -1,0 +1,20 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.3
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.1
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-1-1-3-upg-mas
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+# XXX This is a hack to run only the tests we care about, without importing all of
+# the skip list vars from the v1.1 e2e.sh.
+GINKGO_TEST_ARGS=--ginkgo.skip=Autoscaling\sSuite|resource\susage\stracking|Nodes|Etcd\sFailure|MasterCerts|experimental\sresource\susage\stracking|ServiceLoadBalancer|Shell|Daemon\sset|Deployment|Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster
+
+# In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
+# was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
+NUM_MINIONS=3
+# Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
+# override it here (specifically for HPA tests).
+MACHINE_TYPE='n1-standard-2'
+

--- a/job-configs/kubernetes-e2e-gke-1.2-1.1-kubectl-skew.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.1-kubectl-skew.env
@@ -1,0 +1,7 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.1
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+PROJECT=kube-gke-upg-1-2-1-1-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-1.2-1.3-kubectl-skew.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.3-kubectl-skew.env
@@ -1,0 +1,7 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+PROJECT=kube-gke-upg-1-2-1-3-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-1.2-1.3-upgrade-cluster-new.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.3-upgrade-cluster-new.env
@@ -1,0 +1,9 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.3
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-2-1-3-upg-clu-n
+

--- a/job-configs/kubernetes-e2e-gke-1.2-1.3-upgrade-cluster.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.3-upgrade-cluster.env
@@ -1,0 +1,11 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.3
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-2-1-3-upg-clu
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+
+

--- a/job-configs/kubernetes-e2e-gke-1.2-1.3-upgrade-master.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.3-upgrade-master.env
@@ -1,0 +1,11 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.3
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-2-1-3-upg-mas
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+
+

--- a/job-configs/kubernetes-e2e-gke-1.2-1.4-upgrade-cluster-new.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.4-upgrade-cluster-new.env
@@ -1,0 +1,9 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.4
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-2-1-4-upg-clu-n
+

--- a/job-configs/kubernetes-e2e-gke-1.2-1.4-upgrade-cluster.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.4-upgrade-cluster.env
@@ -1,0 +1,11 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.4
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-2-1-4-upg-clu
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+
+

--- a/job-configs/kubernetes-e2e-gke-1.2-1.4-upgrade-master.env
+++ b/job-configs/kubernetes-e2e-gke-1.2-1.4-upgrade-master.env
@@ -1,0 +1,11 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.4
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-2-1-4-upg-mas
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+
+

--- a/job-configs/kubernetes-e2e-gke-1.3-1.2-kubectl-skew.env
+++ b/job-configs/kubernetes-e2e-gke-1.3-1.2-kubectl-skew.env
@@ -1,0 +1,7 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+PROJECT=kube-gke-upg-1-3-1-2-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-1.3-1.4-kubectl-skew.env
+++ b/job-configs/kubernetes-e2e-gke-1.3-1.4-kubectl-skew.env
@@ -1,0 +1,7 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+PROJECT=kube-gke-upg-1-3-1-4-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new.env
+++ b/job-configs/kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new.env
@@ -1,0 +1,9 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.4
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-3-1-4-upg-clu-n
+

--- a/job-configs/kubernetes-e2e-gke-1.3-1.4-upgrade-cluster.env
+++ b/job-configs/kubernetes-e2e-gke-1.3-1.4-upgrade-cluster.env
@@ -1,0 +1,11 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.4
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-3-1-4-upg-clu
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+
+

--- a/job-configs/kubernetes-e2e-gke-1.3-1.4-upgrade-master.env
+++ b/job-configs/kubernetes-e2e-gke-1.3-1.4-upgrade-master.env
@@ -1,0 +1,11 @@
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.4
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-1-3-1-4-upg-mas
+# Set legacy skip list, only when testing old version
+# TODO remove when we no longer care about v1.1
+
+

--- a/job-configs/kubernetes-e2e-gke-1.4-1.3-kubectl-skew.env
+++ b/job-configs/kubernetes-e2e-gke-1.4-1.3-kubectl-skew.env
@@ -1,0 +1,7 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+PROJECT=kube-gke-upg-1-4-1-3-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-autoscaling.env
+++ b/job-configs/kubernetes-e2e-gke-autoscaling.env
@@ -1,0 +1,5 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
+NUM_NODES=3
+PROJECT=k8s-e2e-gke-autoscaling
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-flaky.env
+++ b/job-configs/kubernetes-e2e-gke-flaky.env
@@ -1,0 +1,4 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
+PROJECT=k8s-jkns-e2e-gke-ci-flaky
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-gci-serial.env
+++ b/job-configs/kubernetes-e2e-gke-gci-serial.env
@@ -1,0 +1,6 @@
+ENABLE_GARBAGE_COLLECTOR=true
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=jenkins-gke-gci-e2e-serial
+KUBE_OS_DISTRIBUTION=gci
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gke-gci-slow.env
+++ b/job-configs/kubernetes-e2e-gke-gci-slow.env
@@ -1,0 +1,5 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-gke-gci-slow
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gke-gci.env
+++ b/job-configs/kubernetes-e2e-gke-gci.env
@@ -1,0 +1,5 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+PROJECT=k8s-jkns-e2e-gke-gci-ci
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-e2e-gke-ingress-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gke-ingress-release-1.2.env
@@ -1,0 +1,4 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+PROJECT=kubernetes-gke-ingress-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-ingress-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gke-ingress-release-1.3.env
@@ -1,0 +1,4 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+PROJECT=kubernetes-gke-ingress-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-ingress.env
+++ b/job-configs/kubernetes-e2e-gke-ingress.env
@@ -1,0 +1,5 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+PROJECT=kubernetes-gke-ingress
+# TODO: Enable this when we've split 1.2 tests into another project.
+FAIL_ON_GCP_RESOURCE_LEAK=false
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-large-cluster.env
+++ b/job-configs/kubernetes-e2e-gke-large-cluster.env
@@ -1,0 +1,20 @@
+E2E_NAME=gke-large-cluster
+PROJECT=kubernetes-scale
+# TODO: Remove FAIL_ON_GCP_RESOURCE_LEAK when PROJECT changes back to gke-large-cluster-jenkins.
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# TODO: should test kube-proxy test is not designed to run in large clusters.
+#   We should change it start running it here too.
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|should\stest\skube-proxy --system-pods-startup-timeout=120m
+GINKGO_PARALLEL=y
+ZONE=us-east1-a
+NUM_NODES=2000
+MACHINE_TYPE=n1-standard-1
+HEAPSTER_MACHINE_TYPE=n1-standard-4
+ALLOWED_NOTREADY_NODES=20
+# We were asked (by MIG team) to not create more than 5 MIGs per zone.
+# We also paged SREs with max-nodes-per-pool=400 (5 concurrent MIGs)
+# So setting max-nodes-per-pool=1000, to check if that helps.
+GKE_CREATE_FLAGS=--max-nodes-per-pool=1000
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-multizone.env
+++ b/job-configs/kubernetes-e2e-gke-multizone.env
@@ -1,0 +1,6 @@
+ADDITIONAL_ZONES=us-central1-a,us-central1-b
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+PROJECT=k8s-jkns-e2e-gke-multizone
+ZONE=us-central1-f
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-pre-release.env
+++ b/job-configs/kubernetes-e2e-gke-pre-release.env
@@ -1,0 +1,4 @@
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+JENKINS_PUBLISHED_VERSION=release/latest
+PROJECT=k8s-jkns-e2e-gke-prerel
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-prod-parallel.env
+++ b/job-configs/kubernetes-e2e-gke-prod-parallel.env
@@ -1,0 +1,9 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_USE_SERVER_VERSION=y
+PROJECT=k8s-e2e-gke-prod-parallel
+ZONE=us-central1-b
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-prod-smoke.env
+++ b/job-configs/kubernetes-e2e-gke-prod-smoke.env
@@ -1,0 +1,9 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_USE_SERVER_VERSION=y
+PROJECT=k8s-e2e-gke-prod-smoke
+ZONE=asia-east1-b
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-prod.env
+++ b/job-configs/kubernetes-e2e-gke-prod.env
@@ -1,0 +1,7 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+PROJECT=k8s-jkns-e2e-gke-prod
+ZONE=us-central1-b
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-reboot-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gke-reboot-release-1.3.env
@@ -1,0 +1,4 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+PROJECT=k8s-jkns-gke-reboot-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-reboot.env
+++ b/job-configs/kubernetes-e2e-gke-reboot.env
@@ -1,0 +1,4 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
+PROJECT=k8s-jkns-e2e-gke-ci-reboot
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gke-release-1.2.env
@@ -1,0 +1,5 @@
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+PROJECT=k8s-jkns-e2e-gke-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gke-release-1.3.env
@@ -1,0 +1,5 @@
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+PROJECT=k8s-jkns-gke-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-serial-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gke-serial-release-1.2.env
@@ -1,0 +1,4 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+PROJECT=k8s-jkns-e2e-gke-serial-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-serial-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gke-serial-release-1.3.env
@@ -1,0 +1,4 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+PROJECT=k8s-jkns-gke-serial-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-serial.env
+++ b/job-configs/kubernetes-e2e-gke-serial.env
@@ -1,0 +1,6 @@
+ENABLE_GARBAGE_COLLECTOR=true
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+PROJECT=jenkins-gke-e2e-serial
+KUBE_NODE_OS_DISTRIBUTION=debian
+KUBE_ENABLE_RESCHEDULER=true

--- a/job-configs/kubernetes-e2e-gke-slow-release-1.2.env
+++ b/job-configs/kubernetes-e2e-gke-slow-release-1.2.env
@@ -1,0 +1,5 @@
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+PROJECT=k8s-jkns-e2e-gke-slow-1-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-slow-release-1.3.env
+++ b/job-configs/kubernetes-e2e-gke-slow-release-1.3.env
@@ -1,0 +1,5 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3
+PROJECT=k8s-jkns-gke-slow-1-3
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-slow.env
+++ b/job-configs/kubernetes-e2e-gke-slow.env
@@ -1,0 +1,5 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-gke-slow
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-staging-parallel.env
+++ b/job-configs/kubernetes-e2e-gke-staging-parallel.env
@@ -1,0 +1,8 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_USE_SERVER_VERSION=y
+PROJECT=k8s-e2e-gke-staging-parallel
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-staging.env
+++ b/job-configs/kubernetes-e2e-gke-staging.env
@@ -1,0 +1,6 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+PROJECT=k8s-jkns-e2e-gke-staging
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-subnet.env
+++ b/job-configs/kubernetes-e2e-gke-subnet.env
@@ -1,0 +1,8 @@
+# auto-subnet manually created - if deleted, it will need to be recreated
+# gcloud alpha compute networks create auto-subnet --mode auto
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_NAME=auto-subnet
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+PROJECT=k8s-jkns-e2e-gke-subnet
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-test.env
+++ b/job-configs/kubernetes-e2e-gke-test.env
@@ -1,0 +1,5 @@
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+PROJECT=k8s-jkns-e2e-gke-test
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-trusty-prod-parallel.env
+++ b/job-configs/kubernetes-e2e-gke-trusty-prod-parallel.env
@@ -1,0 +1,11 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_NAME=gke-e2e-prod-pa-trusty
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_USE_SERVER_VERSION=y
+KUBE_GCE_ZONE=asia-east1-b
+KUBE_OS_DISTRIBUTION=trusty
+PROJECT=e2e-gke-trusty-prod-p
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-trusty-prod.env
+++ b/job-configs/kubernetes-e2e-gke-trusty-prod.env
@@ -1,0 +1,9 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_NAME=gke-e2e-prod-trusty
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+KUBE_GCE_ZONE=asia-east1-b
+KUBE_OS_DISTRIBUTION=trusty
+PROJECT=kubekins-e2e-gke-trusty-prod
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-trusty-staging-parallel.env
+++ b/job-configs/kubernetes-e2e-gke-trusty-staging-parallel.env
@@ -1,0 +1,10 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_NAME=gke-e2e-staging-pa-trusty
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_USE_SERVER_VERSION=y
+KUBE_OS_DISTRIBUTION=trusty
+PROJECT=e2e-gke-trusty-staging-p
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-trusty-staging.env
+++ b/job-configs/kubernetes-e2e-gke-trusty-staging.env
@@ -1,0 +1,8 @@
+CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_NAME=gke-e2e-staging-trusty
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+KUBE_OS_DISTRIBUTION=trusty
+PROJECT=e2e-gke-trusty-staging
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-trusty-subnet.env
+++ b/job-configs/kubernetes-e2e-gke-trusty-subnet.env
@@ -1,0 +1,10 @@
+# Subnetwork jkns-gke-e2e-subnet-trusty is manually created -
+# if deleted, it will need to be recreated via
+# `gcloud alpha compute networks create jkns-gke-e2e-subnet-trusty --mode auto`
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_NAME=gke-e2e-subnet-trusty
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+KUBE_OS_DISTRIBUTION=trusty
+PROJECT=k8s-e2e-gke-trusty-subnet
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-trusty-test.env
+++ b/job-configs/kubernetes-e2e-gke-trusty-test.env
@@ -1,0 +1,7 @@
+CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
+E2E_NAME=gke-e2e-test-trusty
+E2E_OPT=--check_version_skew=false
+JENKINS_USE_SERVER_VERSION=y
+KUBE_OS_DISTRIBUTION=trusty
+PROJECT=kubekins-e2e-gke-trusty-test
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke-updown.env
+++ b/job-configs/kubernetes-e2e-gke-updown.env
@@ -1,0 +1,5 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
+PROJECT=kubernetes-e2e-gke-updown
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-e2e-gke.env
+++ b/job-configs/kubernetes-e2e-gke.env
@@ -1,0 +1,5 @@
+CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+PROJECT=k8s-jkns-e2e-gke-ci
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-garbagecollector-feature.env
+++ b/job-configs/kubernetes-garbagecollector-feature.env
@@ -1,0 +1,6 @@
+# Start the gc in controller plane
+ENABLE_GARBAGE_COLLECTOR=true
+E2E_NAME=gc-feature
+PROJECT=k8s-jenkins-garbagecollector
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:GarbageCollector\]
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-kubemark-100-gce.env
+++ b/job-configs/kubernetes-kubemark-100-gce.env
@@ -1,0 +1,19 @@
+ENABLE_GARBAGE_COLLECTOR=true
+E2E_NAME=kubemark-100
+PROJECT=k8s-jenkins-kubemark
+E2E_TEST=false
+USE_KUBEMARK=true
+KUBEMARK_TESTS=\[Feature:Performance\]
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --garbage-collector-enabled=true
+CREATE_SERVICES=true
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override defaults to be independent from GCE defaults and set kubemark parameters
+NUM_NODES=3
+MASTER_SIZE=n1-standard-2
+NODE_SIZE=n1-standard-4
+KUBE_GCE_ZONE=us-central1-f
+KUBEMARK_MASTER_SIZE=n1-standard-4
+KUBEMARK_NUM_NODES=100
+# The kubemark scripts build a Docker image
+JENKINS_ENABLE_DOCKER_IN_DOCKER=y
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-kubemark-5-gce-gci.env
+++ b/job-configs/kubernetes-kubemark-5-gce-gci.env
@@ -1,0 +1,20 @@
+ENABLE_GARBAGE_COLLECTOR=true
+E2E_NAME=kubemark-5
+PROJECT=k8s-jenkins-gci-kubemark
+E2E_TEST=false
+USE_KUBEMARK=true
+KUBEMARK_TESTS=starting\s30\spods\sper\snode
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --garbage-collector-enabled=true
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override defaults to be independent from GCE defaults and set kubemark parameters
+NUM_NODES=1
+MASTER_SIZE=n1-standard-1
+NODE_SIZE=n1-standard-2
+KUBE_GCE_ZONE=us-central1-f
+# TODO: This is to check if that helps with #26185.
+# Revert it after migrating to etcd3.
+KUBEMARK_MASTER_SIZE=n1-standard-2
+KUBEMARK_NUM_NODES=5
+# The kubemark scripts build a Docker image
+JENKINS_ENABLE_DOCKER_IN_DOCKER=y
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-kubemark-5-gce.env
+++ b/job-configs/kubernetes-kubemark-5-gce.env
@@ -1,0 +1,20 @@
+ENABLE_GARBAGE_COLLECTOR=true
+E2E_NAME=kubemark-5
+PROJECT=k8s-jenkins-kubemark
+E2E_TEST=false
+USE_KUBEMARK=true
+KUBEMARK_TESTS=starting\s30\spods\sper\snode
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --garbage-collector-enabled=true
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override defaults to be independent from GCE defaults and set kubemark parameters
+NUM_NODES=1
+MASTER_SIZE=n1-standard-1
+NODE_SIZE=n1-standard-2
+KUBE_GCE_ZONE=us-central1-f
+# TODO: This is to check if that helps with #26185.
+# Revert it after migrating to etcd3.
+KUBEMARK_MASTER_SIZE=n1-standard-2
+KUBEMARK_NUM_NODES=5
+# The kubemark scripts build a Docker image
+JENKINS_ENABLE_DOCKER_IN_DOCKER=y
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-kubemark-500-gce-gci.env
+++ b/job-configs/kubernetes-kubemark-500-gce-gci.env
@@ -1,0 +1,22 @@
+ENABLE_GARBAGE_COLLECTOR=true
+E2E_NAME=kubemark-500
+PROJECT=k8s-jenkins-block-kubemark-gci
+E2E_TEST=false
+USE_KUBEMARK=true
+KUBEMARK_TESTS=\[Feature:Performance\]
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --garbage-collector-enabled=true
+# Increase throughput in Kubemark master components.
+KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS=--kube-api-qps=100 --kube-api-burst=100
+# Increase throughput in Load test.
+LOAD_TEST_THROUGHPUT=50
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override defaults to be independent from GCE defaults and set kubemark parameters
+NUM_NODES=6
+MASTER_SIZE=n1-standard-4
+NODE_SIZE=n1-standard-8
+KUBE_GCE_ZONE=us-central1-f
+KUBEMARK_MASTER_SIZE=n1-standard-16
+KUBEMARK_NUM_NODES=500
+# The kubemark scripts build a Docker image
+JENKINS_ENABLE_DOCKER_IN_DOCKER=y
+KUBE_OS_DISTRIBUTION=gci

--- a/job-configs/kubernetes-kubemark-500-gce.env
+++ b/job-configs/kubernetes-kubemark-500-gce.env
@@ -1,0 +1,22 @@
+ENABLE_GARBAGE_COLLECTOR=true
+E2E_NAME=kubemark-500
+PROJECT=k8s-jenkins-blocking-kubemark
+E2E_TEST=false
+USE_KUBEMARK=true
+KUBEMARK_TESTS=\[Feature:Performance\]
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --garbage-collector-enabled=true
+# Increase throughput in Kubemark master components.
+KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS=--kube-api-qps=100 --kube-api-burst=100
+# Increase throughput in Load test.
+LOAD_TEST_THROUGHPUT=50
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override defaults to be independent from GCE defaults and set kubemark parameters
+NUM_NODES=6
+MASTER_SIZE=n1-standard-4
+NODE_SIZE=n1-standard-8
+KUBE_GCE_ZONE=us-central1-f
+KUBEMARK_MASTER_SIZE=n1-standard-16
+KUBEMARK_NUM_NODES=500
+# The kubemark scripts build a Docker image
+JENKINS_ENABLE_DOCKER_IN_DOCKER=y
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-kubemark-gce-scale.env
+++ b/job-configs/kubernetes-kubemark-gce-scale.env
@@ -1,0 +1,30 @@
+ENABLE_GARBAGE_COLLECTOR=true
+# XXX Not a unique project
+E2E_NAME=kubemark-2000
+PROJECT=kubernetes-scale
+E2E_TEST=false
+USE_KUBEMARK=true
+KUBEMARK_TESTS=\[Feature:Performance\]
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --garbage-collector-enabled=true --kube-api-content-type=application/vnd.kubernetes.protobuf
+# Increase throughput in Kubemark master components.
+KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS=--kube-api-qps=100 --kube-api-burst=100
+# Increase throughput in Load test.
+LOAD_TEST_THROUGHPUT=50
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override defaults to be independent from GCE defaults and set kubemark parameters
+# We need 11 so that we won't hit max-pods limit (set to 100). TODO: do it in a nicer way.
+NUM_NODES=21
+MASTER_SIZE=n1-standard-4
+# Note: can fit about 17 hollow nodes per core so NUM_NODES x
+# cores_per_node should be set accordingly.
+NODE_SIZE=n1-standard-8
+KUBEMARK_MASTER_SIZE=n1-standard-32
+KUBEMARK_NUM_NODES=2000
+KUBE_GCE_ZONE=us-central1-f
+# Use protobufs
+TEST_CLUSTER_API_CONTENT_TYPE=--kube-api-content-type=application/vnd.kubernetes.protobuf
+# TODO: Uncomment when we make the final decision to store protobufs in etcd.
+# TEST_CLUSTER_STORAGE_CONTENT_TYPE=--storage-media-type=application/vnd.kubernetes.protobuf
+# The kubemark scripts build a Docker image
+JENKINS_ENABLE_DOCKER_IN_DOCKER=y
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-kubemark-high-density-100-gce.env
+++ b/job-configs/kubernetes-kubemark-high-density-100-gce.env
@@ -1,0 +1,18 @@
+ENABLE_GARBAGE_COLLECTOR=true
+E2E_NAME=kubemark-100pods
+PROJECT=k8s-jenkins-kubemark
+E2E_TEST=false
+USE_KUBEMARK=true
+KUBEMARK_TESTS=\[Feature:HighDensityPerformance\]
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --garbage-collector-enabled=true
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override defaults to be independent from GCE defaults and set kubemark parameters
+NUM_NODES=3
+MASTER_SIZE=n1-standard-2
+NODE_SIZE=n1-standard-4
+KUBE_GCE_ZONE=us-east1-d
+KUBEMARK_MASTER_SIZE=n1-standard-4
+KUBEMARK_NUM_NODES=100
+# The kubemark scripts build a Docker image
+JENKINS_ENABLE_DOCKER_IN_DOCKER=y
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-soak-continuous-e2e-gce-1.2.env
+++ b/job-configs/kubernetes-soak-continuous-e2e-gce-1.2.env
@@ -1,0 +1,3 @@
+PROJECT=k8s-jkns-gce-soak-1-2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-soak-continuous-e2e-gce-1.3.env
+++ b/job-configs/kubernetes-soak-continuous-e2e-gce-1.3.env
@@ -1,0 +1,3 @@
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-jkns-gce-soak-1-3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3

--- a/job-configs/kubernetes-soak-continuous-e2e-gce-2.env
+++ b/job-configs/kubernetes-soak-continuous-e2e-gce-2.env
@@ -1,0 +1,3 @@
+HAIRPIN_MODE=hairpin-veth
+PROJECT=k8s-jkns-gce-soak-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-soak-continuous-e2e-gce-gci.env
+++ b/job-configs/kubernetes-soak-continuous-e2e-gce-gci.env
@@ -1,0 +1,1 @@
+PROJECT=k8s-jkns-gce-gci-soak

--- a/job-configs/kubernetes-soak-continuous-e2e-gce.env
+++ b/job-configs/kubernetes-soak-continuous-e2e-gce.env
@@ -1,0 +1,1 @@
+PROJECT=k8s-jkns-gce-soak

--- a/job-configs/kubernetes-soak-continuous-e2e-gke-gci.env
+++ b/job-configs/kubernetes-soak-continuous-e2e-gke-gci.env
@@ -1,0 +1,5 @@
+KUBE_OS_DISTRIBUTION=gci
+PROJECT=k8s-jkns-gke-gci-soak
+# Need at least n1-standard-2 nodes to run kubelet_perf tests
+MACHINE_TYPE=n1-standard-2
+E2E_OPT=--check_version_skew=false

--- a/job-configs/kubernetes-soak-continuous-e2e-gke.env
+++ b/job-configs/kubernetes-soak-continuous-e2e-gke.env
@@ -1,0 +1,5 @@
+PROJECT=k8s-jkns-gke-soak
+# Need at least n1-standard-2 nodes to run kubelet_perf tests
+MACHINE_TYPE=n1-standard-2
+KUBE_NODE_OS_DISTRIBUTION=debian
+E2E_OPT=--check_version_skew=false

--- a/job-configs/kubernetes-soak-weekly-deploy-gce-1.2.env
+++ b/job-configs/kubernetes-soak-weekly-deploy-gce-1.2.env
@@ -1,0 +1,3 @@
+PROJECT=k8s-jkns-gce-soak-1-2
+JENKINS_PUBLISHED_VERSION=ci/latest-1.2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-soak-weekly-deploy-gce-1.3.env
+++ b/job-configs/kubernetes-soak-weekly-deploy-gce-1.3.env
@@ -1,0 +1,3 @@
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-jkns-gce-soak-1-3
+JENKINS_PUBLISHED_VERSION=ci/latest-1.3

--- a/job-configs/kubernetes-soak-weekly-deploy-gce-2.env
+++ b/job-configs/kubernetes-soak-weekly-deploy-gce-2.env
@@ -1,0 +1,3 @@
+HAIRPIN_MODE=hairpin-veth
+PROJECT=k8s-jkns-gce-soak-2
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/job-configs/kubernetes-soak-weekly-deploy-gce-gci.env
+++ b/job-configs/kubernetes-soak-weekly-deploy-gce-gci.env
@@ -1,0 +1,1 @@
+PROJECT=k8s-jkns-gce-gci-soak

--- a/job-configs/kubernetes-soak-weekly-deploy-gce.env
+++ b/job-configs/kubernetes-soak-weekly-deploy-gce.env
@@ -1,0 +1,1 @@
+PROJECT=k8s-jkns-gce-soak

--- a/job-configs/kubernetes-soak-weekly-deploy-gke-gci.env
+++ b/job-configs/kubernetes-soak-weekly-deploy-gke-gci.env
@@ -1,0 +1,5 @@
+KUBE_OS_DISTRIBUTION=gci
+PROJECT=k8s-jkns-gke-gci-soak
+# Need at least n1-standard-2 nodes to run kubelet_perf tests
+MACHINE_TYPE=n1-standard-2
+E2E_OPT=--check_version_skew=false

--- a/job-configs/kubernetes-soak-weekly-deploy-gke.env
+++ b/job-configs/kubernetes-soak-weekly-deploy-gke.env
@@ -1,0 +1,5 @@
+PROJECT=k8s-jkns-gke-soak
+# Need at least n1-standard-2 nodes to run kubelet_perf tests
+MACHINE_TYPE=n1-standard-2
+KUBE_NODE_OS_DISTRIBUTION=debian
+E2E_OPT=--check_version_skew=false


### PR DESCRIPTION
- Require e2e jobs to set `KUBEKINS_PROVIDER_ENV` and `KUBEKINS_JOB_ENV`
  - Update dockerized-e2e-runner.sh to inject these into the image
- Prevent jobs from having `{provider-env}` and `{job-env}' shell lines.
- Require `provider-env` to be the name of a `.env` file (migrate previous exports to the .env file)
- Copy all job-env exports to an .env file with the same name as the job.
  - Wrote a quick-and-dirty script to extract this information from the yaml files
  - Once we have this working I plan to start deleting job-env lines from jobs, starting with non-critical jobs
- Require e2e jobs to check out the test-infra repository

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/435)

<!-- Reviewable:end -->
