### PR TITLE
kops: Add kops AWS PR builder

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml
@@ -89,6 +89,10 @@
         max-total: 12
         job-name: pull-kubernetes-e2e-gke-gci
         repo-name: 'k8s.io/kubernetes'
+    - kubernetes-e2e-kops-aws:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-kops-aws
+        repo-name: 'k8s.io/kubernetes'
     - kubernetes-federation-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-federation-e2e-gce

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -36,7 +36,7 @@
             export KOPS_DEPLOY_LATEST_KUBE=y
             export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
             # TODO(zmerlynn): Take out --kops-ssh-key after fixing kops-e2e-runner again.
-            export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${{E2E_NAME}}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/"
+            export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${{E2E_NAME}}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/ --kops-nodes=4"
             export GINKGO_PARALLEL="y"
             timeout -k {kill-timeout}m {timeout}m {runner} && rc=$? || rc=$?
             {report-rc}

--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+# TODO(fejta): remove this
+case "${ghprbTargetBranch:-}" in
+  "release-1.0"|"release-1.1"|"release-1.2"|"release-1.3")
+    echo "PR AWS kops job disabled for legacy branches."
+    exit
+    ;;
+esac
+
+export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
+export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
+export KUBE_GCS_UPDATE_LATEST=n
+export JENKINS_USE_LOCAL_BINARIES=y
+export KUBE_FASTBUILD=true
+
+if [[ -z "${SKIP_BUILD:-}" ]]; then
+  ./hack/jenkins/build.sh
+fi
+
+readonly version=$(source build-tools/util.sh && echo $(kube::release::semantic_version))
+export KUBERNETES_PROVIDER="kops-aws"
+
+export KOPS_STATE_STORE="${KOPS_STATE_STORE:-s3://k8s-kops-jenkins/}"
+export KOPS_CLUSTER_DOMAIN="${KOPS_CLUSTER_DOMAIN:-test-aws.k8s.io}"
+export E2E_NAME="aws-kops-${NODE_NAME}-${EXECUTOR_NUMBER:-0}"
+export E2E_OPT="${E2E_OPT:-}\
+  --kops-cluster ${E2E_NAME}.${KOPS_CLUSTER_DOMAIN}\
+  --kops-kubernetes-version https://storage.googleapis.com/${KUBE_GCS_RELEASE_BUCKET}/ci${KUBE_GCS_RELEASE_SUFFIX}/${version}\
+  --kops-nodes 4\
+  --kops-state ${KOPS_STATE_STORE}"
+export E2E_MIN_STARTUP_PODS="1"
+
+export AWS_CONFIG_FILE="/workspace/.aws/credentials"
+export AWS_SHARED_CREDENTIALS_FILE="/workspace/.aws/credentials"
+
+# Flake detection. Individual tests get a second chance to pass.
+export GINKGO_TOLERATE_FLAKES="y"
+export GINKGO_PARALLEL="y"
+# This list should match the list in kubernetes-e2e-kops-aws.
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector|Dashboard|Services.*functioning.*NodePort'
+# GINKGO_PARALLEL_NODES should match kubernetes-e2e-kops-aws.
+export GINKGO_PARALLEL_NODES="30"
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="true"
+export E2E_TEST="true"
+export E2E_DOWN="true"
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+
+# Get golang into our PATH so we can run e2e.go
+export PATH=${PATH}:/usr/local/go/bin
+
+export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
+timeout -k 15m 55m "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
+if [[ ${rc} -ne 0 ]]; then
+  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+    echo "Dumping logs for any remaining nodes"
+    ./cluster/log-dump.sh _artifacts
+  fi
+fi
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+  echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+  echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -122,6 +122,11 @@ kubernetes/kubernetes:
   rerun_command: "@k8s-bot gci gce e2e test this"
   trigger: "@k8s-bot (gci )?(gce )?(e2e )?test this"
 
+- name: pull-kubernetes-e2e-kops-aws
+  context: Jenkins kops AWS e2e
+  rerun_command: "@k8s-bot kops aws e2e test this"
+  trigger: "@k8s-bot kops aws (e2e )?test this"
+
 - name: pull-kubernetes-federation-e2e-gce
   context: Jenkins Federation GCE e2e
   rerun_command: "@k8s-bot federation gce e2e test this"


### PR DESCRIPTION
This is the PR builder for the Kubernetes repo for AWS-via-kops. After
I get this working, I'll implement the PR builder for the kops repo as
well (which can use this same script, but I need to fix something in
the e2e image first).

Along the way: bump `kops-node` to 4 in the main test run as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/979)
<!-- Reviewable:end -->
