### PR TITLE
Add other alpha features to alpha e2e job, release-1.4 job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -163,8 +163,7 @@
             job-env: |
               export KUBE_FEATURE_GATES="AllAlpha=true"
               export RUNTIME_CONFIG="api/all=true"
-              # TODO(jlowdermilk): add all 1.4 alpha Feature:... tests here
-              export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ExternalTrafficLocalOnly\]"
+              export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(externalTrafficLocalOnly|PetSet)\]|ScheduledJob"
               export PROJECT="k8s-jkns-e2e-gce-alpha"
         - 'gce-flaky':  # kubernetes-e2e-gce-flaky
             description: 'Run the flaky tests on GCE, sequentially.'
@@ -591,6 +590,15 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-4"
                 export KUBE_OS_DISTRIBUTION="gci"
+        - 'gce-alpha-features-release-1.4':
+            description: 'Run alpha feature tests on GCE on the release-1.4 branch.'
+            timeout: 90
+            job-env: |
+                export KUBE_FEATURE_GATES="AllAlpha=true"
+                export RUNTIME_CONFIG="api/all=true"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(externalTrafficLocalOnly|PetSet)\]|ScheduledJob"
+                export PROJECT="k8s-jkns-e2e-gce-alpha1-4"
         # TODO: Move gce-scalability-release-1.3 here (gce-scalability-release-1.4) once we cut the release branch
     jobs:
         - 'kubernetes-e2e-{suffix}'


### PR DESCRIPTION
Run petset and scheduledjob tests in kubernetes-e2e-gce-alpha-features
and add a job to run the same suite on the release-1.4 branch.

cc @bprashanth @soltysh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/530)
<!-- Reviewable:end -->
