### PR TITLE
Fix project name for GCI GCE autoscaling test

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -150,7 +150,7 @@
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] \
                                          --ginkgo.skip=\[Flaky\]"
-                export PROJECT="k8s-jkns-e2e-gci-autoscaling"
+                export PROJECT="k8s-jkns-gci-autoscaling"
                 # Override GCE default for cluster size autoscaling purposes.
                 export ENABLE_CUSTOM_METRICS="true"
                 export KUBE_ENABLE_CLUSTER_AUTOSCALER="true"


### PR DESCRIPTION
The name was not correct. I noticed this while auditing quota this morning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/695)
<!-- Reviewable:end -->
