### PR TITLE
Include protoc instruction

### DIFF
--- a/testgrid/config/README.md
+++ b/testgrid/config/README.md
@@ -13,11 +13,32 @@ User should only add/update config.yaml
 -- Yaml representation for configuring testgrid.k8s.io
 
 To add a new test:
+
 1. Append a new testgroup under test_groups, specity the name and where to get the log.
+
 2. Append a new dashboardtab under the dashboard you would like to add the testgroup to,
+
   or create a new dashboard and assign the testgroup to the dashboard.
+  
   * The testgroup name from a dashboardtab should match the name from a testgroup
+  
   ** Note that a testgroup can be within multiple dashboards. 
-3. Run config_test.go to make sure the config is valid.
+  
+3. Run `config_test.go` to make sure the config is valid.
+
 
 Contact us before you make changes to config.proto
+
+#
+Devs -
+If you changed config.proto, do:
+
+1. Make sure [protoc](https://github.com/golang/protobuf) is installed and
+
+2. `protoc --go_out=pb config.proto`
+
+3. Please kindly search-replace all `json:"foo,omitempty"` with `yaml:"foo,omitempty"`.
+
+   -- replace all `json:"` with `yaml:"` would work
+   
+4. Commit both config.proto and config.pb.go


### PR DESCRIPTION
Include protoc instruction when changing config.proto.

And fix the format - it was not very readable without new lines..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/955)
<!-- Reviewable:end -->
