### PR TITLE
Removed exporting KUBE_ENABLE_RESCHEDULER since it's true by default

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -105,7 +105,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
                 export KUBE_OS_DISTRIBUTION="gci"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
             timeout: 50
@@ -274,7 +273,6 @@
                 export PROJECT="e2e-gce-gci-qa-serial-master"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'm54':  # kubernetes-e2e-gce-gci-qa-m54
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 54, in parallel.'
             timeout: 50
@@ -306,7 +304,6 @@
                 export PROJECT="e2e-gce-gci-qa-serial-m54"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'm53':  # kubernetes-e2e-gce-gci-qa-m53
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 53, in parallel.'
             timeout: 50
@@ -338,7 +335,6 @@
                 export PROJECT="e2e-gce-gci-qa-serial-m53"
                 export KUBE_MASTER_OS_DISTRIBUTION="gci"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'm52':  # kubernetes-e2e-gce-gci-qa-m52
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 52, in parallel.'
             timeout: 50  # See #21138
@@ -367,6 +363,5 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m52"
                 export KUBE_OS_DISTRIBUTION="gci"
-                export KUBE_ENABLE_RESCHEDULER=true
     jobs:
         - 'kubernetes-e2e-gce-gci-qa-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -108,7 +108,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="kubernetes-jkns-e2e-gce-serial"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'gce-gci-serial':  # kubernetes-e2e-gce-gci-serial
             description: 'Run [Serial], [Disruptive], tests on GCE.'
             timeout: 300
@@ -118,7 +117,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-gci-serial"
                 export KUBE_OS_DISTRIBUTION="gci"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'gce-reboot':  # kubernetes-e2e-gce-reboot
             description: 'Run [Feature:Reboot] tests on GCE.'
             timeout: 180
@@ -552,7 +550,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-gce-serial-1-4"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'gce-ingress-release-1.4':  # kubernetes-e2e-gce-ingress-release-1.4
             description: 'Run [Feature:Ingress] tests on GCE on the release-1.4 branch.'
             timeout: 90

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -106,7 +106,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-e2e-serial"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'gke-gci-serial':  # kubernetes-e2e-gke-gci-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
@@ -117,7 +116,6 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-gci-e2e-serial"
                 export KUBE_OS_DISTRIBUTION="gci"
-                export KUBE_ENABLE_RESCHEDULER=true
         - 'gke-updown':  # kubernetes-e2e-gke-updown
             cron-string: '{sq-cron-string}'
             description: 'Brings a cluster up, checks networking, brings it down (against GKE test endpoint)'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -65,7 +65,6 @@
         # [Disruptive] tests kill/restart components or nodes in the cluster,
         # defeating the purpose of a soak cluster. (#15722)
         export GINKGO_TEST_ARGS="--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-        export KUBE_ENABLE_RESCHEDULER=true
     properties:
         - build-blocker:
             use-build-blocker: true


### PR DESCRIPTION
enabled by default in https://github.com/kubernetes/kubernetes/pull/31974

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/531)
<!-- Reviewable:end -->
