### PR TITLE
Add JENKINS_USE_GET_KUBE_SCRIPT option to support using get-kube.sh

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -45,10 +45,11 @@ ENV FAIL_ON_GCP_RESOURCE_LEAK=true \
 
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
+    "https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/e2e.go", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/forked/shell2junit/sh2ju.sh", \
     "/workspace/"]
-RUN ["chmod", "+x", "/workspace/upload-to-gcs.sh", "/workspace/sh2ju.sh"]
+RUN ["chmod", "+x", "/workspace/get-kube.sh", "/workspace/upload-to-gcs.sh", "/workspace/sh2ju.sh"]
 
 ENTRYPOINT "/workspace/e2e-runner.sh"


### PR DESCRIPTION
Additionally include the get-kube.sh script in kubekins-e2e.

By default, this should have no effect on Jenkins. Testing in https://github.com/kubernetes/kubernetes/pull/35083 anyway. (Previous runs there set `JENKINS_USE_GET_KUBE_SCRIPT=y` to force that flow on PR Jenkins, and everything still worked.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/885)
<!-- Reviewable:end -->
