### PR TITLE
Don't delete .git when cleaning the workspace.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/charts-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/charts-pull.yaml
@@ -84,6 +84,7 @@
                 PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
         - workspace-cleanup:
             dirmatch: true
+            exclude: ['.git']
             external-deletion-command: 'sudo rm -rf %s'
         - timeout:
             timeout: 90

--- a/jenkins/job-configs/kubernetes-jenkins-pull/fejta-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/fejta-pull.yaml
@@ -48,6 +48,7 @@
                 PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
         - workspace-cleanup:
             dirmatch: true
+            exclude: ['.git']
             external-deletion-command: 'sudo rm -rf %s'
         - timeout:
             timeout: 90

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -255,6 +255,7 @@
                 PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
         - workspace-cleanup:
             dirmatch: true
+            exclude: ['.git']
             external-deletion-command: 'sudo rm -rf %s'
         - timeout:
             timeout: 90

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -24,6 +24,7 @@
         - gcs-uploader
         - workspace-cleanup:
             dirmatch: true
+            exclude: ['.git']
             external-deletion-command: 'sudo rm -rf %s'
     scm:
         - git:
@@ -45,6 +46,7 @@
         - timestamps
         - workspace-cleanup:
             dirmatch: true
+            exclude: ['.git']
             external-deletion-command: 'sudo rm -rf %s'
 
 - project:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -37,6 +37,7 @@
         - timestamps
         - workspace-cleanup:
             dirmatch: true
+            exclude: ['.git']
             external-deletion-command: 'sudo rm -rf %s'
         - e2e-credentials-binding
 


### PR DESCRIPTION
This means a full clone isn't necessary, reducing the likelihood that
Github will rate-limit our repository.

I manually added this to the kubernetes-pull-verify-all job for testing, and it seems to be working fine. The git plugin Does The Right Thing when .git already exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/475)
<!-- Reviewable:end -->
