### PR TITLE
Set CLOUDSDK_CONFIG to point to workspace

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-test-history.yaml
@@ -18,6 +18,9 @@
             skip-tag: true
     wrappers:
         - e2e-credentials-binding
+        - inject:
+            properties-content: |
+                CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
     builders:
         - activate-gce-service-account
         - shell: |

--- a/jenkins/job-configs/kubernetes-jenkins/testgrid-config-upload.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/testgrid-config-upload.yaml
@@ -22,6 +22,7 @@
         - e2e-credentials-binding
         - inject:
             properties-content: |
+                CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
                 GOROOT=/usr/local/go
                 GOPATH=$WORKSPACE/go
                 PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin


### PR DESCRIPTION
**kubernetes-test-summary** and **testgrid-config-upload** are failing right now because they are trying to use credentials saved in `/var/lib/jenkins/.config/gcloud` instead of the workspace (where `activate-gce-service-account` saves them).

The real fix is to move these to bootstrap, but this is a simpler fix to get things working again.

cc @krzyzacy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1035)
<!-- Reviewable:end -->
