### PR TITLE
Show build node and metadata on build result page.

### DIFF
--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -18,10 +18,21 @@
 		% set pl = pr_digest.payload
 		<p><a href="/pr/{{pl['author']}}">{{pl['author']}}</a>: {{pl['title']}}
 	% endif
+	<p>Build Result: {{finished['result'] if finished else 'Not Finished'}}
 	% if started
 		<p><a href="https://github.com/kubernetes/kubernetes/commit/{{commit}}">{{started['version']}}</a>
+		% if 'jenkins-node' in started
+			<p>Builder: {{started['jenkins-node']}}
+		% endif
+		% if 'metadata' in started
+			<table border=1 align="center">
+			<tr><th>Metadata Key<th>Value
+			% for k, v in started['metadata']|dictsort
+			<tr><td>{{k}}<td>{{v}}
+			% endfor
+			</table>
+		% endif
 	% endif
-	<p>Build Result: {{finished['result'] if finished else 'Not Finished'}}
 	<p><a href="https://console.cloud.google.com/storage/browser{{build_dir}}">artifacts</a>
 	<a href="https://storage.googleapis.com{{build_dir}}/build-log.txt">build-log.txt</a>
 	% if testgrid_query

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -111,6 +111,21 @@ class BuildTest(main_test.TestBase):
         response = self.get_build_page()
         self.assertIn('No Test Failures', response)
 
+    def test_show_metadata(self):
+        write(self.BUILD_DIR + 'started.json',
+            {
+                'version': 'v1+56',
+                'timestamp': 1406535800,
+                'jenkins-node': 'agent-light-7',
+                'metadata': {
+                    'master-version': 'm12'
+                }
+            })
+        response = self.get_build_page()
+        self.assertIn('v1+56', response)
+        self.assertIn('agent-light-7', response)
+        self.assertIn('<td>master-version<td>m12', response)
+
     def test_build_show_log(self):
         """Test that builds that failed with no failures show the build log."""
         gcs.delete(self.BUILD_DIR + 'artifacts/junit_01.xml')


### PR DESCRIPTION
This makes it easier to debug GCI failures.

![image](https://cloud.githubusercontent.com/assets/211868/18690167/bfee02d8-7f41-11e6-9eb3-7fa1e9822fd0.png)

/cc @wonderfly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/626)
<!-- Reviewable:end -->
