### PR TITLE
Reduce the frequency of more 1.2/1.3 CI tests.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-upgrade.yaml
@@ -57,6 +57,7 @@
             version-old: '1.2'
             version-new: '1.3'
             version-infix: '1-2-1-3'
+            cron-string: '{old-cron-string}'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
@@ -278,11 +279,13 @@
             version-cluster: '1.2'
             version-client: '1.3'
             version-infix: '1-2-1-3'
+            cron-string: '{old-cron-string}'
             version-env: ''
         - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
             version-cluster: '1.3'
             version-client: '1.2'
             version-infix: '1-3-1-2'
+            cron-string: '{old-cron-string}'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
@@ -291,11 +294,13 @@
             version-cluster: '1.3'
             version-client: '1.4'
             version-infix: '1-3-1-4'
+            cron-string: '{old-cron-string}'
             version-env: ''
         - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
             version-cluster: '1.4'
             version-client: '1.3'
             version-infix: '1-4-1-3'
+            cron-string: '{old-cron-string}'
             version-env: |
                 export JENKINS_USE_SKEW_TESTS="true"
         - 'kubernetes-e2e-gke-{version-cluster}-{version-client}-kubectl-skew':
@@ -363,11 +368,13 @@
             version-cluster: 'latest-1.3'
             version-client: 'latest-1.4'
             version-infix: '1-3-1-4'
+            cron-string: '{old-cron-string}'
             version-env: ''
         - 'kubernetes-e2e-gce-{version-cluster}-{version-client}-kubectl-skew':
             version-cluster: 'latest-1.4'
             version-client: 'latest-1.3'
             version-infix: '1-4-1-3'
+            cron-string: '{old-cron-string}'
             version-env: |
                 export JENKINS_USE_SKEW_TESTS="true"
         - 'kubernetes-e2e-gce-{version-cluster}-{version-client}-kubectl-skew':
@@ -471,6 +478,7 @@
             version-infix: 'c1-2-g1-3'
             image-old: 'container_vm'
             image-new: 'gci'
+            cron-string: '@daily'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
@@ -480,6 +488,7 @@
             version-infix: 'g1-2-c1-3'
             image-old: 'gci'
             image-new: 'container_vm'
+            cron-string: '@daily'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
@@ -489,6 +498,7 @@
             version-infix: 'g1-2-g1-3'
             image-old: 'gci'
             image-new: 'gci'
+            cron-string: '@daily'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
@@ -498,6 +508,7 @@
             version-infix: 'c1-2-g1-4'
             image-old: 'container_vm'
             image-new: 'gci'
+            cron-string: '@daily'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
@@ -507,6 +518,7 @@
             version-infix: 'g1-2-c1-4'
             image-old: 'gci'
             image-new: 'container_vm'
+            cron-string: '@daily'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"
@@ -516,6 +528,7 @@
             version-infix: 'g1-2-g1-4'
             image-old: 'gci'
             image-new: 'gci'
+            cron-string: '@daily'
             version-env: |
                 # 1.2 doesn't support IAM, so we should use cert auth.
                 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE="true"


### PR DESCRIPTION
Running these old upgrade tests every 30 minutes isn't very useful.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1016)
<!-- Reviewable:end -->
