### PR TITLE
Retire GCI m52 qa jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -305,30 +305,5 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m53"
-        - 'm52':  # kubernetes-e2e-gce-gci-qa-m52
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 52, in parallel.'
-            timeout: 50  # See #21138
-            job-env: |
-                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-52"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-qa-m52"
-        - 'slow-m52':  # kubernetes-e2e-gce-gci-qa-slow-m52
-            description: 'Runs slow tests on GCE with GCI images on milestone 52, sequentially.'
-            timeout: 60
-            job-env: |
-                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-52"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-qa-slow-m52"
-        - 'serial-m52':  # kubernetes-e2e-gce-gci-qa-serial-m52
-            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 52.'
-            timeout: 300
-            job-env: |
-                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-52"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-qa-serial-m52"
     jobs:
         - 'kubernetes-e2e-gce-gci-qa-{suffix}'


### PR DESCRIPTION
GCI 52 is now deprecated so we could stop running release qualification tests on it.

@aulanov Can you review?

cc/ @kubernetes/goog-image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/566)
<!-- Reviewable:end -->
