### PR TITLE
Update the project names for GCI m55 v.s. k8s 1.4 CI jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -112,7 +112,7 @@
                 export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-1-4"
+                export PROJECT="kubekins-gce-gci-ci-1-4"
         - 'slow-release-1.4':  # kubernetes-e2e-gce-gci-ci-slow-release-1.4
             description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.4 branch.'
             timeout: 150
@@ -124,7 +124,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-slow-1-4"
+                export PROJECT="kubekins-gce-gci-ci-slow-1-4"
         - 'serial-release-1.4':  # kubernetes-e2e-gce-gci-ci-serial-release-1.4
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.4 branch.'
             timeout: 300
@@ -135,7 +135,7 @@
                 export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-ci-serial-1-4"
+                export PROJECT="kubekins-gce-gci-ci-serial-1-4"
         - 'release-1.3':  # kubernetes-e2e-gce-gci-ci-release-1.3
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.3 branch.'
             timeout: 50


### PR DESCRIPTION
The projects added in https://github.com/kubernetes/test-infra/pull/598 were
taken.

@vishh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/600)
<!-- Reviewable:end -->
