### PR TITLE
Fix Chart Pull admin list typo

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/charts-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/charts-pull.yaml
@@ -60,7 +60,7 @@
                 - vaikas-google
                 - viglesiasce
                 - etune
-                - prydonious
+                - prydonius
                 - runseb
                 - technosophos
                 - michelleN


### PR DESCRIPTION
There was a typo in one of the admins screen names for Charts Pull

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/463)
<!-- Reviewable:end -->
