### PR TITLE
Adding test cases for release 1.5

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -90,5 +90,15 @@
               export KUBE_FASTBUILD=true
               export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-4
               export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release-1-4
+        - 'federation-build-1.5':
+            branch: 'release-1.5'
+            timeout: 50
+            job-env: |
+              export PROJECT="k8s-jkns-e2e-gce-f8n-1-5"
+              export FEDERATION=true
+              export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-f8n-1-5"
+              export KUBE_FASTBUILD=true
+              export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-5
+              export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release-1-5
     jobs:
         - 'kubernetes-{build}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml
@@ -66,6 +66,10 @@
             branch: 'release-1.4'
             timeout: 50
             job-env: ''  # Empty expected
+        - 'build-1.5':
+            branch: 'release-1.5'
+            timeout: 50
+            job-env: ''  # Empty expected
         - 'federation-build':
             branch: 'master'
             timeout: 50

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-aws.yaml
@@ -68,5 +68,13 @@
                 export E2E_NAME="e2e-aws-1-4"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector"
+        - 'aws-release-1.5':  # kubernetes-e2e-aws-release-1.5
+            description: 'Run e2e tests on AWS using the latest successful 1.5 Kubernetes build.'
+            cron-string: '@daily'
+            trigger-job: 'kubernetes-build-1.5'
+            job-env: |
+                export E2E_NAME="e2e-aws-1-5"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector"
     jobs:
         - 'kubernetes-e2e-{aws-suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -98,6 +98,37 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-ci-serial"
+        - 'release-1.5':  # kubernetes-e2e-gce-gci-ci-release-1.5
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.5 branch.'
+            timeout: 50
+            trigger-job: 'kubernetes-build-1.5'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="kubekins-gce-gci-ci-1-5"
+        - 'slow-release-1.5':  # kubernetes-e2e-gce-gci-ci-slow-release-1.5
+            description: 'Runs slow tests on GCE with GCI images, sequentially on the release-1.5 branch.'
+            timeout: 150
+            trigger-job: 'kubernetes-build-1.5'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="kubekins-gce-gci-ci-slow-1-5"
+        - 'serial-release-1.5':  # kubernetes-e2e-gce-gci-ci-serial-release-1.5
+            description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images, on the release-1.5 branch.'
+            timeout: 300
+            trigger-job: 'kubernetes-build-1.5'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="kubekins-gce-gci-ci-serial-1-5"
         - 'release-1.4':  # kubernetes-e2e-gce-gci-ci-release-1.4
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images in parallel on the release-1.4 branch.'
             timeout: 50

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -794,6 +794,120 @@
         - 'kubernetes-e2e-{suffix}'
 
 - project:
+    name: kubernetes-e2e-gce-1-5
+    trigger-job: 'kubernetes-build-1.5'
+    test-owner: 'saad-ali'
+    suffix:
+        - 'gce-release-1.5':  # kubernetes-e2e-gce-release-1.5
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.5 branch.'
+            timeout: 50  # See kubernetes/kubernetes#21138
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-gce-1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-reboot-release-1.5':  # kubernetes-e2e-gce-reboot-release-1.5
+            description: 'Run [Feature:Reboot] tests on GCE on the release-1.5 branch.'
+            timeout: 180
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export PROJECT="k8s-jkns-gce-reboot-1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-slow-release-1.5':  # kubernetes-e2e-gce-slow-release-1.5
+            description: 'Runs slow tests on GCE, sequentially on the release-1.5 branch.'
+            timeout: 150  #  See kubernetes/kubernetes#24072
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="k8s-jkns-gce-slow-1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-serial-release-1.5':  # kubernetes-e2e-gce-serial-release-1.5
+            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.5 branch.'
+            timeout: 300
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="k8s-jkns-gce-serial-1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-ingress-release-1.5':  # kubernetes-e2e-gce-ingress-release-1.5
+            description: 'Run [Feature:Ingress] tests on GCE on the release-1.5 branch.'
+            timeout: 90
+            emails: 'beeps@google.com'
+            test-owner: 'beeps'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+                export PROJECT="k8s-jkns-gce-ingress1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-alpha-features-release-1.5': # kubernetes-e2e-gce-alpha-features-release-1.5
+            description: 'Run alpha feature tests on GCE on the release-1.5 branch.'
+            timeout: 180
+            job-env: |
+                export KUBE_FEATURE_GATES="AllAlpha=true"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
+                export PROJECT="k8s-jkns-e2e-gce-alpha1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+        # Uncomment when 1.4 scale tests are turned off
+        # - 'gce-scalability-release-1.5':  # kubernetes-e2e-gce-scalability-release-1.5
+        #     description: 'Run scalability E2E tests on GCE from the release-1.5 branch.'
+        #     timeout: 120
+        #     cron-string: '@daily'
+        #     job-env: |
+        #         export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+        #         export E2E_NAME="e2e-scalability-1-5"
+        #         export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+        #                                  --gather-resource-usage=true \
+        #                                  --gather-metrics-at-teardown=true \
+        #                                  --gather-logs-sizes=true \
+        #                                  --output-print-type=json"
+        #         # Use the 1.1 project for now, since it has quota.
+        #         # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+        #         export PROJECT="k8s-e2e-gce-scalability-1-1"
+        #         export FAIL_ON_GCP_RESOURCE_LEAK="false"
+        #         # Override GCE defaults.
+        #         export KUBE_GCE_ZONE="us-east1-b"
+        #         export MASTER_SIZE="n1-standard-4"
+        #         export NODE_SIZE="n1-standard-1"
+        #         export NODE_DISK_SIZE="50GB"
+        #         export NUM_NODES="100"
+        #         export REGISTER_MASTER="true"
+        #         # Reduce logs verbosity
+        #         export TEST_CLUSTER_LOG_LEVEL="--v=2"
+        #         # TODO: Remove when we figure out the reason for occasional failures #19048
+        #         export KUBELET_TEST_LOG_LEVEL="--v=4"
+        #         # Increase resync period to simulate production
+        #         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+        #         # Increase delete collection parallelism
+        #         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+        #         export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-federation-release-1.5':  # kubernetes-e2e-gce-federation-1.5
+            # This test depends on the artifacts generated by the trigger-job. Be careful while changing this test.
+            trigger-job: 'kubernetes-federation-build-1.5'
+            description: 'Run all federation e2e tests.'
+            timeout: 300
+            emails: 'quinton@google.com, colin.hom@coreos.com, madhusudancs@google.com'
+            test-owner: 'madhusudancs'
+            job-env: |
+                export PROJECT="k8s-jkns-e2e-gce-f8n-1-5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
+                export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
+                export FEDERATION="true"
+                export DNS_ZONE_NAME="release1-5.test-f8n.k8s.io."
+                export FEDERATIONS_DOMAIN_MAP="federation=release1-5.test-f8n.k8s.io"
+                export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
+                export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-f8n-1-5"
+                export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
+                export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-5
+                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-5
+    jobs:
+        - 'kubernetes-e2e-{suffix}'
+- project:
     name: kubernetes-e2e-gci-gce-1-4
     trigger-job: 'kubernetes-build-1.4'
     test-owner: 'pwittrock'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -907,6 +907,103 @@
                 export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-5
     jobs:
         - 'kubernetes-e2e-{suffix}'
+
+- project:
+    name: kubernetes-e2e-gci-gce-1-5
+    trigger-job: 'kubernetes-build-1.5'
+    test-owner: 'saad-ali'
+    suffix:
+        - 'gci-gce-release-1.5':  # kubernetes-e2e-gci-gce-release-1.5
+            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.5 branch, using GCI image.'
+            timeout: 50
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-1-5"
+                export KUBE_OS_DISTRIBUTION="gci"
+        - 'gci-gce-reboot-release-1.5':  # kubernetes-e2e-gci-gce-reboot-release-1.5
+            description: 'Run [Feature:Reboot] tests on GCE on the release-1.5 branch.'
+            timeout: 180
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export PROJECT="k8s-jkns-gci-gce-reboot-1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+        - 'gci-gce-slow-release-1.5':  # kubernetes-e2e-gci-gce-slow-release-1.5
+            description: 'Runs slow tests on GCE, sequentially on the release-1.5 branch, using GCI image.'
+            timeout: 150
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export PROJECT="e2e-gce-gci-ci-slow-1-5"
+                export KUBE_OS_DISTRIBUTION="gci"
+        - 'gci-gce-serial-release-1.5':  # kubernetes-e2e-gci-gce-serial-release-1.5
+            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.5 branch, using GCI image.'
+            timeout: 300
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export PROJECT="e2e-gce-gci-ci-serial-1-5"
+                export KUBE_OS_DISTRIBUTION="gci"
+        - 'gci-gce-ingress-release-1.5':  # kubernetes-e2e-gci-gce-ingress-release-1.5
+            description: 'Run [Feature:Ingress] tests on GCE on the release-1.5 branch.'
+            timeout: 90
+            emails: 'beeps@google.com'
+            test-owner: 'beeps'
+            job-env: |
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+                export PROJECT="k8s-jkns-gci-gce-ingress1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+        - 'gci-gce-alpha-features-release-1.5': # kubernetes-e2e-gci-gce-alpha-features-release-1.5
+            description: 'Run alpha feature tests on GCE on the release-1.5 branch.'
+            timeout: 180
+            job-env: |
+                export KUBE_FEATURE_GATES="AllAlpha=true"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
+                export PROJECT="k8s-jkns-e2e-gci-gce-alpha1-5"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+        # Uncomment when 1.4 scale tests are turned off
+        # - 'gci-gce-scalability-release-1.5':  # kubernetes-e2e-gci-gce-scalability-release-1.5
+        #     description: 'Run scalability E2E tests on GCE from the release-1.5 branch.'
+        #     timeout: 120
+        #     cron-string: '@daily'
+        #     job-env: |
+        #         export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+        #         export E2E_NAME="e2e-scalability-1-5"
+        #         export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+        #                                  --gather-resource-usage=true \
+        #                                  --gather-metrics-at-teardown=true \
+        #                                  --gather-logs-sizes=true \
+        #                                  --output-print-type=json"
+        #         # Use the 1.1 project for now, since it has quota.
+        #         # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+        #         export PROJECT="k8s-e2e-gci-gce-scale-1-4"
+        #         export FAIL_ON_GCP_RESOURCE_LEAK="false"
+        #         # Override GCE defaults.
+        #         export KUBE_GCE_ZONE="us-east1-b"
+        #         export MASTER_SIZE="n1-standard-4"
+        #         export NODE_SIZE="n1-standard-1"
+        #         export NODE_DISK_SIZE="50GB"
+        #         export NUM_NODES="100"
+        #         export REGISTER_MASTER="true"
+        #         # Reduce logs verbosity
+        #         export TEST_CLUSTER_LOG_LEVEL="--v=2"
+        #         # TODO: Remove when we figure out the reason for occasional failures #19048
+        #         export KUBELET_TEST_LOG_LEVEL="--v=4"
+        #         # Increase resync period to simulate production
+        #         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+        #         # Increase delete collection parallelism
+        #         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+        #         export KUBE_NODE_OS_DISTRIBUTION="gci"
+    jobs:
+        - 'kubernetes-e2e-{suffix}'
+
 - project:
     name: kubernetes-e2e-gci-gce-1-4
     trigger-job: 'kubernetes-build-1.4'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -326,6 +326,117 @@
         - 'kubernetes-e2e-{gke-suffix}'
 
 - project:
+    name: kubernetes-e2e-gke-1-5
+    trigger-job: 'kubernetes-build-1.5'
+    test-owner: 'Release owner'
+    gke-suffix:
+        - 'gke-release-1.5':  # kubernetes-e2e-gke-release-1.5
+            description: 'Run E2E tests on GKE from the release-1.5 branch.'
+            timeout: 50  # See kubernetes/kubernetes#21138
+            job-env: |
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gke-1-5"
+        - 'gke-serial-release-1.5':  # kubernetes-e2e-gke-serial-release-1.5
+            description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.5 branch.'
+            timeout: 300
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gke-serial-1-5"
+        - 'gke-alpha-features-release-1.5':
+            description: 'Run alpha feature tests on GKE on the release-1.5 branch.'
+            timeout: 180
+            job-env: |
+                export PROJECT="k8s-jkns-e2e-gke-alpha-1-5"
+                export GKE_CREATE_FLAGS="--enable-kubernetes-alpha"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet)\]|ScheduledJob"
+        - 'gke-slow-release-1.5':  # kubernetes-e2e-gke-slow-release-1.5
+            description: 'Run slow E2E tests on GKE using the release-1.5 branch.'
+            timeout: 150  #  See kubernetes/kubernetes#24072
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gke-slow-1-5"
+        - 'gke-reboot-release-1.5':  # kubernetes-e2e-gke-reboot-release-1.5
+            description: 'Run [Feature:Reboot] tests on GKE on the release-1.5 branch.'
+            timeout: 180
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gke-reboot-1-5"
+        - 'gke-ingress-release-1.5':  # kubernetes-e2e-gke-ingress-release-1.5
+            description: 'Run [Feature:Ingress] tests on GKE on the release-1.5 branch.'
+            timeout: 90
+            emails: 'beeps@google.com'
+            test-owner: 'beeps'
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gke-ingress-1-5"
+    jobs:
+        - 'kubernetes-e2e-{gke-suffix}'
+
+- project:
+    name: kubernetes-e2e-gci-gke-1-5
+    trigger-job: 'kubernetes-build-1.5'
+    test-owner: 'Release owner'
+    gke-suffix:
+        - 'gci-gke-release-1.5':  # kubernetes-e2e-gci-gke-release-1.5
+            description: 'Run E2E tests on GKE from the release-1.5 branch, using GCI image.'
+            timeout: 50  # See kubernetes/kubernetes#21138
+            job-env: |
+                export GINKGO_PARALLEL="y"
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gci-gke-1-5"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-serial-release-1.5':  # kubernetes-e2e-gci-gke-serial-release-1.5
+            description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.5 branch, using GCI image.'
+            timeout: 300
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gci-gke-serial-1-5"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-slow-release-1.5':  # kubernetes-e2e-gci-gke-slow-release-1.5
+            description: 'Run slow E2E tests on GKE using the release-1.5 branch, using GCI image.'
+            timeout: 150  #  See kubernetes/kubernetes#24072
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                export GINKGO_PARALLEL="y"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gci-gke-slow-1-5"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-reboot-release-1.5':  # kubernetes-e2e-gci-gke-reboot-release-1.5
+            description: 'Run [Feature:Reboot] tests on GKE on the release-1.5 branch, using GCI image.'
+            timeout: 180
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gci-gke-reboot-1-5"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+        - 'gci-gke-ingress-release-1.5':  # kubernetes-e2e-gci-gke-ingress-release-1.5
+            description: 'Run [Feature:Ingress] tests on GKE on the release-1.5 branch, using GCI image.'
+            timeout: 90
+            emails: 'beeps@google.com'
+            test-owner: 'beeps'
+            job-env: |
+                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+                export PROJECT="k8s-jkns-gci-gke-ingress-1-5"
+                export KUBE_GKE_IMAGE_TYPE="gci"
+    jobs:
+        - 'kubernetes-e2e-{gke-suffix}'
+
+- project:
     name: kubernetes-e2e-gke-1-4
     trigger-job: 'kubernetes-build-1.4'
     test-owner: 'Release owner'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -183,6 +183,50 @@
                 export FAIL_ON_GCP_RESOURCE_LEAK="true"
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
+        - 'gce-1.5':
+            deploy-description: |
+                Deploy Kubernetes to soak cluster using the latest successful
+                release-1.5 Kubernetes build every week.<br>
+                If a kubernetes-soak-continuous-e2e-gce-1.5 build is running,
+                this deployment build will be blocked and remain in the queue
+                until the test run is complete.<br>
+            e2e-description: |
+                Assumes Kubernetes soak cluster is already deployed.<br>
+                If a kubernetes-soak-weekly-deploy-gce-1.5 build is enqueued,
+                builds will be blocked and remain in the queue until the
+                deployment is complete.<br>
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="8"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="debian"
+            job-env: |
+                export PROJECT="k8s-jkns-gce-soak-1-5"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+        - 'gci-gce-1.5':
+            deploy-description: |
+                Deploy Kubernetes to soak cluster using the latest successful
+                release-1.5 Kubernetes build every week.<br>
+                If a kubernetes-soak-continuous-e2e-gci-gce-1.5 build is running,
+                this deployment build will be blocked and remain in the queue
+                until the test run is complete.<br>
+            e2e-description: |
+                Assumes Kubernetes soak cluster is already deployed.<br>
+                If a kubernetes-soak-weekly-deploy-gci-gce-1.5 build is enqueued,
+                builds will be blocked and remain in the queue until the
+                deployment is complete.<br>
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="8"
+                export KUBE_GCE_ZONE="us-central1-f"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                export KUBE_NODE_OS_DISTRIBUTION="gci"
+            job-env: |
+                export PROJECT="k8s-jkns-gci-gce-soak-1-5"
+                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
         - 'gce-1.4':
             deploy-description: |
                 Deploy Kubernetes to soak cluster using the latest successful

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-go.yaml
@@ -63,6 +63,10 @@
             branch: 'master'
             cron-string: '{sq-cron-string}'
             timeout: 100
+        - 'go-release-1.5':
+            branch: 'release-1.5'
+            cron-string: '{sq-cron-string}'
+            timeout: 100
         - 'go-release-1.4':
             branch: 'release-1.4'
             cron-string: '{sq-cron-string}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -518,6 +518,70 @@
             image-old: 'gci'
             image-new: 'gci'
             version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5
+            version-old: '1.3'
+            version-new: '1.5'
+            version-infix: 'c1-3-c1-5'
+            image-old: 'container_vm'
+            image-new: 'container_vm'
+            version-env: |
+                # 1.3 doesn't support IAM, so we should use cert auth.
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.3-gci-1.5
+            version-old: '1.3'
+            version-new: '1.5'
+            version-infix: 'c1-3-g1-5'
+            image-old: 'container_vm'
+            image-new: 'gci'
+            version-env: |
+                # 1.3 doesn't support IAM, so we should use cert auth.
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.3-container_vm-1.5
+            version-old: '1.3'
+            version-new: '1.5'
+            version-infix: 'g1-3-c1-5'
+            image-old: 'gci'
+            image-new: 'container_vm'
+            version-env: |
+                # 1.3 doesn't support IAM, so we should use cert auth.
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.3-gci-1.5
+            version-old: '1.3'
+            version-new: '1.5'
+            version-infix: 'g1-3-g1-5'
+            image-old: 'gci'
+            image-new: 'gci'
+            version-env: |
+                # 1.3 doesn't support IAM, so we should use cert auth.
+                export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5
+            version-old: '1.4'
+            version-new: '1.5'
+            version-infix: 'c1-4-c1-5'
+            image-old: 'container_vm'
+            image-new: 'container_vm'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.4-gci-1.5
+            version-old: '1.4'
+            version-new: '1.5'
+            version-infix: 'c1-4-g1-5'
+            image-old: 'container_vm'
+            image-new: 'gci'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.4-container_vm-1.5
+            version-old: '1.4'
+            version-new: '1.5'
+            version-infix: 'g1-4-c1-5'
+            image-old: 'gci'
+            image-new: 'container_vm'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-gci-1.4-gci-1.5
+            version-old: '1.4'
+            version-new: '1.5'
+            version-infix: 'g1-4-g1-5'
+            image-old: 'gci'
+            image-new: 'gci'
+            version-env: ''
         - 'kubernetes-e2e-gke-{image-old}-{version-old}-{image-new}-{version-new}':  # kubernetes-e2e-gke-container_vm-1.3-container_vm-latest
             version-old: '1.3'
             version-new: 'latest'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -365,6 +365,17 @@
             version-infix: '1-4-1-3'
             version-env: |
                 export JENKINS_USE_SKEW_TESTS="true"
+        - 'kubernetes-e2e-gce-{version-cluster}-{version-client}-kubectl-skew':
+            version-cluster: '1.4'
+            version-client: '1.5'
+            version-infix: '1-4-1-5'
+            version-env: ''
+        - 'kubernetes-e2e-gce-{version-cluster}-{version-client}-kubectl-skew':
+            version-cluster: '1.5'
+            version-client: '1.4'
+            version-infix: '1-5-1-4'
+            version-env: |
+                export JENKINS_USE_SKEW_TESTS="true"
 
 # These is the job definition for all new GKE upgrade tests.
 - job-group:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -130,6 +130,11 @@
             version-new: '1.4'
             version-infix: '1-3-1-4'
             version-env: ''
+        - 'kubernetes-e2e-gce-{version-old}-{version-new}':  # kubernetes-e2e-gce-1.3-1.4
+            version-old: '1.4'
+            version-new: '1.5'
+            version-infix: '1-4-1-5'
+            version-env: ''
 
 # This is the job definition for GCE upgrade tests for GCI and between container-vm and GCI.
 - job-group:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -295,6 +295,17 @@
                 export JENKINS_USE_SKEW_TESTS="true"
         - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
             version-cluster: '1.4'
+            version-client: '1.5'
+            version-infix: '1-4-1-5'
+            version-env: ''
+        - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
+            version-cluster: '1.5'
+            version-client: '1.4'
+            version-infix: '1-5-1-4'
+            version-env: |
+                export JENKINS_USE_SKEW_TESTS="true"
+        - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
+            version-cluster: '1.4'
             version-client: 'latest'
             version-infix: '1-4-lat'
             version-env: ''

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-verify.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-verify.yaml
@@ -48,6 +48,10 @@
             branch: 'master'
             cron-string: '{sq-cron-string}'
             timeout: 80
+        - 'release-1.5': # kubernetes-verify-release-1.5
+            branch: 'release-1.5'
+            cron-string: '{sq-cron-string}'
+            timeout: 80
         - 'release-1.4': # kubernetes-verify-release-1.4
             branch: 'release-1.4'
             cron-string: '{sq-cron-string}'

--- a/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/node-e2e.yaml
@@ -219,3 +219,16 @@
             shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-ci.properties'
     jobs:
         - '{gitproject}-gce-e2e-ci'
+
+- project:
+    name: node-gce-e2e-1.5
+    gitproject:
+        - 'kubelet-1.5':
+            cron-string: '{sq-cron-string}'
+            repoName: 'kubernetes/kubernetes'
+            gitbasedir: 'k8s.io/kubernetes'
+            branch: 'release-1.5'
+            owner: 'dawnchen@google.com'
+            shell: 'test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-ci.properties'
+    jobs:
+        - '{gitproject}-gce-e2e-ci'

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -603,6 +603,55 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew
 - name: kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew
+- name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master
+- name: kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master
+- name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master
+- name: kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master
+- name: kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster
+- name: kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master
+  
 - name: kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster
 - name: kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster-new
@@ -1613,6 +1662,33 @@ dashboards:
   - name: gke-gci-1.3-gci-1.4-upgrade-master
     test_group_name: kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master
 
+- name: google-1.3-1.5-upgrade
+  dashboard_tab:
+  - name: gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
+  - name: gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
+  - name: gke-container_vm-1.3-container_vm-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master
+  - name: gke-container_vm-1.3-gci-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster
+  - name: gke-container_vm-1.3-gci-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new
+  - name: gke-container_vm-1.3-gci-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master
+  - name: gke-gci-1.3-container_vm-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster
+  - name: gke-gci-1.3-container_vm-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new
+  - name: gke-gci-1.3-container_vm-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master
+  - name: gke-gci-1.3-gci-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster
+  - name: gke-gci-1.3-gci-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new
+  - name: gke-gci-1.3-gci-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master
+
 - name: google-1.4-1.5-upgrade
   dashboard_tab:
   - name: gce-cvm-1.4-cvm-1.5-upgrade-cluster
@@ -1621,6 +1697,30 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new
   - name: gce-cvm-1.4-cvm-1.5-upgrade-master
     test_group_name: kubernetes-e2e-gce-1.4-1.5-upgrade-master
+  - name: gke-container_vm-1.4-container_vm-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster
+  - name: gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new
+  - name: gke-container_vm-1.4-container_vm-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master
+  - name: gke-container_vm-1.4-gci-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster
+  - name: gke-container_vm-1.4-gci-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new
+  - name: gke-container_vm-1.4-gci-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master
+  - name: gke-gci-1.4-container_vm-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster
+  - name: gke-gci-1.4-container_vm-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new
+  - name: gke-gci-1.4-container_vm-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master
+  - name: gke-gci-1.4-gci-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster
+  - name: gke-gci-1.4-gci-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new
+  - name: gke-gci-1.4-gci-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master
 
 - name: google-gke-latest-upgrade
   dashboard_tab:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -701,6 +701,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-staging-release-1.2
 - name: kubelet-1.4-gce-e2e-ci
   gcs_prefix: kubernetes-jenkins/logs/kubelet-1.4-gce-e2e-ci
+- name: kubelet-1.5-gce-e2e-ci
+  gcs_prefix: kubernetes-jenkins/logs/kubelet-1.5-gce-e2e-ci
 - name: kubernetes-federation-build
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-federation-build
 - name: kubernetes-e2e-gke-gci-prod-parallel-release-1.2
@@ -1694,6 +1696,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-gci-staging-release-1.2
   - name: kubelet-1.4-gce-e2e-ci
     test_group_name: kubelet-1.4-gce-e2e-ci
+  - name: kubelet-1.5-gce-e2e-ci
+    test_group_name: kubelet-1.5-gce-e2e-ci
   - name: federation-build
     test_group_name: kubernetes-federation-build
   - name: gke-gci-prod-parallel-release-1.2

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -336,6 +336,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-alpha-features
 - name: kubernetes-e2e-gke-alpha-features-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-alpha-features-release-1.4
+- name: kubernetes-e2e-gke-alpha-features-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-alpha-features-release-1.5
 - name: kubernetes-e2e-gke-autoscaling
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-autoscaling
 - name: kubernetes-e2e-gci-gke-autoscaling
@@ -360,8 +362,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-ingress-release-1.3
 - name: kubernetes-e2e-gke-ingress-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-ingress-release-1.4
+- name: kubernetes-e2e-gke-ingress-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-ingress-release-1.5
 - name: kubernetes-e2e-gci-gke-ingress-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-ingress-release-1.4
+- name: kubernetes-e2e-gci-gke-ingress-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-ingress-release-1.5
 - name: kubernetes-e2e-gke-large-cluster
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-large-cluster
 - name: kubernetes-e2e-gke-multizone
@@ -394,8 +400,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-reboot-release-1.3
 - name: kubernetes-e2e-gke-reboot-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-reboot-release-1.4
+- name: kubernetes-e2e-gke-reboot-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-reboot-release-1.5
 - name: kubernetes-e2e-gci-gke-reboot-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-reboot-release-1.4
+- name: kubernetes-e2e-gci-gke-reboot-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-reboot-release-1.5
 - name: kubernetes-e2e-gke-release-1.2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-release-1.2
 - name: kubernetes-e2e-gke-release-1.3
@@ -404,8 +414,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-release-1.3
 - name: kubernetes-e2e-gke-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-release-1.4
+- name: kubernetes-e2e-gke-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-release-1.5
 - name: kubernetes-e2e-gci-gke-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-release-1.4
+- name: kubernetes-e2e-gci-gke-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-release-1.5
 - name: kubernetes-e2e-gke-serial
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-serial
 - name: kubernetes-e2e-gke-serial-release-1.2
@@ -416,8 +430,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-serial-release-1.3
 - name: kubernetes-e2e-gke-serial-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-serial-release-1.4
+- name: kubernetes-e2e-gke-serial-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-serial-release-1.5
 - name: kubernetes-e2e-gci-gke-serial-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-serial-release-1.4
+- name: kubernetes-e2e-gci-gke-serial-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-serial-release-1.5
 - name: kubernetes-e2e-gke-slow
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-slow
 - name: kubernetes-e2e-gke-slow-release-1.2
@@ -428,8 +446,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-slow-release-1.3
 - name: kubernetes-e2e-gke-slow-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-slow-release-1.4
+- name: kubernetes-e2e-gke-slow-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-slow-release-1.5
 - name: kubernetes-e2e-gci-gke-slow-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-slow-release-1.4
+- name: kubernetes-e2e-gci-gke-slow-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gke-slow-release-1.5
 - name: kubernetes-e2e-gke-staging
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-staging
 - name: kubernetes-e2e-gci-gke-staging
@@ -1176,6 +1198,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gke-alpha-features
   - name: gke-alpha-features-release-1.4
     test_group_name: kubernetes-e2e-gke-alpha-features-release-1.4
+  - name: gke-alpha-features-release-1.5
+    test_group_name: kubernetes-e2e-gke-alpha-features-release-1.5
   - name: gke-autoscaling
     test_group_name: kubernetes-e2e-gke-autoscaling
   - name: gci-gke-autoscaling
@@ -1200,8 +1224,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gke-ingress-release-1.3
   - name: gke-ingress-release-1.4
     test_group_name: kubernetes-e2e-gke-ingress-release-1.4
+  - name: gke-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gke-ingress-release-1.5
   - name: gci-gke-ingress-release-1.4
     test_group_name: kubernetes-e2e-gci-gke-ingress-release-1.4
+  - name: gci-gke-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-ingress-release-1.5
   - name: gke-large-cluster
     test_group_name: kubernetes-e2e-gke-large-cluster
   - name: gke-multizone
@@ -1234,8 +1262,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gke-reboot-release-1.3
   - name: gke-reboot-release-1.4
     test_group_name: kubernetes-e2e-gke-reboot-release-1.4
+  - name: gke-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gke-reboot-release-1.5
   - name: gci-gke-reboot-release-1.4
     test_group_name: kubernetes-e2e-gci-gke-reboot-release-1.4
+  - name: gci-gke-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-reboot-release-1.5
   - name: gke-release-1.2
     test_group_name: kubernetes-e2e-gke-release-1.2
   - name: gke-release-1.3
@@ -1244,8 +1276,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gke-release-1.3
   - name: gke-release-1.4
     test_group_name: kubernetes-e2e-gke-release-1.4
+  - name: gke-release-1.5
+    test_group_name: kubernetes-e2e-gke-release-1.5
   - name: gci-gke-release-1.4
     test_group_name: kubernetes-e2e-gci-gke-release-1.4
+  - name: gci-gke-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-release-1.5
   - name: gke-serial
     test_group_name: kubernetes-e2e-gke-serial
   - name: gke-serial-release-1.2
@@ -1256,8 +1292,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gke-serial-release-1.3
   - name: gke-serial-release-1.4
     test_group_name: kubernetes-e2e-gke-serial-release-1.4
+  - name: gke-serial-release-1.5
+    test_group_name: kubernetes-e2e-gke-serial-release-1.5
   - name: gci-gke-serial-release-1.4
     test_group_name: kubernetes-e2e-gci-gke-serial-release-1.4
+  - name: gci-gke-serial-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-serial-release-1.5
   - name: gke-slow
     test_group_name: kubernetes-e2e-gke-slow
   - name: gke-slow-release-1.2
@@ -1268,8 +1308,12 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gke-slow-release-1.3
   - name: gke-slow-release-1.4
     test_group_name: kubernetes-e2e-gke-slow-release-1.4
+  - name: gke-slow-release-1.5
+    test_group_name: kubernetes-e2e-gke-slow-release-1.5
   - name: gci-gke-slow-release-1.4
     test_group_name: kubernetes-e2e-gci-gke-slow-release-1.4
+  - name: gci-gke-slow-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-slow-release-1.5
   - name: gke-staging
     test_group_name: kubernetes-e2e-gke-staging
   - name: gci-gke-staging

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -587,6 +587,14 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew
 - name: kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
+- name: kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew
+- name: kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew
+- name: kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew
+- name: kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew
 - name: kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew
 - name: kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew
@@ -1479,6 +1487,14 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
   - name: gce-1.4-1.3-gci-kubectl-skew
     test_group_name: kubernetes-e2e-gce-1.4-1.3-gci-kubectl-skew
+  - name: gke-1.4-1.5-cvm-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew
+  - name: gke-1.4-1.5-gci-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew
+  - name: gke-1.5-1.4-cvm-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew
+  - name: gke-1.5-1.4-gci-kubectl-skew
+    test_group_name: kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew
   - name: gke-1.4-latest-gci-kubectl-skew
     test_group_name: kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew
   - name: gke-1.4-latest-cvm-kubectl-skew

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -720,6 +720,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-gci-staging-parallel-release-1.2
 - name: kubernetes-federation-build-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-federation-build-1.4
+- name: kubernetes-federation-build-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-federation-build-1.5
 - name: kubernetes-e2e-gke-large-teardown
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-large-teardown
 - name: kubernetes-update-jenkins-jobs
@@ -1695,6 +1697,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-gci-staging-parallel-release-1.2
   - name: federation-build-1.4
     test_group_name: kubernetes-federation-build-1.4
+  - name: federation-build-1.5
+    test_group_name: kubernetes-federation-build-1.5
   - name: gke-large-teardown
     test_group_name: kubernetes-e2e-gke-large-teardown
   - name: update-jenkins-jobs

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -671,6 +671,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new
 - name: kubernetes-e2e-gce-1.3-1.4-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.3-1.4-upgrade-master
+- name: kubernetes-e2e-gce-1.4-1.5-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.5-upgrade-cluster
+- name: kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new
+- name: kubernetes-e2e-gce-1.4-1.5-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.5-upgrade-master
 - name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster
 - name: kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new
@@ -1606,6 +1612,15 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master
   - name: gke-gci-1.3-gci-1.4-upgrade-master
     test_group_name: kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master
+
+- name: google-1.4-1.5-upgrade
+  dashboard_tab:
+  - name: gce-cvm-1.4-cvm-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gce-1.4-1.5-upgrade-cluster
+  - name: gce-cvm-1.4-cvm-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new
+  - name: gce-cvm-1.4-cvm-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gce-1.4-1.5-upgrade-master
 
 - name: google-gke-latest-upgrade
   dashboard_tab:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -472,6 +472,9 @@ test_groups:
 - name: kubernetes-test-go-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-test-go-release-1.4
   days_of_results: 4
+- name: kubernetes-test-go-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-test-go-release-1.5
+  days_of_results: 4
 - name: kubernetes-verify-master
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-verify-master
 - name: kubernetes-verify-release-1.4
@@ -1297,6 +1300,8 @@ dashboards:
     test_group_name: kubernetes-test-go-release-1.3
   - name: test-go-release-1.4
     test_group_name: kubernetes-test-go-release-1.4
+  - name: test-go-release-1.5
+    test_group_name: kubernetes-test-go-release-1.5
   - name: verify-master
     test_group_name: kubernetes-verify-master
   - name: verify-release-1.4

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -70,6 +70,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-build-1.3
 - name: kubernetes-build-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-build-1.4
+- name: kubernetes-build-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-build-1.5
 - name: kubernetes-e2e-aws
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-aws
 - name: kubernetes-e2e-aws-release-1.4
@@ -1283,6 +1285,8 @@ dashboards:
     test_group_name: kubernetes-build-1.3
   - name: build-1.4
     test_group_name: kubernetes-build-1.4
+  - name: build-1.5
+    test_group_name: kubernetes-build-1.5
   - name: test-go
     test_group_name: kubernetes-test-go
   - name: test-go-release-1.2

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -661,6 +661,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.3-1.4-cvm-kubectl-skew
 - name: kubernetes-e2e-gce-1.3-1.4-gci-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.3-1.4-gci-kubectl-skew
+- name: kubernetes-e2e-gce-1.4-1.5-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.5-cvm-kubectl-skew
+- name: kubernetes-e2e-gce-1.4-1.5-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.5-gci-kubectl-skew
 - name: kubernetes-e2e-gce-1.3-1.4-upgrade-cluster
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.3-1.4-upgrade-cluster
 - name: kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new
@@ -719,6 +723,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.3-cvm-kubectl-skew
 - name: kubernetes-e2e-gce-1.4-1.3-gci-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.4-1.3-gci-kubectl-skew
+- name: kubernetes-e2e-gce-1.5-1.4-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.5-1.4-cvm-kubectl-skew
+- name: kubernetes-e2e-gce-1.5-1.4-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-1.5-1.4-gci-kubectl-skew
 - name: kubelet-flaky-gce-e2e-ci
   gcs_prefix: kubernetes-jenkins/logs/kubelet-flaky-gce-e2e-ci
 - name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
@@ -1487,10 +1495,18 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
   - name: gce-1.4-1.3-gci-kubectl-skew
     test_group_name: kubernetes-e2e-gce-1.4-1.3-gci-kubectl-skew
+  - name: gce-1.4-1.5-cvm-kubectl-skew
+    test_group_name: kubernetes-e2e-gce-1.4-1.5-cvm-kubectl-skew
+  - name: gce-1.4-1.5-gci-kubectl-skew
+    test_group_name: kubernetes-e2e-gce-1.4-1.5-gci-kubectl-skew
   - name: gke-1.4-1.5-cvm-kubectl-skew
     test_group_name: kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew
   - name: gke-1.4-1.5-gci-kubectl-skew
     test_group_name: kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew
+  - name: gce-1.5-1.4-cvm-kubectl-skew
+    test_group_name: kubernetes-e2e-gce-1.5-1.4-cvm-kubectl-skew
+  - name: gce-1.5-1.4-gci-kubectl-skew
+    test_group_name: kubernetes-e2e-gce-1.5-1.4-gci-kubectl-skew
   - name: gke-1.5-1.4-cvm-kubectl-skew
     test_group_name: kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew
   - name: gke-1.5-1.4-gci-kubectl-skew

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -90,6 +90,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features
 - name: kubernetes-e2e-gce-alpha-features-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-alpha-features-release-1.4
+- name: kubernetes-e2e-gce-alpha-features-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-alpha-features-release-1.5
 - name: kubernetes-e2e-gci-gce-alpha-features-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features-release-1.4
 - name: kubernetes-e2e-gce-autoscaling
@@ -118,6 +120,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-federation
 - name: kubernetes-e2e-gce-federation-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-federation-release-1.4
+- name: kubernetes-e2e-gce-federation-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-federation-release-1.5
 - name: kubernetes-soak-weekly-deploy-gce-federation
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-federation
 - name: kubernetes-soak-continuous-e2e-gce-federation
@@ -212,6 +216,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.3
 - name: kubernetes-e2e-gce-ingress-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress-release-1.4
+- name: kubernetes-e2e-gce-ingress-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress-release-1.5
 - name: kubernetes-e2e-gci-gce-ingress-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.4
 - name: kubernetes-e2e-gce-kubenet
@@ -248,6 +254,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.3
 - name: kubernetes-e2e-gce-reboot-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.4
+- name: kubernetes-e2e-gce-reboot-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.5
 - name: kubernetes-e2e-gci-gce-reboot-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.4
 - name: kubernetes-e2e-gce-release-1.2
@@ -260,10 +268,15 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-release-1.3
 - name: kubernetes-e2e-gce-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-release-1.4
+- name: kubernetes-e2e-gce-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-release-1.5
 - name: kubernetes-e2e-gce-scalability
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-scalability
 - name: kubernetes-e2e-gce-scalability-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-scalability-release-1.4
+# Uncomment when 1.4 scale tests are turned off
+# - name: kubernetes-e2e-gce-scalability-release-1.5
+#   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-scalability-release-1.5
 - name: kubernetes-e2e-gci-gce-scalability-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-scalability-release-1.4
 - name: kubernetes-e2e-gce-serial
@@ -278,6 +291,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.3
 - name: kubernetes-e2e-gce-serial-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-serial-release-1.4
+- name: kubernetes-e2e-gce-serial-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-serial-release-1.5
 - name: kubernetes-e2e-gce-slow
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-slow
 - name: kubernetes-e2e-gce-slow-release-1.2
@@ -290,6 +305,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.3
 - name: kubernetes-e2e-gce-slow-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-slow-release-1.4
+- name: kubernetes-e2e-gce-slow-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-slow-release-1.5
 - name: kubernetes-e2e-gke
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke
 - name: kubernetes-e2e-gke-alpha-features
@@ -882,6 +899,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-alpha-features
   - name: gce-alpha-features-release-1.4
     test_group_name: kubernetes-e2e-gce-alpha-features-release-1.4
+  - name: gce-alpha-features-release-1.5
+    test_group_name: kubernetes-e2e-gce-alpha-features-release-1.5
   - name: gci-gce-alpha-features-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-alpha-features-release-1.4
   - name: gce-autoscaling
@@ -926,6 +945,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-ingress-release-1.3
   - name: gce-ingress-release-1.4
     test_group_name: kubernetes-e2e-gce-ingress-release-1.4
+  - name: gce-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gce-ingress-release-1.5
   - name: gci-gce-ingress-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-ingress-release-1.4
   - name: gce-kubenet
@@ -962,6 +983,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-reboot-release-1.3
   - name: gce-reboot-release-1.4
     test_group_name: kubernetes-e2e-gce-reboot-release-1.4
+  - name: gce-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gce-reboot-release-1.5
   - name: gci-gce-reboot-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-reboot-release-1.4
   - name: gce-release-1.2
@@ -974,12 +997,17 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-release-1.3
   - name: gce-release-1.4
     test_group_name: kubernetes-e2e-gce-release-1.4
+  - name: gce-release-1.5
+    test_group_name: kubernetes-e2e-gce-release-1.5
   - name: gce-scalability
     test_group_name: kubernetes-e2e-gce-scalability
   - name: gci-gce-scalability
     test_group_name: kubernetes-e2e-gci-gce-scalability
   - name: gce-scalability-release-1.4
     test_group_name: kubernetes-e2e-gce-scalability-release-1.4
+  # Uncomment when 1.4 scale tests are turned off
+  # - name: gce-scalability-release-1.5
+  #   test_group_name: kubernetes-e2e-gce-scalability-release-1.5
   - name: gci-gce-scalability-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.4
   - name: gce-serial
@@ -996,6 +1024,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-serial-release-1.3
   - name: gce-serial-release-1.4
     test_group_name: kubernetes-e2e-gce-serial-release-1.4
+  - name: gce-serial-release-1.5
+    test_group_name: kubernetes-e2e-gce-serial-release-1.5
   - name: gce-slow
     test_group_name: kubernetes-e2e-gce-slow
   - name: gci-gce-slow
@@ -1010,6 +1040,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-slow-release-1.3
   - name: gce-slow-release-1.4
     test_group_name: kubernetes-e2e-gce-slow-release-1.4
+  - name: gce-slow-release-1.5
+    test_group_name: kubernetes-e2e-gce-slow-release-1.5
 
 - name: google-gci
   dashboard_tab:
@@ -1500,6 +1532,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce-federation
   - name: gce-federation-1.4
     test_group_name: kubernetes-e2e-gce-federation-release-1.4
+  - name: gce-federation-1.5
+    test_group_name: kubernetes-e2e-gce-federation-release-1.5
   - name: soak-weekly-deploy-gce-federation
     test_group_name: kubernetes-soak-weekly-deploy-gce-federation
   - name: soak-continuous-e2e-gce-federation

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -142,6 +142,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-release-1.3
 - name: kubernetes-e2e-gce-gci-ci-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-release-1.4
+- name: kubernetes-e2e-gce-gci-ci-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-release-1.5
 - name: kubernetes-e2e-gce-gci-ci-serial-master
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-serial-master
 - name: kubernetes-e2e-gce-gci-ci-serial-release-1.2
@@ -150,6 +152,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-serial-release-1.3
 - name: kubernetes-e2e-gce-gci-ci-serial-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-serial-release-1.4
+- name: kubernetes-e2e-gce-gci-ci-serial-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-serial-release-1.5
 - name: kubernetes-e2e-gce-gci-ci-slow-master
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-slow-master
 - name: kubernetes-e2e-gce-gci-ci-slow-release-1.2
@@ -158,6 +162,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-slow-release-1.3
 - name: kubernetes-e2e-gce-gci-ci-slow-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-slow-release-1.4
+- name: kubernetes-e2e-gce-gci-ci-slow-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-ci-slow-release-1.5
 - name: kubernetes-e2e-gci-gce-examples
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-examples
 - name: kubernetes-e2e-gci-gce-federation
@@ -1079,6 +1085,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-gci-ci-release-1.3
   - name: gci-ci-release-1.4
     test_group_name: kubernetes-e2e-gce-gci-ci-release-1.4
+  - name: gci-ci-release-1.5
+    test_group_name: kubernetes-e2e-gce-gci-ci-release-1.5
   - name: gci-ci-serial-master
     test_group_name: kubernetes-e2e-gce-gci-ci-serial-master
   - name: gci-ci-serial-release-1.2
@@ -1087,6 +1095,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-gci-ci-serial-release-1.3
   - name: gci-ci-serial-release-1.4
     test_group_name: kubernetes-e2e-gce-gci-ci-serial-release-1.4
+  - name: gci-ci-serial-release-1.5
+    test_group_name: kubernetes-e2e-gce-gci-ci-serial-release-1.5
   - name: gci-ci-slow-master
     test_group_name: kubernetes-e2e-gce-gci-ci-slow-master
   - name: gci-ci-slow-release-1.2
@@ -1095,6 +1105,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-gci-ci-slow-release-1.3
   - name: gci-ci-slow-release-1.4
     test_group_name: kubernetes-e2e-gce-gci-ci-slow-release-1.4
+  - name: gci-ci-slow-release-1.5
+    test_group_name: kubernetes-e2e-gce-gci-ci-slow-release-1.5
   - name: gci-examples
     test_group_name: kubernetes-e2e-gci-gce-examples
   - name: gci-qa-m52

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -78,6 +78,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-aws-release-1.4
 - name: kubernetes-e2e-kops-aws
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-kops-aws
+- name: kubernetes-e2e-aws-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-aws-release-1.5
 - name: kubernetes-e2e-kops-aws-updown
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-kops-aws-updown
 - name: kubernetes-e2e-gce
@@ -861,6 +863,8 @@ dashboards:
     test_group_name: kubernetes-e2e-aws-release-1.4
   - name: kops-aws
     test_group_name: kubernetes-e2e-kops-aws
+  - name: aws-release-1.5
+    test_group_name: kubernetes-e2e-aws-release-1.5
   - name: kops-aws-updown
     test_group_name: kubernetes-e2e-kops-aws-updown
 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -468,8 +468,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-1.3
 - name: kubernetes-soak-continuous-e2e-gce-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-1.4
+- name: kubernetes-soak-continuous-e2e-gce-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-1.5
 - name: kubernetes-soak-continuous-e2e-gci-gce-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gci-gce-1.4
+- name: kubernetes-soak-continuous-e2e-gci-gce-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gci-gce-1.5
 - name: kubernetes-soak-continuous-e2e-gce-2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-2
 - name: kubernetes-soak-continuous-e2e-gce-gci
@@ -488,8 +492,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-1.3
 - name: kubernetes-soak-weekly-deploy-gce-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-1.4
+- name: kubernetes-soak-weekly-deploy-gce-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-1.5
 - name: kubernetes-soak-weekly-deploy-gci-gce-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gci-gce-1.4
+- name: kubernetes-soak-weekly-deploy-gci-gce-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gci-gce-1.5
 - name: kubernetes-soak-weekly-deploy-gce-2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-2
 - name: kubernetes-soak-weekly-deploy-gce-gci
@@ -1329,8 +1337,12 @@ dashboards:
     test_group_name: kubernetes-soak-continuous-e2e-gce-1.3
   - name: soak-continuous-e2e-gce-1.4
     test_group_name: kubernetes-soak-continuous-e2e-gce-1.4
+  - name: soak-continuous-e2e-gce-1.5
+    test_group_name: kubernetes-soak-continuous-e2e-gce-1.5
   - name: soak-continuous-e2e-gci-gce-1.4
     test_group_name: kubernetes-soak-continuous-e2e-gci-gce-1.4
+  - name: soak-continuous-e2e-gci-gce-1.5
+    test_group_name: kubernetes-soak-continuous-e2e-gci-gce-1.5
   - name: soak-continuous-e2e-gce-2
     test_group_name: kubernetes-soak-continuous-e2e-gce-2
   - name: soak-continuous-e2e-gce-gci
@@ -1349,8 +1361,12 @@ dashboards:
     test_group_name: kubernetes-soak-weekly-deploy-gce-1.3
   - name: soak-weekly-deploy-gce-1.4
     test_group_name: kubernetes-soak-weekly-deploy-gce-1.4
+  - name: soak-weekly-deploy-gce-1.5
+    test_group_name: kubernetes-soak-weekly-deploy-gce-1.5
   - name: soak-weekly-deploy-gci-gce-1.4
     test_group_name: kubernetes-soak-weekly-deploy-gci-gce-1.4
+  - name: soak-weekly-deploy-gci-gce-1.5
+    test_group_name: kubernetes-soak-weekly-deploy-gci-gce-1.5
   - name: soak-weekly-deploy-gce-2
     test_group_name: kubernetes-soak-weekly-deploy-gce-2
   - name: soak-weekly-deploy-gce-gci

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1788,6 +1788,138 @@ dashboards:
   - name: soak-continuous-e2e-gce-federation
     test_group_name: kubernetes-soak-continuous-e2e-gce-federation
 
+- name: release-1.5-all
+  dashboard_tab:
+  - name: build-1.5
+    test_group_name: kubernetes-build-1.5
+  - name: gce-alpha-features-release-1.5
+    test_group_name: kubernetes-e2e-gce-alpha-features-release-1.5
+  - name: gci-gce-alpha-features-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-alpha-features-release-1.5
+  - name: test-go-release-1.5
+    test_group_name: kubernetes-test-go-release-1.5
+  - name: gce-slow-release-1.5
+    test_group_name: kubernetes-e2e-gce-slow-release-1.5
+  - name: gce-serial-release-1.5
+    test_group_name: kubernetes-e2e-gce-serial-release-1.5
+  # Uncomment after 1.4 scale tests are turned off
+  # - name: gce-scalability-release-1.5
+  #   test_group_name: kubernetes-e2e-gce-scalability-release-1.5
+  # - name: gci-gce-scalability-release-1.5
+  #   test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.5
+  - name: gce-release-1.5
+    test_group_name: kubernetes-e2e-gce-release-1.5
+  - name: gce-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gce-reboot-release-1.5
+  - name: gci-gce-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-reboot-release-1.5
+  - name: gce-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gce-ingress-release-1.5
+  - name: gci-gce-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-ingress-release-1.5
+  - name: gke-slow-release-1.5
+    test_group_name: kubernetes-e2e-gke-slow-release-1.5
+  - name: gci-gke-slow-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-slow-release-1.5
+  - name: gke-serial-release-1.5
+    test_group_name: kubernetes-e2e-gke-serial-release-1.5
+  - name: gci-gke-serial-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-serial-release-1.5
+  - name: gke-release-1.5
+    test_group_name: kubernetes-e2e-gke-release-1.5
+  - name: gci-gke-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-release-1.5
+  - name: gke-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gke-reboot-release-1.5
+  - name: gci-gke-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-reboot-release-1.5
+  - name: gke-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gke-ingress-release-1.5
+  - name: gci-gke-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-ingress-release-1.5
+  - name: gci-slow-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-slow-release-1.5
+  - name: gci-serial-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-serial-release-1.5
+  - name: gci-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-release-1.5
+  - name: gci-ci-slow-release-1.5
+    test_group_name: kubernetes-e2e-gce-gci-ci-slow-release-1.5
+  - name: gci-ci-serial-release-1.5
+    test_group_name: kubernetes-e2e-gce-gci-ci-serial-release-1.5
+  - name: gci-ci-release-1.5
+    test_group_name: kubernetes-e2e-gce-gci-ci-release-1.5
+  - name: aws-release-1.5
+    test_group_name: kubernetes-e2e-aws-release-1.5
+  - name: soak-weekly-deploy-gce-1.5
+    test_group_name: kubernetes-soak-weekly-deploy-gce-1.5
+  - name: soak-weekly-deploy-gci-gce-1.5
+    test_group_name: kubernetes-soak-weekly-deploy-gci-gce-1.5
+  - name: soak-continuous-e2e-gce-1.5
+    test_group_name: kubernetes-soak-continuous-e2e-gce-1.5
+  - name: soak-continuous-e2e-gci-gce-1.5
+    test_group_name: kubernetes-soak-continuous-e2e-gci-gce-1.5
+  - name: gke-1.3-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
+  - name: gke-1.3-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
+  - name: gke-1.3-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master
+  - name: gke-1.4-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster
+  - name: gke-1.4-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new
+  - name: gke-1.4-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master
+
+- name: release-1.5-blocking
+  dashboard_tab:
+  - name: build-1.5
+    test_group_name: kubernetes-build-1.5
+  - name: verify-release-1.5
+    test_group_name: kubernetes-verify-release-1.5
+  - name: gce-release-1.5
+    test_group_name: kubernetes-e2e-gce-release-1.5
+  - name: gce-serial-release-1.5
+    test_group_name: kubernetes-e2e-gce-serial-release-1.5
+  - name: gce-slow-release-1.5
+    test_group_name: kubernetes-e2e-gce-slow-release-1.5
+  - name: gce-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gce-reboot-release-1.5
+  # Uncomment after 1.4 scale tests are turned off
+  # - name: gce-scalability-release-1.5
+  #   test_group_name: kubernetes-e2e-gce-scalability-release-1.5
+  - name: test-go-release-1.5
+    test_group_name: kubernetes-test-go-release-1.5
+  - name: gke-release-1.5
+    test_group_name: kubernetes-e2e-gke-release-1.5
+  - name: gci-gke-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-release-1.5
+  - name: gke-serial-release-1.5
+    test_group_name: kubernetes-e2e-gke-serial-release-1.5
+  - name: gci-gke-serial-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-serial-release-1.5
+  - name: gke-slow-release-1.5
+    test_group_name: kubernetes-e2e-gke-slow-release-1.5
+  - name: gci-gke-slow-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-slow-release-1.5
+  - name: gke-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gke-reboot-release-1.5
+  - name: gci-gke-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gci-gke-reboot-release-1.5
+  - name: gke-1.3-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
+  - name: gke-1.3-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
+  - name: gke-1.3-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master
+  - name: gke-1.4-1.5-upgrade-cluster
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster
+  - name: gke-1.4-1.5-upgrade-cluster-new
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new
+  - name: gke-1.4-1.5-upgrade-master
+    test_group_name: kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master
+
 - name: release-1.4-all
   dashboard_tab:
   - name: build-1.4

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -94,6 +94,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-alpha-features-release-1.5
 - name: kubernetes-e2e-gci-gce-alpha-features-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features-release-1.4
+- name: kubernetes-e2e-gci-gce-alpha-features-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features-release-1.5
 - name: kubernetes-e2e-gce-autoscaling
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-autoscaling
 - name: kubernetes-e2e-gci-gce-autoscaling
@@ -192,16 +194,22 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-gci-qa-slow-master
 - name: kubernetes-e2e-gci-gce-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-release-1.4
+- name: kubernetes-e2e-gci-gce-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-release-1.5
 - name: kubernetes-e2e-gci-gce-scalability
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-scalability
 - name: kubernetes-e2e-gci-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial
 - name: kubernetes-e2e-gci-gce-serial-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.4
+- name: kubernetes-e2e-gci-gce-serial-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.5
 - name: kubernetes-e2e-gci-gce-slow
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow
 - name: kubernetes-e2e-gci-gce-slow-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.4
+- name: kubernetes-e2e-gci-gce-slow-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.5
 - name: kubernetes-e2e-gce-ingress
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress
 - name: kubernetes-e2e-gci-gce-ingress
@@ -220,6 +228,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress-release-1.5
 - name: kubernetes-e2e-gci-gce-ingress-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.4
+- name: kubernetes-e2e-gci-gce-ingress-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.5
 - name: kubernetes-e2e-gce-kubenet
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-kubenet
 - name: kubernetes-e2e-gci-gce-kubenet
@@ -258,6 +268,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.5
 - name: kubernetes-e2e-gci-gce-reboot-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.4
+- name: kubernetes-e2e-gci-gce-reboot-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.5
 - name: kubernetes-e2e-gce-release-1.2
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-release-1.2
 - name: kubernetes-e2e-gci-gce-release-1.2
@@ -279,6 +291,9 @@ test_groups:
 #   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-scalability-release-1.5
 - name: kubernetes-e2e-gci-gce-scalability-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-scalability-release-1.4
+# Uncomment when 1.4 scale tests are turned off
+# - name: kubernetes-e2e-gci-gce-scalability-release-1.5
+#   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-scalability-release-1.5
 - name: kubernetes-e2e-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-serial
 - name: kubernetes-e2e-gce-serial-release-1.2
@@ -903,6 +918,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-alpha-features-release-1.5
   - name: gci-gce-alpha-features-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-alpha-features-release-1.4
+  - name: gci-gce-alpha-features-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-alpha-features-release-1.5
   - name: gce-autoscaling
     test_group_name: kubernetes-e2e-gce-autoscaling
   - name: gci-gce-autoscaling
@@ -949,6 +966,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-ingress-release-1.5
   - name: gci-gce-ingress-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-ingress-release-1.4
+  - name: gci-gce-ingress-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-ingress-release-1.5
   - name: gce-kubenet
     test_group_name: kubernetes-e2e-gce-kubenet
   - name: gci-gce-kubenet
@@ -987,6 +1006,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-reboot-release-1.5
   - name: gci-gce-reboot-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-reboot-release-1.4
+  - name: gci-gce-reboot-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-reboot-release-1.5
   - name: gce-release-1.2
     test_group_name: kubernetes-e2e-gce-release-1.2
   - name: gci-gce-release-1.2
@@ -1010,6 +1031,9 @@ dashboards:
   #   test_group_name: kubernetes-e2e-gce-scalability-release-1.5
   - name: gci-gce-scalability-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.4
+  # Uncomment when 1.4 scale tests are turned off
+  # - name: gci-gce-scalability-release-1.5
+  #   test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.5
   - name: gce-serial
     test_group_name: kubernetes-e2e-gce-serial
   - name: gci-gce-serial
@@ -1105,16 +1129,22 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-gci-qa-slow-master
   - name: gci-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-release-1.4
+  - name: gci-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-release-1.5
   - name: gci-scalability
     test_group_name: kubernetes-e2e-gci-gce-scalability
   - name: gci-serial
     test_group_name: kubernetes-e2e-gci-gce-serial
   - name: gci-serial-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-serial-release-1.4
+  - name: gci-serial-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-serial-release-1.5
   - name: gci-slow
     test_group_name: kubernetes-e2e-gci-gce-slow
   - name: gci-slow-release-1.4
     test_group_name: kubernetes-e2e-gci-gce-slow-release-1.4
+  - name: gci-slow-release-1.5
+    test_group_name: kubernetes-e2e-gci-gce-slow-release-1.5
 
 - name: google-gke
   dashboard_tab:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -477,6 +477,8 @@ test_groups:
   days_of_results: 4
 - name: kubernetes-verify-master
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-verify-master
+- name: kubernetes-verify-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/kubernetes-verify-release-1.5
 - name: kubernetes-verify-release-1.4
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-verify-release-1.4
 - name: kubernetes-verify-release-1.3
@@ -1304,6 +1306,8 @@ dashboards:
     test_group_name: kubernetes-test-go-release-1.5
   - name: verify-master
     test_group_name: kubernetes-verify-master
+  - name: verify-release-1.5
+    test_group_name: kubernetes-verify-release-1.5
   - name: verify-release-1.4
     test_group_name: kubernetes-verify-release-1.4
   - name: verify-release-1.3


### PR DESCRIPTION
This is adding the following Jenkins jobs:

Build and release:
```
kubernetes-build-1.5
kubernetes-test-go-release-1.5
kubernetes-verify-release-1.5
kubernetes-federation-build-1.5
```

Misc e2es:
```
kubernetes-e2e-aws-release-1.5
kubelet-1.5-gce-e2e-ci
```

GCE e2es:
```
kubernetes-e2e-gce-alpha-features-release-1.5
kubernetes-e2e-gce-federation-release-1.5
kubernetes-e2e-gce-ingress-release-1.5
kubernetes-e2e-gce-reboot-release-1.5
kubernetes-e2e-gce-release-1.5
kubernetes-e2e-gce-scalability-release-1.5 # disabled for now
kubernetes-e2e-gce-serial-release-1.5
kubernetes-e2e-gce-slow-release-1.5
kubernetes-e2e-gce-gci-ci-release-1.5
kubernetes-e2e-gce-gci-ci-serial-release-1.5
kubernetes-e2e-gce-gci-ci-slow-release-1.5
kubernetes-e2e-gci-gce-alpha-features-release-1.5
kubernetes-e2e-gci-gce-ingress-release-1.5
kubernetes-e2e-gci-gce-reboot-release-1.5
kubernetes-e2e-gci-gce-release-1.5
kubernetes-e2e-gci-gce-scalability-release-1.5 # disabled for now
kubernetes-e2e-gci-gce-serial-release-1.5
kubernetes-e2e-gci-gce-slow-release-1.5
kubernetes-soak-continuous-e2e-gce-1.5
kubernetes-soak-continuous-e2e-gci-gce-1.5
kubernetes-soak-weekly-deploy-gce-1.5
kubernetes-soak-weekly-deploy-gci-gce-1.5
```

GCE Upgrades:
```
kubernetes-e2e-gce-1.4-1.5-cvm-kubectl-skew
kubernetes-e2e-gce-1.4-1.5-gci-kubectl-skew
kubernetes-e2e-gce-1.4-1.5-upgrade-cluster
kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new
kubernetes-e2e-gce-1.4-1.5-upgrade-master
kubernetes-e2e-gce-1.5-1.4-cvm-kubectl-skew
kubernetes-e2e-gce-1.5-1.4-gci-kubectl-skew
```

GKE e2es:
```
kubernetes-e2e-gci-gke-ingress-release-1.5
kubernetes-e2e-gci-gke-reboot-release-1.5
kubernetes-e2e-gci-gke-release-1.5
kubernetes-e2e-gci-gke-serial-release-1.5
kubernetes-e2e-gci-gke-slow-release-1.5
kubernetes-e2e-gke-alpha-features-release-1.5
kubernetes-e2e-gke-ingress-release-1.5
kubernetes-e2e-gke-reboot-release-1.5
kubernetes-e2e-gke-release-1.5
kubernetes-e2e-gke-serial-release-1.5
kubernetes-e2e-gke-slow-release-1.5
```

GKE Upgrades:
```
kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew
kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew
kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew
kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew
kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master
kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster
kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new
kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master
kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster
kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new
kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master
kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster
kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new
kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master
kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster
kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new
kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master
kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster
kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new
kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master
kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster
kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new
kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master
kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster
kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new
kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master
```

The following GCE projects need to be created.

GCE Projects:
```
k8s-jkns-e2e-gce-alpha1-5
k8s-jkns-e2e-gce-f8n-1-5
k8s-jkns-gce-ingress1-5
k8s-jkns-gce-reboot-1-5
k8s-jkns-gce-1-5
k8s-jkns-gce-serial-1-5
k8s-jkns-gce-slow-1-5
kubekins-gce-gci-ci-1-5
kubekins-gce-gci-ci-serial-1-5
kubekins-gce-gci-ci-slow-1-5
k8s-jkns-e2e-gci-gce-alpha1-5
k8s-jkns-gci-gce-ingress1-5
k8s-jkns-gci-gce-reboot-1-5
e2e-gce-gci-ci-1-5
e2e-gce-gci-ci-serial-1-5
e2e-gce-gci-ci-slow-1-5
k8s-jkns-gce-soak-1-5
k8s-jkns-gci-gce-soak-1-5
```

GCE Upgrade projects:
```
gce-cvm-upg-1-4-1-5-ctl-skew
gce-gci-upg-1-4-1-5-ctl-skew
kube-gce-upg-1-4-1-5-upg-clu
kube-gce-upg-1-4-1-5-upg-clu-n
kube-gce-upg-1-4-1-5-upg-mas
gce-cvm-upg-1-5-1-4-ctl-skew
gce-gci-upg-1-5-1-4-ctl-skew
```

GKE Projects:
```
k8s-jkns-gci-gke-ingress-1-5
k8s-jkns-gci-gke-reboot-1-5
k8s-jkns-gci-gke-1-5
k8s-jkns-gci-gke-serial-1-5
k8s-jkns-gci-gke-slow-1-5
k8s-jkns-e2e-gke-alpha-1-5
k8s-jkns-gke-ingress-1-5
k8s-jkns-gke-reboot-1-5
k8s-jkns-gke-1-5
k8s-jkns-gke-serial-1-5
k8s-jkns-gke-slow-1-5
```

GKE Upgrade Projects:
```
kube-gke-upg-1-4-1-5-ctl-skew
gke-gci-upg-1-4-1-5-ctl-skew
kube-gke-upg-1-5-1-4-ctl-skew
gke-gci-upg-1-5-1-4-ctl-skew
gke-up-c1-3-c1-5-up-clu
gke-up-c1-3-c1-5-up-clu-n
gke-up-c1-3-c1-5-up-mas
gke-up-c1-4-c1-5-up-clu
gke-up-c1-4-c1-5-up-clu-n
gke-up-c1-4-c1-5-up-mas
gke-up-c1-3-g1-5-up-clu
gke-up-c1-3-g1-5-up-clu-n
gke-up-c1-3-g1-5-up-mas
gke-up-c1-4-g1-5-up-clu
gke-up-c1-4-g1-5-up-clu-n
gke-up-c1-4-g1-5-up-mas
gke-up-g1-3-c1-5-up-clu
gke-up-g1-3-c1-5-up-clu-n
gke-up-g1-3-c1-5-up-mas
gke-up-g1-3-g1-5-up-clu
gke-up-g1-3-g1-5-up-clu-n
gke-up-g1-3-g1-5-up-mas
gke-up-g1-4-c1-5-up-clu
gke-up-g1-4-c1-5-up-clu-n
gke-up-g1-4-c1-5-up-mas
gke-up-g1-4-g1-5-up-clu
gke-up-g1-4-g1-5-up-clu-n
gke-up-g1-4-g1-5-up-mas
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/986)
<!-- Reviewable:end -->
