### PR TITLE
Correct env var for image type in GKE soak tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -297,7 +297,7 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
+                export KUBE_GKE_IMAGE_TYPE="debian"
             job-env: |
                 export PROJECT="k8s-jkns-gke-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests
@@ -330,7 +330,7 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export KUBE_OS_DISTRIBUTION="gci"
+                export KUBE_GKE_IMAGE_TYPE="gci"
             job-env: |
                 export PROJECT="k8s-jkns-gke-gci-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests


### PR DESCRIPTION
Env var for OS image on GKE is `KUBE_GKE_IMAGE_TYPE`

This is the same problem fixed for kubernetes-pull GKE tests in https://github.com/kubernetes/test-infra/pull/659

As a result of this issue, the `soak-continuous-e2e-gke-gci` test (https://k8s-testgrid.appspot.com/google-soak#soak-continuous-e2e-gke-gci), etc. are actually running on container-vm instead of gci.