### PR TITLE
Run gcloud info after installing gcloud for debugging purposes

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -173,6 +173,7 @@ function install_google_cloud_sdk_tarball() {
     export CLOUDSDK_CORE_DISABLE_PROMPTS=1
     record_command "${STAGE_PRE}" "install_gcloud" "${install_dir}/google-cloud-sdk/install.sh" --disable-installation-options --bash-completion=false --path-update=false --usage-reporting=false
     export PATH=${install_dir}/google-cloud-sdk/bin:${PATH}
+    gcloud info
 }
 
 # Figures out the builtin k8s version of a GCI image.


### PR DESCRIPTION
See internal bug 31616968 for motivation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/630)
<!-- Reviewable:end -->
