### PR TITLE
Revert "Run kubemark-scale with etcd3 and protobufs in storage"

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -206,12 +206,8 @@
                 export KUBE_GCE_ZONE="us-central1-f"
                 # Use protobufs
                 export TEST_CLUSTER_API_CONTENT_TYPE="--kube-api-content-type=application/vnd.kubernetes.protobuf"
-                # ==========================================
-                # Configuration we are targetting for 1.5
-                # Run in etcd3 mode
-                export TEST_ETCD_VERSION="3.0.10-experimental.1"
-                export STORAGE_BACKEND="etcd3"
-                export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
+                # TODO: Uncomment when we make the final decision to store protobufs in etcd.
+                # export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"


### PR DESCRIPTION
Reverts kubernetes/test-infra#689

__ Etcd3 doesn't scale for now (the main bottleneck is in the kubernetes part of the client fortunately): see https://github.com/kubernetes/kubernetes/issues/33653 __

We may consider enabling just protobufs though for the purpose of testing...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/690)
<!-- Reviewable:end -->
