### PR TITLE
Automated Docker Validation: Add docker validation test in test-grid.

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -397,6 +397,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.1-1.2-upgrade-cluster
 - name: kubernetes-e2e-gke-1.1-1.3-upgrade-cluster
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.1-1.3-upgrade-cluster
+- name: continuous-node-e2e-docker-validation
+  gcs_prefix: kubernetes-jenkins/logs/continuous-node-e2e-docker-validation
+- name: continuous-node-e2e-docker-benchmark
+  gcs_prefix: kubernetes-jenkins/logs/continuous-node-e2e-docker-benchmark
+- name: continuous-e2e-docker-validation
+  gcs_prefix: kubernetes-jenkins/logs/continuous-e2e-docker-validation-gci
 ### Add new testgroups here
 
 #
@@ -424,6 +430,14 @@ dashboards:
   - name: rktnetes
     test_group_name: kubernetes-rktnetes
   name:  rkt
+- dashboard_tab:
+  - name: docker-validation
+    test_group_name: continuous-node-e2e-docker-validation
+  - name: docker-benchmark
+    test_group_name: continuous-node-e2e-docker-benchmark
+  - name: master-docker-validation
+    test_group_name: continuous-e2e-docker-validation
+  name: docker
 - dashboard_tab:
   - name: kubelet
     test_group_name: kubelet-gce-e2e-ci


### PR DESCRIPTION
For https://github.com/kubernetes/features/issues/57.

This PR enabled three docker validation tests in test-grid:
* docker/docker-benchmark: This test continuously runs node e2e benchmark with newest docker release against Kubernetes HEAD.
* docker/docker-validation: This test continuously runs node e2e functionality test with newest docker release against Kubernetes HEAD.
* docker/master-docker-benchmark: This test continuously runs cluster e2e with newest docker release on master against Kubernetes HEAD.

@dchen1107 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/523)
<!-- Reviewable:end -->
