### PR TITLE
Remove redundant variables when using JENKINS_GCI_HEAD_IMAGE_FAMILY

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -200,6 +200,11 @@ function setup_gci_vars() {
     export KUBE_GCE_NODE_IMAGE="${image_name}"
     export KUBE_NODE_OS_DISTRIBUTION="gci"
 
+    # For backward compatibility (Older versions of Kubernetes don't understand
+    # KUBE_MASTER_OS_DISTRIBUTION or KUBE_NODE_OS_DISTRIBUTION. Only KUBE_OS_DISTRIBUTION can be
+    # used for them.)
+    export KUBE_OS_DISTRIBUTION="gci"
+
     if [[ "${JENKINS_GCI_HEAD_IMAGE_FAMILY}" == "gci-canary-test" ]]; then
         # The family "gci-canary-test" is reserved for a special type of GCI images
         # that are used to continuously validate Docker releases.

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -83,7 +83,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'slow-master': # kubernetes-e2e-gce-gci-ci-slow-master
             description: 'Runs slow tests on GCE with GCI images, sequentially on the master branch.'
             timeout: 150  #  See #24072
@@ -94,7 +93,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-master-slow"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'serial-master': # kubernetes-e2e-gce-gci-ci-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images.'
             timeout: 300
@@ -104,7 +102,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
             timeout: 50
@@ -115,8 +112,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-3"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'slow-release-1.3':  # kubernetes-e2e-gce-gci-ci-slow-release-1.3
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.3 branch.'
             timeout: 150
@@ -128,8 +123,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-slow-1-3"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'serial-release-1.3':  # kubernetes-e2e-gce-gci-ci-serial-release-1.3
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.3 branch.'
             timeout: 300
@@ -140,8 +133,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-3"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'release-1.2':  # kubernetes-e2e-gce-gci-ci-release-1.2
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.2 branch.'
             timeout: 50  # See #21138
@@ -152,7 +143,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-1-2"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'slow-release-1.2':  # kubernetes-e2e-gce-gci-ci-slow-release-1.2
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.2 branch.'
             timeout: 150  #  See #24072
@@ -164,7 +154,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-ci-slow-1-2"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'serial-release-1.2':  # kubernetes-e2e-gce-gci-ci-serial-release-1.2
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.2 branch.'
             timeout: 300
@@ -175,7 +164,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial-1-2"
-                export KUBE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-e2e-gce-gci-ci-{suffix}'
 
@@ -250,8 +238,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-master"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'slow-master':  # kubernetes-e2e-gce-gci-qa-slow-master
             description: 'Runs slow tests on GCE with GCI images from the master branch, sequentially.'
             timeout: 150
@@ -261,8 +247,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-master"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'serial-master':  # kubernetes-e2e-gce-gci-qa-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images from the master branch.'
             timeout: 300
@@ -271,8 +255,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-master"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'm54':  # kubernetes-e2e-gce-gci-qa-m54
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 54, in parallel.'
             timeout: 50
@@ -281,8 +263,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m54"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'slow-m54':  # kubernetes-e2e-gce-gci-qa-slow-m54
             description: 'Runs slow tests on GCE with GCI images on milestone 54, sequentially.'
             timeout: 150
@@ -292,8 +272,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m54"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'serial-m54':  # kubernetes-e2e-gce-gci-qa-serial-m54
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 54.'
             timeout: 300
@@ -302,8 +280,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m54"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'm53':  # kubernetes-e2e-gce-gci-qa-m53
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 53, in parallel.'
             timeout: 50
@@ -312,8 +288,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m53"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'slow-m53':  # kubernetes-e2e-gce-gci-qa-slow-m53
             description: 'Runs slow tests on GCE with GCI images on milestone 53, sequentially.'
             timeout: 150
@@ -323,8 +297,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m53"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'serial-m53':  # kubernetes-e2e-gce-gci-qa-serial-m53
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 53.'
             timeout: 300
@@ -333,8 +305,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m53"
-                export KUBE_MASTER_OS_DISTRIBUTION="gci"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'm52':  # kubernetes-e2e-gce-gci-qa-m52
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 52, in parallel.'
             timeout: 50  # See #21138
@@ -343,7 +313,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m52"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'slow-m52':  # kubernetes-e2e-gce-gci-qa-slow-m52
             description: 'Runs slow tests on GCE with GCI images on milestone 52, sequentially.'
             timeout: 60
@@ -353,7 +322,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m52"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'serial-m52':  # kubernetes-e2e-gce-gci-qa-serial-m52
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 52.'
             timeout: 300
@@ -362,6 +330,5 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m52"
-                export KUBE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-e2e-gce-gci-qa-{suffix}'


### PR DESCRIPTION
As JENKINS_GCI_HEAD_IMAGE_FAMILY already implies that OS distribution
is GCI, this patch removes the redundant variable settings in the job
configuration.

Also, to be compatibe with older releases, sets up
KUBE_OS_DISTRIBUTION variable in setup_gci_vars() in e2e-runner.sh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/560)
<!-- Reviewable:end -->
