### PR TITLE
Setting JENKINS_USE_SKEW_TESTS for 1.4-1.3 and 1.3-1.2 kubectl-skew tests.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -630,6 +630,7 @@
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
+                export JENKINS_USE_SKEW_TESTS="true"
         - 'kubernetes-e2e-{provider}-{version-cluster}-{version-client}-kubectl-skew':
             version-cluster: '1.3'
             version-client: '1.4'
@@ -639,4 +640,5 @@
             version-cluster: '1.4'
             version-client: '1.3'
             version-infix: '1-4-1-3'
-            version-env: ''
+            version-env: |
+                export JENKINS_USE_SKEW_TESTS="true"


### PR DESCRIPTION
We should be using the min(cluster_version, kubectl_version) when running kubectl-skew tests, this addresses that.
cc @spxtr @vishh @jlowdermilk @pwittrock

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/572)
<!-- Reviewable:end -->
