### PR TITLE
Don't delete .git dirs in CI jobs.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/continuous-docker-validation.yaml
@@ -35,6 +35,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     publishers:
         - junit-publisher
         - email-ext:
@@ -118,6 +119,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     go-env: |
         export GOROOT=/usr/local/go
         export GOPATH=$WORKSPACE/go

--- a/jenkins/job-configs/kubernetes-jenkins/kops-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kops-build.yaml
@@ -23,6 +23,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     scm:
         - git:
             url: https://github.com/kubernetes/kops
@@ -43,6 +44,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
 
 - project:
     name: kops-builds

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-anywhere-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-anywhere-e2e.yaml
@@ -33,6 +33,7 @@
     - workspace-cleanup:
         dirmatch: true
         external-deletion-command: 'sudo rm -rf %s'
+        exclude: ['**/.git/']
     publishers:
     - junit-publisher
     - gcs-uploader

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-debian-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-debian-build.yaml
@@ -22,6 +22,7 @@
     - workspace-cleanup:
         dirmatch: true
         external-deletion-command: 'sudo rm -rf %s'
+        exclude: ['**/.git/']
     scm:
     - git:
         url: https://github.com/kubernetes/release
@@ -42,6 +43,7 @@
     - workspace-cleanup:
         dirmatch: true
         external-deletion-command: 'sudo rm -rf %s'
+        exclude: ['**/.git/']
 
 - project:
     name: kubernetes-debian-builds

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -43,6 +43,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
 
 - project:
     name: kubernetes-aws

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -46,6 +46,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     publishers:
         - junit-publisher
         - email-ext:
@@ -233,6 +234,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     publishers:
         - junit-publisher
         - email-ext:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -39,6 +39,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     publishers:
         - junit-publisher
         - email-ext:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -33,6 +33,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     triggers:
         - reverse:
             jobs: '{trigger-job}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -48,6 +48,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
 
 - project:
     name: kubernetes-kops-aws

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-garbagecollector.yaml
@@ -33,6 +33,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
         - e2e-credentials-binding
 
 - project:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -41,6 +41,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
 
 - job-template:
     name: 'kubernetes-soak-continuous-e2e-{suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -54,6 +54,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
 
 - project:
     name: kubernetes-test-go

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-verify.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-verify.yaml
@@ -39,6 +39,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
 
 - project:
     name: kubernetes-verify

--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -105,6 +105,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     # Template defaults. Can be override in job definition
     branch: 'master'
 
@@ -131,6 +132,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
 
 - project:
     name: node-gce-e2e

--- a/jenkins/job-configs/kubernetes-jenkins/testgrid-config-upload.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/testgrid-config-upload.yaml
@@ -28,6 +28,7 @@
         - workspace-cleanup:
             dirmatch: true
             external-deletion-command: 'sudo rm -rf %s'
+            exclude: ['**/.git/']
     builders:
         - activate-gce-service-account
         - shell: |


### PR DESCRIPTION
We're [seeing failures](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-test-go/18760/) where fetching the git repo is timing out after 10
minutes, since it's cloning slowly (~150KB/s).

Syntax should be good based on [the Jenkins plugin](https://wiki.jenkins-ci.org/display/JENKINS/Workspace+Cleanup+Plugin) and the [associated JavaDoc](http://www.docjar.org/docs/api/org/apache/tools/ant/DirectoryScanner.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/944)
<!-- Reviewable:end -->
