### PR TITLE
Highlight error words even when preceded by ANSI color codes. Fixes #826

### DIFF
--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -22,8 +22,10 @@ def wordRE(word):
     return re.compile(r'\b(%s)\b' % word, re.IGNORECASE)
 
 # Match lines with error messages
+# HACK: match ANSI colored lines by allowing preceding "m",
+# as in"\x1b[0;31mFAILED\x1b[0m"
 error_re = re.compile(
-    r'\b(error|fatal|fail|failed|build timed out)\b', re.IGNORECASE)
+    r'(?:\b|(?<=m))(error|fatal|fail|failed|build timed out)\b', re.IGNORECASE)
 
 # Match the dictionary string in the given line
 def objref(line):

--- a/gubernator/regex_test.py
+++ b/gubernator/regex_test.py
@@ -43,6 +43,7 @@ class RegexTest(unittest.TestCase):
             ('there was a FaTaL error', True),
             ('we failed to read logs', True),
             ('FAIL k8s.io/kubernetes/pkg/client/record', True),
+            ('\x1b[0;31mFAILED\x1b[0m', True),  # color codes
         ]:
             self.assertEqual(bool(regex.error_re.search(text)), matches,
                 'error_re.search(%r) should be %r' % (text, matches))


### PR DESCRIPTION
The fix just allows an "m" before one of the error words.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/837)
<!-- Reviewable:end -->
