### PR TITLE
velodrome: Move all tokens into the same secret

### DIFF
--- a/velodrome/fetcher/README.md
+++ b/velodrome/fetcher/README.md
@@ -4,9 +4,9 @@ Deploying the fetcher
 First time only
 ---------------
 
-Create the github-token secret:
+Create the github-tokens secret:
 ```
-kubectl create secret generic github-token --from-literal=token=${your_token}
+kubectl create secret generic github-tokens --from-literal=token_login_1=${your_1st_token} --from-literal=token_login_2=${your_2nd_token}
 ```
 
 And install the certificate if you haven't done it yet:

--- a/velodrome/fetcher/deployment.yaml
+++ b/velodrome/fetcher/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
       - name: fetcher
         args:
-        - --token-file=/etc/secret-volume/token
+        - --token-file=/etc/secret-volume/k8s-merge-robot
         - --stderrthreshold=0
         - --host=sqlproxy-service
         image: gcr.io/google-containers/github-fetcher:v1472240677
@@ -25,7 +25,7 @@ spec:
       volumes:
       - name: secret-volume
         secret:
-          secretName: github-token
+          secretName: github-tokens
       - name: certificates
         configMap:
           name: certificates

--- a/velodrome/token-counter/deployment.yaml
+++ b/velodrome/token-counter/deployment.yaml
@@ -15,7 +15,8 @@ spec:
         - --stderrthreshold=0
         - --influx-host=http://influxdb-service:8086
         - --influx-password=$(INFLUXDB_ROOT_PWD)
-        - --token=/github-token/token
+        - --token=/github-tokens/k8s-merge-robot
+        - --token=/github-tokens/k8s-ci-robot
         image: gcr.io/google-containers/github-token-counter:v20160922-095333
         env:
         - name: INFLUXDB_ROOT_PWD
@@ -24,7 +25,7 @@ spec:
               name: influxdb
               key: rootpassword
         volumeMounts:
-        - mountPath: /github-token
+        - mountPath: /github-tokens
           readOnly: true
           name: secret-volume
         - mountPath: /etc/ssl/certs
@@ -32,7 +33,7 @@ spec:
       volumes:
       - name: secret-volume
         secret:
-          secretName: github-token
+          secretName: github-tokens
       - name: certificates
         configMap:
           name: certificates


### PR DESCRIPTION
Previously we had:
- `github-token` secret: one token named `token`

Now we have:
- `github-tokens` secret: each token with it's login name
e.g.

github-tokens:k8s-merge-robot
github-tokens:k8s-ci-robot

It's more explicit what token we use for each task (just read in the
deployment) and easier to just mount one secret and have all tokens
available (especially for token-counter).

Also update the token-counter to consider both tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/693)
<!-- Reviewable:end -->
