### PR TITLE
4 nodes, 30 parallel processes.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -441,8 +441,9 @@
               export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
               export FAIL_ON_GCP_RESOURCE_LEAK="false"
               export PROJECT="k8s-jkns-pr-gce"
-              # NUM_NODES should match kubernetes-e2e-gce.
-              export NUM_NODES="3"
+              # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
+              export NUM_NODES="4"
+              export GINKGO_PARALLEL_NODES="30"
 
               # Force to use container-vm.
               export KUBE_NODE_OS_DISTRIBUTION="debian"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -65,6 +65,8 @@
                 export GINKGO_PARALLEL="y"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-e2e-gce"
+                export NUM_NODES="4"
+                export GINKGO_PARALLEL_NODES="30"
         - 'gce-gci':  # kubernetes-e2e-gce-gci
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI in parallel.'


### PR DESCRIPTION
25 is safe for 3 nodes, (4/3)*25 = 33 so 30 should be safe for 4. I think we have enough quota but it can be hard to tell.

Relevant:

https://github.com/kubernetes/contrib/issues/1522
https://github.com/kubernetes/kubernetes/pull/25548

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/481)
<!-- Reviewable:end -->
