### PR TITLE
gcsweb: ensure icons are readable

### DIFF
--- a/gcsweb/Dockerfile.in
+++ b/gcsweb/Dockerfile.in
@@ -19,6 +19,7 @@ MAINTAINER Tim Hockin <thockin@google.com>
 RUN apk update --no-cache && apk add ca-certificates
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 ADD icons /icons
+RUN chmod a+r /ARG_BIN /icons/*
 
 USER nobody:nobody
 ENTRYPOINT ["/ARG_BIN"]


### PR DESCRIPTION
This is the second time in the last week that restrictive umasks have seemingly broken a docker image. (The other was https://github.com/kubernetes/kubernetes/pull/34288.) I wonder if we need a more robust fix for this sort of issue. Is there some docker pattern we're missing?

```console
$ docker run --entrypoint=ls gcr.io/google_containers/gcsweb-amd64:v1.0.0-rc1 -l /icons
total 12
-rw-r--r--    1 root     root           654 Oct  1 03:31 back.png
-rw-r--r--    1 root     root           484 Oct  1 03:31 dir.png
-rw-r--r--    1 root     root          3132 Oct  1 03:31 file.png
$ docker run --entrypoint=ls gcr.io/google_containers/gcsweb-amd64:v1.0.0 -l /icons
total 12
-rw-r-----    1 root     root           654 Oct  7 22:29 back.png
-rw-r-----    1 root     root           484 Oct  7 22:29 dir.png
-rw-r-----    1 root     root          3132 Oct  7 22:29 file.png
$ docker run --entrypoint=ls gcr.io/google_containers/gcsweb-amd64:v1.0.1 -l /icons
total 12
-rw-r-----    1 root     root           654 Oct  7 22:29 back.png
-rw-r-----    1 root     root           484 Oct  7 22:29 dir.png
-rw-r-----    1 root     root          3132 Oct  7 22:29 file.png
```

I'm not sure if we should bump the version for this fix or just force-push over the existing image.

(http://gcsweb.k8s.io currently only works if you have the icons cached already.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/797)
<!-- Reviewable:end -->
