### PR TITLE
Use kubekins-e2e:v20161024-fac6eee and set JENKINS_USE_GET_KUBE_SCRIPT=y on a few sacrificial jobs

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,7 +30,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20161012-49ce7f4'
+KUBEKINS_E2E_IMAGE_TAG='v20161024-fac6eee'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -267,6 +267,7 @@
             timeout: 150
             job-env: |
                 export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -210,6 +210,7 @@
             description: 'Run the flaky tests on GCE, sequentially.'
             timeout: 180
             job-env: |
+                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
                                          --ginkgo.skip=\[Feature:.+\]"
                 export PROJECT="k8s-jkns-e2e-gce-flaky"
@@ -218,6 +219,7 @@
             description: 'Run the flaky tests on GCE, sequentially.'
             timeout: 180
             job-env: |
+                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
                                          --ginkgo.skip=\[Feature:.+\]"
                 export PROJECT="k8s-jkns-gci-gce-flaky"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -104,6 +104,7 @@
                 - tests: ci/latest.txt
             timeout: 300
             job-env: |
+                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
                                          --ginkgo.skip=\[Feature:.+\]"
@@ -283,6 +284,7 @@
                 - tests: ci/latest.txt
             timeout: 300
             job-env: |
+                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
                                          --ginkgo.skip=\[Feature:.+\]"
@@ -619,6 +621,7 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_USE_SERVER_VERSION="y"
+                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export PROJECT="k8s-e2e-gke-staging-parallel"
         - 'gke-prod':  # kubernetes-e2e-gke-prod
             description: 'Run E2E tests on GKE prod endpoint.'


### PR DESCRIPTION
How I chose:
* **kubernetes-e2e-gce-gci-qa-slow-master** uses `JENKINS_USE_GCI_VERSION`. It has been failing for an unrelated reason for 2 weeks and nobody seems to have noticed, so if I happen to break it more, it's probably not a big deal.
* **kubernetes-e2e-gke-staging-parallel** uses `JENKINS_USE_SERVER_VERSION`, runs quickly, and doesn't block the submit queue.
* The rest are flaky suites, so nobody will cry (much) if they break. We've got GCE and GKE covered here.

I'm not testing anything on PR Jenkins yet, because release-1.2 and -1.3 will fail until we merge https://github.com/kubernetes/kubernetes/pull/35459 and https://github.com/kubernetes/kubernetes/pull/35458.

I intend to watch the builds closely after merging to make sure I haven't broken anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/913)
<!-- Reviewable:end -->
