### PR TITLE
Add retries and some unit tests.

### DIFF
--- a/ciongke/kube/client_test.go
+++ b/ciongke/kube/client_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func getClient(url string) *Client {
+	return &Client{
+		baseURL:   url,
+		client:    &http.Client{},
+		token:     "abcd",
+		namespace: "ns",
+	}
+}
+
+func TestListPods(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/namespaces/ns/pods" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"items": [{}, {}]}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	ps, err := c.ListPods(nil)
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if len(ps) != 2 {
+		t.Error("Expected two pods.")
+	}
+}
+
+func TestDeletePod(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/namespaces/ns/pods/po" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	err := c.DeletePod("po")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+}
+
+func TestGetJob(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/batch/v1/namespaces/ns/jobs/jo" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"metadata": {"name": "abcd"}}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	jo, err := c.GetJob("jo")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if jo.Metadata.Name != "abcd" {
+		t.Errorf("Wrong name: %s", jo.Metadata.Name)
+	}
+}
+
+func TestListJobs(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/batch/v1/namespaces/ns/jobs" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"items": [{}, {}]}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	js, err := c.ListJobs(nil)
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if len(js) != 2 {
+		t.Error("Expected two jobs.")
+	}
+}
+
+func TestCreateJob(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/batch/v1/namespaces/ns/jobs" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"metadata": {"name": "abcd"}}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	jo, err := c.CreateJob(Job{})
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if jo.Metadata.Name != "abcd" {
+		t.Errorf("Wrong name: %s", jo.Metadata.Name)
+	}
+}
+
+func TestDeleteJob(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/batch/v1/namespaces/ns/jobs/jo" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	err := c.DeleteJob("jo")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+}


### PR DESCRIPTION
The retries should get us through a kuberentes master reboot or upgrade, a github hiccup, or a Jenkins hiccup. This should fix #709. I'm currently only retrying on transport failure. If we're actually seeing 500s then I don't currently retry, but we can add that behavior if we want.

This will not fix outages longer than ~10 minutes, such as the one github had last night :disappointed:. The unit tests for the kube client aren't entirely where we want them to be yet, but they're better than nothing.