### PR TITLE
Make release-1.4 tests use container-vm explicitly.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -83,8 +83,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'slow-master': # kubernetes-e2e-gce-gci-ci-slow-master
             description: 'Runs slow tests on GCE with GCI images, sequentially on the master branch.'
             timeout: 150  #  See #24072
@@ -95,8 +94,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master-slow"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBE_OS_DISTRIBUTION="gci"
         - 'serial-master': # kubernetes-e2e-gce-gci-ci-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images.'
             timeout: 300
@@ -106,46 +104,8 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBE_OS_DISTRIBUTION="gci"
                 export KUBE_ENABLE_RESCHEDULER=true
-        - 'release-1.4':  # kubernetes-e2e-gce-gci-ci-release-1.4
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
-            timeout: 50
-            trigger-job: 'kubernetes-build-1.4'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-1-4"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'slow-release-1.4':  # kubernetes-e2e-gce-gci-ci-slow-release-1.4
-            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.4 branch.'
-            timeout: 150
-            trigger-job: 'kubernetes-build-1.4'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-slow-1-4"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'serial-release-1.4':  # kubernetes-e2e-gce-gci-ci-serial-release-1.4
-            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.4 branch.'
-            timeout: 300
-            trigger-job: 'kubernetes-build-1.4'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export JENKINS_GCI_IMAGE_FAMILY="gci-canary"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-ci-serial-1-4"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
             timeout: 50

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -511,6 +511,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-gce-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-reboot-release-1.4':  # kubernetes-e2e-gce-reboot-release-1.4
             description: 'Run [Feature:Reboot] tests on GCE on the release-1.4 branch.'
             timeout: 180
@@ -518,6 +519,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-gce-reboot-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-slow-release-1.4':  # kubernetes-e2e-gce-slow-release-1.4
             description: 'Runs slow tests on GCE, sequentially on the release-1.4 branch.'
             timeout: 150  #  See kubernetes/kubernetes#24072
@@ -527,6 +529,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-gce-slow-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-serial-release-1.4':  # kubernetes-e2e-gce-serial-release-1.4
             description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.4 branch.'
             timeout: 300
@@ -535,6 +538,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-gce-serial-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-ingress-release-1.4':  # kubernetes-e2e-gce-ingress-release-1.4
             description: 'Run [Feature:Ingress] tests on GCE on the release-1.4 branch.'
             timeout: 90
@@ -544,6 +548,35 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export PROJECT="k8s-jkns-gce-ingress1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-gci-release-1.4':  # kubernetes-e2e-gce-gci-release-1.4
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
+            timeout: 50
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-1-4"
+                export KUBE_OS_DISTRIBUTION="gci"
+        - 'gce-gci-slow-release-1.4':  # kubernetes-e2e-gce-gci-slow-release-1.4
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.4 branch.'
+            timeout: 150
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-slow-1-4"
+                export KUBE_OS_DISTRIBUTION="gci"
+        - 'gce-gci-serial-release-1.4':  # kubernetes-e2e-gce-gci-serial-release-1.4
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.4 branch.'
+            timeout: 300
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-ci-serial-1-4"
+                export KUBE_OS_DISTRIBUTION="gci"
         # TODO: Move gce-scalability-release-1.3 here (gce-scalability-release-1.4) once we cut the release branch
     jobs:
         - 'kubernetes-e2e-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -550,7 +550,7 @@
                 export PROJECT="k8s-jkns-gce-ingress1-4"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-gci-release-1.4':  # kubernetes-e2e-gce-gci-release-1.4
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.4 branch.'
             timeout: 50
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -217,6 +217,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-serial-release-1.4':  # kubernetes-e2e-gke-serial-release-1.4
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.4 branch.'
             timeout: 300
@@ -225,6 +226,7 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-serial-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-slow-release-1.4':  # kubernetes-e2e-gke-slow-release-1.4
             description: 'Run slow E2E tests on GKE using the release-1.4 branch.'
             timeout: 150  #  See kubernetes/kubernetes#24072
@@ -234,6 +236,7 @@
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-slow-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-reboot-release-1.4':  # kubernetes-e2e-gke-reboot-release-1.4
             description: 'Run [Feature:Reboot] tests on GKE on the release-1.4 branch.'
             timeout: 180
@@ -241,6 +244,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-reboot-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-ingress-release-1.4':  # kubernetes-e2e-gke-ingress-release-1.4
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.4 branch.'
             timeout: 90
@@ -250,6 +254,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-ingress-1-4"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -176,6 +176,7 @@
                 export KUBE_GCE_ZONE="us-central1-f"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-4"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"


### PR DESCRIPTION
GCI testing on release 1.4 should not use gci head since GCI is being
decoupled from k8s releases from v1.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/462)
<!-- Reviewable:end -->
