### PR TITLE
Set up a test-infra PR job.

### DIFF
--- a/ciongke/Makefile
+++ b/ciongke/Makefile
@@ -62,8 +62,8 @@ test:
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook github.com/kubernetes/test-infra/ciongke/cmd/hook
-	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.4" cmd/hook
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.4"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.5" cmd/hook
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.5"
 
 hook-deployment:
 	kubectl apply -f hook_deployment.yaml

--- a/ciongke/cmd/hook/githubagent.go
+++ b/ciongke/cmd/hook/githubagent.go
@@ -31,6 +31,7 @@ type GitHubAgent struct {
 	Org          string
 	GitHubClient githubClient
 
+	// Repo FullName (eg "kubernetes/kubernetes") -> []JenkinsJob
 	JenkinsJobs map[string][]JenkinsJob
 
 	PullRequestEvents  <-chan github.PullRequestEvent

--- a/ciongke/cmd/hook/githubagent.go
+++ b/ciongke/cmd/hook/githubagent.go
@@ -31,7 +31,7 @@ type GitHubAgent struct {
 	Org          string
 	GitHubClient githubClient
 
-	JenkinsJobs []JenkinsJob
+	JenkinsJobs map[string][]JenkinsJob
 
 	PullRequestEvents  <-chan github.PullRequestEvent
 	IssueCommentEvents <-chan github.IssueCommentEvent
@@ -105,12 +105,14 @@ func (ga *GitHubAgent) handlePullRequestEvent(pr github.PullRequestEvent) error 
 
 // commentBodyMatches looks at a comment body and decides which Jenkins jobs to
 // build based on it.
-func (ga *GitHubAgent) commentBodyMatches(body string) []JenkinsJob {
+func (ga *GitHubAgent) commentBodyMatches(fullRepoName, body string) []JenkinsJob {
 	var result []JenkinsJob
 	ott := okToTest.MatchString(body)
-	for _, job := range ga.JenkinsJobs {
-		if job.Trigger.MatchString(body) || (ott && job.AlwaysRun) {
-			result = append(result, job)
+	if jobs, ok := ga.JenkinsJobs[fullRepoName]; ok {
+		for _, job := range jobs {
+			if job.Trigger.MatchString(body) || (ott && job.AlwaysRun) {
+				result = append(result, job)
+			}
 		}
 	}
 	return result
@@ -138,7 +140,7 @@ func (ga *GitHubAgent) handleIssueCommentEvent(ic github.IssueCommentEvent) erro
 		}
 
 		// Which jobs does the comment want us to run?
-		requestedJobs := ga.commentBodyMatches(ic.Comment.Body)
+		requestedJobs := ga.commentBodyMatches(ic.Repo.FullName, ic.Comment.Body)
 		if len(requestedJobs) == 0 {
 			return nil
 		}
@@ -234,18 +236,22 @@ func makeKubeRequest(job JenkinsJob, pr github.PullRequest) KubeRequest {
 }
 
 func (ga *GitHubAgent) buildAll(pr github.PullRequest) {
-	for _, job := range ga.JenkinsJobs {
-		if !job.AlwaysRun {
-			continue
+	if jobs, ok := ga.JenkinsJobs[pr.Base.Repo.FullName]; ok {
+		for _, job := range jobs {
+			if !job.AlwaysRun {
+				continue
+			}
+			kr := makeKubeRequest(job, pr)
+			ga.BuildRequests <- kr
 		}
-		kr := makeKubeRequest(job, pr)
-		ga.BuildRequests <- kr
 	}
 }
 
 func (ga *GitHubAgent) deleteAll(pr github.PullRequest) {
-	for _, job := range ga.JenkinsJobs {
-		kr := makeKubeRequest(job, pr)
-		ga.DeleteRequests <- kr
+	if jobs, ok := ga.JenkinsJobs[pr.Base.Repo.FullName]; ok {
+		for _, job := range jobs {
+			kr := makeKubeRequest(job, pr)
+			ga.DeleteRequests <- kr
+		}
 	}
 }

--- a/ciongke/cmd/hook/githubagent_test.go
+++ b/ciongke/cmd/hook/githubagent_test.go
@@ -226,7 +226,7 @@ func TestHandleIssueComment(t *testing.T) {
 		s := &GitHubAgent{
 			GitHubClient: g,
 			JenkinsJobs: map[string][]JenkinsJob{
-				"org/repo": []JenkinsJob{
+				"org/repo": {
 					{
 						Name:      "job",
 						Trigger:   regexp.MustCompile(`@k8s-bot test this`),
@@ -313,10 +313,15 @@ func TestCommentBodyMatches(t *testing.T) {
 			"@k8s-bot test this",
 			[]string{"cadveapster"},
 		},
+		{
+			"org/repo3",
+			"@k8s-bot test this",
+			[]string{},
+		},
 	}
 	ga := &GitHubAgent{
 		JenkinsJobs: map[string][]JenkinsJob{
-			"org/repo": []JenkinsJob{
+			"org/repo": {
 				{
 					Name:      "gce",
 					Trigger:   regexp.MustCompile(`@k8s-bot (gce )?test this`),
@@ -338,7 +343,7 @@ func TestCommentBodyMatches(t *testing.T) {
 					AlwaysRun: false,
 				},
 			},
-			"org/repo2": []JenkinsJob{
+			"org/repo2": {
 				{
 					Name:      "cadveapster",
 					Trigger:   regexp.MustCompile(`@k8s-bot test this`),
@@ -378,7 +383,7 @@ func TestClosePR(t *testing.T) {
 	drc := make(chan KubeRequest, 2)
 	s := &GitHubAgent{
 		JenkinsJobs: map[string][]JenkinsJob{
-			"org/repo": []JenkinsJob{
+			"org/repo": {
 				{
 					Name:      "job1",
 					AlwaysRun: true,

--- a/ciongke/cmd/hook/githubagent_test.go
+++ b/ciongke/cmd/hook/githubagent_test.go
@@ -225,12 +225,14 @@ func TestHandleIssueComment(t *testing.T) {
 		}
 		s := &GitHubAgent{
 			GitHubClient: g,
-			JenkinsJobs: []JenkinsJob{
-				{
-					Name:      "job",
-					Trigger:   regexp.MustCompile(`@k8s-bot test this`),
-					AlwaysRun: true,
-					Context:   "job job",
+			JenkinsJobs: map[string][]JenkinsJob{
+				"org/repo": []JenkinsJob{
+					{
+						Name:      "job",
+						Trigger:   regexp.MustCompile(`@k8s-bot test this`),
+						AlwaysRun: true,
+						Context:   "job job",
+					},
 				},
 			},
 			BuildRequests: brc,
@@ -242,7 +244,8 @@ func TestHandleIssueComment(t *testing.T) {
 		event := github.IssueCommentEvent{
 			Action: "created",
 			Repo: github.Repo{
-				Name: "repo",
+				Name:     "repo",
+				FullName: "org/repo",
 			},
 			Comment: github.IssueComment{
 				Body: tc.Body,
@@ -276,52 +279,76 @@ func TestHandleIssueComment(t *testing.T) {
 
 func TestCommentBodyMatches(t *testing.T) {
 	var testcases = []struct {
+		repo         string
 		body         string
 		expectedJobs []string
 	}{
 		{
+			"org/repo",
+			"this is a random comment",
+			[]string{},
+		},
+		{
+			"org/repo",
 			"ok to test",
 			[]string{"gce", "unit"},
 		},
 		{
+			"org/repo",
 			"@k8s-bot test this",
 			[]string{"gce", "unit", "gke"},
 		},
 		{
+			"org/repo",
 			"@k8s-bot unit test this",
 			[]string{"unit"},
 		},
 		{
+			"org/repo",
 			"@k8s-bot federation test this",
 			[]string{"federation"},
 		},
+		{
+			"org/repo2",
+			"@k8s-bot test this",
+			[]string{"cadveapster"},
+		},
 	}
 	ga := &GitHubAgent{
-		JenkinsJobs: []JenkinsJob{
-			{
-				Name:      "gce",
-				Trigger:   regexp.MustCompile(`@k8s-bot (gce )?test this`),
-				AlwaysRun: true,
+		JenkinsJobs: map[string][]JenkinsJob{
+			"org/repo": []JenkinsJob{
+				{
+					Name:      "gce",
+					Trigger:   regexp.MustCompile(`@k8s-bot (gce )?test this`),
+					AlwaysRun: true,
+				},
+				{
+					Name:      "unit",
+					Trigger:   regexp.MustCompile(`@k8s-bot (unit )?test this`),
+					AlwaysRun: true,
+				},
+				{
+					Name:      "gke",
+					Trigger:   regexp.MustCompile(`@k8s-bot (gke )?test this`),
+					AlwaysRun: false,
+				},
+				{
+					Name:      "federation",
+					Trigger:   regexp.MustCompile(`@k8s-bot federation test this`),
+					AlwaysRun: false,
+				},
 			},
-			{
-				Name:      "unit",
-				Trigger:   regexp.MustCompile(`@k8s-bot (unit )?test this`),
-				AlwaysRun: true,
-			},
-			{
-				Name:      "gke",
-				Trigger:   regexp.MustCompile(`@k8s-bot (gke )?test this`),
-				AlwaysRun: false,
-			},
-			{
-				Name:      "federation",
-				Trigger:   regexp.MustCompile(`@k8s-bot federation test this`),
-				AlwaysRun: false,
+			"org/repo2": []JenkinsJob{
+				{
+					Name:      "cadveapster",
+					Trigger:   regexp.MustCompile(`@k8s-bot test this`),
+					AlwaysRun: true,
+				},
 			},
 		},
 	}
 	for _, tc := range testcases {
-		actualJobs := ga.commentBodyMatches(tc.body)
+		actualJobs := ga.commentBodyMatches(tc.repo, tc.body)
 		match := true
 		if len(actualJobs) != len(tc.expectedJobs) {
 			match = false
@@ -350,14 +377,16 @@ func TestCommentBodyMatches(t *testing.T) {
 func TestClosePR(t *testing.T) {
 	drc := make(chan KubeRequest, 2)
 	s := &GitHubAgent{
-		JenkinsJobs: []JenkinsJob{
-			{
-				Name:      "job1",
-				AlwaysRun: true,
-			},
-			{
-				Name:      "job2",
-				AlwaysRun: false,
+		JenkinsJobs: map[string][]JenkinsJob{
+			"org/repo": []JenkinsJob{
+				{
+					Name:      "job1",
+					AlwaysRun: true,
+				},
+				{
+					Name:      "job2",
+					AlwaysRun: false,
+				},
 			},
 		},
 		DeleteRequests: drc,
@@ -366,6 +395,11 @@ func TestClosePR(t *testing.T) {
 		Action: "closed",
 		PullRequest: github.PullRequest{
 			Number: 3,
+			Base: github.PullRequestBranch{
+				Repo: github.Repo{
+					FullName: "org/repo",
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/ciongke/cmd/hook/main.go
+++ b/ciongke/cmd/hook/main.go
@@ -44,9 +44,8 @@ var (
 	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 )
 
-// Repo FullName (eg "kubernetes/kubernetes") -> []JenkinsJob
 var defaultJenkinsJobs = map[string][]JenkinsJob{
-	"kubernetes/test-infra": []JenkinsJob{
+	"kubernetes/test-infra": {
 		{
 			Name:      "testinfra-pull-gotest",
 			Trigger:   regexp.MustCompile(`@k8s-bot (go )?test this`),

--- a/ciongke/cmd/hook/main.go
+++ b/ciongke/cmd/hook/main.go
@@ -44,42 +44,15 @@ var (
 	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 )
 
-var defaultJenkinsJobs = []JenkinsJob{
-	{
-		Name:      "kubernetes-pull-build-test-e2e-gce",
-		Trigger:   regexp.MustCompile(`@k8s-bot (gce )?(e2e )?test this`),
-		AlwaysRun: true,
-		Context:   "Jenkins GCE e2e",
-	},
-	{
-		Name:      "kubernetes-pull-build-test-e2e-gke",
-		Trigger:   regexp.MustCompile(`@k8s-bot (gke )?(smoke )?(e2e )?test this`),
-		AlwaysRun: true,
-		Context:   "Jenkins GKE smoke e2e",
-	},
-	{
-		Name:      "kubernetes-pull-build-test-unit-integration",
-		Trigger:   regexp.MustCompile(`@k8s-bot (unit )?test this`),
-		AlwaysRun: true,
-		Context:   "Jenkins unit/integration",
-	},
-	{
-		Name:      "kubernetes-pull-verify-all",
-		Trigger:   regexp.MustCompile(`@k8s-bot (verify )?test this`),
-		AlwaysRun: true,
-		Context:   "Jenkins verification",
-	},
-	{
-		Name:      "kubernetes-pull-build-test-federation-e2e-gce",
-		Trigger:   regexp.MustCompile(`@k8s-bot federation (gce )?(e2e )?test this`),
-		AlwaysRun: false,
-		Context:   "Jenkins Federation GCE e2e",
-	},
-	{
-		Name:      "kubernetes-pull-build-test-kubemark-e2e-gce",
-		Trigger:   regexp.MustCompile(`@k8s-bot kubemark test this`),
-		AlwaysRun: false,
-		Context:   "Jenkins Jenkins Kubemark GCE e2e",
+// Repo FullName (eg "kubernetes/kubernetes") -> []JenkinsJob
+var defaultJenkinsJobs = map[string][]JenkinsJob{
+	"kubernetes/test-infra": []JenkinsJob{
+		{
+			Name:      "testinfra-pull-gotest",
+			Trigger:   regexp.MustCompile(`@k8s-bot (go )?test this`),
+			AlwaysRun: true,
+			Context:   "Jenkins go test",
+		},
 	},
 }
 

--- a/ciongke/github/github.go
+++ b/ciongke/github/github.go
@@ -71,9 +71,10 @@ type PullRequestBranch struct {
 
 // Repo contains general repository information.
 type Repo struct {
-	Owner   User   `json:"owner"`
-	Name    string `json:"name"`
-	HTMLURL string `json:"html_url"`
+	Owner    User   `json:"owner"`
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	HTMLURL  string `json:"html_url"`
 }
 
 type IssueCommentEvent struct {

--- a/jenkins/job-configs/kubernetes-jenkins-pull/testinfra-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/testinfra-pull.yaml
@@ -1,0 +1,63 @@
+- job:
+    name: 'testinfra-pull-gotest'
+    concurrent: true
+    properties:
+        - build-discarder:
+            days-to-keep: 7
+        - github:
+            url: 'https://github.com/kubernetes/test-infra'
+        - throttle:
+            max-total: 10
+            max-per-node: 1
+            option: project
+        - raw:
+            xml: |
+                <com.cloudbees.plugins.JobPrerequisites plugin="slave-prerequisites@1.0">
+                    <script>docker version; gcloud version</script>
+                    <interpreter>shell script</interpreter>
+                </com.cloudbees.plugins.JobPrerequisites>
+    parameters:
+        - string:
+            name: ghprbPullId
+        - string:
+            name: ghprbTargetBranch
+        # The test job tracks a run through the queue using the buildId parameter.
+        - string:
+            name: buildId
+    scm:
+        - git:
+            remotes:
+                - remote:
+                    url: 'https://github.com/kubernetes/test-infra'
+                    refspec: '+refs/heads/*:refs/remotes/upstream/*'
+                - remote:
+                    url: 'https://github.com/kubernetes/test-infra'
+                    refspec: '+refs/pull/${ghprbPullId}/merge:refs/remotes/origin/pr/${ghprbPullId}/merge'
+            branches:
+                - 'origin/pr/${ghprbPullId}/merge'
+            basedir: 'go/src/github.com/kubernetes/test-infra'
+            browser: githubweb
+            browser-url: 'https://github.com/kubernetes/test-infra'
+            timeout: 20
+            wipe-workspace: false
+            skip-tag: true
+    wrappers:
+        - inject:
+            properties-content: |
+                GOROOT=/usr/local/go
+                GOPATH=$WORKSPACE/go
+                PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
+        - workspace-cleanup:
+            dirmatch: true
+            exclude: ['.git/']
+            external-deletion-command: 'sudo rm -rf %s'
+        - timeout:
+            timeout: 600
+            fail: true
+        - ansicolor:
+            colormap: xterm
+    builders:
+        - shell: |
+            cd ${WORKSPACE}/go/src/github.com/kubernetes/test-infra
+            go test $(go list ./... | grep -v vendor)
+ 


### PR DESCRIPTION
This PR makes ciongke handle multiple repos properly and adds a gotest job to PR Jenkins for the test-infra repo. This new PR job won't add any "ok to test" messages since it isn't triggered by the usual plugin :).

The remaining multirepo problem that this doesn't solve is #476. Until that's fixed I'm not going to bother uploading logs.

After this goes in and I've made sure things look reasonable I'll make a tiny PR switching off dry-run. !!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/484)
<!-- Reviewable:end -->
