### PR TITLE
Don't fail on missing junit in gci-e2e-gke

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-pull-e2e.yaml
@@ -209,6 +209,7 @@
                 echo "Exiting with code: ${{rc}}"
                 exit ${{rc}}
         - 'gci-e2e-gke': # kubernetes-pull-build-test-gci-e2e-gke
+            skip-if-no-test-files: true  # old branches are skipped and do not produce JUnit
             cmd: |
                 case "${{ghprbTargetBranch:-}}" in
                   release-1.0|release-1.1|release-1.2)


### PR DESCRIPTION
Missed this one in #607, I think because this build was added at about the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/666)
<!-- Reviewable:end -->
