### PR TITLE
CRI: Add cluster/node e2e serial and node benchmark cri validation test.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -998,6 +998,19 @@
                 export GINKGO_PARALLEL="y"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
                 export KUBELET_TEST_ARGS="--experimental-runtime-integration-type=cri"
+        - 'gci-gce-cri-serial': # kubernetes-e2e-gci-gce-cri-serial
+            description: 'Run [Serial], [Disruptive], tests with CRI enabled on GCE with GCI, sequentially.'
+            timeout: 300
+            emails: 'lantaol@google.com'
+            test-owner: 'Random-Liu'
+            job-env: |
+                export ENABLE_GARBAGE_COLLECTOR="true"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="jkns-e2e-cri-serial-validation" # kubernetes-e2e-cri-serial-validation exceeds the length limit.
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+                export KUBELET_TEST_ARGS="--experimental-runtime-integration-type=cri"
+
     jobs:
         - 'kubernetes-e2e-{suffix}'
 

--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -179,14 +179,35 @@
             repoName: 'kubernetes/kubernetes'
             gitbasedir: 'k8s.io/kubernetes'
             owner: 'lantaol@google.com'
-            shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-flaky.properties'
-        - 'kubelet-cri':
+            shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-flaky.properties' 
+    jobs:
+        - '{gitproject}-gce-e2e-ci'
+
+- project:
+    name: cri-validation
+    gitproject:
+        - 'kubelet-cri': # kubelet-cri-gce-e2e-ci
             scm-cron-string: 'H/30 * * * *'
             cron-string: 'H H/1 * * *'
             repoName: 'kubernetes/kubernetes'
             gitbasedir: 'k8s.io/kubernetes'
             owner: 'yjhong@google.com'
             shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/cri_validation/jenkins-validation.properties'
+        - 'kubelet-cri-serial': # kubelet-cri-serial-gce-e2e-ci
+            scm-cron-string: 'H H/1 * * *'
+            cron-string: 'H H/2 * * *'
+            test-timeout: '{jenkins-timeout}'
+            repoName: 'kubernetes/kubernetes'
+            gitbasedir: 'k8s.io/kubernetes'
+            owner: 'lantaol@google.com'
+            shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/cri_validation/jenkins-serial.properties'
+        - 'kubelet-cri-benchmark': # kubelet-cri-benchmark-gce-e2e-ci
+            scm-cron-string: 'H H/2 * * *'
+            cron-string: 'H H/4 * * *'
+            repoName: 'kubernetes/kubernetes'
+            gitbasedir: 'k8s.io/kubernetes'
+            owner: 'lantaol@google.com'
+            shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties'
     jobs:
         - '{gitproject}-gce-e2e-ci'
 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -50,6 +50,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubelet-benchmark-gce-e2e-ci
 - name: kubelet-cri-gce-e2e-ci
   gcs_prefix: kubernetes-jenkins/logs/kubelet-cri-gce-e2e-ci
+- name: kubelet-cri-serial-gce-e2e-ci
+  gcs_prefix: kubernetes-jenkins/logs/kubelet-cri-serial-gce-e2e-ci
+- name: kubelet-cri-benchmark-gce-e2e-ci
+  gcs_prefix: kubernetes-jenkins/logs/kubelet-cri-benchmark-gce-e2e-ci
 - name: kubelet-gce-e2e-ci
   gcs_prefix: kubernetes-jenkins/logs/kubelet-gce-e2e-ci
 - name: kubelet-serial-gce-e2e-ci
@@ -216,6 +220,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-petset
 - name: kubernetes-e2e-gci-gce-cri
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-cri
+- name: kubernetes-e2e-gci-gce-cri-serial
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-cri-serial
 - name: kubernetes-e2e-gce-proto
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-proto
 - name: kubernetes-e2e-gci-gce-proto
@@ -787,6 +793,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-petset
   - name: gci-gce-cri
     test_group_name: kubernetes-e2e-gci-gce-cri
+  - name: gci-gce-cri-serial
+    test_group_name: kubernetes-e2e-gci-gce-cri-serial
   - name: gce-proto
     test_group_name: kubernetes-e2e-gce-proto
   - name: gci-gce-proto
@@ -1097,6 +1105,10 @@ dashboards:
     test_group_name: kubelet-serial-gce-e2e-ci
   - name: kubelet-cri-gce-e2e
     test_group_name: kubelet-cri-gce-e2e-ci
+  - name: kubelet-cri-serial-gce-e2e
+    test_group_name: kubelet-cri-serial-gce-e2e-ci
+  - name: kubelet-cri-benchmark-gce-e2e
+    test_group_name: kubelet-cri-benchmark-gce-e2e-ci
   - name: kubelet-flaky-gce-e2e
     test_group_name: kubelet-flaky-gce-e2e-ci
   name: google-node


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/31459.

Add cluster e2e serial, node e2e serial and node benchmark test for cri validation.

@yujuhong @feiskyer @yifan-gu 
/cc @kubernetes/sig-node 