### PR TITLE
Add GCI tests for kubernetes-e2e-gke-version-pinned and kubernetes-e2e-gci-gke-features jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -524,6 +524,102 @@
         - 'kubernetes-e2e-{gke-suffix}'
 
 - project:
+    name: kubernetes-e2e-gci-gke-version-pinned
+    trigger-job: 'kubernetes-build-1.3'  # TODO(spxtr) float with current release.
+    test-owner: 'GKE on-call'
+    gke-suffix:
+        - 'gci-gke-pre-release':  # kubernetes-e2e-gci-gke-pre-release
+            description: 'Run E2E tests on GKE test endpoint against the latest prerelease (alpha/beta).'
+            timeout: 480
+            job-env: |
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export JENKINS_PUBLISHED_VERSION="release/latest"
+                export PROJECT="k8s-jkns-e2e-gci-gke-prerel"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-test':  # kubernetes-e2e-gci-gke-test
+            description: 'Run E2E tests on GKE test endpoint.'
+            timeout: 480
+            job-env: |
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export E2E_OPT="--check_version_skew=false"
+                export JENKINS_USE_SERVER_VERSION="y"
+                export PROJECT="k8s-jkns-e2e-gci-gke-test"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-subnet':  # kubernetes-e2e-gci-gke-subnet
+            description: 'Run E2E tests on GKE test endpoint in a subnet.'
+            timeout: 480
+            job-env: |
+                # auto-subnet manually created - if deleted, it will need to be recreated
+                # gcloud alpha compute networks create auto-subnet --mode auto
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export E2E_NAME="auto-subnet"
+                export E2E_OPT="--check_version_skew=false"
+                export JENKINS_USE_SERVER_VERSION="y"
+                export PROJECT="k8s-jkns-e2e-gci-gke-subnet"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-staging':  # kubernetes-e2e-gci-gke-staging
+            description: 'Run E2E tests on GKE staging endpoint.'
+            timeout: 480
+            job-env: |
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export E2E_OPT="--check_version_skew=false"
+                export JENKINS_USE_SERVER_VERSION="y"
+                export PROJECT="k8s-jkns-e2e-gci-gke-staging"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-staging-parallel':  # kubernetes-e2e-gci-gke-staging-parallel
+            description: 'Run E2E tests on GKE staging endpoint in parallel.'
+            timeout: 80
+            job-env: |
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export E2E_OPT="--check_version_skew=false"
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export JENKINS_USE_SERVER_VERSION="y"
+                export PROJECT="k8s-e2e-gci-gke-staging-plel"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-prod':  # kubernetes-e2e-gci-gke-prod
+            description: 'Run E2E tests on GKE prod endpoint.'
+            timeout: 480
+            job-env: |
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export E2E_OPT="--check_version_skew=false"
+                export JENKINS_USE_SERVER_VERSION="y"
+                export PROJECT="k8s-jkns-e2e-gci-gke-prod"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+                export ZONE="us-central1-b"
+        - 'gci-gke-prod-parallel':  # kubernetes-e2e-gci-gke-prod-parallel
+            description: 'Run E2E tests on GKE prod endpoint in parallel.'
+            timeout: 80
+            job-env: |
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export E2E_OPT="--check_version_skew=false"
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export JENKINS_USE_SERVER_VERSION="y"
+                export PROJECT="k8s-e2e-gci-gke-prod-parallel"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+                export ZONE="us-central1-b"
+        - 'gci-gke-prod-smoke':  # kubernetes-e2e-gci-gke-prod-smoke
+            description: 'Run smoke tests on GKE prod day 1 zone (asia-east1-b).'
+            timeout: 80
+            job-env: |
+                export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://container.googleapis.com/"
+                export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/rc"
+                export E2E_OPT="--check_version_skew=false"
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export JENKINS_USE_SERVER_VERSION="y"
+                export PROJECT="k8s-e2e-gci-gke-prod-smoke"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+                export ZONE="asia-east1-b"
+    jobs:
+        - 'kubernetes-e2e-{gke-suffix}'
+
+- project:
     name: kubernetes-e2e-gke-features
     trigger-job: 'kubernetes-build'
     gke-suffix:
@@ -537,6 +633,24 @@
                 export PROJECT="kubernetes-gke-ingress"
                 # TODO: Enable this when we've split 1.2 tests into another project.
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
+    jobs:
+        - 'kubernetes-e2e-{gke-suffix}'
+
+- project:
+    name: kubernetes-e2e-gci-gke-features
+    trigger-job: 'kubernetes-build'
+    gke-suffix:
+        - 'gci-gke-ingress':  # kubernetes-e2e-gke-ingress
+            description: 'Run [Feature:Ingress] tests on GKE using the latest successful build, using GCI image.'
+            timeout: 90
+            emails: 'beeps@google.com'
+            test-owner: 'beeps'
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+                export PROJECT="kubernetes-gci-gke-ingress"
+                # TODO: Enable this when we've split 1.2 tests into another project.
+                export FAIL_ON_GCP_RESOURCE_LEAK="false"
+                export KUBE_GKE_IMAGE_TYPE="gci"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -437,7 +437,7 @@
 
 - project:
     name: kubernetes-e2e-gke-version-pinned
-    trigger-job: 'kubernetes-build-1.2'  # TODO(spxtr) float with current release.
+    trigger-job: 'kubernetes-build-1.3'  # TODO(spxtr) float with current release.
     test-owner: 'GKE on-call'
     gke-suffix:
         - 'gke-pre-release':  # kubernetes-e2e-gke-pre-release

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -380,6 +380,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-slow
 - name: kubernetes-e2e-gke-ingress
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-ingress
+- name: kubernetes-e2e-gci-gke-ingress
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-ingress
 - name: kubernetes-e2e-gke-ingress-release-1.2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-ingress-release-1.2
 - name: kubernetes-e2e-gci-gke-ingress-release-1.2
@@ -398,12 +400,20 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-multizone
 - name: kubernetes-e2e-gke-pre-release
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-pre-release
+- name: kubernetes-e2e-gci-gke-pre-release
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-pre-release
 - name: kubernetes-e2e-gke-prod
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-prod
+- name: kubernetes-e2e-gci-gke-prod
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-prod
 - name: kubernetes-e2e-gke-prod-parallel
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-prod-parallel
+- name: kubernetes-e2e-gci-gke-prod-parallel
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-prod-parallel
 - name: kubernetes-e2e-gke-prod-smoke
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-prod-smoke
+- name: kubernetes-e2e-gci-gke-prod-smoke
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-prod-smoke
 - name: kubernetes-e2e-gke-reboot
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-reboot
 - name: kubernetes-e2e-gke-reboot-release-1.3
@@ -456,12 +466,20 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-slow-release-1.4
 - name: kubernetes-e2e-gke-staging
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-staging
+- name: kubernetes-e2e-gci-gke-staging
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-staging
 - name: kubernetes-e2e-gke-staging-parallel
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-staging-parallel
+- name: kubernetes-e2e-gci-gke-staging-parallel
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-staging-parallel
 - name: kubernetes-e2e-gke-subnet
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-subnet
+- name: kubernetes-e2e-gci-gke-subnet
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-subnet
 - name: kubernetes-e2e-gke-test
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-test
+- name: kubernetes-e2e-gci-gke-test
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-test
 - name: kubernetes-e2e-gke-trusty-staging
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-trusty-staging
 - name: kubernetes-e2e-gke-trusty-staging-parallel
@@ -592,12 +610,20 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-examples
   - name: gke-staging
     test_group_name: kubernetes-e2e-gke-staging
+  - name: gci-gke-staging
+    test_group_name: kubernetes-e2e-gci-gke-staging
   - name: gke-staging-parallel
     test_group_name: kubernetes-e2e-gke-staging-parallel
+  - name: gci-gke-staging-parallel
+    test_group_name: kubernetes-e2e-gci-gke-staging-parallel
   - name: gke-subnet
     test_group_name: kubernetes-e2e-gke-subnet
+  - name: gci-gke-subnet
+    test_group_name: kubernetes-e2e-gci-gke-subnet
   - name: gke-test
     test_group_name: kubernetes-e2e-gke-test
+  - name: gci-gke-test
+    test_group_name: kubernetes-e2e-gci-gke-test
   - name: rktnetes
     test_group_name: kubernetes-rktnetes
   - name: azure
@@ -862,6 +888,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-gci-slow
   - name: gke-ingress
     test_group_name: kubernetes-e2e-gke-ingress
+  - name: gci-gke-ingress
+    test_group_name: kubernetes-e2e-gci-gke-ingress
   - name: gke-ingress-release-1.2
     test_group_name: kubernetes-e2e-gke-ingress-release-1.2
   - name: gci-gke-ingress-release-1.2
@@ -880,12 +908,20 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-multizone
   - name: gke-pre-release
     test_group_name: kubernetes-e2e-gke-pre-release
+  - name: gci-gke-pre-release
+    test_group_name: kubernetes-e2e-gci-gke-pre-release
   - name: gke-prod
     test_group_name: kubernetes-e2e-gke-prod
+  - name: gci-gke-prod
+    test_group_name: kubernetes-e2e-gci-gke-prod
   - name: gke-prod-parallel
     test_group_name: kubernetes-e2e-gke-prod-parallel
+  - name: gci-gke-prod-parallel
+    test_group_name: kubernetes-e2e-gci-gke-prod-parallel
   - name: gke-prod-smoke
     test_group_name: kubernetes-e2e-gke-prod-smoke
+  - name: gci-gke-prod-smoke
+    test_group_name: kubernetes-e2e-gci-gke-prod-smoke
   - name: gke-reboot
     test_group_name: kubernetes-e2e-gke-reboot
   - name: gke-reboot-release-1.3
@@ -938,12 +974,18 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gke-slow-release-1.4
   - name: gke-staging
     test_group_name: kubernetes-e2e-gke-staging
+  - name: gci-gke-staging
+    test_group_name: kubernetes-e2e-gci-gke-staging
   - name: gke-staging-parallel
     test_group_name: kubernetes-e2e-gke-staging-parallel
+  - name: gci-gke-staging-parallel
+    test_group_name: kubernetes-e2e-gci-gke-staging-parallel
   - name: gke-subnet
     test_group_name: kubernetes-e2e-gke-subnet
-  - name: gke-test
-    test_group_name: kubernetes-e2e-gke-test
+  - name: gci-gke-subnet
+    test_group_name: kubernetes-e2e-gci-gke-subnet
+  - name: gci-gke-test
+    test_group_name: kubernetes-e2e-gci-gke-test
   - name: gke-updown
     test_group_name: kubernetes-e2e-gke-updown
   name: google-gke


### PR DESCRIPTION
Job,GCE Project
`kubernetes-e2e-gci-gke-pre-release`,`k8s-jkns-e2e-gci-gke-prerel`
`kubernetes-e2e-gci-gke-test`,`k8s-jkns-e2e-gci-gke-test`
`kubernetes-e2e-gci-gke-subnet`,`k8s-jkns-e2e-gci-gke-subnet`
`kubernetes-e2e-gci-gke-staging`,`k8s-jkns-e2e-gci-gke-staging`
`kubernetes-e2e-gci-gke-staging-parallel`,`k8s-e2e-gci-gke-staging-plel`
`kubernetes-e2e-gci-gke-prod`,`k8s-jkns-e2e-gci-gke-prod`
`kubernetes-e2e-gci-gke-prod-parallel`,`k8s-e2e-gci-gke-prod-parallel`
`kubernetes-e2e-gci-gke-prod-smoke`,`k8s-e2e-gci-gke-prod-smoke`
`kubernetes-e2e-gci-gke-ingress`,`kubernetes-gci-gke-ingress`

This also floats the test trigger for version pinned jobs to `kubernetes-build-1.3`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/633)
<!-- Reviewable:end -->
