### PR TITLE
Fix "failed to stop containers" message when container has nonzero exit.

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -83,6 +83,7 @@ docker run --rm -i \
   -e "WORKSPACE=/workspace" \
   ${GOOGLE_APPLICATION_CREDENTIALS:+-e "GOOGLE_APPLICATION_CREDENTIALS=/service-account.json"} \
   "${docker_extra_args[@]:+${docker_extra_args[@]}}" \
-  "gcr.io/google-containers/kubekins-e2e:${KUBEKINS_E2E_IMAGE_TAG}"
+  "gcr.io/google-containers/kubekins-e2e:${KUBEKINS_E2E_IMAGE_TAG}" && rc=$? || rc=$?
 
-trap '' EXIT  # container exited normally
+trap '' EXIT  # container exited
+exit ${rc}


### PR DESCRIPTION
Here's a build that ran into it: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-e2e-gke-slow/8837

The message is confusing, but otherwise harmless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/602)
<!-- Reviewable:end -->
