### PR TITLE
Whitelist plugins based on repository.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HOOK_VERSION   = 0.41
+HOOK_VERSION   = 0.42
 LINE_VERSION   = 0.23
 SINKER_VERSION = 0.3
 DECK_VERSION   = 0.4

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -54,6 +54,7 @@ create-cluster:
 	kubectl create secret generic jenkins-token --from-file=jenkins=$(JENKINS_SECRET_FILE)
 	kubectl create configmap jenkins-address --from-file=jenkins-address=$(JENKINS_ADDRESS_FILE)
 	kubectl create configmap job-configs --from-file=jobs=jobs.yaml
+	kubectl create configmap plugins --from-file=plugins=plugins.yaml
 	@make line-image --no-print-directory
 	@make hook-image --no-print-directory
 	@make deck-image --no-print-directory
@@ -82,6 +83,9 @@ update-cluster: get-cluster-credentials
 update-jobs: get-cluster-credentials
 	kubectl create configmap job-configs --from-file=jobs=jobs.yaml --dry-run -o yaml | kubectl replace configmap job-configs -f -
 
+update-plugins: get-cluster-credentials
+	kubectl create configmap plugins --from-file=plugins=plugins.yaml --dry-run -o yaml | kubectl replace configmap plugins -f -
+
 get-cluster-credentials:
 	gcloud container clusters get-credentials ciongke --project="$(PROJECT)"
 
@@ -91,7 +95,7 @@ clean:
 test:
 	go test -cover $$(go list ./... | grep -v "\/vendor\/")
 
-.PHONY: create-cluster update-cluster update-jobs clean test get-cluster-credentials
+.PHONY: create-cluster update-cluster update-jobs update-plugins clean test get-cluster-credentials
 
 hook-image:
 	CGO_ENABLED=0 go build -o cmd/hook/hook k8s.io/test-infra/prow/cmd/hook

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -52,6 +52,9 @@ spec:
         - name: job-configs
           mountPath: /etc/jobs
           readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
+          readOnly: true
       volumes:
       - name: hmac
         secret:
@@ -62,3 +65,6 @@ spec:
       - name: job-configs
         configMap:
           name: job-configs
+      - name: plugins
+        configMap:
+          name: plugins

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.41
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.42
         imagePullPolicy: Always
         args:
         - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.23

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -37,7 +37,8 @@ var (
 	dryRun    = flag.Bool("dry-run", true, "Whether or not to avoid mutating calls to GitHub.")
 	org       = flag.String("org", "kubernetes", "GitHub org to trust.")
 
-	jobConfig = flag.String("job-config", "/etc/jobs/jobs", "Path to job config file.")
+	jobConfig    = flag.String("job-config", "/etc/jobs/jobs", "Path to job config file.")
+	pluginConfig = flag.String("plugin-config", "/etc/plugins/plugins", "Path to plugin config file.")
 
 	lineImage = flag.String("line-image", "", "Image to use for testing PRs.")
 
@@ -91,12 +92,16 @@ func main() {
 	jobAgent := &JobAgent{}
 	jobAgent.Start(*jobConfig)
 
+	pluginAgent := &PluginAgent{}
+	pluginAgent.Start(*pluginConfig)
+
 	githubAgent := &GitHubAgent{
 		DryRun:       *dryRun,
 		Org:          *org,
 		GitHubClient: githubClient,
 
 		JenkinsJobs: jobAgent,
+		Plugins:     pluginAgent,
 
 		PullRequestEvents:  prc,
 		IssueCommentEvents: icc,

--- a/prow/cmd/hook/plugins.go
+++ b/prow/cmd/hook/plugins.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/ghodss/yaml"
+)
+
+// TODO(spxtr): Consider better architectures for this that lets us test that
+// the yaml is valid.
+
+type PluginAgent struct {
+	mut sync.Mutex
+	// Repo FullName (eg "kubernetes/kubernetes") -> list of plugins
+	plugins map[string][]string
+}
+
+func (pa *PluginAgent) Start(path string) {
+	pa.tryLoad(path)
+	ticker := time.Tick(1 * time.Minute)
+	go func() {
+		for range ticker {
+			pa.tryLoad(path)
+		}
+	}()
+}
+
+func (pa *PluginAgent) Enabled(repo, plugin string) bool {
+	pa.mut.Lock()
+	defer pa.mut.Unlock()
+	for _, p := range pa.plugins[repo] {
+		if p == plugin {
+			return true
+		}
+	}
+	return false
+}
+
+// Hold the lock.
+func (pa *PluginAgent) load(path string) error {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	np := map[string][]string{}
+	if err := yaml.Unmarshal(b, &np); err != nil {
+		return err
+	}
+	pa.plugins = np
+	return nil
+}
+
+func (pa *PluginAgent) tryLoad(path string) {
+	pa.mut.Lock()
+	defer pa.mut.Unlock()
+	if err := pa.load(path); err != nil {
+		logrus.WithField("path", path).WithError(err).Error("Error loading plugin config.")
+	}
+}

--- a/prow/cmd/hook/trigger.go
+++ b/prow/cmd/hook/trigger.go
@@ -22,6 +22,9 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
+// TODO(spxtr): Move all of this into a separate package.
+
+const triggerPluginName = "trigger"
 const lgtmLabel = "lgtm"
 
 func (ga *GitHubAgent) prTrigger(pr github.PullRequestEvent) error {

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -1,0 +1,16 @@
+---
+google/cadvisor:
+- trigger
+
+kubernetes/charts:
+- trigger
+
+kubernetes/heapster:
+- trigger
+
+kubernetes/kubernetes:
+- trigger
+
+kubernetes/test-infra:
+- lgtm
+- trigger

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package lgtm
 
 import (
 	"testing"
@@ -122,9 +122,6 @@ func TestLGTMComment(t *testing.T) {
 		fc := &fakegithub.FakeClient{
 			IssueComments: make(map[int][]github.IssueComment),
 		}
-		ga := &GitHubAgent{
-			GitHubClient: fc,
-		}
 		ice := github.IssueCommentEvent{
 			Action: tc.action,
 			Comment: github.IssueComment{
@@ -142,7 +139,7 @@ func TestLGTMComment(t *testing.T) {
 		if tc.hasLGTM {
 			ice.Issue.Labels = []github.Label{{Name: lgtmLabel}}
 		}
-		if err := ga.lgtmComment(ice); err != nil {
+		if err := HandleIssueComment(fc, ice); err != nil {
 			t.Errorf("For case %s, didn't expect error from lgtmComment: %v", tc.name, err)
 			continue
 		}


### PR DESCRIPTION
Couple things to do in future PRs.

1. Move the triggering logic into its own package.
1. Make an actual plugin framework, rather than hardcoding function calls like this.

I think this is a good start, and it lets us use `/lgtm` in the test-infra repo first :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/942)
<!-- Reviewable:end -->
