### PR TITLE
Let test pods store their state in their job annotations.

### DIFF
--- a/ciongke/Makefile
+++ b/ciongke/Makefile
@@ -85,8 +85,8 @@ test:
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook github.com/kubernetes/test-infra/ciongke/cmd/hook
-	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.36" cmd/hook
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.36"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.37" cmd/hook
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.37"
 
 hook-deployment:
 	kubectl apply -f hook_deployment.yaml
@@ -96,21 +96,21 @@ hook-service:
 
 line-image:
 	CGO_ENABLED=0 go build -o cmd/line/line github.com/kubernetes/test-infra/ciongke/cmd/line
-	docker build -t "gcr.io/kubernetes-jenkins-pull/line:0.18" cmd/line
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/line:0.18"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/line:0.19" cmd/line
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/line:0.19"
 
 sinker-image:
 	CGO_ENABLED=0 go build -o cmd/sinker/sinker github.com/kubernetes/test-infra/ciongke/cmd/sinker
-	docker build -t "gcr.io/kubernetes-jenkins-pull/sinker:0.1" cmd/sinker
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/sinker:0.1"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/sinker:0.2" cmd/sinker
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/sinker:0.2"
 
 sinker-deployment:
 	kubectl apply -f sinker_deployment.yaml
 
 deck-image:
 	CGO_ENABLED=0 go build -o cmd/deck/deck github.com/kubernetes/test-infra/ciongke/cmd/deck
-	docker build -t "gcr.io/kubernetes-jenkins-pull/deck:0.0" cmd/deck
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/deck:0.0"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/deck:0.1" cmd/deck
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/deck:0.1"
 
 deck-deployment:
 	kubectl apply -f deck_deployment.yaml

--- a/ciongke/cmd/deck/jobs.go
+++ b/ciongke/cmd/deck/jobs.go
@@ -29,16 +29,19 @@ import (
 )
 
 const (
-	period = time.Minute
+	period = 10 * time.Second
 )
 
 type Job struct {
-	Repo     string `json:"repo"`
-	Number   int    `json:"number"`
-	Job      string `json:"job"`
-	Started  string `json:"started"`
-	Finished string `json:"finished"`
-	Duration string `json:"duration"`
+	Repo        string `json:"repo"`
+	Number      int    `json:"number"`
+	Job         string `json:"job"`
+	Started     string `json:"started"`
+	Finished    string `json:"finished"`
+	Duration    string `json:"duration"`
+	State       string `json:"state"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
 
 	st time.Time `json:"-"`
 	ft time.Time `json:"-"`
@@ -88,9 +91,12 @@ func (ja *JobAgent) update() error {
 	var njs []Job
 	for _, j := range js {
 		nj := Job{
-			Repo:    fmt.Sprintf("%s/%s", j.Metadata.Labels["owner"], j.Metadata.Labels["repo"]),
-			Job:     j.Metadata.Labels["jenkins-job-name"],
-			Started: j.Status.StartTime.Format(time.Stamp),
+			Repo:        fmt.Sprintf("%s/%s", j.Metadata.Labels["owner"], j.Metadata.Labels["repo"]),
+			Job:         j.Metadata.Labels["jenkins-job-name"],
+			Started:     j.Status.StartTime.Format(time.Stamp),
+			State:       j.Metadata.Annotations["state"],
+			Description: j.Metadata.Annotations["description"],
+			URL:         j.Metadata.Annotations["url"],
 
 			st: j.Status.StartTime,
 			ft: j.Status.CompletionTime,

--- a/ciongke/cmd/deck/static/index.html
+++ b/ciongke/cmd/deck/static/index.html
@@ -24,9 +24,11 @@
         <table id="builds">
             <thead>
                 <tr>
+                    <th></th>
                     <th>Repository</th>
                     <th>#</th>
                     <th>Jenkins Job</th>
+                    <th>State</th>
                     <th>Started</th>
                     <th>Finished</th>
                     <th>Duration</th>

--- a/ciongke/cmd/deck/static/script.js
+++ b/ciongke/cmd/deck/static/script.js
@@ -58,9 +58,11 @@ function redraw() {
             continue;
 
         var r = document.createElement("tr");
+        r.appendChild(stateCell(allBuilds[i].state));
         r.appendChild(createCell(allBuilds[i].repo));
         r.appendChild(createCell(allBuilds[i].number));
         r.appendChild(createCell(allBuilds[i].job));
+        r.appendChild(createCell(allBuilds[i].description));
         r.appendChild(createCell(allBuilds[i].started));
         r.appendChild(createCell(allBuilds[i].finished));
         r.appendChild(createCell(allBuilds[i].duration));
@@ -71,5 +73,18 @@ function redraw() {
 function createCell(text) {
     var c = document.createElement("td");
     c.appendChild(document.createTextNode(text));
+    return c;
+}
+
+function stateCell(state) {
+    var c = document.createElement("td");
+    c.className = state;
+    if (state === "triggered" || state === "pending") {
+        c.appendChild(document.createTextNode("\u2022"));
+    } else if (state === "success") {
+        c.appendChild(document.createTextNode("\u2713"));
+    } else if (state === "failure" || state === "error" || state === "aborted") {
+        c.appendChild(document.createTextNode("\u2717"));
+    }
     return c;
 }

--- a/ciongke/cmd/deck/static/style.css
+++ b/ciongke/cmd/deck/static/style.css
@@ -83,3 +83,23 @@ td, th {
 th {
     color: #333;
 }
+
+.triggered, .pending, .success, .failure, .error, .aborted {
+    font-weight: bold;
+}
+
+.triggered, .pending {
+    color: #ffa500;
+}
+
+.success {
+    color: #22dd22;
+}
+
+.failure {
+    color: #dd2222;
+}
+
+.error, .aborted {
+    color: #888888;
+}

--- a/ciongke/cmd/hook/kubeagent_test.go
+++ b/ciongke/cmd/hook/kubeagent_test.go
@@ -74,7 +74,7 @@ func TestDeletePR(t *testing.T) {
 			{
 				// Delete this one.
 				Metadata: kube.ObjectMeta{
-					Name: "o-r-pr-3-abcd-job",
+					Name: "12345",
 					Labels: map[string]string{
 						"owner":            "o",
 						"pr":               "3",
@@ -86,7 +86,7 @@ func TestDeletePR(t *testing.T) {
 			{
 				// Different PR.
 				Metadata: kube.ObjectMeta{
-					Name: "o-r-pr-4-qwer-job",
+					Name: "abcde",
 					Labels: map[string]string{
 						"owner":            "o",
 						"pr":               "4",
@@ -98,44 +98,12 @@ func TestDeletePR(t *testing.T) {
 			{
 				// Different repo.
 				Metadata: kube.ObjectMeta{
-					Name: "o-q-pr-3-wxyz-job",
+					Name: "qwerty",
 					Labels: map[string]string{
 						"owner":            "o",
 						"pr":               "3",
 						"repo":             "q",
 						"jenkins-job-name": "job",
-					},
-				},
-			},
-			{
-				// Different job name.
-				Metadata: kube.ObjectMeta{
-					Name: "o-r-pr-3-abcd-otherjob",
-					Labels: map[string]string{
-						"owner":            "o",
-						"pr":               "3",
-						"repo":             "r",
-						"jenkins-job-name": "otherjob",
-					},
-				},
-			},
-		},
-		Pods: []kube.Pod{
-			{
-				// Delete this one.
-				Metadata: kube.ObjectMeta{
-					Name: "o-r-pr-3-abcd-test",
-					Labels: map[string]string{
-						"job-name": "o-r-pr-3-abcd-job",
-					},
-				},
-			},
-			{
-				// Different job.
-				Metadata: kube.ObjectMeta{
-					Name: "r-pr-4-qwer-test",
-					Labels: map[string]string{
-						"job-name": "r-pr-4-qwer-job",
 					},
 				},
 			},
@@ -151,14 +119,11 @@ func TestDeletePR(t *testing.T) {
 		RepoName:  "r",
 	}
 	s.deleteJob(br)
-	if len(c.DeletedJobs) == 0 {
-		t.Error("Job for PR 3 not deleted.")
-	} else if len(c.DeletedJobs) > 1 {
-		t.Error("Too many jobs deleted.")
-	}
-	if len(c.DeletedPods) == 0 {
-		t.Error("Pod for PR 3 not deleted.")
-	} else if len(c.DeletedPods) > 1 {
-		t.Error("Too many pods deleted.")
+	for _, j := range c.Jobs {
+		if j.Metadata.Name == "12345" && j.Spec.Parallelism == nil {
+			t.Error("Job not deleted.")
+		} else if j.Metadata.Name != "12345" && j.Spec.Parallelism != nil {
+			t.Errorf("Deleted wrong job: %s", j.Metadata.Name)
+		}
 	}
 }

--- a/ciongke/cmd/hook/kubeagent_test.go
+++ b/ciongke/cmd/hook/kubeagent_test.go
@@ -107,6 +107,18 @@ func TestDeletePR(t *testing.T) {
 					},
 				},
 			},
+			{
+				// Different job name.
+				Metadata: kube.ObjectMeta{
+					Name: "o-r-pr-3-abcd-otherjob",
+					Labels: map[string]string{
+						"owner":            "o",
+						"pr":               "3",
+						"repo":             "r",
+						"jenkins-job-name": "otherjob",
+					},
+				},
+			},
 		},
 	}
 	s := &KubeAgent{

--- a/ciongke/cmd/line/main.go
+++ b/ciongke/cmd/line/main.go
@@ -193,7 +193,6 @@ func (c *testClient) TestPR() error {
 
 	resultURL := c.guberURL(result.Number)
 	c.tryCreateStatus(github.Pending, "Build started.", resultURL)
-	time.Sleep(2 * time.Minute)
 	for {
 		if err != nil {
 			c.tryCreateStatus(github.Error, "Error waiting for build.", "")
@@ -286,7 +285,7 @@ func getKubeJob(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	re := regexp.MustCompile(`^job-name="([A-Za-z0-9\-]+)"$`)
+	re := regexp.MustCompile(`^job-name="([^"]+)"$`)
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		m := re.FindStringSubmatch(scanner.Text())

--- a/ciongke/cmd/sinker/main.go
+++ b/ciongke/cmd/sinker/main.go
@@ -63,19 +63,13 @@ func clean(kc kubeClient) {
 		return
 	}
 	for _, job := range jobs {
-		if job.Status.Active == 0 &&
-			job.Status.Succeeded > 0 &&
-			time.Since(job.Status.StartTime) > maxAge {
+		if jobComplete(job) && time.Since(job.Status.StartTime) > maxAge {
 			// Delete successful jobs. Don't quit if we fail to delete one.
 			if err := kc.DeleteJob(job.Metadata.Name); err == nil {
 				logrus.WithField("job", job.Metadata.Name).Info("Deleted old completed job.")
 			} else {
-				logrus.WithError(err).Error("Error deleting job.")
+				logrus.WithField("job", job.Metadata.Name).WithError(err).Error("Error deleting job.")
 			}
-		} else if job.Status.Succeeded == 0 &&
-			time.Since(job.Status.StartTime) > maxAge {
-			// Warn about old, unsuccessful jobs.
-			logrus.WithField("job", job.Metadata.Name).Warning("Old, unsuccessful job.")
 		}
 	}
 
@@ -96,4 +90,15 @@ func clean(kc kubeClient) {
 			}
 		}
 	}
+}
+
+func jobComplete(j kube.Job) bool {
+	if j.Status.Active > 0 {
+		return false
+	} else if j.Status.Succeeded > 0 {
+		return true
+	} else if j.Spec.Parallelism != nil && *j.Spec.Parallelism == 0 {
+		return true
+	}
+	return false
 }

--- a/ciongke/cmd/sinker/main.go
+++ b/ciongke/cmd/sinker/main.go
@@ -69,6 +69,19 @@ func clean(kc kubeClient) {
 				logrus.WithField("job", job.Metadata.Name).Info("Deleted old completed job.")
 			} else {
 				logrus.WithField("job", job.Metadata.Name).WithError(err).Error("Error deleting job.")
+				continue
+			}
+			pods, err := kc.ListPods(map[string]string{"job-name": job.Metadata.Name})
+			if err != nil {
+				logrus.WithField("job", job.Metadata.Name).WithError(err).Error("Error listing pods for job.")
+				continue
+			}
+			for _, pod := range pods {
+				if err := kc.DeletePod(pod.Metadata.Name); err == nil {
+					logrus.WithField("pod", pod.Metadata.Name).Info("Deleted old pod for old job.")
+				} else {
+					logrus.WithField("pod", pod.Metadata.Name).WithError(err).Error("Error deleting old pod for old job.")
+				}
 			}
 		}
 	}

--- a/ciongke/cmd/sinker/main_test.go
+++ b/ciongke/cmd/sinker/main_test.go
@@ -67,6 +67,7 @@ func TestClean(t *testing.T) {
 		"old, failed",
 		"old, succeeded",
 	}
+	zero := 0
 	jobs := []kube.Job{
 		{
 			Metadata: kube.ObjectMeta{
@@ -75,6 +76,19 @@ func TestClean(t *testing.T) {
 			Status: kube.JobStatus{
 				Active:    0,
 				Succeeded: 1,
+				StartTime: time.Now().Add(-maxAge).Add(-time.Second),
+			},
+		},
+		{
+			Metadata: kube.ObjectMeta{
+				Name: "old, deleted",
+			},
+			Spec: kube.JobSpec{
+				Parallelism: &zero,
+			},
+			Status: kube.JobStatus{
+				Active:    0,
+				Succeeded: 0,
 				StartTime: time.Now().Add(-maxAge).Add(-time.Second),
 			},
 		},
@@ -108,9 +122,23 @@ func TestClean(t *testing.T) {
 				StartTime: time.Now(),
 			},
 		},
+		{
+			Metadata: kube.ObjectMeta{
+				Name: "new, deleted",
+			},
+			Spec: kube.JobSpec{
+				Parallelism: &zero,
+			},
+			Status: kube.JobStatus{
+				Active:    0,
+				Succeeded: 0,
+				StartTime: time.Now(),
+			},
+		},
 	}
 	deletedJobs := []string{
 		"old, complete",
+		"old, deleted",
 	}
 	kc := &fakekube.FakeClient{
 		Pods: pods,

--- a/ciongke/cmd/sinker/main_test.go
+++ b/ciongke/cmd/sinker/main_test.go
@@ -62,10 +62,23 @@ func TestClean(t *testing.T) {
 				StartTime: time.Now().Add(-maxAge).Add(-time.Second),
 			},
 		},
+		{
+			Metadata: kube.ObjectMeta{
+				Name: "old, running with job",
+				Labels: map[string]string{
+					"job-name": "old, aborted with pod",
+				},
+			},
+			Status: kube.PodStatus{
+				Phase:     kube.PodRunning,
+				StartTime: time.Now().Add(-maxAge).Add(-time.Second),
+			},
+		},
 	}
 	deletedPods := []string{
 		"old, failed",
 		"old, succeeded",
+		"old, running with job",
 	}
 	zero := 0
 	jobs := []kube.Job{
@@ -135,10 +148,24 @@ func TestClean(t *testing.T) {
 				StartTime: time.Now(),
 			},
 		},
+		{
+			Metadata: kube.ObjectMeta{
+				Name: "old, aborted with pod",
+			},
+			Spec: kube.JobSpec{
+				Parallelism: &zero,
+			},
+			Status: kube.JobStatus{
+				Active:    0,
+				Succeeded: 0,
+				StartTime: time.Now().Add(-maxAge).Add(-time.Second),
+			},
+		},
 	}
 	deletedJobs := []string{
 		"old, complete",
 		"old, deleted",
+		"old, aborted with pod",
 	}
 	kc := &fakekube.FakeClient{
 		Pods: pods,

--- a/ciongke/deck_deployment.yaml
+++ b/ciongke/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/kubernetes-jenkins-pull/deck:0.0
+        image: gcr.io/kubernetes-jenkins-pull/deck:0.1
         ports:
           - name: http
             containerPort: 80

--- a/ciongke/hook_deployment.yaml
+++ b/ciongke/hook_deployment.yaml
@@ -33,10 +33,10 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.36
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.37
         imagePullPolicy: Always
         args:
-        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.18
+        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.19
         - --org=kubernetes
         - --dry-run=false
         ports:

--- a/ciongke/kube/client_test.go
+++ b/ciongke/kube/client_test.go
@@ -149,3 +149,45 @@ func TestDeleteJob(t *testing.T) {
 		t.Errorf("Didn't expect error: %v", err)
 	}
 }
+
+func TestPatchJob(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/batch/v1/namespaces/ns/jobs/jo" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/strategic-merge-patch+json" {
+			t.Errorf("Bad Content-Type: %s", r.Header.Get("Content-Type"))
+		}
+		fmt.Fprint(w, `{"metadata": {"name": "abcd"}}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	_, err := c.PatchJob("jo", Job{})
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+}
+
+func TestPatchJobStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/batch/v1/namespaces/ns/jobs/jo/status" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/strategic-merge-patch+json" {
+			t.Errorf("Bad Content-Type: %s", r.Header.Get("Content-Type"))
+		}
+		fmt.Fprint(w, `{"metadata": {"name": "abcd"}}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	_, err := c.PatchJobStatus("jo", Job{})
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+}

--- a/ciongke/kube/fakekube/fakekube.go
+++ b/ciongke/kube/fakekube/fakekube.go
@@ -87,6 +87,25 @@ func (c *FakeClient) DeleteJob(name string) error {
 	return fmt.Errorf("job %s not found", name)
 }
 
+func (c *FakeClient) PatchJob(name string, job kube.Job) (kube.Job, error) {
+	for i, j := range c.Jobs {
+		if j.Metadata.Name == name {
+			c.Jobs[i].Metadata.Annotations = job.Metadata.Annotations
+			c.Jobs[i].Spec = job.Spec
+		}
+	}
+	return job, nil
+}
+
+func (c *FakeClient) PatchJobStatus(name string, job kube.Job) (kube.Job, error) {
+	for i, j := range c.Jobs {
+		if j.Metadata.Name == name {
+			c.Jobs[i].Status = job.Status
+		}
+	}
+	return job, nil
+}
+
 func labelsMatch(l1 map[string]string, l2 map[string]string) bool {
 	for k1, v1 := range l1 {
 		matched := false

--- a/ciongke/kube/types.go
+++ b/ciongke/kube/types.go
@@ -21,11 +21,13 @@ import (
 )
 
 type ObjectMeta struct {
-	Name      string            `json:"name,omitempty"`
-	Namespace string            `json:"namespace,omitempty"`
-	Labels    map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 
 	ResourceVersion string `json:"resourceVersion,omitempty"`
+	UID             string `json:"uid,omitempty"`
 }
 
 type Job struct {
@@ -35,9 +37,9 @@ type Job struct {
 }
 
 type JobSpec struct {
-	Parallelism           int `json:"parallelism,omitempty"`
-	Completions           int `json:"completions,omitempty"`
-	ActiveDeadlineSeconds int `json:"activeDeadlineSeconds,omitempty"`
+	Completions           *int `json:"completions,omitempty"`
+	Parallelism           *int `json:"parallelism,omitempty"`
+	ActiveDeadlineSeconds int  `json:"activeDeadlineSeconds,omitempty"`
 
 	Template PodTemplateSpec `json:"template,omitempty"`
 }
@@ -85,12 +87,26 @@ type PodStatus struct {
 }
 
 type Volume struct {
-	Name   string        `json:"name,omitempty"`
-	Secret *SecretSource `json:"secret,omitempty"`
+	Name        string             `json:"name,omitempty"`
+	Secret      *SecretSource      `json:"secret,omitempty"`
+	DownwardAPI *DownwardAPISource `json:"downwardAPI,omitempty"`
 }
 
 type SecretSource struct {
 	Name string `json:"secretName,omitempty"`
+}
+
+type DownwardAPISource struct {
+	Items []DownwardAPIFile `json:"items,omitempty"`
+}
+
+type DownwardAPIFile struct {
+	Path  string              `json:"path"`
+	Field ObjectFieldSelector `json:"fieldRef,omitempty"`
+}
+
+type ObjectFieldSelector struct {
+	FieldPath string `json:"fieldPath"`
 }
 
 type Container struct {

--- a/ciongke/sinker_deployment.yaml
+++ b/ciongke/sinker_deployment.yaml
@@ -13,4 +13,4 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/kubernetes-jenkins-pull/sinker:0.1
+        image: gcr.io/kubernetes-jenkins-pull/sinker:0.2


### PR DESCRIPTION
Sorry this is a bit of a tricky PR.

1. I made us delete jobs by setting their parallelism to 0, which will make them stop creating pods (and delete any running pods) but keep the job item around.
1. I made the test pods consume their own labels via downward API, which lets them learn their job name.
1. I made them update their job's annotations when interesting things happen.
1. I made the dashboard display that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/813)
<!-- Reviewable:end -->
