### PR TITLE
kops: Enable KOPS_DEPLOY_LATEST_URL

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -30,8 +30,9 @@
             export KUBE_SSH_USER=admin
             {job-env}
             {post-env}
+            export KOPS_DEPLOY_LATEST_KUBE=y
             export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
-            export E2E_OPT="--deployment kops --kops /workspace/kops --kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${{E2E_NAME}}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/"
+            export E2E_OPT="--kops-cluster ${{E2E_NAME}}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/"
             export GINKGO_PARALLEL="y"
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}


### PR DESCRIPTION
Probably should have just rolled this into https://github.com/kubernetes/test-infra/pull/749, but enable KOPS_DEPLOY_LATEST_URL and trim the kops E2E options now that https://github.com/kubernetes/test-infra/pull/747 is live.