### PR TITLE
Correct non-k8s.io/kubernetes paths

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -360,7 +360,6 @@ def ci_paths(job, build):
 def pr_paths(repo, job, build, pull):
     """Return a Paths() instance for a PR."""
     pull = str(pull)
-    # Wouldn't this be better as a dir than prefix?
     if repo in ['k8s.io/kubernetes', 'kubernetes/kubernetes']:
         prefix = ''
     elif repo.startswith('k8s.io/'):
@@ -370,7 +369,7 @@ def pr_paths(repo, job, build, pull):
     else:
         prefix = repo.replace('/', '_')
     base = 'gs://kubernetes-jenkins/pr-logs'
-    pull = prefix + pull
+    pull = os.path.join(prefix, pull)
     pr_path = os.path.join(base, 'pull', pull, job, build)
     result_cache = os.path.join(
             base, 'directory', job, 'jobResultsCache.json')

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -511,13 +511,17 @@ class PRPathsTest(unittest.TestCase):
         """Test the kubernetes/something prefix."""
         path = bootstrap.pr_paths('kubernetes/prefix', JOB, BUILD, PULL)
         self.assertTrue(any(
-            'prefix%s' % PULL == p for p in path.build_log.split('/')))
+            'prefix' in p for p in path.build_log.split('/')), path.build_log)
+        self.assertTrue(any(
+            str(PULL) in p for p in path.build_log.split('/')), path.build_log)
 
     def testOther(self):
         """Test the none kubernetes prefixes."""
         path = bootstrap.pr_paths('random/repo', JOB, BUILD, PULL)
         self.assertTrue(any(
-            'random_repo%s' % PULL == p for p in path.build_log.split('/')))
+            'random_repo' in p for p in path.build_log.split('/')), path.build_log)
+        self.assertTrue(any(
+            str(PULL) in p for p in path.build_log.split('/')), path.build_log)
 
 
 class BootstrapTest(unittest.TestCase):


### PR DESCRIPTION
We want repo/pr and org_repo/pr not repo_pr and org_repo_pr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/864)
<!-- Reviewable:end -->
