### PR TITLE
Fix: kubernetes-pull-gci-build-test-e2e-gce -> kubernetes-pull-build-test-gci-e2e-gce

### DIFF
--- a/ciongke/Makefile
+++ b/ciongke/Makefile
@@ -67,8 +67,8 @@ test:
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook github.com/kubernetes/test-infra/ciongke/cmd/hook
-	docker build -t "gcr.io/k8s-ci-on-gke/hook:0.19" cmd/hook
-	gcloud docker push "gcr.io/k8s-ci-on-gke/hook:0.19"
+	docker build -t "gcr.io/k8s-ci-on-gke/hook:0.20" cmd/hook
+	gcloud docker push "gcr.io/k8s-ci-on-gke/hook:0.20"
 
 hook-deployment:
 	kubectl apply -f hook_deployment.yaml

--- a/ciongke/cmd/hook/main.go
+++ b/ciongke/cmd/hook/main.go
@@ -53,7 +53,7 @@ var defaultJenkinsJobs = map[string][]JenkinsJob{
 			Context:   "Jenkins GKE smoke e2e",
 		},
 		{
-			Name:    "kubernetes-pull-gci-build-test-e2e-gce",
+			Name:    "kubernetes-pull-build-test-gci-e2e-gce",
 			Trigger: regexp.MustCompile(`@k8s-bot gci (gce )?(e2e )?test this`),
 			Context: "GCI GCE e2e",
 		},

--- a/ciongke/hook_deployment.yaml
+++ b/ciongke/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-ci-on-gke/hook:0.19
+        image: gcr.io/k8s-ci-on-gke/hook:0.20
         imagePullPolicy: Always
         args:
         - -test-pr-image=gcr.io/k8s-ci-on-gke/test-pr:0.9

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
@@ -152,7 +152,7 @@
                 fi
                 echo "Exiting with code: ${{rc}}"
                 exit ${{rc}}
-        - 'gci-build-test-e2e-gce': # kubernetes-pull-gci-build-test-e2e-gce
+        - 'gci-e2e-gce': # kubernetes-pull-build-test-gci-e2e-gce
             cmd: |
                 export KUBE_SKIP_PUSH_GCS=y
                 export KUBE_RUN_FROM_OUTPUT=y


### PR DESCRIPTION
The naming convention changed from {git-project}-pull-{suffix} to kubernetes-pull-build-test-{suffix} with the new hooks, and I didn't notice this in #578.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/596)
<!-- Reviewable:end -->
