### PR TITLE
Switch kubernetes-e2e-gce-enormous-cluster and kubernetes-e2e-gke-large-cluster testing to GCI image

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -950,6 +950,6 @@
         # Increase throughput in Load test.
         # TODO: Uncomment after validating 1.4 release.
         # export LOAD_TEST_THROUGHPUT=50
-        export KUBE_NODE_OS_DISTRIBUTION="debian"
+        export KUBE_NODE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-e2e-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -162,6 +162,7 @@
                 export GKE_CREATE_FLAGS="--max-nodes-per-pool=1000"
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://staging-container.sandbox.googleapis.com/"
+                export KUBE_GKE_IMAGE_TYPE="gci"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/657)
<!-- Reviewable:end -->
