### PR TITLE
Make dockerized-e2e-runner.sh kill the container on timeout.

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -60,8 +60,16 @@ if [[ "${KUBE_RUN_FROM_OUTPUT:-}" =~ ^[yY]$ ]]; then
     )
 fi
 
+# Timeouts can leak the container, causing weird issues where the job keeps
+# running and *deletes resources* that the next job is using.
+# Give the container a unique name, and stop it when bash EXITs,
+# which will happen during a timeout.
+CONTAINER_NAME="${JOB_NAME}-${BUILD_NUMBER}"
+trap "docker stop ${CONTAINER_NAME}" EXIT
+
 echo "Starting..."
-docker run --rm=true -i \
+docker run --rm -i \
+  --name="${CONTAINER_NAME}"
   -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
   -v /etc/localtime:/etc/localtime:ro \
   ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:+-v "${JENKINS_GCE_SSH_PRIVATE_KEY_FILE}:/workspace/.ssh/google_compute_engine:ro"} \
@@ -76,3 +84,5 @@ docker run --rm=true -i \
   ${GOOGLE_APPLICATION_CREDENTIALS:+-e "GOOGLE_APPLICATION_CREDENTIALS=/service-account.json"} \
   "${docker_extra_args[@]:+${docker_extra_args[@]}}" \
   "gcr.io/google-containers/kubekins-e2e:${KUBEKINS_E2E_IMAGE_TAG}"
+
+trap '' EXIT  # container exited normally


### PR DESCRIPTION
This was tested manually with the small script:

    #!/bin/bash
    # test with "timeout -k4 2 ./leak-test.sh"
    # observe that the trap properly cleans up the container.

    CONTAINER_NAME="leak-$$"

    echo "container: $CONTAINER_NAME"
    trap "docker kill ${CONTAINER_NAME}" EXIT

    docker run --rm --name="${CONTAINER_NAME}" ubuntu sleep 600

    trap '' EXIT

This should fix flakes associated with leaked containers:
kubernetes/kubernetes#30962 and kubernetes/kubernetes#31213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/483)
<!-- Reviewable:end -->
