### PR TITLE
Use container_vm for original pull-e2e-gke job so we have a comparison point for GCI

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
@@ -181,8 +181,9 @@
                 export E2E_TEST="true"
                 export E2E_DOWN="true"
                 export E2E_OPT="--check_version_skew=false"
-                # ContainerVM is not supported any more. Use GCI.
-                export KUBE_GKE_IMAGE_TYPE="gci"
+                # TODO(mtaufen): Change this to "gci" once we are confident
+                #                that tests behave similarly enough on GCI.
+                export KUBE_GKE_IMAGE_TYPE="container_vm"
                 # Skip gcloud update checking
                 export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
                 # GKE variables


### PR DESCRIPTION
We want to keep per-pr container vm and GCI jobs around long enough to have a comparison point with GCI. Since the wrong environment variable was being used to set the image for GKE (the var for GCE, not GKE was being used, see #659), and even when the var was fixed it had the wrong value (see #664), we ought to continue testing against both for the time being.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/665)
<!-- Reviewable:end -->
