### PR TITLE
Remove kubemark-500-gce-gci project

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -175,36 +175,6 @@
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - '500-gce-gci':
-            description: 'Run Kubemark test on a fake 500 node cluster to test for regressions on bigger clusters'
-            jenkins_node: 'e2e'
-            timeout: 300
-            cron-string: '{sq-cron-string}'
-            job-env: |
-                export ENABLE_GARBAGE_COLLECTOR="true"
-                export E2E_NAME="kubemark-500"
-                export PROJECT="k8s-jenkins-block-kubemark-gci"
-                export E2E_TEST="false"
-                export USE_KUBEMARK="true"
-                export KUBEMARK_TESTS="\[Feature:Performance\]"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
-                # Increase throughput in Kubemark master components.
-                export KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS="--kube-api-qps=100 --kube-api-burst=100"
-                # Increase limit for inflight requests in apiserver.
-                export TEST_CLUSTER_MAX_REQUESTS_INFLIGHT="--max-requests-inflight=600"
-                # Increase throughput in Load test.
-                export LOAD_TEST_THROUGHPUT=50
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                # Override defaults to be independent from GCE defaults and set kubemark parameters
-                export NUM_NODES="6"
-                export MASTER_SIZE="n1-standard-4"
-                export NODE_SIZE="n1-standard-8"
-                export KUBE_GCE_ZONE="us-central1-f"
-                export KUBEMARK_MASTER_SIZE="n1-standard-16"
-                export KUBEMARK_NUM_NODES="500"
-                # The kubemark scripts build a Docker image
-                export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                export KUBE_OS_DISTRIBUTION="gci"
         - 'gce-scale':
             description: 'Run Density test on Kubemark in very large cluster. Currently only scheduled to run every 12 hours so as not to waste too many resources.'
             # TODO: We should replace it with 'scalability' instead of using


### PR DESCRIPTION
There's absolutely no reason to run kubemark tests on GCI specifically - they're using fake nodes, so OS distro doesn't actually do anything. Only difference may be kubemark-5-gci that should be running to make sure that GCI don't break kubemark. @vishh 

cc @ixdy - do we need to delete Jenkins job by hand, or does it happen automatically now?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/574)
<!-- Reviewable:end -->
