### PR TITLE
Switch on test-infra PR job.

### DIFF
--- a/ciongke/hook_deployment.yaml
+++ b/ciongke/hook_deployment.yaml
@@ -33,12 +33,12 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: "gcr.io/kubernetes-jenkins-pull/hook:0.4"
+        image: "gcr.io/kubernetes-jenkins-pull/hook:0.5"
         imagePullPolicy: Always
         args: 
         - -test-pr-image=gcr.io/kubernetes-jenkins-pull/test-pr:0.4
         - -org=kubernetes
-        - -dry-run=true
+        - -dry-run=false
         ports:
           - name: http
             containerPort: 8888

--- a/jenkins/job-configs/kubernetes-jenkins-pull/testinfra-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/testinfra-pull.yaml
@@ -58,6 +58,5 @@
             colormap: xterm
     builders:
         - shell: |
-            cd ${WORKSPACE}/go/src/github.com/kubernetes/test-infra
+            cd ${WORKSPACE}/go/src/github.com/kubernetes/test-infra/ciongke
             go test $(go list ./... | grep -v vendor)
- 


### PR DESCRIPTION
Lets do this!

(the testgrid unit tests complain with this error, they probably need to just swap k8s.io for github.com/kubernetes. I'm switching it to only run ciongke tests for now)
```
testgrid/config/main.go:24:5: cannot find package "k8s.io/test-infra/testgrid/config/yaml2proto" in any of:
	/var/lib/jenkins/workspace/testinfra-pull-gotest/go/src/github.com/kubernetes/test-infra/testgrid/vendor/k8s.io/test-infra/testgrid/config/yaml2proto (vendor tree)
	/usr/local/go/src/k8s.io/test-infra/testgrid/config/yaml2proto (from $GOROOT)
	/var/lib/jenkins/workspace/testinfra-pull-gotest/go/src/k8s.io/test-infra/testgrid/config/yaml2proto (from $GOPATH)
testgrid/config/yaml2proto/yaml2proto.go:25:5: cannot find package "k8s.io/test-infra/testgrid/config/pb" in any of:
	/var/lib/jenkins/workspace/testinfra-pull-gotest/go/src/github.com/kubernetes/test-infra/testgrid/vendor/k8s.io/test-infra/testgrid/config/pb (vendor tree)
	/usr/local/go/src/k8s.io/test-infra/testgrid/config/pb (from $GOROOT)
	/var/lib/jenkins/workspace/testinfra-pull-gotest/go/src/k8s.io/test-infra/testgrid/config/pb (from $GOPATH)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/485)
<!-- Reviewable:end -->
