### PR TITLE
Use default value for KUBERNETES_RELEASE_URL if not set

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -132,7 +132,7 @@ function call_get_kube() {
       # We'll have to download and extract them ourselves instead.
       echo "Grabbing test binaries since cluster/get-kube-binaries.sh does not exist."
       local -r test_tarball=kubernetes-test.tar.gz
-      curl -L "${KUBERNETES_RELEASE_URL}/${KUBERNETES_RELEASE}/${test_tarball}" -o "${test_tarball}"
+      curl -L "${KUBERNETES_RELEASE_URL:-https://storage.googleapis.com/kubernetes-release/release}/${KUBERNETES_RELEASE}/${test_tarball}" -o "${test_tarball}"
       md5sum "${test_tarball}"
       tar -xzf "${test_tarball}"
     fi

--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -50,6 +50,7 @@ STAGE_KUBEMARK="KUBEMARK"
 
 : ${KUBE_GCS_RELEASE_BUCKET:="kubernetes-release"}
 : ${KUBE_GCS_DEV_RELEASE_BUCKET:="kubernetes-release-dev"}
+: ${JENKINS_USE_GET_KUBE_SCRIPT:=y}
 
 # Explicitly set config path so staging gcloud (if installed) uses same path
 export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"


### PR DESCRIPTION
I'll get this working eventually.

GCI build is broken with
```
+ echo 'Grabbing test binaries since cluster/get-kube-binaries.sh does not exist.'
+ local -r test_tarball=kubernetes-test.tar.gz
/workspace/e2e-runner.sh: line 135: KUBERNETES_RELEASE_URL: unbound variable
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/918)
<!-- Reviewable:end -->
