### PR TITLE
update trigger jobs version for gke pre release test jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -573,7 +573,7 @@
 
 - project:
     name: kubernetes-e2e-gke-version-pinned
-    trigger-job: 'kubernetes-build-1.3'  # TODO(spxtr) float with current release.
+    trigger-job: 'kubernetes-build-1.4'  # TODO(spxtr) float with current release.
     test-owner: 'GKE on-call'
     gke-suffix:
         - 'gke-pre-release':  # kubernetes-e2e-gke-pre-release
@@ -661,7 +661,7 @@
 
 - project:
     name: kubernetes-e2e-gci-gke-version-pinned
-    trigger-job: 'kubernetes-build-1.3'  # TODO(spxtr) float with current release.
+    trigger-job: 'kubernetes-build-1.4'  # TODO(spxtr) float with current release.
     test-owner: 'GKE on-call'
     gke-suffix:
         - 'gci-gke-pre-release':  # kubernetes-e2e-gci-gke-pre-release


### PR DESCRIPTION
They are currently being triggered by v1.3 build jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/708)
<!-- Reviewable:end -->
