### PR TITLE
Add more GCI tests for GCE (alpha, autoscaling, autoscaling-migs, soak)

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -135,6 +135,22 @@
                 export KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
+        - 'gci-gce-autoscaling':  # kubernetes-e2e-gci-gce-autoscaling
+            description: 'Run autoscaling E2E tests on GCE.'
+            timeout: 210
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] \
+                                         --ginkgo.skip=\[Flaky\]"
+                export PROJECT="k8s-jkns-e2e-gci-autoscaling"
+                # Override GCE default for cluster size autoscaling purposes.
+                export ENABLE_CUSTOM_METRICS="true"
+                export KUBE_ENABLE_CLUSTER_AUTOSCALER="true"
+                export NUM_NODES=3
+                export KUBE_AUTOSCALER_MIN_NODES=3
+                export KUBE_AUTOSCALER_MAX_NODES=5
+                export KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
         - 'gce-autoscaling-migs':  # kubernetes-e2e-gce-autoscaling-migs
             description: 'Run autoscaling E2E tests on GCE with multiple MIGs.'
             timeout: 210
@@ -150,6 +166,21 @@
                 export KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
+        - 'gci-gce-autoscaling-migs':  # kubernetes-e2e-gci-gce-autoscaling-migs
+            description: 'Run autoscaling E2E tests on GCE with multiple MIGs.'
+            timeout: 210
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]"
+                export PROJECT="k8s-jkns-gci-autoscaling-migs"
+                # Override GCE default for cluster size autoscaling purposes.
+                export KUBE_ENABLE_CLUSTER_AUTOSCALER="true"
+                export NUM_NODES=3
+                export MAX_INSTANCES_PER_MIG=2
+                export KUBE_AUTOSCALER_MIN_NODES=3
+                export KUBE_AUTOSCALER_MAX_NODES=5
+                export KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBE_ADMISSION_CONTROL="NamespaceLifecycle,InitialResources,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
         - 'gce-alpha-features': # kubernetes-e2e-gce-alpha-features
             description: 'Run alpha feature E2E tests on GCE.'
             timeout: 180
@@ -158,6 +189,14 @@
               export KUBE_FEATURE_GATES="AllAlpha=true"
               export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet)\]|ScheduledJob"
               export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gci-gce-alpha-features': # kubernetes-e2e-gce-alpha-features
+            description: 'Run alpha feature E2E tests on GCE.'
+            timeout: 180
+            job-env: |
+              export PROJECT="k8s-jkns-e2e-gci-gce-alpha"
+              export KUBE_FEATURE_GATES="AllAlpha=true"
+              export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet)\]|ScheduledJob"
+              export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gce-flaky':  # kubernetes-e2e-gce-flaky
             description: 'Run the flaky tests on GCE, sequentially.'
             timeout: 180

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -170,6 +170,28 @@
             job-env: |
                 export PROJECT="k8s-jkns-gce-soak-1-4"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+        - 'gci-gce-1.4':
+            deploy-description: |
+                Deploy Kubernetes to soak cluster using the latest successful
+                release-1.4 Kubernetes build every week.<br>
+                If a kubernetes-soak-continuous-e2e-gci-gce-1.4 build is running,
+                this deployment build will be blocked and remain in the queue
+                until the test run is complete.<br>
+            e2e-description: |
+                Assumes Kubernetes soak cluster is already deployed.<br>
+                If a kubernetes-soak-weekly-deploy-gci-gce-1.4 build is enqueued,
+                builds will be blocked and remain in the queue until the
+                deployment is complete.<br>
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="8"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+            job-env: |
+                export PROJECT="k8s-jkns-gci-gce-soak-1-4"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
         - 'gce-1.3':
             deploy-description: |
                 Deploy Kubernetes to soak cluster using the latest successful

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -78,14 +78,20 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce
 - name: kubernetes-e2e-gce-alpha-features
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-alpha-features
+- name: kubernetes-e2e-gci-gce-alpha-features
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features
 - name: kubernetes-e2e-gce-alpha-features-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-alpha-features-release-1.4
 - name: kubernetes-e2e-gci-gce-alpha-features-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features-release-1.4
 - name: kubernetes-e2e-gce-autoscaling
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-autoscaling
+- name: kubernetes-e2e-gci-gce-autoscaling
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-autoscaling
 - name: kubernetes-e2e-gce-autoscaling-migs
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-autoscaling-migs
+- name: kubernetes-e2e-gci-gce-autoscaling-migs
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-autoscaling-migs
 - name: kubernetes-e2e-gce-conformance
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-conformance
 - name: kubernetes-e2e-gce-container-vm
@@ -526,6 +532,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-1.3
 - name: kubernetes-soak-continuous-e2e-gce-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-1.4
+- name: kubernetes-soak-continuous-e2e-gci-gce-1.4
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gci-gce-1.4
 - name: kubernetes-soak-continuous-e2e-gce-2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-2
 - name: kubernetes-soak-continuous-e2e-gce-gci
@@ -542,6 +550,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-1.3
 - name: kubernetes-soak-weekly-deploy-gce-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-1.4
+- name: kubernetes-soak-weekly-deploy-gci-gce-1.4
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gci-gce-1.4
 - name: kubernetes-soak-weekly-deploy-gce-2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-2
 - name: kubernetes-soak-weekly-deploy-gce-gci
@@ -691,14 +701,20 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce
   - name: gce-alpha-features
     test_group_name: kubernetes-e2e-gce-alpha-features
+  - name: gci-gce-alpha-features
+    test_group_name: kubernetes-e2e-gci-gce-alpha-features
   - name: gce-alpha-features-release-1.4
     test_group_name: kubernetes-e2e-gce-alpha-features-release-1.4
   - name: gci-gce-alpha-features-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-alpha-features-release-1.4
   - name: gce-autoscaling
     test_group_name: kubernetes-e2e-gce-autoscaling
+  - name: gci-gce-autoscaling
+    test_group_name: kubernetes-e2e-gci-gce-autoscaling
   - name: gce-autoscaling-migs
     test_group_name: kubernetes-e2e-gce-autoscaling-migs
+  - name: gci-gce-autoscaling-migs
+    test_group_name: kubernetes-e2e-gci-gce-autoscaling-migs
   - name: gce-conformance
     test_group_name: kubernetes-e2e-gce-conformance
   - name: gce-container-vm
@@ -1075,6 +1091,8 @@ dashboards:
     test_group_name: kubernetes-soak-continuous-e2e-gce-1.3
   - name: soak-continuous-e2e-gce-1.4
     test_group_name: kubernetes-soak-continuous-e2e-gce-1.4
+  - name: soak-continuous-e2e-gci-gce-1.4
+    test_group_name: kubernetes-soak-continuous-e2e-gci-gce-1.4
   - name: soak-continuous-e2e-gce-2
     test_group_name: kubernetes-soak-continuous-e2e-gce-2
   - name: soak-continuous-e2e-gce-gci
@@ -1091,6 +1109,8 @@ dashboards:
     test_group_name: kubernetes-soak-weekly-deploy-gce-1.3
   - name: soak-weekly-deploy-gce-1.4
     test_group_name: kubernetes-soak-weekly-deploy-gce-1.4
+  - name: soak-weekly-deploy-gci-gce-1.4
+    test_group_name: kubernetes-soak-weekly-deploy-gci-gce-1.4
   - name: soak-weekly-deploy-gce-2
     test_group_name: kubernetes-soak-weekly-deploy-gce-2
   - name: soak-weekly-deploy-gce-gci
@@ -1295,8 +1315,12 @@ dashboards:
     test_group_name: kubernetes-e2e-aws-release-1.4
   - name: soak-weekly-deploy-gce-1.4
     test_group_name: kubernetes-soak-weekly-deploy-gce-1.4
+  - name: soak-weekly-deploy-gci-gce-1.4
+    test_group_name: kubernetes-soak-weekly-deploy-gci-gce-1.4
   - name: soak-continuous-e2e-gce-1.4
     test_group_name: kubernetes-soak-continuous-e2e-gce-1.4
+  - name: soak-continuous-e2e-gci-gce-1.4
+    test_group_name: kubernetes-soak-continuous-e2e-gci-gce-1.4
   - name: gke-1.2-1.4-upgrade-cluster
     test_group_name: kubernetes-e2e-gke-1.2-1.4-upgrade-cluster
   - name: gke-1.2-1.4-upgrade-cluster-new


### PR DESCRIPTION
Job,GCE Project
`kubernetes-e2e-gce-autoscaling`,`k8s-jkns-gci-autoscaling`
`kubernetes-e2e-gce-autoscaling-migs`,`k8s-jkns-gci-autoscaling-migs`
`kubernetes-e2e-gce-alpha-features`,`k8s-jkns-gci-gce-alpha`
`kubernetes-soak-continuous-e2e-gce-1.4`,`k8s-jkns-e2e-gci-gce-soak-1-4`
`kubernetes-soak-weekly-deploy-gce-1.4`,`k8s-jkns-e2e-gci-gce-soak-1-4`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/656)
<!-- Reviewable:end -->
