### PR TITLE
Always run pull-kubernetes-node-e2e-cri

### DIFF
--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -160,9 +160,10 @@ kubernetes/kubernetes:
   rerun_command: "@k8s-bot cri e2e test this"
 
 - name: pull-kubernetes-node-e2e-cri
+  always_run: true
   context: Jenkins CRI GCE Node e2e
   rerun_command: "@k8s-bot cri node e2e test this"
-  trigger: "@k8s-bot cri (node e2e )?test this"
+  trigger: "@k8s-bot (cri node e2e )?test this"
 
 - name: pull-kubernetes-kubemark-e2e-gce
   context: Bootstrap Kubemark GCE e2e


### PR DESCRIPTION
The suite has been quite stable recently. Make the PR builder always run to prevent
regression.
https://k8s-testgrid.appspot.com/google-node#kubelet-cri-gce-e2e&width=5

/cc @Random-Liu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1038)
<!-- Reviewable:end -->
