### PR TITLE
gcsweb: make sure directories have a trailing slash

### DIFF
--- a/gcsweb/Makefile
+++ b/gcsweb/Makefile
@@ -25,7 +25,7 @@ REGISTRY ?= gcr.io/google_containers
 ARCH ?= amd64
 
 # The version string.
-VERSION := v1.0.0
+VERSION := v1.0.1
 
 ###
 ### These variables should not need tweaking.

--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -26,6 +26,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	net_url "net/url"
 	"os"
 	"strings"
 	"time"
@@ -148,7 +149,7 @@ func gcsRequest(w http.ResponseWriter, r *http.Request) {
 		// whether the object is a file or a dir.  If it is a dir, the
 		// contents will include a record for itself.  If it is a file it
 		// will not.
-		url += "&prefix=" + object + "/"
+		url += "&prefix=" + net_url.QueryEscape(object+"/")
 	}
 
 	if markers, found := r.URL.Query()["marker"]; found {
@@ -406,6 +407,10 @@ func htmlGridItem(out io.Writer, icon, url, name, size, modified string) error {
 // Render writes HTML representing this gcsDir to the provided output.
 func (dir *gcsDir) Render(out http.ResponseWriter, inPath string) {
 	htmlPageHeader(out, dir.Name)
+
+	if !strings.HasSuffix(inPath, "/") {
+		inPath += "/"
+	}
 
 	htmlContentHeader(out, dir.Name, inPath)
 


### PR DESCRIPTION
Also URL-escape paths to account for things like '+'s. (Right now, http://gcsweb.k8s.io/gcs/kubernetes-release-dev/ci/v1.5.0-alpha.0.2081+e19e78916cff8b/ doesn't work.)

Fixes #771.

Tested manually locally, but not yet pushed anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/774)
<!-- Reviewable:end -->
