### PR TITLE
CRI: Add e2e cri validation test.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -993,6 +993,17 @@
                 export PROJECT="kubernetes-gci-petset"
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"  # TODO: Enable once we've fixed #23032
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
+        - 'gci-gce-cri': # kubernetes-e2e-gci-gce-cri
+            description: 'Runs all non-slow, non-serial, non-disruptive, non-flaky tests with CRI enabled on GCE with GCI in parallel.'
+            timeout: 90
+            emails: 'lantaol@google.com'
+            test-owner: 'Random-Liu'
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="kubernetes-e2e-cri-validation"
+                export GINKGO_PARALLEL="y"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBELET_TEST_ARGS="--experimental-runtime-integration-type=cri"
     jobs:
         - 'kubernetes-e2e-{suffix}'
 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -236,6 +236,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-petset
 - name: kubernetes-e2e-gci-gce-petset
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-petset
+- name: kubernetes-e2e-gci-gce-cri
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-cri
 - name: kubernetes-e2e-gce-proto
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-proto
 - name: kubernetes-e2e-gci-gce-proto
@@ -837,6 +839,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-petset
   - name: gci-gce-petset
     test_group_name: kubernetes-e2e-gci-gce-petset
+  - name: gci-gce-cri
+    test_group_name: kubernetes-e2e-gci-gce-cri
   - name: gce-proto
     test_group_name: kubernetes-e2e-gce-proto
   - name: gci-gce-proto


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/31459.

Add a e2e jenkins job for cri validation.

Currently the job runs all non-slow, non-serial, non-disruptive, non-flaky tests with CRI enabled on GCE with GCI in parallel.
Notice that both master and node are gci.

@yujuhong @feiskyer @yifan-gu @freehan 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/712)
<!-- Reviewable:end -->
