### PR TITLE
Modifying trusty jobs to use GCI.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -63,7 +63,6 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-gci':  # kubernetes-e2e-gke
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)'
@@ -73,7 +72,7 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-gci-ci"
-                export KUBE_OS_DISTRIBUTION="gci"
+                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-slow':  # kubernetes-e2e-gke-slow
             cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
@@ -84,7 +83,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gke-slow"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-gci-slow':  # kubernetes-e2e-gke-gci-slow
             cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
@@ -95,7 +93,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gke-gci-slow"
-                export KUBE_OS_DISTRIBUTION="gci"
+                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-serial':  # kubernetes-e2e-gke-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
@@ -105,7 +103,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-e2e-serial"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-gci-serial':  # kubernetes-e2e-gke-gci-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
@@ -115,7 +112,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-gci-e2e-serial"
-                export KUBE_OS_DISTRIBUTION="gci"
+                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-updown':  # kubernetes-e2e-gke-updown
             cron-string: '{sq-cron-string}'
             description: 'Brings a cluster up, checks networking, brings it down (against GKE test endpoint)'
@@ -125,7 +122,6 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]"
                 export PROJECT="kubernetes-e2e-gke-updown"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-reboot':  # kubernetes-e2e-gke-reboot
             description: 'Run [Feature:Reboot] tests on GKE using the latest successful build.'
             timeout: 180
@@ -133,7 +129,6 @@
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci-reboot"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-flaky':  # kubernetes-e2e-gke-flaky
             description: |
                 Run flaky e2e tests using the following config:<br>
@@ -149,7 +144,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
                                          --ginkgo.skip=\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci-flaky"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-multizone':  # kubernetes-e2e-gke-multizone
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel, and in a multi-zone cluster.'
             timeout: 150
@@ -160,7 +154,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-multizone"
                 export ZONE="us-central1-f"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-autoscaling':  # kubernetes-e2e-gke-autoscaling
             description: 'Run all cluster autoscaler tests on GKE.'
             timeout: 300
@@ -170,7 +163,6 @@
                                          --ginkgo.skip=\[Flaky\]"
                 export NUM_NODES=3
                 export PROJECT="k8s-e2e-gke-autoscaling"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-large-cluster':  # kubernetes-e2e-gke-large-cluster
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel on a large GKE cluster'
             timeout: 450
@@ -199,7 +191,6 @@
                 export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -216,7 +207,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-serial-release-1.4':  # kubernetes-e2e-gke-serial-release-1.4
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.4 branch.'
             timeout: 300
@@ -225,7 +215,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-serial-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-slow-release-1.4':  # kubernetes-e2e-gke-slow-release-1.4
             description: 'Run slow E2E tests on GKE using the release-1.4 branch.'
             timeout: 150  #  See kubernetes/kubernetes#24072
@@ -235,7 +224,6 @@
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-slow-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-reboot-release-1.4':  # kubernetes-e2e-gke-reboot-release-1.4
             description: 'Run [Feature:Reboot] tests on GKE on the release-1.4 branch.'
             timeout: 180
@@ -243,7 +231,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-reboot-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-ingress-release-1.4':  # kubernetes-e2e-gke-ingress-release-1.4
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.4 branch.'
             timeout: 90
@@ -253,7 +240,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export PROJECT="k8s-jkns-gke-ingress-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -270,7 +256,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-serial-release-1.3':  # kubernetes-e2e-gke-serial-release-1.3
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.3 branch.'
             timeout: 300
@@ -279,7 +264,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-serial-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-slow-release-1.3':  # kubernetes-e2e-gke-slow-release-1.3
             description: 'Run slow E2E tests on GKE using the release-1.3 branch.'
             timeout: 150  #  See kubernetes/kubernetes#24072
@@ -289,7 +273,6 @@
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-slow-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-reboot-release-1.3':  # kubernetes-e2e-gke-reboot-release-1.3
             description: 'Run [Feature:Reboot] tests on GKE on the release-1.3 branch.'
             timeout: 180
@@ -297,7 +280,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="k8s-jkns-gke-reboot-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-ingress-release-1.2':  # kubernetes-e2e-gke-ingress-release-1.2
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.2 branch.'
             timeout: 90
@@ -307,7 +289,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="kubernetes-gke-ingress-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-ingress-release-1.3':  # kubernetes-e2e-gke-ingress-release-1.3
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.3 branch.'
             timeout: 90
@@ -317,7 +298,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
                 export PROJECT="kubernetes-gke-ingress-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
 
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
@@ -335,7 +315,6 @@
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-serial-release-1.2':  # kubernetes-e2e-gke-serial-release-1.2
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.2 branch.'
             timeout: 300
@@ -344,7 +323,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-serial-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-slow-release-1.2':  # kubernetes-e2e-gke-slow-release-1.2
             description: 'Run slow E2E tests on GKE using the release-1.2 branch.'
             timeout: 150  #  See kubernetes/kubernetes#24072
@@ -354,7 +332,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
                 export PROJECT="k8s-jkns-e2e-gke-slow-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -370,7 +347,6 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
                 export JENKINS_PUBLISHED_VERSION="release/latest"
                 export PROJECT="k8s-jkns-e2e-gke-prerel"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-test':  # kubernetes-e2e-gke-test
             description: 'Run E2E tests on GKE test endpoint.'
             timeout: 480
@@ -379,7 +355,6 @@
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-test"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-subnet':  # kubernetes-e2e-gke-subnet
             description: 'Run E2E tests on GKE test endpoint in a subnet.'
             timeout: 480
@@ -391,7 +366,6 @@
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-subnet"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-staging':  # kubernetes-e2e-gke-staging
             description: 'Run E2E tests on GKE staging endpoint.'
             timeout: 480
@@ -401,7 +375,6 @@
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-staging"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-staging-parallel':  # kubernetes-e2e-gke-staging-parallel
             description: 'Run E2E tests on GKE staging endpoint in parallel.'
             timeout: 80
@@ -413,7 +386,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-e2e-gke-staging-parallel"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-prod':  # kubernetes-e2e-gke-prod
             description: 'Run E2E tests on GKE prod endpoint.'
             timeout: 480
@@ -424,7 +396,6 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-jkns-e2e-gke-prod"
                 export ZONE="us-central1-b"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-prod-parallel':  # kubernetes-e2e-gke-prod-parallel
             description: 'Run E2E tests on GKE prod endpoint in parallel.'
             timeout: 80
@@ -437,7 +408,6 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-e2e-gke-prod-parallel"
                 export ZONE="us-central1-b"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gke-prod-smoke':  # kubernetes-e2e-gke-prod-smoke
             description: 'Run smoke tests on GKE prod day 1 zone (asia-east1-b).'
             timeout: 80
@@ -450,7 +420,6 @@
                 export JENKINS_USE_SERVER_VERSION="y"
                 export PROJECT="k8s-e2e-gke-prod-smoke"
                 export ZONE="asia-east1-b"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -468,73 +437,65 @@
                 export PROJECT="kubernetes-gke-ingress"
                 # TODO: Enable this when we've split 1.2 tests into another project.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
-# Jobs that run e2e tests on GKE with Trusty as node image on the release-1.2
-# branch. Note that the variable "E2E_NAME" in all following jobs are set to
-# have the "-trusty" suffix, which is required to start a GKE cluster with
-# Trusty images. The variable "KUBE_OS_DISTRIBUTION" is set to "trusty" so that
-# the OS dependendent test cases will use Trusty in their assertions.
+# Jobs that run e2e tests on GKE with GCI as the node image on the release-1.2
+# branch.
 - project:
-    name: kubernetes-e2e-gke-trusty
+    name: kubernetes-e2e-gke-gci-release-1.2
     trigger-job: 'kubernetes-build-1.2'
     test-owner: 'wonderfly'
     emails: 'gci-alerts+kubekins@google.com'
     gke-suffix:
-        - 'gke-trusty-test':  # kubernetes-e2e-gke-trusty-test
+        - 'gke-gci-test-release-1.2':  # kubernetes-e2e-gke-gci-test-release-1.2
             description: 'Run E2E tests on GKE test endpoint.'
             timeout: 480
             job-env: |
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
-                export E2E_NAME="gke-e2e-test-trusty"
+                export E2E_NAME="gke-e2e-test-gci"
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export KUBE_OS_DISTRIBUTION="trusty"
+                export KUBE_GKE_IMAGE_TYPE="gci"
                 export PROJECT="kubekins-e2e-gke-trusty-test"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gke-trusty-subnet':  # kubernetes-e2e-gke-trusty-subnet
+        - 'gke-gci-subnet-release-1.2':  # kubernetes-e2e-gke-gci-subnet-release-1.2
             description: 'Run E2E tests on GKE test endpoint in a subnet.'
             timeout: 480
             job-env: |
-                # Subnetwork "jkns-gke-e2e-subnet-trusty" is manually created -
+                # Subnetwork "gke-e2e-subnet-gci" is manually created -
                 # if deleted, it will need to be recreated via
-                # `gcloud alpha compute networks create jkns-gke-e2e-subnet-trusty --mode auto`
+                # `gcloud alpha compute networks create gke-e2e-subnet-gci --mode auto`
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
-                export E2E_NAME="gke-e2e-subnet-trusty"
+                export E2E_NAME="gke-e2e-subnet-gci"
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export KUBE_OS_DISTRIBUTION="trusty"
+                export KUBE_GKE_IMAGE_TYPE="gci"
                 export PROJECT="k8s-e2e-gke-trusty-subnet"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gke-trusty-staging':  # kubernetes-e2e-gke-trusty-staging
+        - 'gke-gci-staging-release-1.2':  # kubernetes-e2e-gke-gci-staging-release-1.2
             description: 'Run E2E tests on GKE staging endpoint.'
             timeout: 480
             job-env: |
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
-                export E2E_NAME="gke-e2e-staging-trusty"
+                export E2E_NAME="gke-e2e-staging-gci"
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export KUBE_OS_DISTRIBUTION="trusty"
+                export KUBE_GKE_IMAGE_TYPE="gci"
                 export PROJECT="e2e-gke-trusty-staging"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gke-trusty-staging-parallel':  # kubernetes-e2e-gke-trusty-staging-parallel
+        - 'gke-gci-staging-parallel-release-1.2':  # kubernetes-e2e-gke-gci-staging-parallel-release-1.2
             description: 'Run E2E tests on GKE staging endpoint in parallel.'
             timeout: 80
             job-env: |
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
-                export E2E_NAME="gke-e2e-staging-pa-trusty"
+                export E2E_NAME="gke-e2e-staging-pa-gci"
                 export E2E_OPT="--check_version_skew=false"
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export KUBE_OS_DISTRIBUTION="trusty"
+                export KUBE_GKE_IMAGE_TYPE="gci"
                 export PROJECT="e2e-gke-trusty-staging-p"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gke-trusty-prod':  # kubernetes-e2e-gke-trusty-prod
+        - 'gke-gci-prod-release-1.2':  # kubernetes-e2e-gke-gci-prod-release-1.2
             # Failing constantly due to a known issue (tracked internally).
             disable_job: true
             description: 'Run E2E tests on GKE prod endpoint.'
@@ -542,14 +503,13 @@
             job-env: |
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
-                export E2E_NAME="gke-e2e-prod-trusty"
+                export E2E_NAME="gke-e2e-prod-gci"
                 export E2E_OPT="--check_version_skew=false"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_GCE_ZONE="asia-east1-b"
-                export KUBE_OS_DISTRIBUTION="trusty"
+                export KUBE_GKE_IMAGE_TYPE="gci"
                 export PROJECT="kubekins-e2e-gke-trusty-prod"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gke-trusty-prod-parallel':  # kubernetes-e2e-gke-trusty-prod-parallel
+        - 'gke-gci-prod-parallel-release-1.2':  # kubernetes-e2e-gke-gci-prod-parallel-release-1.2
             # Failing constantly due to a known issue (tracked internally).
             disable_job: true
             description: 'Run E2E tests on GKE prod endpoint in parallel.'
@@ -557,15 +517,14 @@
             job-env: |
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
-                export E2E_NAME="gke-e2e-prod-pa-trusty"
+                export E2E_NAME="gke-e2e-prod-pa-gci"
                 export E2E_OPT="--check_version_skew=false"
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_USE_SERVER_VERSION="y"
                 export KUBE_GCE_ZONE="asia-east1-b"
-                export KUBE_OS_DISTRIBUTION="trusty"
+                export KUBE_GKE_IMAGE_TYPE="gci"
                 export PROJECT="e2e-gke-trusty-prod-p"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -585,7 +544,6 @@
                 export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gke-upg-{version-infix}-upg-mas"
                 # Set legacy skip list, only when testing old version
                 # TODO remove when we no longer care about v1.1
@@ -601,7 +559,6 @@
                 export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gke-upg-{version-infix}-upg-clu"
                 # Set legacy skip list, only when testing old version
                 # TODO remove when we no longer care about v1.1
@@ -618,7 +575,6 @@
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
                 export JENKINS_USE_SKEW_TESTS="true"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gke-upg-{version-infix}-upg-clu-n"
                 {version-env}
 
@@ -706,7 +662,6 @@
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-client}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-cluster}"
                 export PROJECT="kube-gke-upg-{version-infix}-ctl-skew"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
 
 - project:
     name: 'kubernetes-e2e-kubectl-skew-gke'


### PR DESCRIPTION
The KUBE_NODE_OS_DISTRIBUTION and KUBE_OS_DISTRIBUTION variables are meaningless for GKE, removing them as well.

@vishh @spxtr @wonderfly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/480)
<!-- Reviewable:end -->
