### PR TITLE
Fix verify-munge-docs.sh breaking because it's missing the upstream release branch.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -313,6 +313,8 @@
             # verify-godeps compares against upstream, but remote/master might be stale
             # if .git was retained between runs. Update it explicitly here.
             git fetch remote master:refs/remotes/remote/master
+            # similarly, verify-munge-docs compares against the latest release branch.
+            git fetch remote release-1.4:remote/release-1.4
             export KUBE_VERIFY_GIT_BRANCH="${{ghprbTargetBranch}}"
             export KUBE_TEST_SCRIPT="./hack/jenkins/verify-dockerized.sh"
             ./hack/jenkins/gotest-dockerized.sh


### PR DESCRIPTION
Most documentation PRs are breaking the build because of this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/536)
<!-- Reviewable:end -->
