### PR TITLE
Add 1.3 and 1.4 to head upgrade testing between container-vm and gci

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -73,7 +73,7 @@
             version-infix: '1-3-1-4'
             version-env: ''
 
-# This is the job definition for GCE upgrade tests.
+# This is the job definition for GCE upgrade tests on container-vm clusters.
 - job-group:
     name: 'kubernetes-e2e-gce-{version-old}-{version-new}'
     test-owner: 'davidopp'
@@ -129,6 +129,101 @@
             version-old: '1.3'
             version-new: '1.4'
             version-infix: '1-3-1-4'
+            version-env: ''
+
+# This is the job definition for GCE upgrade tests for GCI and between container-vm and GCI.
+- job-group:
+    name: 'kubernetes-e2e-gce-{image-old}-{version-old}-{image-new}-{version-new}'
+    test-owner: 'mtaufen'
+    trigger-job: 'kubernetes-build'
+    jobs:
+        - 'kubernetes-e2e-{suffix}':
+            suffix: 'gce-{image-old}-{version-old}-{image-new}-{version-new}-upgrade-master'
+            step: 'upgrade-master'
+            description: 'Deploys a cluster at v{version-old} at {image-old}, upgrades the master to v{version-new} at {image-new}, and runs the v{version-old} tests.'
+            timeout: 600
+            job-env: |
+                export E2E_OPT="--check_version_skew=false"
+                export E2E_UPGRADE_TEST="true"
+                export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/{version-new} --upgrade-image={image-new}"
+                export JENKINS_PUBLISHED_SKEW_VERSION="ci/{version-new}"
+                export JENKINS_PUBLISHED_VERSION="ci/{version-old}"
+                export KUBE_NODE_OS_DISTRIBUTION="{image-old}"
+                export PROJECT="gce-up-{version-infix}-up-mas"
+                {version-env}
+        - 'kubernetes-e2e-{suffix}':
+            suffix: 'gce-{image-old}-{version-old}-{image-new}-{version-new}-upgrade-cluster'
+            description: 'Deploys a cluster at v{version-old} at {image-old}, upgrades the master to v{version-new} at {image-new}, and runs the v{version-old} tests.'
+            timeout: 600
+            job-env: |
+                export E2E_OPT="--check_version_skew=false"
+                export E2E_UPGRADE_TEST="true"
+                export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/{version-new} --upgrade-image={image-new}"
+                export JENKINS_PUBLISHED_SKEW_VERSION="ci/{version-new}"
+                export JENKINS_PUBLISHED_VERSION="ci/{version-old}"
+                export KUBE_NODE_OS_DISTRIBUTION="{image-old}"
+                export PROJECT="gce-up-{version-infix}-up-clu"
+                {version-env}
+        - 'kubernetes-e2e-{suffix}':
+            suffix: 'gce-{image-old}-{version-old}-{image-new}-{version-new}-upgrade-cluster-new'
+            description: 'Deploys a cluster at v{version-old} at {image-old}, upgrades the master to v{version-new} at {image-new}, and runs the v{version-old} tests.'
+            timeout: 600
+            job-env: |
+                export E2E_OPT="--check_version_skew=false"
+                export E2E_UPGRADE_TEST="true"
+                export GINKGO_UPGRADE_TEST_ARGS="--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/{version-new} --upgrade-image={image-new}"
+                export JENKINS_PUBLISHED_SKEW_VERSION="ci/{version-new}"
+                export JENKINS_PUBLISHED_VERSION="ci/{version-old}"
+                export JENKINS_USE_SKEW_TESTS="true"
+                export KUBE_NODE_OS_DISTRIBUTION="{image-old}"
+                export PROJECT="gce-up-{version-infix}-up-clu-n"
+                {version-env}
+
+# This is the job configuration for GCE upgrade tests for GCI and between container-vm and GCI.
+- project:
+    name: kubernetes-e2e-upgrades-gce-cross-image-and-gci
+    jobs:
+        - 'kubernetes-e2e-gce-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gce-debian-latest-1.3-gci-latest
+            version-old: 'latest-1.3'
+            version-new: 'latest'
+            version-infix: 'c1-3-glat'
+            image-old: 'debian'
+            image-new: 'gci'
+            version-env: ''
+        - 'kubernetes-e2e-gce-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gce-gci-latest-1.3-debian-latest
+            version-old: 'latest-1.3'
+            version-new: 'latest'
+            version-infix: 'g1-3-clat'
+            image-old: 'gci'
+            image-new: 'debian'
+            version-env: ''
+        - 'kubernetes-e2e-gce-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gce-gci-latest-1.3-gci-latest
+            version-old: 'latest-1.3'
+            version-new: 'latest'
+            version-infix: 'g1-3-glat'
+            image-old: 'gci'
+            image-new: 'gci'
+            version-env: ''
+        - 'kubernetes-e2e-gce-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gce-debian-latest-1.4-gci-latest
+            version-old: 'latest-1.4'
+            version-new: 'latest'
+            version-infix: 'c1-4-glat'
+            image-old: 'debian'
+            image-new: 'gci'
+            version-env: ''
+        - 'kubernetes-e2e-gce-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gce-gci-latest-1.4-debian-latest
+            version-old: 'latest-1.4'
+            version-new: 'latest'
+            version-infix: 'g1-4-clat'
+            image-old: 'gci'
+            image-new: 'debian'
+            version-env: ''
+        - 'kubernetes-e2e-gce-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gce-gci-latest-1.4-gci-latest
+            version-old: 'latest-1.4'
+            version-new: 'latest'
+            version-infix: 'g1-4-glat'
+            image-old: 'gci'
+            image-new: 'gci'
             version-env: ''
 
 # This is the job definition for all GKE kubectl skew tests

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -586,6 +586,42 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.3-gci-kubectl-skew
 - name: kubelet-flaky-gce-e2e-ci
   gcs_prefix: kubernetes-jenkins/logs/kubelet-flaky-gce-e2e-ci
+- name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
+- name: kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master
+- name: kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master
+- name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster
+- name: kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master
+- name: kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master
+- name: kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master
+- name: kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster
+- name: kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new
 
 # Manual, federated groups
 # rktnetes
@@ -1412,3 +1448,41 @@ dashboards:
   - name: gke-1.3-1.4-upgrade-master
     test_group_name: kubernetes-e2e-gke-1.3-1.4-upgrade-master
   name: release-1.4-blocking
+- dashboard_tab:
+  - name: gce-debian-latest-1.3-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
+  - name: gce-gci-latest-1.3-debian-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master
+  - name: gce-gci-latest-1.3-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master
+  - name: gce-debian-latest-1.3-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster
+  - name: gce-gci-latest-1.3-debian-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster
+  - name: gce-gci-latest-1.3-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster
+  - name: gce-debian-latest-1.3-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new
+  - name: gce-gci-latest-1.3-debian-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new
+  - name: gce-gci-latest-1.3-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new
+  - name: gce-debian-latest-1.4-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master
+  - name: gce-gci-latest-1.4-debian-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master
+  - name: gce-gci-latest-1.4-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master
+  - name: gce-debian-latest-1.4-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster
+  - name: gce-gci-latest-1.4-debian-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster
+  - name: gce-gci-latest-1.4-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster
+  - name: gce-debian-latest-1.4-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new
+  - name: gce-gci-latest-1.4-debian-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new
+  - name: gce-gci-latest-1.4-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new
+  name: upgrades-gce-cvm-and-gci


### PR DESCRIPTION
For both ci/latest-1.3 -> ci/latest and ci/latest-1.4 -> ci/latest:
gci -> gci
container-vm -> gci
gci -> container-vm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/738)
<!-- Reviewable:end -->
