### PR TITLE
Add gke-alpha-features-release-1.4 to testgrid

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -294,6 +294,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-alpha-features
 - name: kubernetes-e2e-gci-gke-alpha-features
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-alpha-features
+- name: kubernetes-e2e-gke-alpha-features-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-alpha-features-release-1.4
 - name: kubernetes-e2e-gke-autoscaling
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-autoscaling
 - name: kubernetes-e2e-gci-gke-autoscaling
@@ -943,6 +945,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-alpha-features
   - name: gci-gke-alpha-features
     test_group_name: kubernetes-e2e-gci-gke-alpha-features
+  - name: gke-alpha-features-release-1.4
+    test_group_name: kubernetes-e2e-gke-alpha-features-release-1.4
   - name: gke-autoscaling
     test_group_name: kubernetes-e2e-gke-autoscaling
   - name: gci-gke-autoscaling


### PR DESCRIPTION
Suite has passing and stable (as expected) since creation.