### PR TITLE
Always curl the build log. Bump soak timeout.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
@@ -33,9 +33,7 @@
                 - ensure-upload-to-gcs-script:
                     git-basedir: '{git-basedir}'
                 - shell: |
-                    if [[ "${{NODE_NAME:-}}" != 'master' ]]; then
-                      curl -fsS --retry 3 "http://pull-jenkins-master:8080/job/${{JOB_NAME}}/${{BUILD_NUMBER}}/consoleText" > "${{WORKSPACE}}/build-log.txt"
-                    fi
+                    curl -fsS --retry 3 "http://pull-jenkins-master:8080/job/${{JOB_NAME}}/${{BUILD_NUMBER}}/consoleText" > "${{WORKSPACE}}/build-log.txt"
                 - conditional-step:
                     condition-kind: current-status
                     condition-worst: SUCCESS

--- a/jenkins/job-configs/kubernetes-jenkins/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/global.yaml
@@ -13,9 +13,7 @@
                     curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" > ./_tmp/upload-to-gcs.sh
                     chmod +x ./_tmp/upload-to-gcs.sh
 
-                    if [[ "${NODE_NAME:-}" != 'master' ]]; then
-                      curl -fsS --retry 3 "http://jenkins-master:8080/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" > "${WORKSPACE}/build-log.txt"
-                    fi
+                    curl -fsS --retry 3 "http://jenkins-master:8080/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" > "${WORKSPACE}/build-log.txt"
                 - conditional-step:
                     condition-kind: current-status
                     condition-worst: SUCCESS

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -51,7 +51,7 @@
     <<: *soak_defaults
     description: '{e2e-description} Test Owner: {test-owner}'
     workspace: '/var/lib/jenkins/jobs/kubernetes-soak-weekly-deploy-{suffix}/workspace'
-    run-timeout: 360
+    run-timeout: 600
     soak-env: |
         export JENKINS_USE_EXISTING_BINARIES="y"
         export FAIL_ON_GCP_RESOURCE_LEAK="false"


### PR DESCRIPTION
The original intent of this check was that on master the build log would exist, but it doesn't. Lets just always curl it to avoid snowflakes.

The soak tests were passing in over 5 hours previously, so 6 hours is probably too tight. Bumped to 10 hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/452)
<!-- Reviewable:end -->
