### PR TITLE
Expose both head and base SHA for pull requests.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -85,8 +85,8 @@ test:
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook k8s.io/test-infra/prow/cmd/hook
-	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.38" cmd/hook
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.38"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/hook:0.39" cmd/hook
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/hook:0.39"
 
 hook-deployment:
 	kubectl apply -f hook_deployment.yaml
@@ -96,8 +96,8 @@ hook-service:
 
 line-image:
 	CGO_ENABLED=0 go build -o cmd/line/line k8s.io/test-infra/prow/cmd/line
-	docker build -t "gcr.io/kubernetes-jenkins-pull/line:0.20" cmd/line
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/line:0.20"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/line:0.21" cmd/line
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/line:0.21"
 
 sinker-image:
 	CGO_ENABLED=0 go build -o cmd/sinker/sinker k8s.io/test-infra/prow/cmd/sinker
@@ -109,8 +109,8 @@ sinker-deployment:
 
 deck-image:
 	CGO_ENABLED=0 go build -o cmd/deck/deck k8s.io/test-infra/prow/cmd/deck
-	docker build -t "gcr.io/kubernetes-jenkins-pull/deck:0.2" cmd/deck
-	gcloud docker push "gcr.io/kubernetes-jenkins-pull/deck:0.2"
+	docker build -t "gcr.io/kubernetes-jenkins-pull/deck:0.3" cmd/deck
+	gcloud docker push "gcr.io/kubernetes-jenkins-pull/deck:0.3"
 
 deck-deployment:
 	kubectl apply -f deck_deployment.yaml

--- a/prow/cmd/deck/jobs.go
+++ b/prow/cmd/deck/jobs.go
@@ -34,6 +34,9 @@ const (
 
 type Job struct {
 	Repo        string `json:"repo"`
+	Branch      string `json:"branch"`
+	HeadSHA     string `json:"head_sha"`
+	BaseSHA     string `json:"base_sha"`
 	Number      int    `json:"number"`
 	Author      string `json:"author"`
 	Job         string `json:"job"`
@@ -93,6 +96,9 @@ func (ja *JobAgent) update() error {
 	for _, j := range js {
 		nj := Job{
 			Repo:        fmt.Sprintf("%s/%s", j.Metadata.Labels["owner"], j.Metadata.Labels["repo"]),
+			Branch:      j.Metadata.Annotations["branch"],
+			HeadSHA:     j.Metadata.Annotations["head-sha"],
+			BaseSHA:     j.Metadata.Annotations["base-sha"],
 			Author:      j.Metadata.Annotations["author"],
 			Job:         j.Metadata.Labels["jenkins-job-name"],
 			Started:     j.Status.StartTime.Format(time.Stamp),

--- a/prow/cmd/deck/jobs.go
+++ b/prow/cmd/deck/jobs.go
@@ -34,9 +34,9 @@ const (
 
 type Job struct {
 	Repo        string `json:"repo"`
-	Branch      string `json:"branch"`
-	HeadSHA     string `json:"head_sha"`
+	BaseRef     string `json:"base_ref"`
 	BaseSHA     string `json:"base_sha"`
+	PullSHA     string `json:"pull_sha"`
 	Number      int    `json:"number"`
 	Author      string `json:"author"`
 	Job         string `json:"job"`
@@ -96,9 +96,9 @@ func (ja *JobAgent) update() error {
 	for _, j := range js {
 		nj := Job{
 			Repo:        fmt.Sprintf("%s/%s", j.Metadata.Labels["owner"], j.Metadata.Labels["repo"]),
-			Branch:      j.Metadata.Annotations["branch"],
-			HeadSHA:     j.Metadata.Annotations["head-sha"],
+			BaseRef:     j.Metadata.Annotations["base-ref"],
 			BaseSHA:     j.Metadata.Annotations["base-sha"],
+			PullSHA:     j.Metadata.Annotations["pull-sha"],
 			Author:      j.Metadata.Annotations["author"],
 			Job:         j.Metadata.Labels["jenkins-job-name"],
 			Started:     j.Status.StartTime.Format(time.Stamp),

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -57,12 +57,14 @@ func main() {
 			logrus.WithError(err).Error("Error marshaling jobs.")
 			jd = []byte("[]")
 		}
-		v := "allBuilds"
-		if nv := r.URL.Query().Get("var"); nv != "" {
-			v = nv
+		// If we have a "var" query, then write out "var value = {...};".
+		// Otherwise, just write out the JSON.
+		if v := r.URL.Query().Get("var"); v != "" {
+			fmt.Fprintf(w, "var %s = %s;", v, string(jd))
+		} else {
+			fmt.Fprintf(w, string(jd))
 		}
 		w.Header().Set("Cache-Control", "no-cache")
-		fmt.Fprintf(w, "var %s = %s;", v, string(jd))
 	})
 	logrus.WithError(http.ListenAndServe(":http", nil)).Fatal("ListenAndServe returned.")
 }

--- a/prow/cmd/hook/githubagent.go
+++ b/prow/cmd/hook/githubagent.go
@@ -235,7 +235,8 @@ func makeKubeRequest(job JenkinsJob, pr github.PullRequest) KubeRequest {
 		PR:        pr.Number,
 		Author:    pr.User.Login,
 		Branch:    pr.Base.Ref,
-		SHA:       pr.Head.SHA,
+		HeadSHA:   pr.Head.SHA,
+		BaseSHA:   pr.Base.SHA,
 	}
 }
 

--- a/prow/cmd/hook/githubagent.go
+++ b/prow/cmd/hook/githubagent.go
@@ -234,9 +234,9 @@ func makeKubeRequest(job JenkinsJob, pr github.PullRequest) KubeRequest {
 		RepoName:  pr.Base.Repo.Name,
 		PR:        pr.Number,
 		Author:    pr.User.Login,
-		Branch:    pr.Base.Ref,
-		HeadSHA:   pr.Head.SHA,
+		BaseRef:   pr.Base.Ref,
 		BaseSHA:   pr.Base.SHA,
+		PullSHA:   pr.Head.SHA,
 	}
 }
 

--- a/prow/cmd/hook/kubeagent.go
+++ b/prow/cmd/hook/kubeagent.go
@@ -51,9 +51,9 @@ type KubeRequest struct {
 	RepoName  string
 	PR        int
 	Author    string
-	Branch    string
-	HeadSHA   string
+	BaseRef   string
 	BaseSHA   string
+	PullSHA   string
 }
 
 type kubeClient interface {
@@ -75,9 +75,9 @@ func fields(kr KubeRequest) logrus.Fields {
 		"org":      kr.RepoOwner,
 		"repo":     kr.RepoName,
 		"pr":       kr.PR,
-		"head-sha": kr.HeadSHA,
+		"base-ref": kr.BaseRef,
 		"base-sha": kr.BaseSHA,
-		"branch":   kr.Branch,
+		"pull-sha": kr.PullSHA,
 	}
 }
 
@@ -123,9 +123,9 @@ func (ka *KubeAgent) createJob(kr KubeRequest) error {
 				"author":      kr.Author,
 				"description": "Build triggered.",
 				"url":         "",
-				"branch":      kr.Branch,
-				"head-sha":    kr.HeadSHA,
+				"base-ref":    kr.BaseRef,
 				"base-sha":    kr.BaseSHA,
+				"pull-sha":    kr.PullSHA,
 			},
 		},
 		Spec: kube.JobSpec{
@@ -143,9 +143,9 @@ func (ka *KubeAgent) createJob(kr KubeRequest) error {
 								"--repo-owner=" + kr.RepoOwner,
 								"--repo-name=" + kr.RepoName,
 								"--pr=" + strconv.Itoa(kr.PR),
-								"--branch=" + kr.Branch,
-								"--head-sha=" + kr.HeadSHA,
+								"--base-ref=" + kr.BaseRef,
 								"--base-sha=" + kr.BaseSHA,
+								"--pull-sha=" + kr.PullSHA,
 								"--dry-run=" + strconv.FormatBool(ka.DryRun),
 								"--jenkins-url=$(JENKINS_URL)",
 								"--rerun-command=" + kr.RerunCommand,

--- a/prow/cmd/hook/kubeagent_test.go
+++ b/prow/cmd/hook/kubeagent_test.go
@@ -38,8 +38,8 @@ func TestCreateJob(t *testing.T) {
 		RepoOwner: "kubernetes",
 		RepoName:  "kubernetes",
 		PR:        123,
-		Branch:    "master",
-		HeadSHA:   "12345abcde",
+		BaseRef:   "master",
+		PullSHA:   "12345abcde",
 	}
 	if err := ka.createJob(br); err != nil {
 		t.Fatalf("Didn't expect error: %s", err)

--- a/prow/cmd/hook/kubeagent_test.go
+++ b/prow/cmd/hook/kubeagent_test.go
@@ -39,7 +39,7 @@ func TestCreateJob(t *testing.T) {
 		RepoName:  "kubernetes",
 		PR:        123,
 		Branch:    "master",
-		SHA:       "12345abcde",
+		HeadSHA:   "12345abcde",
 	}
 	if err := ka.createJob(br); err != nil {
 		t.Fatalf("Didn't expect error: %s", err)

--- a/prow/cmd/line/main_test.go
+++ b/prow/cmd/line/main_test.go
@@ -56,7 +56,7 @@ func TestFailureComment(t *testing.T) {
 		Job:          "test-job",
 		Context:      "Jenkins test",
 		PRNumber:     5,
-		HeadSHA:      "abcde",
+		PullSHA:      "abcde",
 		GitHubClient: ghc,
 	}
 	cl.tryCreateFailureComment("url")

--- a/prow/cmd/line/main_test.go
+++ b/prow/cmd/line/main_test.go
@@ -56,7 +56,7 @@ func TestFailureComment(t *testing.T) {
 		Job:          "test-job",
 		Context:      "Jenkins test",
 		PRNumber:     5,
-		Commit:       "abcde",
+		HeadSHA:      "abcde",
 		GitHubClient: ghc,
 	}
 	cl.tryCreateFailureComment("url")

--- a/prow/deck_deployment.yaml
+++ b/prow/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/kubernetes-jenkins-pull/deck:0.2
+        image: gcr.io/kubernetes-jenkins-pull/deck:0.3
         ports:
           - name: http
             containerPort: 80

--- a/prow/hook_deployment.yaml
+++ b/prow/hook_deployment.yaml
@@ -33,10 +33,10 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.38
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.39
         imagePullPolicy: Always
         args:
-        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.20
+        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.21
         - --org=kubernetes
         - --dry-run=false
         ports:

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -46,6 +47,14 @@ type Client struct {
 	user    string
 	token   string
 	dry     bool
+}
+
+type BuildRequest struct {
+	JobName  string
+	PRNumber int
+	Branch   string
+	HeadSHA  string
+	BaseSHA  string
 }
 
 type Build struct {
@@ -103,13 +112,27 @@ func (c *Client) doRequest(method, path string) (*http.Response, error) {
 
 // Build triggers the job on Jenkins with an ID parameter that will let us
 // track it.
-func (c *Client) Build(job string, pr int, branch string) (*Build, error) {
+func (c *Client) Build(br BuildRequest) (*Build, error) {
 	if c.dry {
 		return &Build{}, nil
 	}
 	buildID := uuid.NewV1().String()
-	u := fmt.Sprintf("%s/job/%s/buildWithParameters?ghprbPullId=%d&ghprbTargetBranch=%s&buildId=%s", c.baseURL, job, pr, branch, buildID)
-	resp, err := c.request(http.MethodPost, u)
+	u, err := url.Parse(fmt.Sprintf("%s/job/%s/buildWithParameters", c.baseURL, br.JobName))
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	// These two are provided for backwards-compatability with scripts that
+	// used the ghprb plugin.
+	q.Set("ghprbPullID", strconv.Itoa(br.PRNumber))
+	q.Set("ghprbTargetBranch", br.Branch)
+
+	q.Set("PULL_NUMBER", strconv.Itoa(br.PRNumber))
+	q.Set("PULL_BASE_BRANCH", br.Branch)
+	q.Set("PULL_HEAD_SHA", br.HeadSHA)
+	q.Set("PULL_BASE_SHA", br.BaseSHA)
+	u.RawQuery = q.Encode()
+	resp, err := c.request(http.MethodPost, u.String())
 	if err != nil {
 		return nil, err
 	}
@@ -122,8 +145,8 @@ func (c *Client) Build(job string, pr int, branch string) (*Build, error) {
 		return nil, err
 	}
 	return &Build{
-		jobName:  job,
-		pr:       pr,
+		jobName:  br.JobName,
+		pr:       br.PRNumber,
 		id:       buildID,
 		queueURL: loc,
 	}, nil

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -52,9 +52,9 @@ type Client struct {
 type BuildRequest struct {
 	JobName  string
 	PRNumber int
-	Branch   string
-	HeadSHA  string
+	BaseRef  string
 	BaseSHA  string
+	PullSHA  string
 }
 
 type Build struct {
@@ -125,12 +125,12 @@ func (c *Client) Build(br BuildRequest) (*Build, error) {
 	// These two are provided for backwards-compatability with scripts that
 	// used the ghprb plugin.
 	q.Set("ghprbPullID", strconv.Itoa(br.PRNumber))
-	q.Set("ghprbTargetBranch", br.Branch)
+	q.Set("ghprbTargetBranch", br.BaseRef)
 
 	q.Set("PULL_NUMBER", strconv.Itoa(br.PRNumber))
-	q.Set("PULL_BASE_BRANCH", br.Branch)
-	q.Set("PULL_HEAD_SHA", br.HeadSHA)
+	q.Set("PULL_BASE_REF", br.BaseRef)
 	q.Set("PULL_BASE_SHA", br.BaseSHA)
+	q.Set("PULL_PULL_SHA", br.PullSHA)
 	u.RawQuery = q.Encode()
 	resp, err := c.request(http.MethodPost, u.String())
 	if err != nil {


### PR DESCRIPTION
Mostly plumbing. I'm exposing these environment variables to the Jenkins job, `PULL_NUMBER`, `PULL_BASE_REF`, `PULL_PULL_SHA`, and `PULL_BASE_SHA`, and I'm exposing them to users/consumers of http://prow.k8s.io/data.js as `branch`, `head_sha`, and `base_sha` in each entry. I'm not showing it on the actual dash anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/907)
<!-- Reviewable:end -->
