### PR TITLE
Add kubernetes-e2e-gci-gke-master tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -168,7 +168,7 @@
     trigger-job: 'kubernetes-build'
     test-owner: 'Build Cop'
     gke-suffix:
-        - 'gke-gci':  # kubernetes-e2e-gke
+        - 'gci-gke':  # kubernetes-e2e-gci-gke
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)'
             timeout: 50  # See kubernetes/kubernetes#21138
@@ -178,7 +178,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-gci-ci"
                 export KUBE_GKE_IMAGE_TYPE="gci"
-        - 'gke-gci-slow':  # kubernetes-e2e-gke-gci-slow
+        - 'gci-gke-slow':  # kubernetes-e2e-gci-gke-slow
             cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
             timeout: 150  #  See kubernetes/kubernetes#24072
@@ -189,7 +189,7 @@
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gke-gci-slow"
                 export KUBE_GKE_IMAGE_TYPE="gci"
-        - 'gke-gci-serial':  # kubernetes-e2e-gke-gci-serial
+        - 'gci-gke-serial':  # kubernetes-e2e-gci-gke-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
             job-env: |

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -199,6 +199,61 @@
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-gci-e2e-serial"
                 export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-updown':  # kubernetes-e2e-gci-gke-updown
+            cron-string: '{sq-cron-string}'
+            description: 'Brings a cluster up, checks networking, brings it down (against GKE test endpoint)'
+            timeout: 30  # See kubernetes/kubernetes#21138
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]"
+                export PROJECT="kubernetes-e2e-gci-gke-updown"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-reboot':  # kubernetes-e2e-gci-gke-reboot
+            description: 'Run [Feature:Reboot] tests on GKE using the latest successful build.'
+            timeout: 180
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export PROJECT="k8s-jkns-e2e-gci-gke-ci-reboot"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-flaky':  # kubernetes-e2e-gci-gke-flaky
+            description: |
+                Run flaky e2e tests using the following config:<br>
+                - provider: GKE<br>
+                - api proxy: staging<br>
+                - borg job: test<br>
+                - client (kubectl): ci/latest.txt<br>
+                - cluster (k8s): ci/latest.txt<br>
+                - tests: ci/latest.txt
+            timeout: 300
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
+                                         --ginkgo.skip=\[Feature:.+\]"
+                export PROJECT="k8s-jkns-e2e-gci-gke-ci-flaky"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-multizone':  # kubernetes-e2e-gci-gke-multizone
+            description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel, and in a multi-zone cluster.'
+            timeout: 150
+            emails: 'quinton@google.com'
+            job-env: |
+                export ADDITIONAL_ZONES="us-central1-a,us-central1-b"
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="k8s-jkns-e2e-gci-gke-multizone"
+                export ZONE="us-central1-f"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-autoscaling':  # kubernetes-e2e-gci-gke-autoscaling
+            description: 'Run all cluster autoscaler tests on GKE.'
+            timeout: 300
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] \
+                                         --ginkgo.skip=\[Flaky\]"
+                export NUM_NODES=3
+                export PROJECT="k8s-e2e-gci-gke-autoscaling"
+                export KUBE_GKE_IMAGE_TYPE="gci"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -63,16 +63,6 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci"
-        - 'gke-gci':  # kubernetes-e2e-gke
-            cron-string: '{sq-cron-string}'
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)'
-            timeout: 50  # See kubernetes/kubernetes#21138
-            job-env: |
-                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-                export GINKGO_PARALLEL="y"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-e2e-gke-gci-ci"
-                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-slow':  # kubernetes-e2e-gke-slow
             cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
@@ -83,17 +73,6 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gke-slow"
-        - 'gke-gci-slow':  # kubernetes-e2e-gke-gci-slow
-            cron-string: '{sq-cron-string}'
-            description: 'Run slow E2E tests on GKE using the latest successful build.'
-            timeout: 150  #  See kubernetes/kubernetes#24072
-            job-env: |
-                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-e2e-gke-gci-slow"
-                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-serial':  # kubernetes-e2e-gke-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
@@ -103,16 +82,6 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="jenkins-gke-e2e-serial"
-        - 'gke-gci-serial':  # kubernetes-e2e-gke-gci-serial
-            description: 'Run [Serial], [Disruptive] tests on GKE.'
-            timeout: 300
-            job-env: |
-                export ENABLE_GARBAGE_COLLECTOR="true"
-                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="jenkins-gke-gci-e2e-serial"
-                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-updown':  # kubernetes-e2e-gke-updown
             cron-string: '{sq-cron-string}'
             description: 'Brings a cluster up, checks networking, brings it down (against GKE test endpoint)'
@@ -191,6 +160,45 @@
                 export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
+    jobs:
+        - 'kubernetes-e2e-{gke-suffix}'
+
+- project:
+    name: kubernetes-e2e-gci-gke-master
+    trigger-job: 'kubernetes-build'
+    test-owner: 'Build Cop'
+    gke-suffix:
+        - 'gke-gci':  # kubernetes-e2e-gke
+            cron-string: '{sq-cron-string}'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)'
+            timeout: 50  # See kubernetes/kubernetes#21138
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="k8s-jkns-e2e-gke-gci-ci"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gke-gci-slow':  # kubernetes-e2e-gke-gci-slow
+            cron-string: '{sq-cron-string}'
+            description: 'Run slow E2E tests on GKE using the latest successful build.'
+            timeout: 150  #  See kubernetes/kubernetes#24072
+            job-env: |
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-e2e-gke-gci-slow"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gke-gci-serial':  # kubernetes-e2e-gke-gci-serial
+            description: 'Run [Serial], [Disruptive] tests on GKE.'
+            timeout: 300
+            job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="jenkins-gke-gci-e2e-serial"
+                export KUBE_GKE_IMAGE_TYPE="gci"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -370,12 +370,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-autoscaling
 - name: kubernetes-e2e-gke-flaky
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-flaky
-- name: kubernetes-e2e-gke-gci
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci
-- name: kubernetes-e2e-gke-gci-serial
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-serial
-- name: kubernetes-e2e-gke-gci-slow
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-slow
+- name: kubernetes-e2e-gci-gke
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke
+- name: kubernetes-e2e-gci-gke-serial
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-serial
+- name: kubernetes-e2e-gci-gke-slow
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-slow
 - name: kubernetes-e2e-gke-ingress
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-ingress
 - name: kubernetes-e2e-gke-ingress-release-1.2
@@ -852,12 +852,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-autoscaling
   - name: gke-flaky
     test_group_name: kubernetes-e2e-gke-flaky
-  - name: gke-gci
-    test_group_name: kubernetes-e2e-gke-gci
-  - name: gke-gci-serial
-    test_group_name: kubernetes-e2e-gke-gci-serial
-  - name: gke-gci-slow
-    test_group_name: kubernetes-e2e-gke-gci-slow
+  - name: gci-gke
+    test_group_name: kubernetes-e2e-gci-gke
+  - name: gci-gke-serial
+    test_group_name: kubernetes-e2e-gci-gke-serial
+  - name: gci-gke-slow
+    test_group_name: kubernetes-e2e-gci-gke-slow
   - name: gke-ingress
     test_group_name: kubernetes-e2e-gke-ingress
   - name: gke-ingress-release-1.2

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -368,8 +368,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-1.3-kubectl-skew
 - name: kubernetes-e2e-gke-autoscaling
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-autoscaling
+- name: kubernetes-e2e-gci-gke-autoscaling
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-autoscaling
 - name: kubernetes-e2e-gke-flaky
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-flaky
+- name: kubernetes-e2e-gci-gke-flaky
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-flaky
 - name: kubernetes-e2e-gci-gke
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke
 - name: kubernetes-e2e-gci-gke-serial
@@ -394,6 +398,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-large-cluster
 - name: kubernetes-e2e-gke-multizone
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-multizone
+- name: kubernetes-e2e-gci-gke-multizone
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-multizone
 - name: kubernetes-e2e-gke-pre-release
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-pre-release
 - name: kubernetes-e2e-gke-prod
@@ -404,6 +410,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-prod-smoke
 - name: kubernetes-e2e-gke-reboot
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-reboot
+- name: kubernetes-e2e-gci-gke-reboot
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-reboot
 - name: kubernetes-e2e-gke-reboot-release-1.3
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-reboot-release-1.3
 - name: kubernetes-e2e-gci-gke-reboot-release-1.3
@@ -470,6 +478,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-trusty-test
 - name: kubernetes-e2e-gke-updown
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-updown
+- name: kubernetes-e2e-gci-gke-updown
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-updown
 - name: kubernetes-kubemark-100-gce
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-kubemark-100-gce
 - name: kubernetes-kubemark-5-gce
@@ -850,8 +860,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-1.1
   - name: gke-autoscaling
     test_group_name: kubernetes-e2e-gke-autoscaling
+  - name: gci-gke-autoscaling
+    test_group_name: kubernetes-e2e-gci-gke-autoscaling
   - name: gke-flaky
     test_group_name: kubernetes-e2e-gke-flaky
+  - name: gci-gke-flaky
+    test_group_name: kubernetes-e2e-gci-gke-flaky
   - name: gci-gke
     test_group_name: kubernetes-e2e-gci-gke
   - name: gci-gke-serial
@@ -876,6 +890,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-large-cluster
   - name: gke-multizone
     test_group_name: kubernetes-e2e-gke-multizone
+  - name: gci-gke-multizone
+    test_group_name: kubernetes-e2e-gci-gke-multizone
   - name: gke-pre-release
     test_group_name: kubernetes-e2e-gke-pre-release
   - name: gke-prod
@@ -886,6 +902,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-prod-smoke
   - name: gke-reboot
     test_group_name: kubernetes-e2e-gke-reboot
+  - name: gci-gke-reboot
+    test_group_name: kubernetes-e2e-gci-gke-reboot
   - name: gke-reboot-release-1.3
     test_group_name: kubernetes-e2e-gke-reboot-release-1.3
   - name: gci-gke-reboot-release-1.3
@@ -944,6 +962,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-test
   - name: gke-updown
     test_group_name: kubernetes-e2e-gke-updown
+  - name: gci-gke-updown
+    test_group_name: kubernetes-e2e-gci-gke-updown
   name: google-gke
 - dashboard_tab:
   - name: kubemark-100-gce


### PR DESCRIPTION
This makes some test names more uniform and adds gci based jobs for kubernetes-e2e-gke-master jobs that did not yet have gci equivalents, with the exclusion of the large-cluster test (scale) which we will handle separately.

Job,GCE Project
`kubernetes-e2e-gci-gke-updown`,`kubernetes-e2e-gci-gke-updown`
`kubernetes-e2e-gci-gke-reboot`,`k8s-jkns-e2e-gci-gke-ci-reboot`
`kubernetes-e2e-gci-gke-flaky`,`k8s-jkns-e2e-gci-gke-ci-flaky`
`kubernetes-e2e-gci-gke-multizone`,`k8s-jkns-e2e-gci-gke-multizone`
`kubernetes-e2e-gci-gke-autoscaling`,`k8s-e2e-gci-gke-autoscaling`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/621)
<!-- Reviewable:end -->
