### PR TITLE
Make GKE, Kubemark, and node e2e just pass on release-1.2

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
@@ -90,10 +90,12 @@
     suffix:
         - 'e2e-gke': # kubernetes-pull-build-test-e2e-gke
             cmd: |
-                if [[ "${{ghprbTargetBranch:-}}" == "release-1.0" || "${{ghprbTargetBranch:-}}" == "release-1.1" ]]; then
-                  echo "PR GKE job disabled for legacy branches."
-                  exit
-                fi
+                case "${{ghprbTargetBranch:-}}" in
+                  release-1.0|release-1.1|release-1.2)
+                    echo "PR GKE job disabled for legacy branches."
+                    exit
+                    ;;
+                esac
                 export KUBE_SKIP_PUSH_GCS=n
                 export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
                 export KUBE_RUN_FROM_OUTPUT=y
@@ -266,6 +268,12 @@
                 exit ${{rc}}
         - 'kubemark-e2e-gce': # kubernetes-pull-build-test-kubemark-e2e-gce
             cmd: |
+                case "${{ghprbTargetBranch:-}}" in
+                  release-1.0|release-1.1|release-1.2)
+                    echo "PR Kubemark job disabled for legacy branches."
+                    exit
+                    ;;
+                esac
                 export KUBE_SKIP_PUSH_GCS=y
                 export KUBE_RUN_FROM_OUTPUT=y
                 export KUBE_FASTBUILD=true
@@ -318,6 +326,12 @@
                 exit ${{rc}}
         - 'gci-kubemark-e2e-gce': # kubernetes-pull-build-test-gci-kubemark-e2e-gce
             cmd: |
+                case "${{ghprbTargetBranch:-}}" in
+                  release-1.0|release-1.1|release-1.2)
+                    echo "PR Kubemark job disabled for legacy branches."
+                    exit
+                    ;;
+                esac
                 export KUBE_SKIP_PUSH_GCS=y
                 export KUBE_RUN_FROM_OUTPUT=y
                 export KUBE_FASTBUILD=true

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -475,6 +475,13 @@
             skip-if-no-test-files:   # old branches may not produce JUnit
             trigger-phrase: '(node )?(e2e )?test'
             status-context: 'GCE Node e2e'
-            cmd: './test/e2e_node/jenkins/e2e-node-jenkins.sh ./test/e2e_node/jenkins/jenkins-pull.properties'
+            cmd: |
+                case "${{ghprbTargetBranch:-}}" in
+                  release-1.0|release-1.1|release-1.2)
+                    echo "PR node e2e job disabled for legacy branches."
+                    exit
+                    ;;
+                esac
+                ./test/e2e_node/jenkins/e2e-node-jenkins.sh ./test/e2e_node/jenkins/jenkins-pull.properties
     jobs:
         - '{git-project}-pull-{suffix}'


### PR DESCRIPTION
* Node e2e just seems to be perpetually failing on release-1.2. I don't think we have a CI job for it on 1.2, and I don't think we're going to spend engineering effort trying to fix it.
* GKE fails to build because `build/util.sh` doesn't exist. #25125 is a pretty large PR that we probably don't want to cherry-pick to 1.2; I guess we could selectively cherry-pick just part of it if we really want GKE to work on 1.2.
* I have no idea why Kubemark is failing (e.g. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/32818/kubernetes-pull-build-test-kubemark-e2e-gce/327/) but 1.2 is pretty old, so it wouldn't surprise me if there's some incompatibility between the latest e2e.go and 1.2's Kubemark. @wojtek-t 

The better fix than this PR is simply not triggering these builds for old releases, but that'll require some code changes in our triggering infra.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/591)
<!-- Reviewable:end -->
