### PR TITLE
Revert "Disable gke-large test"

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gke.yaml
@@ -140,9 +140,7 @@
             description: 'Run all non-flaky, non-slow, non-disruptive, non-feature tests on GKE, in parallel on a large GKE cluster'
             timeout: 450
             emails: 'zml@google.com wojtekt@google.com'
-            # TODO: Uncomment when we have permission to run it.
-            # cron-string: '0 17 * * *'
-            cron-string: ''
+            cron-string: '0 17 * * *'
             trigger-job: ''
             job-env: |
                 export E2E_NAME="gke-large-cluster"


### PR DESCRIPTION
Reverts kubernetes/test-infra#934

We are again allowed to run this test.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1017)
<!-- Reviewable:end -->
