### PR TITLE
Add test jenkins job to build/upload config

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/sen-lu-test-config-upload.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/sen-lu-test-config-upload.yaml
@@ -1,0 +1,36 @@
+- job:
+    name: 'senlu-test-config-upload'
+    description: 'Build testgrid config from github and upload to gcs'
+    node: 'master'
+    properties:
+        - build-discarder:
+            num-to-keep: 20
+    triggers:
+        - pollscm:
+            cron: '* * * * *'
+    scm:
+        - git:
+            branches:
+            - config_external
+            browser: githubweb
+            browser-url: https://github.com/krzyzacy/test-infra
+            basedir: go/src/k8s.io/test-infra
+            skip-tag: true
+            url: https://github.com/krzyzacy/test-infra
+            wipe-workspace: false
+    wrappers:
+        - e2e-credentials-binding
+        - inject:
+            properties-content: |
+                GOROOT=/usr/local/go
+                GOPATH=$WORKSPACE/go
+                PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
+        - workspace-cleanup:
+            dirmatch: true
+            external-deletion-command: 'sudo rm -rf %s'
+    builders:
+        - activate-gce-service-account
+        - shell: |
+            export CONFIGDIR=k8s.io/test-infra/testgrid/config
+            go run $CONFIGDIR/main.go $CONFIGDIR/config.yaml $CONFIGDIR/config
+            gsutil cp $GOPATH/src/$CONFIGDIR/config gs://testgrid-sen/config


### PR DESCRIPTION
Added sen-lu-test-config-upload.yaml

It will build and convert the config, and upload to my bucket, for testing purposes. 
Once everything works well we can change the bucket to the real testgrid bucket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/486)
<!-- Reviewable:end -->
