### PR TITLE
Fix env for kubernetes-pull GKE tests

### DIFF
--- a/ciongke/Makefile
+++ b/ciongke/Makefile
@@ -69,8 +69,8 @@ test:
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook github.com/kubernetes/test-infra/ciongke/cmd/hook
-	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.26" cmd/hook
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.26"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.27" cmd/hook
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.27"
 
 hook-deployment:
 	kubectl apply -f hook_deployment.yaml

--- a/ciongke/hook_deployment.yaml
+++ b/ciongke/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.26
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.27
         imagePullPolicy: Always
         args:
         - -test-pr-image=gcr.io/kubernetes-jenkins-pull/test-pr:0.14

--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
@@ -182,7 +182,7 @@
                 export E2E_DOWN="true"
                 export E2E_OPT="--check_version_skew=false"
                 # Force to use container-vm.
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_GKE_IMAGE_TYPE="debian"
                 # Skip gcloud update checking
                 export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
                 # GKE variables
@@ -246,7 +246,7 @@
                 export E2E_DOWN="true"
                 export E2E_OPT="--check_version_skew=false"
                 # Force to use container-vm.
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBE_GKE_IMAGE_TYPE="gci"
                 # Skip gcloud update checking
                 export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
                 # GKE variables


### PR DESCRIPTION
`KUBE_NODE_OS_DISTRIBUTION` has no effect on GKE.
The correct variable is `KUBE_GKE_IMAGE_TYPE`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/659)
<!-- Reviewable:end -->
