### PR TITLE
Change project names to ones actually created

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -805,7 +805,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gce-1-5"
+                export PROJECT="k8s-gce-1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-reboot-release-1.5':  # kubernetes-e2e-gce-reboot-release-1.5
             description: 'Run [Feature:Reboot] tests on GCE on the release-1.5 branch.'
@@ -813,7 +813,7 @@
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-gce-reboot-1-5"
+                export PROJECT="k8s-gce-reboot-1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-slow-release-1.5':  # kubernetes-e2e-gce-slow-release-1.5
             description: 'Runs slow tests on GCE, sequentially on the release-1.5 branch.'
@@ -823,7 +823,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gce-slow-1-5"
+                export PROJECT="k8s-gce-slow-1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-serial-release-1.5':  # kubernetes-e2e-gce-serial-release-1.5
             description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.5 branch.'
@@ -832,7 +832,7 @@
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-gce-serial-1-5"
+                export PROJECT="k8s-gce-serial-1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-ingress-release-1.5':  # kubernetes-e2e-gce-ingress-release-1.5
             description: 'Run [Feature:Ingress] tests on GCE on the release-1.5 branch.'
@@ -842,7 +842,7 @@
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="k8s-jkns-gce-ingress1-5"
+                export PROJECT="k8s-gce-ingress1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
         - 'gce-alpha-features-release-1.5': # kubernetes-e2e-gce-alpha-features-release-1.5
             description: 'Run alpha feature tests on GCE on the release-1.5 branch.'
@@ -851,7 +851,7 @@
                 export KUBE_FEATURE_GATES="AllAlpha=true"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
-                export PROJECT="k8s-jkns-e2e-gce-alpha1-5"
+                export PROJECT="k8s-e2e-gce-alpha1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
         # Uncomment when 1.4 scale tests are turned off
         # - 'gce-scalability-release-1.5':  # kubernetes-e2e-gce-scalability-release-1.5
@@ -894,7 +894,7 @@
             emails: 'quinton@google.com, colin.hom@coreos.com, madhusudancs@google.com'
             test-owner: 'madhusudancs'
             job-env: |
-                export PROJECT="k8s-jkns-e2e-gce-f8n-1-5"
+                export PROJECT="k8s-e2e-gce-f8n-1-5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
                 export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
                 export FEDERATION="true"
@@ -928,7 +928,7 @@
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-gci-gce-reboot-1-5"
+                export PROJECT="k8s-gci-gce-reboot-1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gci-gce-slow-release-1.5':  # kubernetes-e2e-gci-gce-slow-release-1.5
             description: 'Runs slow tests on GCE, sequentially on the release-1.5 branch, using GCI image.'
@@ -957,7 +957,7 @@
             job-env: |
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="k8s-jkns-gci-gce-ingress1-5"
+                export PROJECT="k8s-gci-gce-ingress1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
         - 'gci-gce-alpha-features-release-1.5': # kubernetes-e2e-gci-gce-alpha-features-release-1.5
             description: 'Run alpha feature tests on GCE on the release-1.5 branch.'
@@ -966,7 +966,7 @@
                 export KUBE_FEATURE_GATES="AllAlpha=true"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
-                export PROJECT="k8s-jkns-e2e-gci-gce-alpha1-5"
+                export PROJECT="k8s-e2e-gci-gce-alpha1-5"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
         # Uncomment when 1.4 scale tests are turned off
         # - 'gci-gce-scalability-release-1.5':  # kubernetes-e2e-gci-gce-scalability-release-1.5

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -337,7 +337,7 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gke-1-5"
+                export PROJECT="k8s-gke-1-5"
         - 'gke-serial-release-1.5':  # kubernetes-e2e-gke-serial-release-1.5
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.5 branch.'
             timeout: 300
@@ -345,12 +345,12 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gke-serial-1-5"
+                export PROJECT="k8s-gke-serial-1-5"
         - 'gke-alpha-features-release-1.5':
             description: 'Run alpha feature tests on GKE on the release-1.5 branch.'
             timeout: 180
             job-env: |
-                export PROJECT="k8s-jkns-e2e-gke-alpha-1-5"
+                export PROJECT="k8s-e2e-gke-alpha-1-5"
                 export GKE_CREATE_FLAGS="--enable-kubernetes-alpha"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet)\]|ScheduledJob"
@@ -362,14 +362,14 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gke-slow-1-5"
+                export PROJECT="k8s-gke-slow-1-5"
         - 'gke-reboot-release-1.5':  # kubernetes-e2e-gke-reboot-release-1.5
             description: 'Run [Feature:Reboot] tests on GKE on the release-1.5 branch.'
             timeout: 180
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gke-reboot-1-5"
+                export PROJECT="k8s-gke-reboot-1-5"
         - 'gke-ingress-release-1.5':  # kubernetes-e2e-gke-ingress-release-1.5
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.5 branch.'
             timeout: 90
@@ -378,7 +378,7 @@
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gke-ingress-1-5"
+                export PROJECT="k8s-gke-ingress-1-5"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'
 
@@ -394,7 +394,7 @@
                 export GINKGO_PARALLEL="y"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gci-gke-1-5"
+                export PROJECT="k8s-gci-gke-1-5"
                 export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gci-gke-serial-release-1.5':  # kubernetes-e2e-gci-gke-serial-release-1.5
             description: 'Run [Serial], [Disruptive] tests on GKE on the release-1.5 branch, using GCI image.'
@@ -403,7 +403,7 @@
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
                                          --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gci-gke-serial-1-5"
+                export PROJECT="k8s-gci-gke-serial-1-5"
                 export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gci-gke-slow-release-1.5':  # kubernetes-e2e-gci-gke-slow-release-1.5
             description: 'Run slow E2E tests on GKE using the release-1.5 branch, using GCI image.'
@@ -413,7 +413,7 @@
                                          --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
                 export GINKGO_PARALLEL="y"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gci-gke-slow-1-5"
+                export PROJECT="k8s-gci-gke-slow-1-5"
                 export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gci-gke-reboot-release-1.5':  # kubernetes-e2e-gci-gke-reboot-release-1.5
             description: 'Run [Feature:Reboot] tests on GKE on the release-1.5 branch, using GCI image.'
@@ -421,7 +421,7 @@
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gci-gke-reboot-1-5"
+                export PROJECT="k8s-gci-gke-reboot-1-5"
                 export KUBE_GKE_IMAGE_TYPE="gci"
         - 'gci-gke-ingress-release-1.5':  # kubernetes-e2e-gci-gke-ingress-release-1.5
             description: 'Run [Feature:Ingress] tests on GKE on the release-1.5 branch, using GCI image.'
@@ -431,7 +431,7 @@
             job-env: |
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export PROJECT="k8s-jkns-gci-gke-ingress-1-5"
+                export PROJECT="k8s-gci-gke-ingress-1-5"
                 export KUBE_GKE_IMAGE_TYPE="gci"
     jobs:
         - 'kubernetes-e2e-{gke-suffix}'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -203,7 +203,7 @@
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
                 export KUBE_NODE_OS_DISTRIBUTION="debian"
             job-env: |
-                export PROJECT="k8s-jkns-gce-soak-1-5"
+                export PROJECT="k8s-gce-soak-1-5"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
         - 'gci-gce-1.5':
             deploy-description: |
@@ -225,7 +225,7 @@
                 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
                 export KUBE_NODE_OS_DISTRIBUTION="gci"
             job-env: |
-                export PROJECT="k8s-jkns-gci-gce-soak-1-5"
+                export PROJECT="k8s-gci-gce-soak-1-5"
                 export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
         - 'gce-1.4':
             deploy-description: |


### PR DESCRIPTION
Due to a mistake, `jkns-` was dropped from every project name that had it. Instead of re-creating projects, I'm just changing them to use the projects that were created.

cc @saad-ali

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1010)
<!-- Reviewable:end -->
