### PR TITLE
Disable JENKINS_GCI_PATCH_K8S for m55 and m56 GCI qa test

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce-gci.yaml
@@ -264,7 +264,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-master"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'slow-master':  # kubernetes-e2e-gce-gci-qa-slow-master
             description: 'Runs slow tests on GCE with GCI images from the master branch, sequentially.'
             timeout: 150
@@ -275,7 +275,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-master"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'serial-master':  # kubernetes-e2e-gce-gci-qa-serial-master
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images from the master branch.'
             timeout: 300
@@ -284,7 +284,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-master"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'm55':  # kubernetes-e2e-gce-gci-qa-m55
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 55, in parallel.'
             timeout: 50
@@ -293,7 +293,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m55"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'slow-m55':  # kubernetes-e2e-gce-gci-qa-slow-m55
             description: 'Runs slow tests on GCE with GCI images on milestone 55, sequentially.'
             timeout: 150
@@ -303,7 +303,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m55"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'serial-m55':  # kubernetes-e2e-gce-gci-qa-serial-m55
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 55.'
             timeout: 300
@@ -312,7 +312,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m55"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'm54':  # kubernetes-e2e-gce-gci-qa-m54
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 54, in parallel.'
             timeout: 50
@@ -321,7 +321,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-m54"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'slow-m54':  # kubernetes-e2e-gce-gci-qa-slow-m54
             description: 'Runs slow tests on GCE with GCI images on milestone 54, sequentially.'
             timeout: 150
@@ -331,7 +331,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export PROJECT="e2e-gce-gci-qa-slow-m54"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'serial-m54':  # kubernetes-e2e-gce-gci-qa-serial-m54
             description: 'Run [Serial], [Disruptive], tests on GCE, with GCI images on milestone 54.'
             timeout: 300
@@ -340,7 +340,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export PROJECT="e2e-gce-gci-qa-serial-m54"
-                export JENKINS_GCI_PATCH_K8S="y"
+                export JENKINS_GCI_PATCH_K8S="n"
         - 'm53':  # kubernetes-e2e-gce-gci-qa-m53
             description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE with GCI images on milestone 53, in parallel.'
             timeout: 50


### PR DESCRIPTION
Kubernetes is upgraded to 1.4.5 for m55 and m56 in GCI. Disable the JENKINS_GCI_PATCH_K8S option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/993)
<!-- Reviewable:end -->
