### PR TITLE
Migrate submit queue blockers to using the GCI image and remove now unnecessary GCI equivalents for those jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -60,20 +60,10 @@
                 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
                 export PROJECT="k8s-jkns-e2e-gce"
                 export NUM_NODES="4"
                 export GINKGO_PARALLEL_NODES="30"
-        - 'gci-gce':  # kubernetes-e2e-gci-gce
-            cron-string: '{sq-cron-string}'
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI in parallel.'
-            timeout: 50  # See #21138
-            job-env: |
-                # This list should match the list in kubernetes-pull-build-test-e2e-gce.
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export KUBE_OS_DISTRIBUTION="gci"
-                export PROJECT="k8s-jkns-e2e-gce-gci"
         - 'gce-slow':  # kubernetes-e2e-gce-slow
             cron-string: '{sq-cron-string}'
             description: 'Runs slow tests on GCE, sequentially.'
@@ -83,19 +73,8 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export KUBE_GCE_ZONE="europe-west1-c"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
                 export PROJECT="k8s-jkns-e2e-gce-slow"
-        - 'gci-gce-slow':  # kubernetes-e2e-gci-gce-slow
-            cron-string: '{sq-cron-string}'
-            description: 'Runs slow tests on GCE, sequentially.'
-            timeout: 150  #  See #24072
-            job-env: |
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export KUBE_GCE_ZONE="europe-west1-c"
-                export KUBE_OS_DISTRIBUTION="gci"
-                export PROJECT="k8s-jkns-e2e-gce-gci-slow"
         - 'gce-serial':  # kubernetes-e2e-gce-serial
             description: 'Run [Serial], [Disruptive], tests on GCE.'
             timeout: 300

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -58,6 +58,7 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gke-ci"
+                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-slow':  # kubernetes-e2e-gke-slow
             cron-string: '{sq-cron-string}'
             description: 'Run slow E2E tests on GKE using the latest successful build.'
@@ -68,6 +69,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="k8s-jkns-e2e-gke-slow"
+                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gke-serial':  # kubernetes-e2e-gke-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300
@@ -223,27 +225,6 @@
     trigger-job: 'kubernetes-build'
     test-owner: 'Build Cop'
     gke-suffix:
-        - 'gci-gke':  # kubernetes-e2e-gci-gke
-            cron-string: '{sq-cron-string}'
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GKE in parallel (against GKE test endpoint)'
-            timeout: 50  # See kubernetes/kubernetes#21138
-            job-env: |
-                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-                export GINKGO_PARALLEL="y"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-e2e-gke-gci-ci"
-                export KUBE_GKE_IMAGE_TYPE="gci"
-        - 'gci-gke-slow':  # kubernetes-e2e-gci-gke-slow
-            cron-string: '{sq-cron-string}'
-            description: 'Run slow E2E tests on GKE using the latest successful build.'
-            timeout: 150  #  See kubernetes/kubernetes#24072
-            job-env: |
-                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-e2e-gke-gci-slow"
-                export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gci-gke-serial':  # kubernetes-e2e-gci-gke-serial
             description: 'Run [Serial], [Disruptive] tests on GKE.'
             timeout: 300

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -116,8 +116,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-flaky
 - name: kubernetes-e2e-gci-gce-flaky
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-flaky
-- name: kubernetes-e2e-gci-gce
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce
 - name: kubernetes-e2e-gce-gci-beta-release
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-beta-release
 - name: kubernetes-e2e-gce-gci-beta-serial
@@ -202,8 +200,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial
 - name: kubernetes-e2e-gci-gce-serial-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.4
-- name: kubernetes-e2e-gci-gce-slow
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow
 - name: kubernetes-e2e-gci-gce-slow-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.4
 - name: kubernetes-e2e-gce-ingress
@@ -352,12 +348,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-flaky
 - name: kubernetes-e2e-gci-gke-flaky
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-flaky
-- name: kubernetes-e2e-gci-gke
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke
 - name: kubernetes-e2e-gci-gke-serial
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-serial
-- name: kubernetes-e2e-gci-gke-slow
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-slow
 - name: kubernetes-e2e-gke-ingress
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-ingress
 - name: kubernetes-e2e-gci-gke-ingress
@@ -769,8 +761,6 @@ dashboards:
 - dashboard_tab:
   - name: gce
     test_group_name: kubernetes-e2e-gce
-  - name: gci-gce
-    test_group_name: kubernetes-e2e-gci-gce
   - name: gce-alpha-features
     test_group_name: kubernetes-e2e-gce-alpha-features
   - name: gci-gce-alpha-features
@@ -903,8 +893,6 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-serial-release-1.4
   - name: gce-slow
     test_group_name: kubernetes-e2e-gce-slow
-  - name: gci-gce-slow
-    test_group_name: kubernetes-e2e-gci-gce-slow
   - name: gce-slow-release-1.2
     test_group_name: kubernetes-e2e-gce-slow-release-1.2
   - name: gci-gce-slow-release-1.2
@@ -923,8 +911,6 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-flannel
   name: google-gce
 - dashboard_tab:
-  - name: gci
-    test_group_name: kubernetes-e2e-gci-gce
   - name: gci-beta-release
     test_group_name: kubernetes-e2e-gce-gci-beta-release
   - name: gci-beta-serial
@@ -1007,8 +993,6 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-serial
   - name: gci-serial-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-serial-release-1.4
-  - name: gci-slow
-    test_group_name: kubernetes-e2e-gci-gce-slow
   - name: gci-slow-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-slow-release-1.4
   name: google-gci
@@ -1029,12 +1013,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-flaky
   - name: gci-gke-flaky
     test_group_name: kubernetes-e2e-gci-gke-flaky
-  - name: gci-gke
-    test_group_name: kubernetes-e2e-gci-gke
   - name: gci-gke-serial
     test_group_name: kubernetes-e2e-gci-gke-serial
-  - name: gci-gke-slow
-    test_group_name: kubernetes-e2e-gci-gke-slow
   - name: gke-ingress
     test_group_name: kubernetes-e2e-gke-ingress
   - name: gci-gke-ingress


### PR DESCRIPTION
Migrates submit queue blockers to using the GCI image and remove now unnecessary GCI equivalents for those jobs.

The `gce`/`gci-gce`, `gce-slow`/`gci-gce-slow`, and `gke`/`gci-gke` job pairs are at parity, and we can probably be comfortable moving the original jobs to GCI and removing the duplicates.

I would like to take a closer look at the `gke-slow`/`gci-gke-slow`, specifically this (https://github.com/kubernetes/kubernetes/issues/32684) flaky test, before we merge this. But overall `gci-gke-slow` looks very good as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/723)
<!-- Reviewable:end -->
