### PR TITLE
Show queue backlog over time, add averages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
     - ./verify/verify-boilerplate.py
     - python -m unittest discover -s jenkins/test-history -p "*_test.py"
     - pylint jenkins/bootstrap.py  # TODO(fejta): all python files
+    - pylint queue-health/graph/graph.py  # TODO(fejta): all python files
     - ./jenkins/bootstrap_test.py
     - ./jenkins/diff-job-config-patch.sh
     - ./jenkins/diff-e2e-runner.sh

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=locally-disabled,fixme
+disable=fixme,locally-disabled,locally-enabled
 
 [REPORTS]
 reports=no

--- a/queue-health/graph/Dockerfile
+++ b/queue-health/graph/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/queue-health-base:v20160627
+FROM gcr.io/google-containers/queue-health-base:v20161020
 MAINTAINER Erick Fejta <fejta@google.com>
 
 # Install matplotlib

--- a/queue-health/poll/Dockerfile
+++ b/queue-health/poll/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/queue-health-base:v20160627
+FROM gcr.io/google-containers/queue-health-base:v20161020
 MAINTAINER Erick Fejta <fejta@google.com>
 
 # Install poller and set default variables

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Override with production targets
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph:v20161020
+        image: gcr.io/google-containers/queue-health-graph:v20161021
         command:
         - python
         - /graph.py

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Override with production targets
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph:v20160725
+        image: gcr.io/google-containers/queue-health-graph:v20161020
         command:
         - python
         - /graph.py
@@ -23,7 +23,7 @@ spec:
           mountPath: /creds
           readOnly: true
       - name: poller
-        image: gcr.io/google-containers/queue-health-poll:v20160725
+        image: gcr.io/google-containers/queue-health-poll:v20161020
         command:
         - python
         - /poller.py


### PR DESCRIPTION
@kubernetes/test-infra-maintainers 

Replace the confusing merge capacity chart with backlog (how many hours you will wait).

Sample output: https://storage.googleapis.com/kubernetes-test-history/sq-test/k8s-queue-health.svg