### PR TITLE
Remove Kubemark GCE GCI test clones, change Kubemark GCE tests base image to GCI

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -64,33 +64,7 @@
                 export KUBEMARK_NUM_NODES="5"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - '5-gce-gci':
-            description: 'Run minimal Kubemark with GCI to make sure it is not broken.'
-            jenkins_node: 'e2e'
-            timeout: 60
-            cron-string: '{sq-cron-string}'
-            job-env: |
-                export ENABLE_GARBAGE_COLLECTOR="true"
-                export E2E_NAME="kubemark-5"
-                export PROJECT="k8s-jenkins-gci-kubemark"
-                export E2E_TEST="false"
-                export USE_KUBEMARK="true"
-                export KUBEMARK_TESTS="starting\s30\spods\sper\snode"
-                export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true"
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                # Override defaults to be independent from GCE defaults and set kubemark parameters
-                export NUM_NODES="1"
-                export MASTER_SIZE="n1-standard-1"
-                export NODE_SIZE="n1-standard-2"
-                export KUBE_GCE_ZONE="us-central1-f"
-                # TODO: This is to check if that helps with #26185.
-                # Revert it after migrating to etcd3.
-                export KUBEMARK_MASTER_SIZE="n1-standard-2"
-                export KUBEMARK_NUM_NODES="5"
-                # The kubemark scripts build a Docker image
-                export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                export KUBE_OS_DISTRIBUTION="gci"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - '100-gce':
             description: 'Run small-ish kubemark cluster to continuously run performance experiments'
             jenkins_node: 'e2e'
@@ -115,7 +89,7 @@
                 export KUBEMARK_NUM_NODES="100"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'high-density-100-gce':
             description: 'Run Kubemark high-density (100 pods/node) test on a fake 100 node cluster.'
             jenkins_node: 'e2e'
@@ -139,7 +113,7 @@
                 export KUBEMARK_NUM_NODES="100"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - '500-gce':
             description: 'Run Kubemark test on a fake 500 node cluster to test for regressions on bigger clusters'
             # TODO: We should replace it with 'scalability' instead of using
@@ -169,7 +143,7 @@
                 export KUBEMARK_NUM_NODES="500"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gce-scale':
             description: 'Run Density test on Kubemark in very large cluster. Currently only scheduled to run every 12 hours so as not to waste too many resources.'
             # TODO: We should replace it with 'scalability' instead of using
@@ -214,6 +188,6 @@
                 export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
     jobs:
         - 'kubernetes-kubemark-{suffix}'

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -474,12 +474,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-kubemark-100-gce
 - name: kubernetes-kubemark-5-gce
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-kubemark-5-gce
-- name: kubernetes-kubemark-5-gce-gci
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-kubemark-5-gce-gci
 - name: kubernetes-kubemark-500-gce
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-kubemark-500-gce
-- name: kubernetes-kubemark-500-gce-gci
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-kubemark-500-gce-gci
 - name: kubernetes-kubemark-gce-scale
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-kubemark-gce-scale
 - name: kubernetes-kubemark-high-density-100-gce
@@ -1141,12 +1137,8 @@ dashboards:
     test_group_name: kubernetes-kubemark-100-gce
   - name: kubemark-5-gce
     test_group_name: kubernetes-kubemark-5-gce
-  - name: kubemark-5-gce-gci
-    test_group_name: kubernetes-kubemark-5-gce-gci
   - name: kubemark-500-gce
     test_group_name: kubernetes-kubemark-500-gce
-  - name: kubemark-500-gce-gci
-    test_group_name: kubernetes-kubemark-500-gce-gci
   - name: kubemark-gce-scale
     test_group_name: kubernetes-kubemark-gce-scale
   - name: kubemark-high-density-100-gce


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/700)
<!-- Reviewable:end -->
