### PR TITLE
Disable PR kubemark tests on everything before release-1.4.

### DIFF
--- a/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
@@ -21,10 +21,12 @@ set -o xtrace
 readonly testinfra="$(dirname "${0}")/.."
 
 # TODO(fejta): remove this
-if [[ "${ghprbTargetBranch:-}" == "release-1.0" || "${ghprbTargetBranch:-}" == "release-1.1" ]]; then
-  echo "PR GCE job disabled for legacy branches."
-  exit
-fi
+case "${ghprbTargetBranch:-}" in
+release-1.0|release-1.1|release-1.2|release-1.3)
+  echo "PR Kubemark e2e GCE GCI job disabled for legacy branches."
+  exit 0
+  ;;
+esac
 
 export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"

--- a/jobs/pull-kubernetes-kubemark-e2e-gce.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce.sh
@@ -21,12 +21,12 @@ set -o xtrace
 readonly testinfra="$(dirname "${0}")/.."
 
 # TODO(fejta): remove this
-if [[ "${ghprbTargetBranch:-}" == "release-1.0" \
-      || "${ghprbTargetBranch:-}" == "release-1.1" \
-      || "${ghprbTargetBranch:-}" == "release-1.2" ]]; then
-  echo "PR GCE job disabled for legacy branches."
-  exit
-fi
+case "${ghprbTargetBranch:-}" in
+release-1.0|release-1.1|release-1.2|release-1.3)
+  echo "PR Kubemark e2e GCE job disabled for legacy branches."
+  exit 0
+  ;;
+esac
 
 export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"


### PR DESCRIPTION
Kubemark currently doesn't work on PR tests against release-1.3, and it's a nontrivial effort to fix ([details](https://github.com/kubernetes/kubernetes/pull/35720#issuecomment-256811420)). 

Let's just disable it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/946)
<!-- Reviewable:end -->
