### PR TITLE
kops: I can't spell .ssh

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -35,7 +35,7 @@ export NODEUP_URL="${KOPS_URL}/linux/amd64/nodeup"
 # Get kubectl on the path (works after e2e-runner.sh:unpack_binaries)
 export PATH="${PATH}:/workspace/kubernetes/platforms/linux/amd64"
 
-export E2E_OPT="--deployment kops --kops /workspace/kops --kops-ssh-key /workspace/.aws/kube_aws_rsa ${E2E_OPT}"
+export E2E_OPT="--deployment kops --kops /workspace/kops --kops-ssh-key /workspace/.ssh/kube_aws_rsa ${E2E_OPT}"
 
 # TODO(zmerlynn): This is duplicating some logic in e2e-runner.sh, but
 # I'd rather keep it isolated for now.

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -32,7 +32,8 @@
             {post-env}
             export KOPS_DEPLOY_LATEST_KUBE=y
             export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
-            export E2E_OPT="--kops-cluster ${{E2E_NAME}}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/"
+            # TODO(zmerlynn): Take out --kops-ssh-key after fixing kops-e2e-runner again.
+            export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${{E2E_NAME}}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/"
             export GINKGO_PARALLEL="y"
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}


### PR DESCRIPTION
I forgot to manually test the runner with the options removed, and
kops-e2e-runner.sh inherited the same typo as I fixed earlier today.
Sigh. Fixing both places until a docker image comes out.