### PR TITLE
Unset JENKINS_USE_GET_KUBE_SCRIPT for gke-staging-parallel and kubernetes-e2e-gce-gci-qa-slow-master

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -267,7 +267,6 @@
             timeout: 150
             job-env: |
                 export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
-                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -621,7 +621,6 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_USE_SERVER_VERSION="y"
-                export JENKINS_USE_GET_KUBE_SCRIPT=y
                 export PROJECT="k8s-e2e-gke-staging-parallel"
         - 'gke-prod':  # kubernetes-e2e-gke-prod
             description: 'Run E2E tests on GKE prod endpoint.'


### PR DESCRIPTION
The `cluster/get-kube-binaries.sh` script only exists on master, so 1.4 runs are failing to extract the test tarball.

Disabling this for now for non-master test runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/914)
<!-- Reviewable:end -->
