### PR TITLE
Build kubernetes on kubernetes.

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -466,13 +466,6 @@ def build_name(started):
 
 def setup_credentials():
     """Run some sanity checks and activate gcloud."""
-    # TODO(fejta): also check aws, and skip gce check when not necessary.
-    if not os.path.isfile(os.environ[GCE_KEY_ENV]):
-        raise IOError(
-            'Cannot find gce ssh key',
-            os.environ[GCE_KEY_ENV],
-        )
-
     # TODO(fejta): stop activating inside the image
     # TODO(fejta): allow use of existing gcloud auth
     if not os.path.isfile(os.environ[SERVICE_ACCOUNT_ENV]):

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -967,7 +967,6 @@ class JobTest(unittest.TestCase):
             'errexit',
             'nounset',
             'pipefail',
-            'xtrace',
         }
         for job, job_path in self.jobs:
             with open(job_path) as fp:

--- a/jobs/pull-kubernetes-bazel.sh
+++ b/jobs/pull-kubernetes-bazel.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+bazel test --test_output=errors --test_tag_filters '-skip' //cmd/... //pkg/... //plugin/... && rc=$? || rc=$?
+case "${rc}" in
+    0) echo "Success" ;;
+    1) echo "Build failed" ;;
+    2) echo "Bad environment or flags" ;;
+    3) echo "Build passed, tests failed or timed out" ;;
+    4) echo "Build passed, no tests found" ;;
+    5) echo "Interrupted" ;;
+    *) echo "Unknown exit code: ${rc}" ;;
+esac
+
+# Copy bazel-testlogs/foo/bar/go_default_test/test.xml into _artifacts/foo_bar.xml.
+mkdir -p _artifacts
+for file in $(find -L bazel-testlogs -name "test.xml" -o -name "test.log"); do
+    cp "${file}" "_artifacts/$(echo "${file}" | sed -e "s/bazel-testlogs\///g; s/\/go_default_test\/test//g; s/\//_/g")"
+done
+
+exit "${rc}"

--- a/jobs/pull-kubernetes-bazel/Dockerfile
+++ b/jobs/pull-kubernetes-bazel/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes git, gcloud, and bazel.
+FROM ubuntu:16.04
+MAINTAINER spxtr@google.com
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    openjdk-8-jdk \
+    pkg-config \
+    zip \
+    unzip \
+    zlib1g-dev \
+    bash-completion \
+    git \
+    wget \
+    python && \
+    apt-get clean
+
+RUN wget https://github.com/bazelbuild/bazel/releases/download/0.3.2/bazel_0.3.2-linux-x86_64.deb && \
+    dpkg -i bazel_0.3.2-linux-x86_64.deb && \
+    rm bazel_0.3.2-linux-x86_64.deb
+
+RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-131.0.0-linux-x86_64.tar.gz && \
+    tar xf google-cloud-sdk-131.0.0-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-131.0.0-linux-x86_64.tar.gz && \
+    ./google-cloud-sdk/install.sh
+ENV PATH "/google-cloud-sdk/bin:${PATH}"
+
+WORKDIR /workspace

--- a/jobs/pull-kubernetes-bazel/Makefile
+++ b/jobs/pull-kubernetes-bazel/Makefile
@@ -1,0 +1,23 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION = 0.0
+
+image:
+	docker build -t "gcr.io/k8s-testimages/bazelbuild:$(VERSION)"
+
+push:
+	gcloud docker -- push "gcr.io/k8s-testimages/bazelbuild:$(VERSION)"
+
+.PHONY: image push

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HOOK_VERSION   = 0.42
-LINE_VERSION   = 0.23
+HOOK_VERSION   = 0.43
+LINE_VERSION   = 0.24
 SINKER_VERSION = 0.3
 DECK_VERSION   = 0.4
 

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,10 +33,10 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.42
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.43
         imagePullPolicy: Always
         args:
-        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.23
+        - --line-image=gcr.io/kubernetes-jenkins-pull/line:0.24
         - --org=kubernetes
         - --dry-run=false
         ports:

--- a/prow/cmd/hook/githubagent.go
+++ b/prow/cmd/hook/githubagent.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/jobs"
 	"k8s.io/test-infra/prow/plugins/lgtm"
 )
 
@@ -32,7 +33,7 @@ type GitHubAgent struct {
 	GitHubClient githubClient
 
 	Plugins     *PluginAgent
-	JenkinsJobs *JobAgent
+	JenkinsJobs *jobs.JobAgent
 
 	PullRequestEvents  <-chan github.PullRequestEvent
 	IssueCommentEvents <-chan github.IssueCommentEvent

--- a/prow/cmd/hook/kubeagent_test.go
+++ b/prow/cmd/hook/kubeagent_test.go
@@ -33,7 +33,6 @@ func TestCreateJob(t *testing.T) {
 	}
 	br := KubeRequest{
 		JobName: "kubernetes-e2e-gce",
-		Context: "GCE e2e",
 
 		RepoOwner: "kubernetes",
 		RepoName:  "kubernetes",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/jobs"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -89,7 +90,7 @@ func main() {
 		IssueCommentEvents: icc,
 	}
 
-	jobAgent := &JobAgent{}
+	jobAgent := &jobs.JobAgent{}
 	jobAgent.Start(*jobConfig)
 
 	pluginAgent := &PluginAgent{}

--- a/prow/cmd/line/main_test.go
+++ b/prow/cmd/line/main_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/jobs"
 )
 
 func TestFailureComment(t *testing.T) {
@@ -53,8 +54,10 @@ func TestFailureComment(t *testing.T) {
 		IssueCommentID: 9,
 	}
 	cl := testClient{
-		Job:          "test-job",
-		Context:      "Jenkins test",
+		Job: jobs.JenkinsJob{
+			Name:    "test-job",
+			Context: "Jenkins test",
+		},
 		PRNumber:     5,
 		PullSHA:      "abcde",
 		GitHubClient: ghc,
@@ -100,12 +103,12 @@ func TestGuberURL(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		c := &testClient{
-			Job:       "j",
+			Job:       jobs.JenkinsJob{Name: "j"},
 			PRNumber:  5,
 			RepoOwner: tc.RepoOwner,
 			RepoName:  tc.RepoName,
 		}
-		actual := c.guberURL(1)[len(guberBase):]
+		actual := c.guberURL("1")[len(guberBase):]
 		if actual != tc.ExpectedURL {
 			t.Errorf("Gubernator URL wrong. Got %s, expected %s", actual, tc.ExpectedURL)
 		}

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -1,7 +1,7 @@
 # PR Jenkins job triggering definitions.
 # Keys: Full repo name: "org/repo".
 # Values: List of jobs to run when events occur in the repo.
-#   name:          Jenkins job name.
+#   name:          Job name.
 #   trigger:       Regexp commenters can say to trigger the job.
 #   always_run:    Whether to run for every PR. Default is false. If this is
 #                  set then your trigger needs to match "@k8s-bot test this".
@@ -9,9 +9,11 @@
 #   rerun_command: How should users trigger just this job, as a string, not a
 #                  regex. For example, if the trigger regex is "(e2e )?test",
 #                  then a rerun command might be "e2e test".
+#   spec:          If this exists then run a kubernetes pod with this spec.
+#                  Otherwise, run a Jenkins job.
 # The unit tests in cmd/hook/jobs_test.go ensure that the job definitions are
 # valid.
-# TODO(fejta): ensure all jobs define an owner
+# TODO(fejta): Ensure all jobs define an owner.
 ---
 google/cadvisor:
 - name: pull-cadvisor-e2e
@@ -35,6 +37,44 @@ kubernetes/heapster:
   trigger: "@k8s-bot test this"
 
 kubernetes/kubernetes:
+- name: pull-kubernetes-bazel
+  context: Jenkins Bazel Build
+  rerun_command: "@k8s-bot bazel build this"
+  trigger: "@k8s-bot bazel build this"
+  spec:
+    nodeSelector:
+      role: build
+    containers:
+    - name: builder
+      image: gcr.io/k8s-testimages/bazelbuild:0.0
+      command: ["/bin/bash", "-c"]
+      args: ["git clone https://github.com/kubernetes/test-infra && ./test-infra/jenkins/bootstrap.py --repo=github.com/kubernetes/kubernetes --pull=${PULL_NUMBER} --branch=${PULL_BASE_REF} --job=pull-kubernetes-bazel"]
+      volumeMounts:
+      - name: cache-ssd
+        mountPath: /root/.cache/bazel
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      # We only want one of these to run per node. Once pod affinity is GA, use
+      # that. Until then, use a hostPort.
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # Bazel needs privileged mode in order to sandbox builds.
+      securityContext:
+        privileged: true
+    restartPolicy: Never
+    volumes:
+    - name: cache-ssd
+      hostPath:
+        path: /mnt/disks/ssd0
+    - name: service
+      secret:
+        secretName: service-account
+
 - name: pull-kubernetes-cross
   context: Jenkins Cross Build
   rerun_command: "@k8s-bot build this"

--- a/prow/jobs/jobs_test.go
+++ b/prow/jobs/jobs_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package jobs
 
 import (
 	"fmt"
@@ -28,7 +28,7 @@ const testThis = "@k8s-bot test this"
 // Make sure that our rerun commands match our triggers.
 func TestJobTriggers(t *testing.T) {
 	ja := &JobAgent{}
-	if err := ja.load("../../jobs.yaml"); err != nil {
+	if err := ja.load("../jobs.yaml"); err != nil {
 		t.Fatalf("Could not load job configs: %v", err)
 	}
 	if len(ja.jobs) == 0 {
@@ -66,14 +66,14 @@ func TestJobTriggers(t *testing.T) {
 				}
 			}
 			// Ensure that jobs have a shell script of the same name.
-			if s, err := os.Stat(fmt.Sprintf("../../../jobs/%s.sh", job.Name)); err != nil {
+			if s, err := os.Stat(fmt.Sprintf("../../jobs/%s.sh", job.Name)); err != nil {
 				t.Errorf("Cannot find test-infra/jobs/%s.sh", job.Name)
 			} else {
-				if s.Mode() & 0111 == 0 {
-					t.Errorf("Not executable: %s.sh (%o)", job.Name, s.Mode() & 0777)
+				if s.Mode()&0111 == 0 {
+					t.Errorf("Not executable: %s.sh (%o)", job.Name, s.Mode()&0777)
 				}
-				if s.Mode() & 0444 == 0 {
-					t.Errorf("Not readable: %s.sh (%o)", job.Name, s.Mode() & 0777)
+				if s.Mode()&0444 == 0 {
+					t.Errorf("Not readable: %s.sh (%o)", job.Name, s.Mode()&0777)
 				}
 			}
 		}
@@ -156,7 +156,7 @@ func TestCommentBodyMatches(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		actualJobs := ja.MatchingJobs(tc.repo, tc.body)
+		actualJobs := ja.MatchingJobs(tc.repo, tc.body, regexp.MustCompile(`ok to test`))
 		match := true
 		if len(actualJobs) != len(tc.expectedJobs) {
 			match = false

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -125,6 +125,18 @@ func NewClientInCluster(namespace string) (*Client, error) {
 		namespace: namespace,
 	}, nil
 }
+func (c *Client) GetPod(name string) (Pod, error) {
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s", c.namespace, name)
+	body, err := c.request(http.MethodGet, path, map[string]string{}, nil)
+	if err != nil {
+		return Pod{}, err
+	}
+	var retPod Pod
+	if err = json.Unmarshal(body, &retPod); err != nil {
+		return Pod{}, err
+	}
+	return retPod, nil
+}
 
 func (c *Client) ListPods(labels map[string]string) ([]Pod, error) {
 	var sel []string
@@ -189,6 +201,24 @@ func (c *Client) ListJobs(labels map[string]string) ([]Job, error) {
 		return nil, err
 	}
 	return jl.Items, nil
+}
+
+func (c *Client) CreatePod(p Pod) (Pod, error) {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return Pod{}, err
+	}
+	buf := bytes.NewBuffer(b)
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods", c.namespace)
+	body, err := c.request(http.MethodPost, path, map[string]string{}, buf)
+	if err != nil {
+		return Pod{}, err
+	}
+	var retPod Pod
+	if err = json.Unmarshal(body, &retPod); err != nil {
+		return Pod{}, err
+	}
+	return retPod, nil
 }
 
 func (c *Client) CreateJob(j Job) (Job, error) {

--- a/prow/kube/client_test.go
+++ b/prow/kube/client_test.go
@@ -112,6 +112,48 @@ func TestListJobs(t *testing.T) {
 	}
 }
 
+func TestGetPod(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/namespaces/ns/pods/po" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"metadata": {"name": "abcd"}}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	po, err := c.GetPod("po")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if po.Metadata.Name != "abcd" {
+		t.Errorf("Wrong name: %s", po.Metadata.Name)
+	}
+}
+
+func TestCreatePod(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/namespaces/ns/pods" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"metadata": {"name": "abcd"}}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	po, err := c.CreatePod(Pod{})
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if po.Metadata.Name != "abcd" {
+		t.Errorf("Wrong name: %s", po.Metadata.Name)
+	}
+}
+
 func TestCreateJob(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -64,9 +64,10 @@ type Pod struct {
 }
 
 type PodSpec struct {
-	Volumes       []Volume    `json:"volumes,omitempty"`
-	Containers    []Container `json:"containers,omitempty"`
-	RestartPolicy string      `json:"restartPolicy,omitempty"`
+	Volumes       []Volume          `json:"volumes,omitempty"`
+	Containers    []Container       `json:"containers,omitempty"`
+	RestartPolicy string            `json:"restartPolicy,omitempty"`
+	NodeSelector  map[string]string `json:"nodeSelector,omitempty"`
 }
 
 type PodPhase string
@@ -90,6 +91,16 @@ type Volume struct {
 	Name        string             `json:"name,omitempty"`
 	Secret      *SecretSource      `json:"secret,omitempty"`
 	DownwardAPI *DownwardAPISource `json:"downwardAPI,omitempty"`
+	HostPath    *HostPathSource    `json:"hostPath,omitempty"`
+	ConfigMap   *ConfigMapSource   `json:"configMap,omitempty"`
+}
+
+type ConfigMapSource struct {
+	Name string `json:"name,omitempty"`
+}
+
+type HostPathSource struct {
+	Path string `json:"path,omitempty"`
 }
 
 type SecretSource struct {
@@ -116,15 +127,21 @@ type Container struct {
 	Args    []string `json:"args,omitempty"`
 	WorkDir string   `json:"workingDir,omitempty"`
 	Env     []EnvVar `json:"env,omitempty"`
+	Ports   []Port   `json:"ports,omitempty"`
 
 	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
 	VolumeMounts    []VolumeMount    `json:"volumeMounts,omitempty"`
 }
 
+type Port struct {
+	ContainerPort int `json:"containerPort,omitempty"`
+	HostPort      int `json:"hostPort,omitempty"`
+}
+
 type EnvVar struct {
-	Name      string       `json:"name,omitempty"`
-	Value     string       `json:"value,omitempty"`
-	ValueFrom EnvVarSource `json:"valueFrom,omitempty"`
+	Name      string        `json:"name,omitempty"`
+	Value     string        `json:"value,omitempty"`
+	ValueFrom *EnvVarSource `json:"valueFrom,omitempty"`
 }
 
 type EnvVarSource struct {


### PR DESCRIPTION
1. `cmd/line` consumes `jobs.yaml` instead of being passed pieces of it as arguments.
2. If a job has a field called `spec` of type `kube.PodSpec` then we will start a Kubernetes pod instead of a Jenkins job. This isn't a great way to switch between the two modes, and I'd like to improve it.
3. I added `pull-kubernetes-bazel`.

Sorry that this is a tricky PR to review. `cmd/line` is a mess and this doesn't help. I would like to clean it up and test it properly in a future PR, but I didn't want this PR to get too monstrous.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/957)

<!-- Reviewable:end -->
