### PR TITLE
Fix gce-enormous-cluster so it uses gci

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -1054,7 +1054,7 @@
                 export CLUSTER_IP_RANGE="10.224.0.0/13"
                 export NUM_NODES="2000"
                 export ALLOWED_NOTREADY_NODES="20"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gce-enormous-deploy':  # kuberentes-e2e-gce-enormous-deploy
             description: 'Starts up empty 2000 node cluster and waits until it is running. Used for manual testing.'
             timeout: 300


### PR DESCRIPTION
We had changed the env for the set of tests, but it looks like the
gce-enormous-cluster item was overriding the `KUBE_NODE_OS_DISTRIBUTION`
value. This commit removes that override so everything is on GCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubernetes/test-infra/682)
<!-- Reviewable:end -->
