### PR TITLE
Implement /lgtm and /lgtm cancel in prow.

### DIFF
--- a/prow/cmd/hook/githubagent.go
+++ b/prow/cmd/hook/githubagent.go
@@ -48,6 +48,8 @@ type githubClient interface {
 	ListIssueComments(owner, repo string, issue int) ([]github.IssueComment, error)
 	CreateComment(owner, repo string, number int, comment string) error
 	GetPullRequest(owner, repo string, number int) (*github.PullRequest, error)
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
 }
 
 // Start starts listening for events. It does not block.
@@ -88,6 +90,9 @@ func (ga *GitHubAgent) handleIssueCommentEvent(ic github.IssueCommentEvent) {
 	l.Infof("Issue comment %s.", ic.Action)
 	if err := ga.commentTrigger(ic); err != nil {
 		l.WithError(err).Error("Error triggering after issue comment event.")
+	}
+	if err := ga.lgtmComment(ic); err != nil {
+		l.WithError(err).Error("Error dealing with LGTM command.")
 	}
 }
 

--- a/prow/cmd/hook/lgtm.go
+++ b/prow/cmd/hook/lgtm.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"regexp"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+var (
+	lgtmRe       = regexp.MustCompile(`(?mi)^\/lgtm\r?$`)
+	lgtmCancelRe = regexp.MustCompile(`(?mi)^\/lgtm cancel\r?$`)
+)
+
+// Add or remove LGTM when reviewers comment "/lgtm" or "/lgtm cancel".
+func (ga *GitHubAgent) lgtmComment(ic github.IssueCommentEvent) error {
+	// Only consider open PRs.
+	if ic.Issue.PullRequest == nil || ic.Issue.State != "open" {
+		return nil
+	}
+
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	number := ic.Issue.Number
+
+	// If we create or edit a "/lgtm" comment, add lgtm if necessary.
+	// If we delete a "/lgtm" comment, remove lgtm if necessary.
+	// If we create or edit a "/lgtm cancel" comment, remove lgtm if necessary.
+	act := false
+	wantLGTM := false
+	if lgtmRe.MatchString(ic.Comment.Body) {
+		act = true
+		wantLGTM = ic.Action == "created" || ic.Action == "edited"
+	} else if lgtmCancelRe.MatchString(ic.Comment.Body) {
+		act = ic.Action == "created" || ic.Action == "edited"
+		wantLGTM = false
+	}
+	if !act {
+		return nil
+	}
+
+	isAssignee := false
+	for _, assignee := range ic.Issue.Assignees {
+		if ic.Comment.User.Login == assignee.Login {
+			isAssignee = true
+			break
+		}
+	}
+	isAuthor := ic.Comment.User.Login == ic.Issue.User.Login
+	// Allow authors to cancel LGTM. Do not allow authors to LGTM, and do not
+	// accept commands from any other user.
+	if isAuthor && wantLGTM {
+		return ga.GitHubClient.CreateComment(org, repo, number, fmt.Sprintf("@%s: you can't LGTM your own PR.", ic.Comment.User.Login))
+	} else if !isAuthor {
+		if !isAssignee && wantLGTM {
+			return ga.GitHubClient.CreateComment(org, repo, number, fmt.Sprintf("@%s: you can't LGTM a PR unless you are assigned as a reviewer.", ic.Comment.User.Login))
+		} else if !isAssignee && !wantLGTM {
+			return ga.GitHubClient.CreateComment(org, repo, number, fmt.Sprintf("@%s: you can't remove LGTM from a PR unless you are assigned as a reviewer.", ic.Comment.User.Login))
+		}
+	}
+
+	hasLGTM := false
+	for _, label := range ic.Issue.Labels {
+		if label.Name == lgtmLabel {
+			hasLGTM = true
+			break
+		}
+	}
+
+	if hasLGTM && !wantLGTM {
+		return ga.GitHubClient.RemoveLabel(org, repo, number, lgtmLabel)
+	} else if !hasLGTM && wantLGTM {
+		return ga.GitHubClient.AddLabel(org, repo, number, lgtmLabel)
+	}
+	return nil
+}

--- a/prow/cmd/hook/lgtm_test.go
+++ b/prow/cmd/hook/lgtm_test.go
@@ -59,14 +59,6 @@ func TestLGTMComment(t *testing.T) {
 			shouldToggle: true,
 		},
 		{
-			name:         "lgtm comment by reviewer, no lgtm on pr",
-			action:       "edited",
-			body:         "/lgtm",
-			commenter:    "r1",
-			hasLGTM:      false,
-			shouldToggle: true,
-		},
-		{
 			name:         "lgtm comment by reviewer, lgtm on pr",
 			action:       "created",
 			body:         "/lgtm",
@@ -108,14 +100,6 @@ func TestLGTMComment(t *testing.T) {
 			hasLGTM:       true,
 			shouldToggle:  false,
 			shouldComment: true,
-		},
-		{
-			name:         "lgtm comment deleted by reviewer",
-			action:       "deleted",
-			body:         "/lgtm",
-			commenter:    "r1",
-			hasLGTM:      true,
-			shouldToggle: true,
 		},
 		{
 			name:         "lgtm cancel comment by reviewer",

--- a/prow/cmd/hook/lgtm_test.go
+++ b/prow/cmd/hook/lgtm_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestLGTMComment(t *testing.T) {
+	// "a" is the author, "a", "r1", and "r2" are reviewers.
+	var testcases = []struct {
+		name          string
+		action        string
+		body          string
+		commenter     string
+		hasLGTM       bool
+		shouldToggle  bool
+		shouldComment bool
+	}{
+		{
+			name:         "non-lgtm comment",
+			action:       "created",
+			body:         "uh oh",
+			commenter:    "o",
+			hasLGTM:      false,
+			shouldToggle: false,
+		},
+		{
+			name:         "lgtm comment by reviewer, no lgtm on pr",
+			action:       "created",
+			body:         "/lgtm",
+			commenter:    "r1",
+			hasLGTM:      false,
+			shouldToggle: true,
+		},
+		{
+			name:         "LGTM comment by reviewer, no lgtm on pr",
+			action:       "created",
+			body:         "/LGTM",
+			commenter:    "r1",
+			hasLGTM:      false,
+			shouldToggle: true,
+		},
+		{
+			name:         "lgtm comment by reviewer, no lgtm on pr",
+			action:       "edited",
+			body:         "/lgtm",
+			commenter:    "r1",
+			hasLGTM:      false,
+			shouldToggle: true,
+		},
+		{
+			name:         "lgtm comment by reviewer, lgtm on pr",
+			action:       "created",
+			body:         "/lgtm",
+			commenter:    "r1",
+			hasLGTM:      true,
+			shouldToggle: false,
+		},
+		{
+			name:          "lgtm comment by author",
+			action:        "created",
+			body:          "/lgtm",
+			commenter:     "a",
+			hasLGTM:       false,
+			shouldToggle:  false,
+			shouldComment: true,
+		},
+		{
+			name:         "lgtm cancel by author",
+			action:       "created",
+			body:         "/lgtm cancel",
+			commenter:    "a",
+			hasLGTM:      true,
+			shouldToggle: true,
+		},
+		{
+			name:          "lgtm comment by non-reviewer",
+			action:        "created",
+			body:          "/lgtm",
+			commenter:     "o",
+			hasLGTM:       false,
+			shouldToggle:  false,
+			shouldComment: true,
+		},
+		{
+			name:          "lgtm cancel by non-reviewer",
+			action:        "created",
+			body:          "/lgtm cancel",
+			commenter:     "o",
+			hasLGTM:       true,
+			shouldToggle:  false,
+			shouldComment: true,
+		},
+		{
+			name:         "lgtm comment deleted by reviewer",
+			action:       "deleted",
+			body:         "/lgtm",
+			commenter:    "r1",
+			hasLGTM:      true,
+			shouldToggle: true,
+		},
+		{
+			name:         "lgtm cancel comment by reviewer",
+			action:       "created",
+			body:         "/lgtm cancel",
+			commenter:    "r1",
+			hasLGTM:      true,
+			shouldToggle: true,
+		},
+		{
+			name:         "lgtm cancel comment by reviewer, no lgtm",
+			action:       "created",
+			body:         "/lgtm cancel",
+			commenter:    "r1",
+			hasLGTM:      false,
+			shouldToggle: false,
+		},
+	}
+	for _, tc := range testcases {
+		fc := &fakegithub.FakeClient{
+			IssueComments: make(map[int][]github.IssueComment),
+		}
+		ga := &GitHubAgent{
+			GitHubClient: fc,
+		}
+		ice := github.IssueCommentEvent{
+			Action: tc.action,
+			Comment: github.IssueComment{
+				Body: tc.body,
+				User: github.User{tc.commenter},
+			},
+			Issue: github.Issue{
+				User:        github.User{"a"},
+				Number:      5,
+				State:       "open",
+				PullRequest: &struct{}{},
+				Assignees:   []github.User{{"a"}, {"r1"}, {"r2"}},
+			},
+		}
+		if tc.hasLGTM {
+			ice.Issue.Labels = []github.Label{{Name: lgtmLabel}}
+		}
+		if err := ga.lgtmComment(ice); err != nil {
+			t.Errorf("For case %s, didn't expect error from lgtmComment: %v", tc.name, err)
+			continue
+		}
+		if tc.shouldToggle {
+			if tc.hasLGTM {
+				if len(fc.LabelsRemoved) == 0 {
+					t.Errorf("For case %s, should have removed LGTM.", tc.name)
+				} else if len(fc.LabelsAdded) > 0 {
+					t.Errorf("For case %s, should not have added LGTM.", tc.name)
+				}
+			} else {
+				if len(fc.LabelsAdded) == 0 {
+					t.Errorf("For case %s, should have added LGTM.", tc.name)
+				} else if len(fc.LabelsRemoved) > 0 {
+					t.Errorf("For case %s, should not have removed LGTM.", tc.name)
+				}
+			}
+		} else if len(fc.LabelsRemoved) > 0 || len(fc.LabelsAdded) > 0 {
+			t.Errorf("For case %s, should not have added/removed LGTM.", tc.name)
+		}
+		if tc.shouldComment && len(fc.IssueComments[5]) != 1 {
+			t.Errorf("For case %s, should have commented.", tc.name)
+		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
+			t.Errorf("For case %s, should not have commented.", tc.name)
+		}
+	}
+}


### PR DESCRIPTION
Somewhat RFC, since we might decide to not go in this direction. I think there are definite advantages to doing it over here vs using the munger. We get a quick response, we don't use any more API tokens than necessary, and the logic is simpler.

The first commit shuffles things around a bit since I don't want these things to live in the same file, especially if we're going to add more. The third commit adds the new feature.

If we decide to go with this then we'll need to delete the munger and redeploy before deploying this.

cc @foxish

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/887)
<!-- Reviewable:end -->
