### PR TITLE
Docker no longer supports -f for the tag command

### DIFF
--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -19,7 +19,7 @@ all: build
 
 build:
 	docker build -t $(IMG):$(TAG) .
-	docker tag -f $(IMG):$(TAG) $(IMG):latest
+	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with latest
 
 push: build

--- a/jenkins/test-image/Makefile
+++ b/jenkins/test-image/Makefile
@@ -19,7 +19,7 @@ all: build
 
 build:
 	docker build -t $(IMG):$(TAG) .
-	docker tag -f $(IMG):$(TAG) $(IMG):latest
+	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with $(IMG):latest
 
 push: build


### PR DESCRIPTION
My work machine finally upgraded to 1.12, so of course that means that I could no longer tag any docker images using our Makefiles.

See https://github.com/docker/docker/pull/23090, https://github.com/docker/docker/issues/24494, etc.

Starting from docker 1.10 (https://github.com/docker/docker/pull/18350) this flag was deprecated.

I'm not sure what to do if we keep using docker 1.9.1 in places. (We probably should upgrade Jenkins finally.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/631)
<!-- Reviewable:end -->
