### PR TITLE
Fix some path issue in my test job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/sen-lu-test-config-upload.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/sen-lu-test-config-upload.yaml
@@ -31,6 +31,6 @@
     builders:
         - activate-gce-service-account
         - shell: |
-            export CONFIGDIR=k8s.io/test-infra/testgrid/config
+            export CONFIGDIR=$GOPATH/src/k8s.io/test-infra/testgrid/config
             go run $CONFIGDIR/main.go $CONFIGDIR/config.yaml $CONFIGDIR/config
-            gsutil cp $GOPATH/src/$CONFIGDIR/config gs://testgrid-sen/config
+            gsutil cp $CONFIGDIR/config gs://testgrid-sen/config


### PR DESCRIPTION
gsutil cp actually works fine, go run does not reference GOPATH and it need to use a full path.

Now config uploads to mu bucket properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/493)
<!-- Reviewable:end -->
