### PR TITLE
Upload logs for the test-infra gotest job.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/testinfra-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/testinfra-pull.yaml
@@ -42,6 +42,7 @@
             wipe-workspace: false
             skip-tag: true
     wrappers:
+        - e2e-credentials-binding
         - inject:
             properties-content: |
                 GOROOT=/usr/local/go
@@ -55,6 +56,12 @@
             timeout: 600
             fail: true
     builders:
+        - ensure-upload-to-gcs-script:
+            git-basedir: ''
+        - shell: JENKINS_BUILD_STARTED=true "${WORKSPACE}/_tmp/upload-to-gcs.sh"
         - shell: |
             cd ${WORKSPACE}/go/src/github.com/kubernetes/test-infra/ciongke
             go test $(go list ./... | grep -v vendor)
+    publishers:
+        - gcs-uploader:
+            git-basedir: ''


### PR DESCRIPTION
So that we can make sure gubernator/prow are handling other repos properly.