### PR TITLE
Revert "Retire GCI m52 qa jobs"

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -305,5 +305,30 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m53"
+        - 'm52':  # kubernetes-e2e-gce-gci-qa-m52
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 52, in parallel.'
+            timeout: 50  # See #21138
+            job-env: |
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-52"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-m52"
+        - 'slow-m52':  # kubernetes-e2e-gce-gci-qa-slow-m52
+            description: 'Runs slow tests on GCE with GCI images on milestone 52, sequentially.'
+            timeout: 60
+            job-env: |
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-52"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-qa-slow-m52"
+        - 'serial-m52':  # kubernetes-e2e-gce-gci-qa-serial-m52
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 52.'
+            timeout: 300
+            job-env: |
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-52"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-qa-serial-m52"
     jobs:
         - 'kubernetes-e2e-gce-gci-qa-{suffix}'


### PR DESCRIPTION
Reverts kubernetes/test-infra#566


Apparently 52 is *not* deprecated yet. It will be soon, but since k8s-1.2 still uses it, and we are to support k8s-1.2, we will potentially still make patch releases on m52.

@aulanov, @adityakali 

cc/ @kubernetes/goog-image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/568)
<!-- Reviewable:end -->
