### PR TITLE
Clone kubernetes-pull tests for gce with gci image on nodes

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -609,6 +609,226 @@
             echo "Exiting with code: ${{rc}}"
             exit ${{rc}}
 
+      - gci-build-test-e2e-gce: # kubernetes-pull-gci-build-test-e2e-gce
+          status-context: GCE e2e
+          max-total: 12
+          success-comment: |
+            GCE e2e build/test **passed** for commit ${{ghprbActualCommit}}.
+            * [Test Results](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}})
+            * [Build Log](http://pr-test.k8s.io/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/build-log.txt)
+            * [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/artifacts/)
+            * [Internal Jenkins Results](${{JOB_URL}}/${{BUILD_NUMBER}})
+          failure-comment: |
+            GCE e2e build/test **failed** for commit ${{ghprbActualCommit}}.
+            * [Test Results](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}})
+            * [Build Log](http://pr-test.k8s.io/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/build-log.txt)
+            * [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/artifacts/)
+            * [Internal Jenkins Results](${{JOB_URL}}/${{BUILD_NUMBER}})
+
+            Please reference the [list of currently known flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open) when examining this failure. If you request a re-test, you must reference the issue describing the flake.
+          error-comment: |
+            GCE e2e build/test **errored** for commit ${{ghprbActualCommit}}.
+            * [Test Results](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}})
+            * [Build Log](http://pr-test.k8s.io/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/build-log.txt)
+            * [Test Artifacts](https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/${{ghprbPullId}}/${{JOB_NAME}}/${{BUILD_NUMBER}}/artifacts/)
+            * [Internal Jenkins Results](${{JOB_URL}}/${{BUILD_NUMBER}})
+
+            Please reference the [list of currently known flakes](https://github.com/kubernetes/kubernetes/issues?q=is:issue+label:kind/flake+is:open) when examining this failure. If you request a re-test, you must reference the issue describing the flake.
+          trigger-phrase: '(gce )?(e2e )?test'
+          cmd: |
+            export KUBE_SKIP_PUSH_GCS=y
+            export KUBE_RUN_FROM_OUTPUT=y
+            export KUBE_FASTBUILD=true
+            ./hack/jenkins/build.sh
+            if [[ "${{ghprbTargetBranch:-}}" == "release-1.0" || "${{ghprbTargetBranch:-}}" == "release-1.1" ]]; then
+              ./hack/jenkins/e2e.sh
+            else
+              # Nothing should want Jenkins $HOME
+              export HOME=${{WORKSPACE}}
+
+              export KUBERNETES_PROVIDER="gce"
+              export E2E_MIN_STARTUP_PODS="1"
+              export KUBE_GCE_ZONE="us-central1-f"
+              export FAIL_ON_GCP_RESOURCE_LEAK="true"
+
+              # Flake detection. Individual tests get a second chance to pass.
+              export GINKGO_TOLERATE_FLAKES="y"
+
+              export E2E_NAME="e2e-gce-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+              export GINKGO_PARALLEL="y"
+              # This list should match the list in kubernetes-e2e-gce.
+              export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+              export FAIL_ON_GCP_RESOURCE_LEAK="false"
+              export PROJECT="k8s-jkns-pr-gci-gce"
+              # NUM_NODES should match kubernetes-e2e-gce.
+              export NUM_NODES="3"
+
+              # Force to use container-vm.
+              export KUBE_NODE_OS_DISTRIBUTION="gci"
+              # Assume we're upping, testing, and downing a cluster
+              export E2E_UP="true"
+              export E2E_TEST="true"
+              export E2E_DOWN="true"
+
+              # Skip gcloud update checking
+              export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
+              # GCE variables
+              export INSTANCE_PREFIX=${{E2E_NAME}}
+              export KUBE_GCE_NETWORK=${{E2E_NAME}}
+              export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
+
+              # Get golang into our PATH so we can run e2e.go
+              export PATH=${{PATH}}:/usr/local/go/bin
+
+              timeout -k 15m 55m {runner} && rc=$? || rc=$?
+              if [[ ${{rc}} -ne 0 ]]; then
+                if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+                  echo "Dumping logs for any remaining nodes"
+                  ./cluster/log-dump.sh _artifacts
+                fi
+              fi
+              if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
+                echo "Build timed out" >&2
+              elif [[ ${{rc}} -ne 0 ]]; then
+                echo "Build failed" >&2
+              fi
+              echo "Exiting with code: ${{rc}}"
+              exit ${{rc}}
+            fi
+
+      - gci-build-test-federation-e2e-gce: # kubernetes-pull-gci-build-test-federation-e2e-gce
+          status-context: Federation GCE e2e
+          max-total: 12
+          only-trigger-phrase: true  # This test should run only if explicitly triggered.
+          trigger-phrase: 'federation (gce )?(e2e )?test'
+          cmd: |
+            # Federation specific params
+            export FEDERATION="true"
+            export PROJECT="k8s-jkns-pr-gci-bld-e2e-gce-fd" # Ideally this would read k8s-jkns-pr-gci-bldr-e2e-gce-fdrtn, but there is a 30 char limit on project names.
+            export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn"
+            export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
+            export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
+            export E2E_ZONES="us-central1-a us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
+            export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
+            export DNS_ZONE_NAME="k8s-federation.com."
+            export FEDERATIONS_DOMAIN_MAP="federation=k8s-federation.com"
+
+            export KUBE_SKIP_PUSH_GCS=y
+            export KUBE_RUN_FROM_OUTPUT=y
+            export KUBE_FASTBUILD=true
+            ./hack/jenkins/build.sh
+            # Nothing should want Jenkins $HOME
+            export HOME=${{WORKSPACE}}
+
+            export KUBERNETES_PROVIDER="gce"
+            export E2E_MIN_STARTUP_PODS="1"
+            export FAIL_ON_GCP_RESOURCE_LEAK="true"
+
+            # Flake detection. Individual tests get a second chance to pass.
+            export GINKGO_TOLERATE_FLAKES="y"
+
+            export E2E_NAME="fed-e2e-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+            export FAIL_ON_GCP_RESOURCE_LEAK="false"
+            export NUM_NODES="3"
+
+            # Force to use container-vm.
+            export KUBE_NODE_OS_DISTRIBUTION="gci"
+            # Assume we're upping, testing, and downing a cluster
+            export E2E_UP="true"
+            export E2E_TEST="true"
+            export E2E_DOWN="true"
+
+            # Skip gcloud update checking
+            export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
+            # GCE variables
+            export INSTANCE_PREFIX=${{E2E_NAME}}
+            export KUBE_GCE_NETWORK=${{E2E_NAME}}
+            export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
+
+            # Get golang into our PATH so we can run e2e.go
+            export PATH=${{PATH}}:/usr/local/go/bin
+
+
+            timeout -k 15m 55m {runner} && rc=$? || rc=$?
+            if [[ ${{rc}} -ne 0 ]]; then
+              if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+                echo "Dumping logs for any remaining nodes"
+                ./cluster/log-dump.sh _artifacts
+              fi
+            fi
+            if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
+              echo "Build timed out" >&2
+            elif [[ ${{rc}} -ne 0 ]]; then
+              echo "Build failed" >&2
+            fi
+            echo "Exiting with code: ${{rc}}"
+            exit ${{rc}}
+
+      - gci-build-test-kubemark-e2e-gce: # kubernetes-pull-gci-build-test-kubemark-e2e-gce
+          status-context: Kubemark GCE e2e
+          max-total: 12
+          only-trigger-phrase: true  # This test should run only if explicitly triggered.
+          trigger-phrase: 'kubemark (e2e )?test'
+          cmd: |
+            export KUBE_SKIP_PUSH_GCS=y
+            export KUBE_RUN_FROM_OUTPUT=y
+            export KUBE_FASTBUILD=true
+            ./hack/jenkins/build.sh
+
+            # Nothing should want Jenkins $HOME
+            export HOME=${{WORKSPACE}}
+
+            export KUBERNETES_PROVIDER="gce"
+            # Having full "kubemark" in name will result in exceeding allowed length
+            # of firewall-rule name.
+            export E2E_NAME="k6k-e2e-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+            export PROJECT="k8s-jkns-pr-gci-kubemark"
+            export E2E_UP="true"
+            export E2E_TEST="false"
+            export E2E_DOWN="true"
+            export USE_KUBEMARK="true"
+            export KUBEMARK_TESTS="starting\s30\spods\sper\snode"
+            export FAIL_ON_GCP_RESOURCE_LEAK="false"
+            # Override defaults to be independent from GCE defaults and set kubemark parameters
+            export NUM_NODES="1"
+            export MASTER_SIZE="n1-standard-1"
+            export NODE_SIZE="n1-standard-2"
+            export KUBE_GCE_ZONE="us-central1-f"
+            export KUBEMARK_MASTER_SIZE="n1-standard-1"
+            export KUBEMARK_NUM_NODES="5"
+            # The kubemark scripts build a Docker image
+            export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+
+            # GCE variables
+            export INSTANCE_PREFIX=${{E2E_NAME}}
+            export KUBE_GCE_NETWORK=${{E2E_NAME}}
+            export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
+
+            # Force to use container-vm.
+            export KUBE_NODE_OS_DISTRIBUTION="gci"
+            # Skip gcloud update checking
+            export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
+            # Get golang into our PATH so we can run e2e.go
+            export PATH=${{PATH}}:/usr/local/go/bin
+
+            timeout -k 15m 45m {runner} && rc=$? || rc=$?
+            if [[ ${{rc}} -ne 0 ]]; then
+              if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+                echo "Dumping logs for any remaining nodes"
+                ./cluster/log-dump.sh _artifacts
+              fi
+            fi
+            if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
+              echo "Build timed out" >&2
+            elif [[ ${{rc}} -ne 0 ]]; then
+              echo "Build failed" >&2
+            fi
+            echo "Exiting with code: ${{rc}}"
+            exit ${{rc}}
+
     jobs:
         - '{git-project}-pull-{suffix}'
 


### PR DESCRIPTION
/cc @vishh 

I think this is what we need to get per-PR tests running against gci for gce (not gke yet).

I have created the projects associated with the new suffixes:
- `k8s-jkns-pr-gci-gce`
- `k8s-jkns-pr-gci-bld-e2e-gce-fd` (I wish I could have used `k8s-jkns-pr-gci-bldr-e2e-gce-fdrtn` for this one instead, but there is an unfortunate 30 character limit on project names. If anyone has suggestions for a better name I can try to rename the project I created.)
- `k8s-jkns-pr-gci-kubemark`

Is there anything else left to do to get this to work (other than eventually adding these to the submit queue)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/474)
<!-- Reviewable:end -->
