### PR TITLE
kops: Force KUBERNETES_PROVIDER

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -20,6 +20,8 @@
     builders:
         - activate-gce-service-account
         - shell: |
+            # Fake provider to trick e2e-runner.sh
+            export KUBERNETES_PROVIDER="kops-aws"
             export AWS_CONFIG_FILE="${{WORKSPACE}}/.aws/credentials"
             # This is needed to be able to create PD from the e2e test
             export AWS_SHARED_CREDENTIALS_FILE="${{WORKSPACE}}/.aws/credentials"


### PR DESCRIPTION
This env variables seems to be implicitly set, forcing it to !gce.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/733)
<!-- Reviewable:end -->
