### PR TITLE
Export GCI image versions in started.json.

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -201,6 +201,11 @@ function setup_gci_vars() {
     export KUBE_GCE_NODE_IMAGE="${image_name}"
     export KUBE_NODE_OS_DISTRIBUTION="gci"
 
+    # These will be included in started.json in the metadata dict.
+    # See upload-to-gcs.sh for more details.
+    export BUILD_METADATA_GCE_MASTER_IMAGE="${KUBE_GCE_MASTER_IMAGE}"
+    export BUILD_METADATA_GCE_NODE_IMAGE="${KUBE_GCE_NODE_IMAGE}"
+
     # For backward compatibility (Older versions of Kubernetes don't understand
     # KUBE_MASTER_OS_DISTRIBUTION or KUBE_NODE_OS_DISTRIBUTION. Only KUBE_OS_DISTRIBUTION can be
     # used for them.)


### PR DESCRIPTION
Note that this will require a separate e2e-image update to be activated, since the current upload_to_gcs.sh included in the dockerized e2e runners is outdated -- it was updated in kubernetes/kubernetes#32740

Hopefully kubernetes/kubernetes#32892 can be included in the new e2e-image as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/603)
<!-- Reviewable:end -->
