### PR TITLE
Fix GINKGO_TEST_ARGS overwritten in federation soak tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-soak.yaml
@@ -125,14 +125,9 @@
             branch: 'master'
             job-env: |
                 export PROJECT="k8s-jkns-gce-federation-soak"
-            # Need the 8 essential kube-system pods ready before declaring cluster ready
-            # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
-            # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
-            provider-env: |
-                export KUBERNETES_PROVIDER="gce"
-                export E2E_MIN_STARTUP_PODS="8"
-                export FAIL_ON_GCP_RESOURCE_LEAK="true"
-                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+                # Need the 8 essential kube-system pods ready before declaring cluster ready
+                # etcd-server, kube-apiserver, kube-controller-manager, kube-dns
+                # kube-scheduler, l7-default-backend, l7-lb-controller, kube-addon-manager
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
                 export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
                 export FEDERATION="true"
@@ -140,6 +135,11 @@
                 export FEDERATIONS_DOMAIN_MAP="federation=soak.test-f8n.k8s.io"
                 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
                 export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-gce-federation-soak"
+            provider-env: |
+                export KUBERNETES_PROVIDER="gce"
+                export E2E_MIN_STARTUP_PODS="8"
+                export FAIL_ON_GCP_RESOURCE_LEAK="true"
+                export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
                 export KUBE_GCE_ZONE="us-central1-f"
                 export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
                 export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release


### PR DESCRIPTION
GINKGO_TEST_ARGS is getting overwritten as it is defined in provider-env instead of job-env. so moving the GINKGO_TEST_ARGS and few related variables to job-env.

Link to the build log: https://storage.googleapis.com/kubernetes-jenkins/logs/kubernetes-soak-continuous-e2e-gce-federation/1120/build-log.txt

@madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1050)
<!-- Reviewable:end -->
