### PR TITLE
Re-enable all tests in kubemark-scale

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -159,15 +159,14 @@
                 export PROJECT="kubernetes-scale"
                 export E2E_TEST="false"
                 export USE_KUBEMARK="true"
-                # TODO: Revert to "\[Feature:Performance\]" after the experiment.
-                export KUBEMARK_TESTS="starting\s30\spods\sper\snode"
+                export KUBEMARK_TESTS="\[Feature:Performance\]"
                 export KUBEMARK_TEST_ARGS="--gather-resource-usage=true --garbage-collector-enabled=true --kube-api-content-type=application/vnd.kubernetes.protobuf"
                 # Increase throughput in Kubemark master components.
                 export KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS="--kube-api-qps=100 --kube-api-burst=100"
                 # Increase limit for inflight requests in apiserver.
-                export TEST_CLUSTER_MAX_REQUESTS_INFLIGHT="--max-requests-inflight=1200"
+                export TEST_CLUSTER_MAX_REQUESTS_INFLIGHT="--max-requests-inflight=1600"
                 # Increase throughput in Load test.
-                export LOAD_TEST_THROUGHPUT=50
+                export LOAD_TEST_THROUGHPUT=30
                 export FAIL_ON_GCP_RESOURCE_LEAK="false"
                 # Override defaults to be independent from GCE defaults and set kubemark parameters
                 # We need 11 so that we won't hit max-pods limit (set to 100). TODO: do it in a nicer way.


### PR DESCRIPTION
My current hypothesis is that the previous failures of kubemark-4000 were due to a huge amount of 429s, which resulted in https://github.com/kubernetes/kubernetes/issues/34938

I significantly bumped max-inflight-limit to verify it (it was 800 in previous runs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/853)
<!-- Reviewable:end -->
