### PR TITLE
Disable "Network should set TCP CLOSE_WAIT timeout" in cri test.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -964,7 +964,10 @@
             emails: 'lantaol@google.com'
             test-owner: 'Random-Liu'
             job-env: |
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+                # Temporarily skip the test "Network should set TCP CLOSE_WAIT timeout" because it relies
+                # on host port, which is not implemented in CRI integration yet.
+                # TODO(random-liu): Re-enable the test.
+                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network should set TCP CLOSE_WAIT timeout"
                 export PROJECT="kubernetes-e2e-cri-validation"
                 export GINKGO_PARALLEL="y"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"

--- a/jobs/pull-kubernetes-e2e-gce-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-cri.sh
@@ -43,8 +43,11 @@ export GINKGO_TOLERATE_FLAKES="y"
 
 export E2E_NAME="cri-e2e-${NODE_NAME}-${EXECUTOR_NUMBER:-0}"
 export GINKGO_PARALLEL="y"
+# Temporarily skip the test "Network should set TCP CLOSE_WAIT timeout" because it relies
+# on host port, which is not implemented in CRI integration yet.
+# TODO(random-liu): Re-enable the test.
 # This list should match the list in kubernetes-e2e-gce.
-export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network should set TCP CLOSE_WAIT timeout'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="kubernetes-pr-cri-validation"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/36247.

Disable the test which needs hostport temporarily.

@yujuhong

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/994)
<!-- Reviewable:end -->
