### PR TITLE
kops: Fix two obvious bugs

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -29,6 +29,7 @@ if [[ -z "${KOPS_URL}" ]]; then
 fi
 
 curl -fsS --retry 3 -o "${WORKSPACE}/kops" "${KOPS_URL}/linux/amd64/kops"
+chmod +x "${WORKSPACE}/kops"
 export NODEUP_URL="${KOPS_URL}/linux/amd64/nodeup"
 
 $(dirname "${BASH_SOURCE}")/e2e-runner.sh

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -26,7 +26,7 @@
             export KUBE_SSH_USER=admin
             {job-env}
             {post-env}
-            export E2E_RUNNER="/workspace/kops-e2e-runner.sh"
+            export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
             export E2E_OPT="--deployment kops --kops ${{WORKSPACE}}/kops -kops-cluster ${{E2E_NAME}}.test-aws.k8s.io -kops-state s3://k8s-kops-jenkins/"
             export GINKGO_PARALLEL="y"
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?


### PR DESCRIPTION
* KOPS_E2E_RUNNER != E2E_RUNNER
* The kops binary needs to be executable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/734)
<!-- Reviewable:end -->
