### PR TITLE
Removing GKE upgrade tests for 1.0 -> 1.2, 1.1 -> 1.2 and 1.1 -> 1.3.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -582,51 +582,6 @@
     name: kubernetes-e2e-upgrades-gke
     provider: 'gke'
     jobs:
-        - 'kubernetes-e2e-{provider}-{version-old}-{version-new}':  # kubernetes-e2e-gke-1.0-1.2
-            version-old: '1.0'
-            version-new: '1.2'
-            version-infix: '1-0-1-2'
-            version-env: |
-                # In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
-                # was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
-                export NUM_MINIONS=3
-                # Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
-                # override it here (specifically for HPA tests).
-                export MACHINE_TYPE='n1-standard-2'
-            legacy-ginkgo-test-args-env: |
-                # XXX This is a hack to run only the tests we care about, without importing all of
-                # the skip list vars from the v1.0 e2e.sh.
-                export GINKGO_TEST_ARGS="--ginkgo.skip=Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster"
-        - 'kubernetes-e2e-{provider}-{version-old}-{version-new}':  # kubernetes-e2e-gke-1.1-1.2
-            version-old: '1.1'
-            version-new: '1.2'
-            version-infix: '1-1-1-2'
-            version-env: |
-                # In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
-                # was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
-                export NUM_MINIONS=3
-                # Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
-                # override it here (specifically for HPA tests).
-                export MACHINE_TYPE='n1-standard-2'
-            legacy-ginkgo-test-args-env: |
-                # XXX This is a hack to run only the tests we care about, without importing all of
-                # the skip list vars from the v1.1 e2e.sh.
-                export GINKGO_TEST_ARGS="--ginkgo.skip=Autoscaling\sSuite|resource\susage\stracking|Nodes|Etcd\sFailure|MasterCerts|experimental\sresource\susage\stracking|ServiceLoadBalancer|Shell|Daemon\sset|Deployment|Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster"
-        - 'kubernetes-e2e-{provider}-{version-old}-{version-new}':  # kubernetes-e2e-gke-1.1-1.3
-            version-old: '1.1'
-            version-new: '1.3'
-            version-infix: '1-1-1-3'
-            version-env: |
-                # In v1.1 and below, NUM_MINIONS defaults to 2, so we have to override to 3 here.  NUM_MINIONS
-                # was changed to NUM_NODES in v1.2, but we don't need to override for v1.2 and above.
-                export NUM_MINIONS=3
-                # Similarly, in v1.1 and below, MACHINE_TYPE defaults to 'n1-standard-1', so we need to
-                # override it here (specifically for HPA tests).
-                export MACHINE_TYPE='n1-standard-2'
-            legacy-ginkgo-test-args-env: |
-                # XXX This is a hack to run only the tests we care about, without importing all of
-                # the skip list vars from the v1.1 e2e.sh.
-                export GINKGO_TEST_ARGS="--ginkgo.skip=Autoscaling\sSuite|resource\susage\stracking|Nodes|Etcd\sFailure|MasterCerts|experimental\sresource\susage\stracking|ServiceLoadBalancer|Shell|Daemon\sset|Deployment|Skipped|Restart\sshould\srestart\sall\snodes|Example|Reboot|ServiceLoadBalancer|DaemonRestart\sController\sManager|Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon|Resource\susage\sof\ssystem\scontainers|allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster"
         - 'kubernetes-e2e-{provider}-{version-old}-{version-new}':  # kubernetes-e2e-gke-1.2-1.3
             version-old: '1.2'
             version-new: '1.3'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -624,10 +624,6 @@
     jobs:
         - 'kubernetes-e2e-{provider}-{version-cluster}-{version-client}-kubectl-skew':
             version-cluster: '1.2'
-            version-client: '1.1'
-            version-infix: '1-2-1-1'
-        - 'kubernetes-e2e-{provider}-{version-cluster}-{version-client}-kubectl-skew':
-            version-cluster: '1.2'
             version-client: '1.3'
             version-infix: '1-2-1-3'
         - 'kubernetes-e2e-{provider}-{version-cluster}-{version-client}-kubectl-skew':


### PR DESCRIPTION
These tests are utterly broken at this point.
@spxtr @fabioy @vishh @pwittrock @jfrazelle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/537)
<!-- Reviewable:end -->
