### PR TITLE
Update kubekins-e2e image

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -29,7 +29,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20160824'
+KUBEKINS_E2E_IMAGE_TAG='v20160902-d17ad4a'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/google-containers/kubekins-e2e
-TAG = $(shell date +v%Y%m%d)
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 all: build
 

--- a/jenkins/test-image/Makefile
+++ b/jenkins/test-image/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMG = gcr.io/google-containers/kubekins-test
-TAG = $(shell date +v%Y%m%d)
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 all: build
 


### PR DESCRIPTION
I believe the only changes this pulls in are #443 and https://github.com/kubernetes/kubernetes/pull/31478.

I updated the tag scheme to use the git sha1 when the image is built, so it's a little easier to tell what's changed between images. Two issues with this, though:
a) we should really only be pushing versions which have been merged into master (which I violated here), since rebases/squashes will rewrite history and result in the sha being invalid
b) we pull in some files from kubernetes/kubernetes still, so the sha doesn't help us with finding diffs there

At least b) will eventually go away. We could maybe fix a) with some sort of script, looking for the sha in the upstream repo.

cc @david-mcmahon @wonderfly @fejta

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/509)
<!-- Reviewable:end -->
