### PR TITLE
testgrid: only load 4 days of test-go results

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -459,12 +459,16 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-cri
 - name: kubernetes-test-go
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-test-go
+  days_of_results: 4
 - name: kubernetes-test-go-release-1.2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-test-go-release-1.2
+  days_of_results: 4
 - name: kubernetes-test-go-release-1.3
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-test-go-release-1.3
+  days_of_results: 4
 - name: kubernetes-test-go-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-test-go-release-1.4
+  days_of_results: 4
 - name: kubernetes-verify-master
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-verify-master
 - name: kubernetes-verify-release-1.4


### PR DESCRIPTION
We can't currently display 14 days of results, because of AppEngine timeouts and RAM limits. This should work better.

/cc @fejta @gmarek

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/960)
<!-- Reviewable:end -->
