### PR TITLE
Clone federation and kubemark gce tests to run with GCI image

### DIFF
--- a/ciongke/Makefile
+++ b/ciongke/Makefile
@@ -67,8 +67,8 @@ test:
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook github.com/kubernetes/test-infra/ciongke/cmd/hook
-	docker build -t "gcr.io/k8s-ci-on-gke/hook:0.13" cmd/hook
-	gcloud docker push "gcr.io/k8s-ci-on-gke/hook:0.13"
+	docker build -t "gcr.io/k8s-ci-on-gke/hook:0.14" cmd/hook
+	gcloud docker push "gcr.io/k8s-ci-on-gke/hook:0.14"
 
 hook-deployment:
 	kubectl apply -f hook_deployment.yaml

--- a/ciongke/cmd/hook/main.go
+++ b/ciongke/cmd/hook/main.go
@@ -59,10 +59,22 @@ var defaultJenkinsJobs = map[string][]JenkinsJob{
 			Context:   "Jenkins Federation GCE e2e",
 		},
 		{
+			Name:      "kubernetes-pull-build-test-gci-federation-e2e-gce",
+			Trigger:   regexp.MustCompile(`@k8s-bot federation (gci )?(gce )?(e2e )?test this`),
+			AlwaysRun: false,
+			Context:   "Jenkins GCI Federation GCE e2e",
+		},
+		{
 			Name:      "kubernetes-pull-build-test-kubemark-e2e-gce",
 			Trigger:   regexp.MustCompile(`@k8s-bot kubemark (e2e )?test this`),
 			AlwaysRun: false,
 			Context:   "Jenkins Kubemark GCE e2e",
+		},
+		{
+			Name:      "kubernetes-pull-build-test-gci-kubemark-e2e-gce",
+			Trigger:   regexp.MustCompile(`@k8s-bot kubemark (gci )?(e2e )?test this`),
+			AlwaysRun: false,
+			Context:   "Jenkins GCI Kubemark GCE e2e",
 		},
 		{
 			Name:      "fejta-pull-unit",

--- a/ciongke/hook_deployment.yaml
+++ b/ciongke/hook_deployment.yaml
@@ -33,9 +33,9 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-ci-on-gke/hook:0.13
+        image: gcr.io/k8s-ci-on-gke/hook:0.14
         imagePullPolicy: Always
-        args: 
+        args:
         - -test-pr-image=gcr.io/k8s-ci-on-gke/test-pr:0.7
         - -org=kubernetes
         - -dry-run=false

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
@@ -207,6 +207,63 @@
                 fi
                 echo "Exiting with code: ${{rc}}"
                 exit ${{rc}}
+        - 'gci-federation-e2e-gce': # kubernetes-pull-build-test-gci-federation-e2e-gce
+            cmd: |
+                # Federation specific params
+                export FEDERATION="true"
+                export PROJECT="k8s-jkns-pr-gci-bld-e2e-gce-fd"
+                export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn"
+                export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
+                export E2E_ZONES="us-central1-a us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
+                export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
+                export DNS_ZONE_NAME="k8s-federation-pr-bldr.com."
+                export FEDERATIONS_DOMAIN_MAP="federation=k8s-federation-pr-bldr.com"
+                export KUBE_SKIP_PUSH_GCS=y
+                export KUBE_RUN_FROM_OUTPUT=y
+                export KUBE_FASTBUILD=true
+                # Nothing should want Jenkins $HOME
+                export HOME=${{WORKSPACE}}
+                # Build the images.
+                ./hack/jenkins/build.sh
+                # Push federation images to GCS.
+                ./build/push-federation-images.sh
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="1"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                # Flake detection. Individual tests get a second chance to pass.
+                export GINKGO_TOLERATE_FLAKES="y"
+                export E2E_NAME="fed-e2e-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                export NUM_NODES="3"
+                # Force to use container-vm.
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                # Assume we're upping, testing, and downing a cluster
+                export E2E_UP="true"
+                export E2E_TEST="true"
+                export E2E_DOWN="true"
+                # Skip gcloud update checking
+                export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+                # GCE variables
+                export INSTANCE_PREFIX=${{E2E_NAME}}
+                export KUBE_GCE_NETWORK=${{E2E_NAME}}
+                export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
+                # Get golang into our PATH so we can run e2e.go
+                export PATH=${{PATH}}:/usr/local/go/bin
+                timeout -k 15m 55m {runner} && rc=$? || rc=$?
+                if [[ ${{rc}} -ne 0 ]]; then
+                  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+                    echo "Dumping logs for any remaining nodes"
+                    ./cluster/log-dump.sh _artifacts
+                  fi
+                fi
+                if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
+                  echo "Build timed out" >&2
+                elif [[ ${{rc}} -ne 0 ]]; then
+                  echo "Build failed" >&2
+                fi
+                echo "Exiting with code: ${{rc}}"
+                exit ${{rc}}
         - 'kubemark-e2e-gce': # kubernetes-pull-build-test-kubemark-e2e-gce
             cmd: |
                 export KUBE_SKIP_PUSH_GCS=y
@@ -241,6 +298,58 @@
                 export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
                 # Force to use container-vm.
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+                # Skip gcloud update checking
+                export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+                # Get golang into our PATH so we can run e2e.go
+                export PATH=${{PATH}}:/usr/local/go/bin
+                timeout -k 15m 45m {runner} && rc=$? || rc=$?
+                if [[ ${{rc}} -ne 0 ]]; then
+                  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+                    echo "Dumping logs for any remaining nodes"
+                    ./cluster/log-dump.sh _artifacts
+                  fi
+                fi
+                if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then
+                  echo "Build timed out" >&2
+                elif [[ ${{rc}} -ne 0 ]]; then
+                  echo "Build failed" >&2
+                fi
+                echo "Exiting with code: ${{rc}}"
+                exit ${{rc}}
+        - 'gci-kubemark-e2e-gce': # kubernetes-pull-build-test-gci-kubemark-e2e-gce
+            cmd: |
+                export KUBE_SKIP_PUSH_GCS=y
+                export KUBE_RUN_FROM_OUTPUT=y
+                export KUBE_FASTBUILD=true
+                ./hack/jenkins/build.sh
+                # Nothing should want Jenkins $HOME
+                export HOME=${{WORKSPACE}}
+                export KUBERNETES_PROVIDER="gce"
+                # Having full "kubemark" in name will result in exceeding allowed length
+                # of firewall-rule name.
+                export E2E_NAME="k6k-e2e-${{NODE_NAME}}-${{EXECUTOR_NUMBER}}"
+                export PROJECT="k8s-jkns-pr-gci-kubemark"
+                export E2E_UP="true"
+                export E2E_TEST="false"
+                export E2E_DOWN="true"
+                export USE_KUBEMARK="true"
+                export KUBEMARK_TESTS="starting\s30\spods\sper\snode"
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                # Override defaults to be independent from GCE defaults and set kubemark parameters
+                export NUM_NODES="1"
+                export MASTER_SIZE="n1-standard-1"
+                export NODE_SIZE="n1-standard-2"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export KUBEMARK_MASTER_SIZE="n1-standard-1"
+                export KUBEMARK_NUM_NODES="5"
+                # The kubemark scripts build a Docker image
+                export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
+                # GCE variables
+                export INSTANCE_PREFIX=${{E2E_NAME}}
+                export KUBE_GCE_NETWORK=${{E2E_NAME}}
+                export KUBE_GCE_INSTANCE_PREFIX=${{E2E_NAME}}
+                # Force to use container-vm.
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
                 # Skip gcloud update checking
                 export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
                 # Get golang into our PATH so we can run e2e.go


### PR DESCRIPTION
The new projects for these are `k8s-jkns-pr-gci-bld-e2e-gce-fd` and `k8s-jkns-pr-gci-kubemark`, respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/546)
<!-- Reviewable:end -->
