### PR TITLE
Fix verify-godeps.sh always running due to stale remote/master branches.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -310,6 +310,9 @@
           status-add-test-results: false
           trigger-phrase: 'verify|test'
           cmd: |
+            # verify-godeps compares against upstream, but remote/master might be stale
+            # if .git was retained between runs. Update it explicitly here.
+            git fetch remote master:refs/remotes/remote/master
             export KUBE_VERIFY_GIT_BRANCH="${{ghprbTargetBranch}}"
             export KUBE_TEST_SCRIPT="./hack/jenkins/verify-dockerized.sh"
             ./hack/jenkins/gotest-dockerized.sh


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/498)
<!-- Reviewable:end -->
