### PR TITLE
Velodrome has a domain name now, use static IP

### DIFF
--- a/velodrome/grafana-stack/nginx.yaml
+++ b/velodrome/grafana-stack/nginx.yaml
@@ -40,6 +40,7 @@ spec:
     targetPort: nginx-port
   selector:
     app: nginx
+  loadBalancerIP: 104.197.200.129
   type: LoadBalancer
 ---
 apiVersion: v1


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/454)
<!-- Reviewable:end -->
