### PR TITLE
Ensure k8s.io vanity domain exists in node-e2e.sh

### DIFF
--- a/jobs/fejta-pull-node-e2e.sh
+++ b/jobs/fejta-pull-node-e2e.sh
@@ -18,6 +18,15 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+if [[ ! -d "${GOPATH}/src/k8s.io" ]]; then
+  # Ensure vanity domain exists
+  if [[ ! -d "${GOPATH}/src/github.com/kubernetes" ]]; then
+    echo "Cannot find k8s.io nor github.com/kubernetes in GOPATH/src" >&2
+    exit 1
+  fi
+  ln -s "${GOPATH}/src/github.com/kubernetes" "${GOPATH}/src/k8s.io"
+fi
+
 case "${ghprbTargetBranch:-}" in
 release-1.0|release-1.1|release-1.2)
   echo "PR node e2e job disabled for legacy branches."


### PR DESCRIPTION
Create a k8s.io symlink to github.com/kubernetes in GOPATH/src

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/801)
<!-- Reviewable:end -->
