### PR TITLE
Add charts-pull job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/charts-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/charts-pull.yaml
@@ -1,0 +1,99 @@
+- job:
+    name: 'charts-pull-test-e2e'
+    concurrent: true
+    properties:
+        - build-discarder:
+            days-to-keep: 7
+        - github:
+            url: 'https://github.com/kubernetes/charts'
+        - throttle:
+            max-total: 4
+            max-per-node: 2
+            option: project
+        - raw:
+            xml: |
+                <com.cloudbees.plugins.JobPrerequisites plugin="slave-prerequisites@1.0">
+                    <script>docker version; gcloud version</script>
+                    <interpreter>shell script</interpreter>
+                </com.cloudbees.plugins.JobPrerequisites>
+    parameters:
+        - string:
+            name: sha1
+            description: 'sha1 or refname (e.g. origin/pr/N/head) to build'
+    scm:
+        - git:
+            remotes:
+                - remote:
+                    url: 'https://github.com/kubernetes/charts'
+                    refspec: '+refs/heads/*:refs/remotes/upstream/*'
+                - remote:
+                    url: 'https://github.com/kubernetes/charts'
+                    refspec: '+refs/pull/${{ghprbPullId}}/merge:refs/remotes/origin/pr/${{ghprbPullId}}/merge'
+            branches:
+                - 'origin/pr/${{ghprbPullId}}/merge'
+            basedir: ''
+            browser: githubweb
+            browser-url: 'http://github.com/kubernetes/charts'
+            timeout: 20
+            clean:
+                after: true
+            wipe-workspace: false
+            skip-tag: true
+    triggers:
+        - github-pull-request:
+            # This is the Jenkins GHPRB plugin ID, not the actual github token.
+            auth-id: 'f8e31bc1-9abb-460a-a2ca-9c4aae3ca4e8'
+            trigger-phrase: '(?is).*@k8s-bot\s+(e2e )?test\s+this.*'
+            cron: 'H/2 * * * *'
+            status-context: Jenkins Charts e2e
+            status-url: 'https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/'
+            # This should roughly line up with charts-maintainers.
+            # To go to :
+            #   https://github.com/orgs/kubernetes/teams/charts-maintainers
+            admin-list:
+                - k8s-merge-robot
+                - jackgr
+                - adamreese
+                - bmelville
+                - sgoings
+                - sparkprime
+                - vaikas-google
+                - viglesiasce
+                - etune
+                - prydonious
+                - runseb
+                - technosophos
+                - michelleN
+            # This should roughly line up with charts-collaborators.
+            # To go to :
+            #   https://github.com/orgs/kubernetes/teams/charts-collaborators
+            white-list:
+                - runseb
+                - vaikas-google
+                - jackgr
+            org-list:
+                - kubernetes
+            white-list-target-branches:
+                - master
+    wrappers:
+        - e2e-credentials-binding
+        - inject:
+            properties-content: |
+                GOROOT=/usr/local/go
+                GOPATH=$WORKSPACE/go
+                PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
+        - timeout:
+            timeout: 90
+            fail: true
+        - ansicolor:
+            colormap: xterm
+    builders:
+        - activate-gce-service-account
+        - ensure-upload-to-gcs-script
+        - shell: JENKINS_BUILD_STARTED=true "${{WORKSPACE}}/_tmp/upload-to-gcs.sh"
+        - shell: ./test/e2e.sh
+    publishers:
+        - gcs-uploader


### PR DESCRIPTION
The kubernetes/charts repository needs to implement a Pull Request builder.

The logic for the build is implemented in the test/e2e.sh script of the kubernetes/charts repository. I assume in this PR that the gcs uploader script is placed on the node by the "ensure-upload-to-gcs-script" builder step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/455)
<!-- Reviewable:end -->
