### PR TITLE
Adding 1.3-1.4-head upgrade jobs for GKE

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -289,6 +289,17 @@
             version-infix: '1-4-1-3'
             version-env: |
                 export JENKINS_USE_SKEW_TESTS="true"
+        - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
+            version-cluster: '1.4'
+            version-client: 'latest'
+            version-infix: '1-4-lat'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
+            version-cluster: 'latest'
+            version-client: '1.4'
+            version-infix: 'lat-1-4'
+            version-env: |
+                export JENKINS_USE_SKEW_TESTS="true"
 
 # This is the job definition for all GCE kubectl skew tests
 - job-group:
@@ -470,4 +481,59 @@
             image-old: 'gci'
             image-new: 'gci'
             version-env: ''
-
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.3-container_vm-latest
+            version-old: '1.3'
+            version-new: 'latest'
+            version-infix: 'c1-3-clat'
+            image-old: 'container_vm'
+            image-new: 'container_vm'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.3-gci-latest
+            version-old: '1.3'
+            version-new: 'latest'
+            version-infix: 'c1-3-glat'
+            image-old: 'container_vm'
+            image-new: 'gci'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.3-container_vm-latest
+            version-old: '1.3'
+            version-new: 'latest'
+            version-infix: 'g1-3-clat'
+            image-old: 'gci'
+            image-new: 'container_vm'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.3-gci-latest
+            version-old: '1.3'
+            version-new: 'latest'
+            version-infix: 'g1-3-glat'
+            image-old: 'gci'
+            image-new: 'gci'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.4-container_vm-latest
+            version-old: '1.4'
+            version-new: 'latest'
+            version-infix: 'c1-4-clat'
+            image-old: 'container_vm'
+            image-new: 'container_vm'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.4-gci-latest
+            version-old: '1.4'
+            version-new: 'latest'
+            version-infix: 'c1-4-glat'
+            image-old: 'container_vm'
+            image-new: 'gci'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.4-container_vm-latest
+            version-old: '1.4'
+            version-new: 'latest'
+            version-infix: 'g1-4-clat'
+            image-old: 'gci'
+            image-new: 'container_vm'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.4-gci-latest
+            version-old: '1.4'
+            version-new: 'latest'
+            version-infix: 'g1-4-glat'
+            image-old: 'gci'
+            image-new: 'gci'
+            version-env: ''

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -505,6 +505,14 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew
 - name: kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
+- name: kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew
+- name: kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew
+- name: kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew
+- name: kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew
 - name: kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster
 - name: kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster-new
@@ -569,6 +577,54 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new
 - name: kubernetes-e2e-gce-1.3-1.4-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.3-1.4-upgrade-master
+- name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master
+- name: kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master
+- name: kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master
+- name: kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master
 - name: kubernetes-e2e-gce-1.4-1.3-cvm-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.3-cvm-kubectl-skew
 - name: kubernetes-e2e-gce-1.4-1.3-gci-kubectl-skew
@@ -1261,6 +1317,14 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
   - name: gce-1.4-1.3-gci-kubectl-skew
     test_group_name: kubernetes-e2e-gce-1.4-1.3-gci-kubectl-skew
+  - name: gke-1.4-latest-gci-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew
+  - name: gke-1.4-latest-cvm-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew
+  - name: gke-latest-1.4-gci-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew
+  - name: gke-latest-1.4-cvm-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew
 
 - name: google-1.2-1.3-upgrade
   dashboard_tab:
@@ -1348,6 +1412,57 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master
   - name: gke-gci-1.3-gci-1.4-upgrade-master
     test_group_name: kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master
+
+- name: google-gke-latest-upgrade
+  dashboard_tab:
+  - name: gke-container_vm-1.3-container_vm-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster
+  - name: gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new
+  - name: gke-container_vm-1.3-container_vm-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master
+  - name: gke-container_vm-1.3-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster
+  - name: gke-container_vm-1.3-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new
+  - name: gke-container_vm-1.3-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master
+  - name: gke-gci-1.3-container_vm-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster
+  - name: gke-gci-1.3-container_vm-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new
+  - name: gke-gci-1.3-container_vm-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master
+  - name: gke-gci-1.3-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster
+  - name: gke-gci-1.3-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new
+  - name: gke-gci-1.3-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master
+  - name: gke-container_vm-1.4-container_vm-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster
+  - name: gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new
+  - name: gke-container_vm-1.4-container_vm-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master
+  - name: gke-container_vm-1.4-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster
+  - name: gke-container_vm-1.4-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new
+  - name: gke-container_vm-1.4-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master
+  - name: gke-gci-1.4-container_vm-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster
+  - name: gke-gci-1.4-container_vm-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new
+  - name: gke-gci-1.4-container_vm-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master
+  - name: gke-gci-1.4-gci-latest-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster
+  - name: gke-gci-1.4-gci-latest-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new
+  - name: gke-gci-1.4-gci-latest-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master
 
 - name: google-federation
   dashboard_tab:


### PR DESCRIPTION
This is mostly copy pasted from the immediately preceding GCE config.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/941)

<!-- Reviewable:end -->
