### PR TITLE
Revert "Explicitly use protobufs in kubemark-500"

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -143,8 +143,6 @@
                 export KUBEMARK_NUM_NODES="500"
                 # The kubemark scripts build a Docker image
                 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"
-                # TODO: remove after we verify that this is causing problems with kubemark-scale
-                export TEST_CLUSTER_API_CONTENT_TYPE="--kube-api-content-type=application/vnd.kubernetes.protobuf"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gce-scale':
             description: 'Run Density test on Kubemark in very large cluster. Currently only scheduled to run every 12 hours so as not to waste too many resources.'


### PR DESCRIPTION
Reverts kubernetes/test-infra#717

This run will confirm hypothesis:
http://kubekins.dls.corp.google.com:8080/view/Scalability/job/kubernetes-kubemark-500-gce/6320/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/719)
<!-- Reviewable:end -->
