### PR TITLE
Allow GCI tests to patch buggy k8s

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -181,19 +181,29 @@ function install_google_cloud_sdk_tarball() {
     gcloud info
 }
 
-# Figures out the builtin k8s version of a GCI image.
+# Sets release vars using GCI image builtin k8s version.
+# If JENKINS_GCI_PATCH_K8S is set, uses the latest CI build on the same branch
+# instead.
 # Assumes: JENKINS_GCI_HEAD_IMAGE_FAMILY and KUBE_GCE_MASTER_IMAGE
-function get_gci_k8s_version() {
+function set_release_vars_from_gci_builtin_version() {
     if ! [[ "${JENKINS_USE_GCI_VERSION:-}" =~ ^[yY]$ ]]; then
         echo "JENKINS_USE_GCI_VERSION must be set."
         exit 1
     fi
     if [[ -z "${JENKINS_GCI_HEAD_IMAGE_FAMILY:-}" ]] || [[ -z "${KUBE_GCE_MASTER_IMAGE:-}" ]]; then
-        echo "JENKINS_GCI_HEAD_IMAGE_FAMILY and KUBE_GCE_MASTER_IMAGE must be set."
+        echo "JENKINS_GCI_HEAD_IMAGE_FAMILY and KUBE_GCE_MASTER_IMAGE must both be set."
         exit 1
     fi
-    local -r gci_k8s_version="v$(gsutil cat gs://container-vm-image-staging/k8s-version-map/${KUBE_GCE_MASTER_IMAGE})"
-    echo "${gci_k8s_version}"
+    local -r gci_k8s_version="$(gsutil cat gs://container-vm-image-staging/k8s-version-map/${KUBE_GCE_MASTER_IMAGE})"
+    if [[ "${JENKINS_GCI_PATCH_K8S}" =~ ^[yY]$ ]]; then
+        # We always want to test against the builtin k8s version, but occationally
+        # the builtin version has known bugs that keep our tests red. In those
+        # cases, we use the latest CI build on the same branch instead.
+        set_release_vars_from_gcs "ci/latest-${gci_k8s_version:0:3}"
+    else
+        KUBERNETES_RELEASE="v${gci_k8s_version}"
+        # Use the default KUBERNETES_RELEASE_URL.
+    fi
 }
 
 # Specific settings for tests that use GCI HEAD images. I.e., if your test is
@@ -288,8 +298,8 @@ else
         # test what's running in GKE by default rather than some CI build.
         set_release_vars_from_gke_cluster_version
     elif [[ "${JENKINS_USE_GCI_VERSION:-}" =~ ^[yY]$ ]]; then
-        KUBERNETES_RELEASE="$(get_gci_k8s_version)"
-        # Use the default KUBERNETES_RELEASE_URL.
+        # Use GCI image builtin version. Needed for GCI release qual tests.
+        set_release_vars_from_gci_builtin_version
     else
         # use JENKINS_PUBLISHED_VERSION, default to 'ci/latest', since that's
         # usually what we're testing.

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -264,6 +264,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-master"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'slow-master':  # kubernetes-e2e-gce-gci-qa-slow-master
             description: 'Runs slow tests on GCE with GCI images from the master branch, sequentially.'
             timeout: 150
@@ -274,6 +275,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-master"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'serial-master':  # kubernetes-e2e-gce-gci-qa-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images from the master branch.'
             timeout: 300
@@ -282,6 +284,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-master"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'm55':  # kubernetes-e2e-gce-gci-qa-m55
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 55, in parallel.'
             timeout: 50
@@ -290,6 +293,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m55"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'slow-m55':  # kubernetes-e2e-gce-gci-qa-slow-m55
             description: 'Runs slow tests on GCE with GCI images on milestone 55, sequentially.'
             timeout: 150
@@ -299,6 +303,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m55"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'serial-m55':  # kubernetes-e2e-gce-gci-qa-serial-m55
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 55.'
             timeout: 300
@@ -307,6 +312,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m55"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'm54':  # kubernetes-e2e-gce-gci-qa-m54
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 54, in parallel.'
             timeout: 50
@@ -315,6 +321,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m54"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'slow-m54':  # kubernetes-e2e-gce-gci-qa-slow-m54
             description: 'Runs slow tests on GCE with GCI images on milestone 54, sequentially.'
             timeout: 150
@@ -324,6 +331,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m54"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'serial-m54':  # kubernetes-e2e-gce-gci-qa-serial-m54
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 54.'
             timeout: 300
@@ -332,6 +340,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m54"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'm53':  # kubernetes-e2e-gce-gci-qa-m53
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 53, in parallel.'
             timeout: 50
@@ -340,6 +349,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m53"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'slow-m53':  # kubernetes-e2e-gce-gci-qa-slow-m53
             description: 'Runs slow tests on GCE with GCI images on milestone 53, sequentially.'
             timeout: 150
@@ -349,6 +359,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m53"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'serial-m53':  # kubernetes-e2e-gce-gci-qa-serial-m53
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 53.'
             timeout: 300
@@ -357,6 +368,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m53"
+                export JENKINS_GCI_PATCH_K8S="y"
         - 'm52':  # kubernetes-e2e-gce-gci-qa-m52
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 52, in parallel.'
             timeout: 50  # See #21138


### PR DESCRIPTION
GCI QA tests use the builtin k8s version, which could have known bugs that keep the tests red. In these occasions, we have to wait for the next patch release before tests come back green.

This PR adds a config flag, `JENKINS_GCI_PATCH_K8S`, which if set, tells the tests to use the latest CI build of k8s on the same branch as the builtin one, so that we can pick up bugfixes sooner (_just as what GKE tests do_). The flag is applied to all GCI milestones except m52, which will deleted soon enough.

@adityakali @ixdy Can you review?

cc/ @kubernetes/goog-image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/961)
<!-- Reviewable:end -->
