### PR TITLE
Extend the jenkins kubelet serial test timeout.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -100,7 +100,7 @@
         - ansicolor:
             colormap: xterm
         - timeout:
-            timeout: 90
+            timeout: '{test-timeout}'
             fail: true
         - timestamps
         - inject:
@@ -113,6 +113,7 @@
             external-deletion-command: 'sudo rm -rf %s'
 
     scm-cron-string: 'H/5 * * * *'
+    test-timeout: 90
 
 - project:
     name: node-docker-canary-build
@@ -159,6 +160,7 @@
         - 'kubelet-serial':
             scm-cron-string: 'H/30 * * * *'
             cron-string: 'H H/2 * * *'
+            test-timeout: '{jenkins-timeout}'
             repoName: 'kubernetes/kubernetes'
             gitbasedir: 'k8s.io/kubernetes'
             owner: 'lantaol@google.com'


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/31296#issuecomment-241984460.

This is causing node e2e VM leak, which sometimes block the merge queue.
This PR changes the timeout to default 600 min, which is much safer than 90 min.

@kubernetes/sig-testing Can anyone review this PR? :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/446)
<!-- Reviewable:end -->
