### PR TITLE
Fixing image type for GKE soak tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -298,7 +298,7 @@
                 export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
                 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export KUBE_GKE_IMAGE_TYPE="debian"
+                export KUBE_GKE_IMAGE_TYPE="container_vm"
             job-env: |
                 export PROJECT="k8s-jkns-gke-soak"
                 # Need at least n1-standard-2 nodes to run kubelet_perf tests


### PR DESCRIPTION
A few weeks ago, and environment variable name was corrected, but the
value of the variable was never verified. This test has been broken
since then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/978)
<!-- Reviewable:end -->
