### PR TITLE
Create boostrap version of gce-flaky

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -207,7 +207,7 @@ class GSUtil(object):
                 self.gsutil, '-m', '-q',
                 '-o', 'GSUtil:use_magicfile=True',
                 'cp', '-a', 'public-read', '-r', '-c', '-z', 'log,txt,xml',
-                artifacts, path,
+                '%s/*' % artifacts, path,
             ]
             call(cmd)
 

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -41,3 +41,7 @@
         branch: master
         job-name: ci-kubernetes-e2e-gce-etcd3
         repo-name: k8s.io/kubernetes
+    - kubernetes-e2e-gce-flaky:
+        branch: master
+        job-name: ci-kubernetes-e2e-gce-flaky
+        repo-name: k8s.io/kubernetes

--- a/jobs/ci-kubernetes-e2e-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gce-flaky.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_USE_GET_KUBE_SCRIPT=y
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Flaky\] \
+                         --ginkgo.skip=\[Feature:.+\]"
+export PROJECT="k8s-jkns-e2e-gce-flaky"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -893,6 +893,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-update-jenkins-jobs
 - name: ci-kubernetes-e2e-gce-etcd3
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd3
+- name: ci-kubernetes-e2e-gce-flaky
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-flaky
 # Manual, federated groups
 # rktnetes
 - name: kubernetes-rktnetes
@@ -2170,8 +2172,13 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-large-teardown
   - name: update-jenkins-jobs
     test_group_name: kubernetes-update-jenkins-jobs
+
+- name: bootstrap
+  dashboard_tab:
   - name: ci-kubernetes-e2e-gce-etcd3
     test_group_name: ci-kubernetes-e2e-gce-etcd3
+  - name: ci-kubernetes-e2e-gce-flaky
+    test_group_name: ci-kubernetes-e2e-gce-flaky
 
 - name: maintenance
   dashboard_tab:


### PR DESCRIPTION
1) Add line to `jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml`
2) Copy `ci-kubernetes-e2e-gce-etcd3.sh` to `ci-kubernetes-e2d-gce-flaky.sh`
3) Replace job-env with the info from `jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml`

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1020)
<!-- Reviewable:end -->
