### PR TITLE
Bump to kubekins-e2e:v20161026-2d02d8d

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,7 +30,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20161025-26f0cb0'
+KUBEKINS_E2E_IMAGE_TAG='v20161026-2d02d8d'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -23,6 +23,6 @@ build:
 	@echo Built $(IMG):$(TAG) and tagged with latest
 
 push: build
-	gcloud docker push $(IMG):$(TAG)
-	gcloud docker push $(IMG):latest
+	gcloud docker -- push $(IMG):$(TAG)
+	gcloud docker -- push $(IMG):latest
 	@echo Pushed $(IMG) with :latest and :$(TAG) tags


### PR DESCRIPTION
Hopefully the last one for a while!

This should include https://github.com/kubernetes/kubernetes/pull/35573, which should make upgrade/skew tests actually start testing the right versions again.

Image testing in https://github.com/kubernetes/kubernetes/pull/35083.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/932)
<!-- Reviewable:end -->
