### PR TITLE
kops: Allow KOPS_URL to be overridden

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -20,12 +20,14 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-readonly KOPS_LATEST=${KOPS_LATEST:-"latest-ci.txt"}
-readonly LATEST_URL="https://storage.googleapis.com/kops-ci/bin/${KOPS_LATEST}"
-readonly KOPS_URL=$(curl -fsS --retry 3 "${LATEST_URL}")
-if [[ -z "${KOPS_URL}" ]]; then
-  echo "Can't fetch kops latest URL" >&2
-  exit 1
+if [[ -z "${KOPS_URL:-}" ]]; then
+  readonly KOPS_LATEST=${KOPS_LATEST:-"latest-ci.txt"}
+  readonly LATEST_URL="https://storage.googleapis.com/kops-ci/bin/${KOPS_LATEST}"
+  readonly KOPS_URL=$(curl -fsS --retry 3 "${LATEST_URL}")
+  if [[ -z "${KOPS_URL}" ]]; then
+    echo "Can't fetch kops latest URL" >&2
+    exit 1
+  fi
 fi
 
 curl -fsS --retry 3 -o "${WORKSPACE}/kops" "${KOPS_URL}/linux/amd64/kops"


### PR DESCRIPTION
This is a pre-req for a PR builder in the kops repo.
c.f. #979

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/980)
<!-- Reviewable:end -->
