### PR TITLE
kops e2e: Pass --kops-kubernetes-version appropriately (when desired)

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -24,7 +24,7 @@ readonly KOPS_LATEST=${KOPS_LATEST:-"latest-ci.txt"}
 readonly LATEST_URL="https://storage.googleapis.com/kops-ci/bin/${KOPS_LATEST}"
 readonly KOPS_URL=$(curl -fsS --retry 3 "${LATEST_URL}")
 if [[ -z "${KOPS_URL}" ]]; then
-  echo "Can't fetch kops URL" >&2
+  echo "Can't fetch kops latest URL" >&2
   exit 1
 fi
 
@@ -34,5 +34,21 @@ export NODEUP_URL="${KOPS_URL}/linux/amd64/nodeup"
 
 # Get kubectl on the path (works after e2e-runner.sh:unpack_binaries)
 export PATH="${PATH}:/workspace/kubernetes/platforms/linux/amd64"
+
+export E2E_OPT="--deployment kops --kops /workspace/kops --kops-ssh-key /workspace/.aws/kube_aws_rsa ${E2E_OPT}"
+
+# TODO(zmerlynn): This is duplicating some logic in e2e-runner.sh, but
+# I'd rather keep it isolated for now.
+if [[ "${KOPS_DEPLOY_LATEST_KUBE:-}" =~ ^[yY]$ ]]; then
+  readonly KOPS_KUBE_LATEST_URL=${KOPS_DEPLOY_LATEST_URL:-"https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt"}
+  readonly KOPS_KUBE_LATEST=$(curl -fsS --retry 3 "${KOPS_KUBE_LATEST_URL}")
+  if [[ -z "${KOPS_KUBE_LATEST}" ]]; then
+    echo "Can't fetch kube latest URL" >&2
+    exit 1
+  fi
+  readonly KOPS_KUBE_RELEASE_URL=${KOPS_KUBE_RELEASE_URL:-"https://storage.googleapis.com/kubernetes-release-dev/ci"}
+
+  export E2E_OPT="${E2E_OPT} --kops-kubernetes-version ${KOPS_KUBE_RELEASE_URL}/${KOPS_KUBE_LATEST}"
+fi
 
 $(dirname "${BASH_SOURCE}")/e2e-runner.sh


### PR DESCRIPTION
It looks like we have good signal on kops deploying a default Kube
version, but I accidentally forgot to plumb the version info through.
This is starting to pull up some of the e2e-runner.sh logic, but I'd
rather just avoid interleaving with that code. :/