### PR TITLE
Use node labels to separate long-lived pods from transient pods.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HOOK_VERSION   = 0.44
+HOOK_VERSION   = 0.45
 LINE_VERSION   = 0.26
 SINKER_VERSION = 0.3
 DECK_VERSION   = 0.4
@@ -20,8 +20,6 @@ DECK_VERSION   = 0.4
 # These are the usual GKE variables.
 PROJECT = kubernetes-jenkins-pull
 ZONE = us-central1-f
-NUM_NODES = 3
-MACHINE_TYPE = n1-standard-2
 
 # These are GitHub credentials in files on your own machine.
 # The hook secret is your HMAC token, the OAuth secret is the OAuth
@@ -51,7 +49,7 @@ SERVICE_ACCOUNT_FILE = ${HOME}/service-account.json
 
 # Should probably move this to a script or something.
 create-cluster:
-	gcloud -q container --project "$(PROJECT)" clusters create ciongke --zone "$(ZONE)" --machine-type "$(MACHINE_TYPE)" --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.full_control","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management" --num-nodes "$(NUM_NODES)" --network "default" --enable-cloud-logging --enable-cloud-monitoring
+	gcloud -q container --project "$(PROJECT)" clusters create ciongke --zone "$(ZONE)" --machine-type n1-standard-4 --num-nodes 4 --node-labels=role=ciongke --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.full_control","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management" --network "default" --enable-cloud-logging --enable-cloud-monitoring
 	gcloud -q container node-pools create build-pool --project "$(PROJECT)" --cluster "ciongke" --zone "$(ZONE)" --machine-type n1-standard-8 --num-nodes 4 --local-ssd-count=1 --node-labels=role=build
 	kubectl create secret generic hmac-token --from-file=hmac=$(HOOK_SECRET_FILE)
 	kubectl create secret generic oauth-token --from-file=oauth=$(OAUTH_SECRET_FILE)

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -30,6 +30,8 @@ spec:
       labels:
         app: deck
     spec:
+      nodeSelector:
+        role: ciongke
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: hook
 spec:
-  replicas: 3
+  replicas: 4
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -30,10 +30,12 @@ spec:
       labels:
         app: hook
     spec:
+      nodeSelector:
+        role: ciongke
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.44
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.45
         imagePullPolicy: Always
         env:
         - name: LINE_IMAGE

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -11,6 +11,8 @@ spec:
       labels:
         app: sinker
     spec:
+      nodeSelector:
+        role: ciongke
       containers:
       - name: sinker
         image: gcr.io/kubernetes-jenkins-pull/sinker:0.3

--- a/prow/plugins/trigger/build.go
+++ b/prow/plugins/trigger/build.go
@@ -91,6 +91,9 @@ func createJob(c client, jobName string, pr github.PullRequest) error {
 			ActiveDeadlineSeconds: int(jobDeadline / time.Second),
 			Template: kube.PodTemplateSpec{
 				Spec: kube.PodSpec{
+					NodeSelector: map[string]string{
+						"role": "build",
+					},
 					RestartPolicy: "Never",
 					Containers: []kube.Container{
 						{


### PR DESCRIPTION
Evidently there's still some networking issues when pods are starting up on a node. I'll make a repro, but in the meantime this should keep us happy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/991)
<!-- Reviewable:end -->
