### PR TITLE
Don't fail on missing junit for old release branches

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
@@ -1,5 +1,6 @@
 - job-template:
     name: 'kubernetes-pull-build-test-{suffix}'
+    skip-if-no-test-files: false
     concurrent: true
     properties:
         - build-discarder:
@@ -79,7 +80,7 @@
                     failurenew:
             types:
                 - junit:
-                    skip-if-no-test-files: false
+                    skip-if-no-test-files: '{skip-if-no-test-files}'
                     pattern: '_artifacts/**.xml'
                     deleteoutput: false
         - gcs-uploader:
@@ -89,6 +90,7 @@
     name: kubernetes-pull-e2e
     suffix:
         - 'e2e-gke': # kubernetes-pull-build-test-e2e-gke
+            skip-if-no-test-files: true  # old branches are skipped and do not produce JUnit
             cmd: |
                 case "${{ghprbTargetBranch:-}}" in
                   release-1.0|release-1.1|release-1.2)
@@ -329,6 +331,7 @@
                 echo "Exiting with code: ${{rc}}"
                 exit ${{rc}}
         - 'kubemark-e2e-gce': # kubernetes-pull-build-test-kubemark-e2e-gce
+            skip-if-no-test-files: true  # old branches are skipped and do not produce JUnit
             cmd: |
                 case "${{ghprbTargetBranch:-}}" in
                   release-1.0|release-1.1|release-1.2)
@@ -387,6 +390,7 @@
                 echo "Exiting with code: ${{rc}}"
                 exit ${{rc}}
         - 'gci-kubemark-e2e-gce': # kubernetes-pull-build-test-gci-kubemark-e2e-gce
+            skip-if-no-test-files: true  # old branches are skipped and do not produce JUnit
             cmd: |
                 case "${{ghprbTargetBranch:-}}" in
                   release-1.0|release-1.1|release-1.2)

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull.yaml
@@ -472,7 +472,7 @@
             suffix: 'build-e2e-test'
             owner: 'pwittroc@google.com'
             max-total: 10
-            skip-if-no-test-files:   # old branches may not produce JUnit
+            skip-if-no-test-files: true  # old branches may not produce JUnit
             trigger-phrase: '(node )?(e2e )?test'
             status-context: 'GCE Node e2e'
             cmd: |


### PR DESCRIPTION
Follow-up from #591 that I forgot to push yesterday.

Since we're skipping tests for `release-1.2`, we need to make the xunit plugin not fail, since the junit XML files will be missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/607)
<!-- Reviewable:end -->
