### PR TITLE
Automatically get cluster credentials before updating

### DIFF
--- a/ciongke/Makefile
+++ b/ciongke/Makefile
@@ -53,14 +53,14 @@ create-cluster:
 	@echo "Webhook address: http://$$(kubectl get svc hook -o=json | jq -r .status.loadBalancer.ingress[0].ip):8888/"
 	gcloud compute --project "$(PROJECT)" addresses create ciongke --addresses "$$(kubectl get svc hook -o=json | jq -r .status.loadBalancer.ingress[0].ip)"
 
-update-cluster:
+update-cluster: get-cluster-credentials
 	make test-pr-image --no-print-directory
 	make hook-image --no-print-directory
 	make sinker-image --no-print-directory
 	make hook-deployment --no-print-directory
 	make sinker-deployment --no-print-directory
 
-update-jobs:
+update-jobs: get-cluster-credentials
 	kubectl create configmap job-configs --from-file=jobs=jobs.yaml --dry-run -o yaml | kubectl replace configmap job-configs -f -
 
 get-cluster-credentials:


### PR DESCRIPTION
This tripped me up at first. This operation seems to be idempotent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/726)
<!-- Reviewable:end -->
