### PR TITLE
Pin all the GCE upgrade tests to container-vm

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -87,6 +87,7 @@
                 export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gce-upg-{version-infix}-upg-mas"
                 {version-env}
         - 'kubernetes-e2e-{suffix}':
@@ -99,6 +100,7 @@
                 export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gce-upg-{version-infix}-upg-clu"
                 {version-env}
         - 'kubernetes-e2e-{suffix}':
@@ -112,6 +114,7 @@
                 export JENKINS_PUBLISHED_SKEW_VERSION="ci/latest-{version-new}"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-{version-old}"
                 export JENKINS_USE_SKEW_TESTS="true"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="kube-gce-upg-{version-infix}-upg-clu-n"
                 {version-env}
 


### PR DESCRIPTION
They are not meant to auto-upgrade to gci.
container-vm to gci upgrades will be tested independently and is not critical for gce upgrade testing for v1.4.0
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/593)
<!-- Reviewable:end -->
