### PR TITLE
kops: The AWS credential variables are referencing the dockerized path, too

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -22,9 +22,11 @@
         - shell: |
             # Fake provider to trick e2e-runner.sh
             export KUBERNETES_PROVIDER="kops-aws"
-            export AWS_CONFIG_FILE="${{WORKSPACE}}/.aws/credentials"
+            export AWS_CONFIG_FILE="/workspace/.aws/credentials"
             # This is needed to be able to create PD from the e2e test
-            export AWS_SHARED_CREDENTIALS_FILE="${{WORKSPACE}}/.aws/credentials"
+            export AWS_SHARED_CREDENTIALS_FILE="/workspace/.aws/credentials"
+            # TODO(zmerlynn): Eliminate the other uses of this env variable and then just pass --kops-ssh-key
+            export AWS_SSH_KEY=/workspace/.aws/kube_aws_rsa
             export KUBE_SSH_USER=admin
             {job-env}
             {post-env}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/739)
<!-- Reviewable:end -->
