### PR TITLE
Descrese load test throughput in enormous cluster

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -1047,7 +1047,7 @@
                 # Increase limit for inflight requests in apiserver.
                 export APISERVER_TEST_ARGS="--max-requests-inflight=1000"
                 # Increase throughput in Load test.
-                export LOAD_TEST_THROUGHPUT=35
+                export LOAD_TEST_THROUGHPUT=30
         - 'gce-enormous-deploy':  # kuberentes-e2e-gce-enormous-deploy
             description: 'Starts up empty 2000 node cluster and waits until it is running. Used for manual testing.'
             timeout: 300

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -1047,7 +1047,7 @@
                 # Increase limit for inflight requests in apiserver.
                 export APISERVER_TEST_ARGS="--max-requests-inflight=1000"
                 # Increase throughput in Load test.
-                export LOAD_TEST_THROUGHPUT=40
+                export LOAD_TEST_THROUGHPUT=35
         - 'gce-enormous-deploy':  # kuberentes-e2e-gce-enormous-deploy
             description: 'Starts up empty 2000 node cluster and waits until it is running. Used for manual testing.'
             timeout: 300


### PR DESCRIPTION
Throughput of 40 is still a bit too high for 3000-node cluster (though we successfully managed to go through creation and first phase of scaling of load test).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1002)
<!-- Reviewable:end -->
