### PR TITLE
Update some docs, update some logs, add some cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,19 @@ Job Builder](http://docs.openstack.org/infra/jenkins-job-builder/). Travis will
 run `jenkins/diff-job-config-patch.sh` to print out the XML diff between your
 change and master.
 
+## CI on GKE and PR Jenkins
+
+Due to the abundance of bugs and security vulnerabilities in Jenkins and its
+plugins, we are switching our entire CI system to Kubernetes. Currently, we
+trigger PR Jenkins jobs using the code under `ciongke/`, and we plan on moving
+more functionality out of Jenkins plugins and into there.
+
 ## Viewing Test Results
 
 * The [Kubernetes TestGrid](https://k8s-testgrid.appspot.com/) shows the results
 of test jobs for the last few weeks. It is currently not open-sourced, but we
 we would like to move in that direction eventually.
-* The [Kubernetes test history
+* The [24-hour test history
 dashboard](http://storage.googleapis.com/kubernetes-test-history/static/index.html)
 collects test results from the last 24 hours. It is updated hourly by the
 scripts under `jenkins/test-history`.

--- a/ciongke/Makefile
+++ b/ciongke/Makefile
@@ -85,8 +85,8 @@ test:
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook github.com/kubernetes/test-infra/ciongke/cmd/hook
-	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.35" cmd/hook
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.35"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.36" cmd/hook
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.36"
 
 hook-deployment:
 	kubectl apply -f hook_deployment.yaml
@@ -96,8 +96,8 @@ hook-service:
 
 line-image:
 	CGO_ENABLED=0 go build -o cmd/line/line github.com/kubernetes/test-infra/ciongke/cmd/line
-	docker build -t "gcr.io/kubernetes-jenkins-pull/line:0.17" cmd/line
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/line:0.17"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/line:0.18" cmd/line
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/line:0.18"
 
 sinker-image:
 	CGO_ENABLED=0 go build -o cmd/sinker/sinker github.com/kubernetes/test-infra/ciongke/cmd/sinker

--- a/ciongke/cmd/hook/kubeagent.go
+++ b/ciongke/cmd/hook/kubeagent.go
@@ -84,13 +84,9 @@ func (ka *KubeAgent) Start() {
 			go func(kr KubeRequest) {
 				if err := ka.deleteJob(kr); err != nil {
 					logrus.WithFields(fields(kr)).WithError(err).Error("Error deleting job.")
-				} else {
-					logrus.WithFields(fields(kr)).Info("Deleted job.")
 				}
 				if err := ka.createJob(kr); err != nil {
 					logrus.WithFields(fields(kr)).WithError(err).Error("Error creating job.")
-				} else {
-					logrus.WithFields(fields(kr)).Info("Created job.")
 				}
 			}(kr)
 		}
@@ -100,8 +96,6 @@ func (ka *KubeAgent) Start() {
 			go func(kr KubeRequest) {
 				if err := ka.deleteJob(kr); err != nil {
 					logrus.WithFields(fields(kr)).WithError(err).Error("Error deleting job.")
-				} else {
-					logrus.WithFields(fields(kr)).Info("Deleted job.")
 				}
 			}(kr)
 		}

--- a/ciongke/cmd/line/main.go
+++ b/ciongke/cmd/line/main.go
@@ -151,9 +151,6 @@ func (c *testClient) TestPR() error {
 		c.tryCreateStatus(github.Error, "Error queueing build.", "")
 		return err
 	}
-	if eq {
-		c.tryCreateStatus(github.Pending, "Build queued.", "")
-	}
 	for eq {
 		time.Sleep(10 * time.Second)
 		eq, err = c.JenkinsClient.Enqueued(b)
@@ -204,7 +201,11 @@ func (c *testClient) guberURL(number int) string {
 }
 
 func (c *testClient) tryCreateStatus(state, desc, url string) {
-	logrus.WithFields(fields(c)).Infof("Setting status to %s: %s", state, desc)
+	logrus.WithFields(fields(c)).WithFields(logrus.Fields{
+		"state":       state,
+		"description": desc,
+		"url":         url,
+	}).Info("Setting GitHub status.")
 	err := c.GitHubClient.CreateStatus(c.RepoOwner, c.RepoName, c.Commit, github.Status{
 		State:       state,
 		Description: desc,
@@ -212,7 +213,7 @@ func (c *testClient) tryCreateStatus(state, desc, url string) {
 		TargetURL:   url,
 	})
 	if err != nil {
-		logrus.WithFields(fields(c)).WithError(err).Error("Error creating GitHub status.")
+		logrus.WithFields(fields(c)).WithError(err).Error("Error setting GitHub status.")
 	}
 }
 

--- a/ciongke/hook_deployment.yaml
+++ b/ciongke/hook_deployment.yaml
@@ -33,10 +33,10 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.35
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.36
         imagePullPolicy: Always
         args:
-        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.17
+        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.18
         - --org=kubernetes
         - --dry-run=false
         ports:


### PR DESCRIPTION
The org membership cache is an easy and unnecessary optimization. I got rid of the "Build queued" status context update, since it doesn't really tell us anything. I also made some of the logging more consistent.