### PR TITLE
Explicitly download and extract tests for older release branches

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -126,6 +126,16 @@ function call_get_kube() {
     export KUBERNETES_RELEASE_URL
     KUBERNETES_SKIP_CONFIRM=y KUBERNETES_SKIP_CREATE_CLUSTER=y KUBERNETES_DOWNLOAD_TESTS=y \
       "$(dirname "${0}")/get-kube.sh"
+    if [[ ! -x kubernetes/cluster/get-kube-binaries.sh ]]; then
+      # If the get-kube-binaries.sh script doesn't exist, assume this is an older
+      # release without it, and thus the tests haven't been downloaded yet.
+      # We'll have to download and extract them ourselves instead.
+      echo "Grabbing test binaries since cluster/get-kube-binaries.sh does not exist."
+      local -r test_tarball=kubernetes-test.tar.gz
+      curl -L "${KUBERNETES_RELEASE_URL}/${KUBERNETES_RELEASE}/${test_tarball}" -o "${test_tarball}"
+      md5sum "${test_tarball}"
+      tar -xzf "${test_tarball}"
+    fi
 }
 
 ### END FUNCTIONS TO SUPPORT get-kube.sh ###


### PR DESCRIPTION
A workaround for the issues I discovered testing on Jenkins against release-1.4.

I'm not particularly happy about this, but I'm not sure there's a better way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/915)
<!-- Reviewable:end -->
