### PR TITLE
kops build: Pick up correct service account

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kops-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kops-build.yaml
@@ -8,6 +8,7 @@
     builders:
         - activate-gce-service-account
         - shell: |
+            export CLOUDSDK_CONFIG="${{CLOUDSDK_CONFIG:-${{WORKSPACE}}/.config/gcloud}}"
             {job-env}
             timeout -k {kill-timeout}m {timeout}m make gcs-publish-ci && rc=$? || rc=$?
             {report-rc}


### PR DESCRIPTION
Limited fix for #858 for `kops-build` job. Fixes kubernetes/kops#664. I'll fix the `gs://kops-ci` bucket after this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/859)
<!-- Reviewable:end -->
