### PR TITLE
Add CI jobs for k8s-release-1.4 v.s. GCI milestone 55

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -102,6 +102,40 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
+        - 'release-1.4':  # kubernetes-e2e-gce-gci-ci-release-1.4
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.4 branch.'
+            timeout: 50
+            trigger-job: 'kubernetes-build-1.4'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+                # To qualify GCI milestone 55 for k8s release-1.4.
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-1-4"
+        - 'slow-release-1.4':  # kubernetes-e2e-gce-gci-ci-slow-release-1.4
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.4 branch.'
+            timeout: 150
+            trigger-job: 'kubernetes-build-1.4'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+                # To qualify GCI milestone 55 for k8s release-1.4.
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-slow-1-4"
+        - 'serial-release-1.4':  # kubernetes-e2e-gce-gci-ci-serial-release-1.4
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.4 branch.'
+            timeout: 300
+            trigger-job: 'kubernetes-build-1.4'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+                # To qualify GCI milestone 55 for k8s release-1.4.
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-ci-serial-1-4"
         - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
             timeout: 50


### PR DESCRIPTION
These jobs test against the tip of k8s-release-1.4 and GCI milestone 55. Run them continuously to qualify GCI m55 for k8s release-1.4.

@adityakali @vishh Can you review?

cc/ @kubernetes/goog-image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/598)
<!-- Reviewable:end -->
