### PR TITLE
Set HOME to $WORKSPACE before activating the service account

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/global.yaml
@@ -1,7 +1,10 @@
 - builder:
     name: activate-gce-service-account
     builders:
-      - shell: 'gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"'
+      - shell: |
+          export HOME="${WORKSPACE}"
+          export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
+          gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
 - builder:
     name: ensure-upload-to-gcs-script

--- a/jenkins/job-configs/kubernetes-jenkins/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/global.yaml
@@ -1,7 +1,10 @@
 - builder:
     name: activate-gce-service-account
     builders:
-      - shell: 'gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"'
+      - shell: |
+          export HOME="${WORKSPACE}"
+          export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
+          gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
 - publisher:
     name: gcs-uploader


### PR DESCRIPTION
I suspect the cause for https://github.com/kubernetes/test-infra/issues/470 is that `$HOME` is set to `/var/lib/jenkins` when we try to activate the service account, so when we set `$HOME` to a more reasonable value, we lose the setting.

With this change, we now explicitly set `$HOME` and `$CLOUDSDK_CONFIG` to reasonable per-job values before activating the service account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/521)
<!-- Reviewable:end -->
