### PR TITLE
Delete legacy-runner

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -82,7 +82,6 @@
         echo "Exiting with code: ${{rc}}"
         exit ${{rc}}
     runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/test-infra/master/jenkins/dockerized-e2e-runner.sh")
-    legacy-runner: bash <(curl -fsS --retry 3  "https://raw.githubusercontent.com/kubernetes/test-infra/master/jenkins/e2e-image/e2e-runner.sh")
     post-env: |
         # Nothing should want Jenkins $HOME
         export HOME=${{WORKSPACE}}


### PR DESCRIPTION
We'll redownload e2e tests each time we run tests, so e2e tests might change slightly from run-to-run, but the cluster will still only be redeployed once a week.

Supersedes #927. There's probably an issue this fixes, too, but I don't know where it is.

TESTED=😆

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/928)

<!-- Reviewable:end -->
