### PR TITLE
Install etcd in the kubekins-test image

### DIFF
--- a/jenkins/test-image/Dockerfile
+++ b/jenkins/test-image/Dockerfile
@@ -43,6 +43,13 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
 	--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
+# Download and symlink etcd. We need this for verification and integration tests.
+RUN export ETCD_VERSION=v3.0.4; \
+  mkdir -p /usr/local/src/etcd \
+  && cd /usr/local/src/etcd \
+  && curl -fsSL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz | tar -xz \
+  && ln -s ../src/etcd/etcd-${ETCD_VERSION}-linux-amd64/etcd /usr/local/bin/
+
 # Install docker
 # Note: 1.11+ changes the tarball format
 RUN curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \


### PR DESCRIPTION
Address some complaints from https://github.com/kubernetes/kubernetes/issues/31915 (though it doesn't help a developer's local workflow).

Also a step towards fixing the "downloading etcd" flake.

Next steps:
a) push a new `kubekins-test` image and use it
b) update all of the Jenkins scripts to use `etcd` from the PATH rather than downloading it

We probably also need to document somewhere that changes in kubernetes/kubernetes to the default etcd version need to be included in this repo too.

cc @david-mcmahon @kubernetes/test-infra-maintainers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/522)
<!-- Reviewable:end -->
