### PR TITLE
Add several more gci gce jobs and switch gce-multizone to GCI by default

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -119,6 +119,13 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
                 export PROJECT="k8s-jkns-e2e-gce-ci-reboot"
+        - 'gci-gce-reboot':  # kubernetes-e2e-gci-gce-reboot
+            description: 'Run [Feature:Reboot] tests on GCE.'
+            timeout: 180
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export PROJECT="k8s-jkns-gci-gce-reboot"
         - 'gce-autoscaling':  # kubernetes-e2e-gce-autoscaling
             description: 'Run autoscaling E2E tests on GCE.'
             timeout: 210
@@ -205,6 +212,14 @@
                                          --ginkgo.skip=\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-flaky"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gci-gce-flaky':  # kubernetes-e2e-gci-gce-flaky
+            description: 'Run the flaky tests on GCE, sequentially.'
+            timeout: 180
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
+                                         --ginkgo.skip=\[Feature:.+\]"
+                export PROJECT="k8s-jkns-gci-gce-flaky"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gce-scalability':  # kubernetes-e2e-gce-scalability
             description: 'Run the performance/scalability tests on GCE. A larger cluster is used.'
             timeout: 120
@@ -305,6 +320,23 @@
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
                 # Use new image for etcd.
                 export TEST_ETCD_VERSION="3.0.4-migration.2"
+        - 'gci-gce-etcd3':  # kubernetes-e2e-gci-gce-etcd3
+            cron-string: '{sq-cron-string}'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with etcd3 underneath.'
+            test-owner: 'wojtek-t'
+            emails: 'wojtekt@google.com'
+            timeout: 50  # See #21138
+            job-env: |
+                # This list should match the list in kubernetes-pull-build-test-e2e-gce.
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] \
+                                         --kube-api-content-type=application/vnd.kubernetes.protobuf"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-gci-etcd3"
+                # Use etcd3 as storage backend.
+                export STORAGE_BACKEND="etcd3"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                # Use new image for etcd.
+                export TEST_ETCD_VERSION="3.0.4-migration.2"
         - 'gce-proto':  # kubernetes-e2e-gce-proto
             cron-string: '{sq-cron-string}'
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with protobuf communication.'
@@ -320,6 +352,21 @@
                 # Use protobufs to communicate with apiserver.
                 export TEST_CLUSTER_API_CONTENT_TYPE="--kube-api-content-type=application/vnd.kubernetes.protobuf"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gci-gce-proto':  # kubernetes-e2e-gci-gce-proto
+            cron-string: '{sq-cron-string}'
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel with protobuf communication.'
+            timeout: 50  # See #21138
+            job-env: |
+                # This list should match the list in kubernetes-pull-build-test-e2e-gce.
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] \
+                                         --kube-api-content-type=application/vnd.kubernetes.protobuf"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-gci-gce-protobuf"
+                # Store protobufs in database.
+                export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
+                # Use protobufs to communicate with apiserver.
+                export TEST_CLUSTER_API_CONTENT_TYPE="--kube-api-content-type=application/vnd.kubernetes.protobuf"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gce-examples':  # kubernetes-e2e-gce-examples
             description: 'Run E2E examples test on GCE.'
             timeout: 90
@@ -346,7 +393,7 @@
                 export MULTIZONE="true"
                 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the nodes reside.  Master is in the first one.
                 export KUBE_GCE_ZONE="us-central1-a" # Where the master resides - hangover due to legacy scripts.
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gce-federation':  # kubernetes-e2e-gce-federation
             # This test depends on the artifacts generated by the trigger-job. Be careful while changing this test.
             trigger-job: 'kubernetes-federation-build'
@@ -398,6 +445,17 @@
                 export GINKGO_PARALLEL="y"
                 export NETWORK_PROVIDER="kubenet"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gci-gce-kubenet':  # kubernetes-e2e-gci-gce-kubenet
+            description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GCE using kubenet as network provider'
+            timeout: 120
+            emails: 'mixia@google.com'
+            test-owner: 'mixia'
+            job-env: |
+                export PROJECT="k8s-jkns-gci-gce-kubenet"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export NETWORK_PROVIDER="kubenet"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -49,5 +49,16 @@
                 export PROJECT="k8s-jenkins-garbagecollector"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:GarbageCollector\]"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gci-feature':  # kubernetes-garbagecollector-gci-feature
+            description: 'Run the garbage collector specific tests'
+            timeout: 600
+            cron-string: 'H H/6 * * *'
+            job-env: |
+                # Start the gc in controller plane
+                export ENABLE_GARBAGE_COLLECTOR="true"
+                export E2E_NAME="gc-feature"
+                export PROJECT="k8s-jkns-gci-garbage"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:GarbageCollector\]"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-garbagecollector-{suffix}'

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -108,6 +108,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-es-logging
 - name: kubernetes-e2e-gce-etcd3
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-etcd3
+- name: kubernetes-e2e-gci-gce-etcd3
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-etcd3
 - name: kubernetes-e2e-gce-examples
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-examples
 - name: kubernetes-e2e-gce-federation
@@ -116,6 +118,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-federation-release-1.4
 - name: kubernetes-e2e-gce-flaky
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-flaky
+- name: kubernetes-e2e-gci-gce-flaky
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-flaky
 - name: kubernetes-e2e-gci-gce
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce
 - name: kubernetes-e2e-gce-gci-beta-release
@@ -218,6 +222,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.4
 - name: kubernetes-e2e-gce-kubenet
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-kubenet
+- name: kubernetes-e2e-gci-gce-kubenet
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-kubenet
 - name: kubernetes-e2e-gce-master-on-cvm
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-master-on-cvm
 - name: kubernetes-e2e-gce-multizone
@@ -230,8 +236,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-petset
 - name: kubernetes-e2e-gce-proto
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-proto
+- name: kubernetes-e2e-gci-gce-proto
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-proto
 - name: kubernetes-e2e-gce-reboot
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot
+- name: kubernetes-e2e-gci-gce-reboot
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot
 - name: kubernetes-e2e-gce-reboot-release-1.2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.2
 - name: kubernetes-e2e-gci-gce-reboot-release-1.2
@@ -605,6 +615,8 @@ test_groups:
 # garbage collector tests
 - name: kubernetes-garbage-collector
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-garbagecollector-feature
+- name: kubernetes-gci-garbage-collector
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-garbagecollector-gci-feature
 # Add New Testgroups Here
 
 #
@@ -663,6 +675,8 @@ dashboards:
     test_group_name: kubernetes-azure
   - name: garbage-collector
     test_group_name: kubernetes-garbage-collector
+  - name: gci-garbage-collector
+    test_group_name: kubernetes-gci-garbage-collector
   name: k8s
 - dashboard_tab:
   - name: azure
@@ -731,12 +745,16 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-es-logging
   - name: gce-etcd3
     test_group_name: kubernetes-e2e-gce-etcd3
+  - name: gci-gce-etcd3
+    test_group_name: kubernetes-e2e-gci-gce-etcd3
   - name: gce-examples
     test_group_name: kubernetes-e2e-gce-examples
   - name: gci-gce-examples
     test_group_name: kubernetes-e2e-gci-gce-examples
   - name: gce-flaky
     test_group_name: kubernetes-e2e-gce-flaky
+  - name: gci-gce-flaky
+    test_group_name: kubernetes-e2e-gci-gce-flaky
   - name: gce-ingress
     test_group_name: kubernetes-e2e-gce-ingress
   - name: gci-gce-ingress
@@ -755,6 +773,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-ingress-release-1.4
   - name: gce-kubenet
     test_group_name: kubernetes-e2e-gce-kubenet
+  - name: gci-gce-kubenet
+    test_group_name: kubernetes-e2e-gci-gce-kubenet
   - name: gce-master-on-cvm
     test_group_name: kubernetes-e2e-gce-master-on-cvm
   - name: gce-multizone
@@ -767,8 +787,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-petset
   - name: gce-proto
     test_group_name: kubernetes-e2e-gce-proto
+  - name: gci-gce-proto
+    test_group_name: kubernetes-e2e-gci-gce-proto
   - name: gce-reboot
     test_group_name: kubernetes-e2e-gce-reboot
+  - name: gci-gce-reboot
+    test_group_name: kubernetes-e2e-gci-gce-reboot
   - name: gce-reboot-release-1.2
     test_group_name: kubernetes-e2e-gce-reboot-release-1.2
   - name: gci-gce-reboot-release-1.2


### PR DESCRIPTION
Job,GCE Project
`kubernetes-garbagecollector-gci-feature`,`k8s-jkns-gci-garbage`
`kubernetes-e2e-gci-gce-etcd3`,`k8s-jkns-gci-etcd3`
`kubernetes-e2e-gci-gce-flaky`,`k8s-jkns-gci-gce-flaky`
`kubernetes-e2e-gci-gce-kubenet`,`k8s-jkns-gci-gce-kubenet`
`kubernetes-e2e-gci-gce-proto`,`k8s-jkns-gci-gce-protobuf`
`kubernetes-e2e-gci-gce-reboot`,`k8s-jkns-gci-gce-reboot`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/672)
<!-- Reviewable:end -->
