### PR TITLE
Decrease timeout for kubemark-scale

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-kubemark.yaml
@@ -150,7 +150,7 @@
             # reusing "build" tag here once agents will have this tag.
             jenkins_node: 'build'
             # 12h - load tests take really, really, really long time.
-            timeout: 720
+            timeout: 600
             cron-string: 'H H/12 * * *'
             job-env: |
                 export ENABLE_GARBAGE_COLLECTOR="true"


### PR DESCRIPTION
The problem is that once it first times out, the next run is failing because the cluster disappears. And we are in the kind of "crash-loop' in that mode then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/958)
<!-- Reviewable:end -->
