### PR TITLE
Enable kops PR builder on all PRs

### DIFF
--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -123,9 +123,10 @@ kubernetes/kubernetes:
   trigger: "@k8s-bot (gci )?(gce )?(e2e )?test this"
 
 - name: pull-kubernetes-e2e-kops-aws
+  always_run: true
   context: Jenkins kops AWS e2e
   rerun_command: "@k8s-bot kops aws e2e test this"
-  trigger: "@k8s-bot kops aws (e2e )?test this"
+  trigger: "@k8s-bot (kops )?(aws )?(e2e )?test this"
 
 - name: pull-kubernetes-federation-e2e-gce
   context: Jenkins Federation GCE e2e


### PR DESCRIPTION
c.f. https://k8s-testgrid.appspot.com/google-aws#kops-aws and https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kops-aws (the first two failed due to credentials and missing env variables, now fixed).

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1015)
<!-- Reviewable:end -->
