### PR TITLE
Adding cla comment, and enabling it on contrib

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HOOK_VERSION   = 0.49
+HOOK_VERSION   = 0.50
 LINE_VERSION   = 0.26
 SINKER_VERSION = 0.3
 DECK_VERSION   = 0.4

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/kubernetes-jenkins-pull/hook:0.49
+        image: gcr.io/kubernetes-jenkins-pull/hook:0.50
         imagePullPolicy: Always
         env:
         - name: LINE_IMAGE

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -10,6 +10,7 @@ kubernetes/charts:
 
 kubernetes/contrib:
 - lgtm
+- cla
 
 kubernetes/heapster:
 - trigger

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -43,6 +43,10 @@ Once you've signed, please reply here (e.g. "I signed it!") and we'll verify.  T
 - If you signed the CLA as a corporation, please sign in with your organization's credentials at <https://identity.linuxfoundation.org/projects/cncf> to be authorized.
 
 <!-- need_sender_cla -->
+
+<details>
+%s
+</details>
 	`
 )
 
@@ -126,7 +130,7 @@ func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
 		if hasCncfYes {
 			gc.RemoveLabel(org, repo, number, claYesLabel)
 		}
-		gc.CreateComment(org, repo, number, cncfclaNotFoundMessage)
+		gc.CreateComment(org, repo, number, fmt.Sprintf(cncfclaNotFoundMessage, plugins.AboutThisBot))
 		gc.AddLabel(org, repo, number, claNoLabel)
 	}
 	return nil

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -27,10 +27,23 @@ import (
 )
 
 const (
-	pluginName     = "cla"
-	claContextName = "cla/linuxfoundation"
-	claYesLabel    = "cncf-cla: yes"
-	claNoLabel     = "cncf-cla: no"
+	pluginName             = "cla"
+	claContextName         = "cla/linuxfoundation"
+	claYesLabel            = "cncf-cla: yes"
+	claNoLabel             = "cncf-cla: no"
+	cncfclaNotFoundMessage = `Thanks for your pull request. Before we can look at your pull request, you'll need to sign a Contributor License Agreement (CLA).
+
+:memo: **Please visit <https://identity.linuxfoundation.org/projects/cncf> to sign.**
+
+Once you've signed, please reply here (e.g. "I signed it!") and we'll verify.  Thanks.
+
+---
+
+- If you've already signed a CLA, it's possible we don't have your GitHub username or you're using a different email address.  Check your existing CLA data and verify that your [email is set on your git commits](https://help.github.com/articles/setting-your-email-in-git/).
+- If you signed the CLA as a corporation, please sign in with your organization's credentials at <https://identity.linuxfoundation.org/projects/cncf> to be authorized.
+
+<!-- need_sender_cla -->
+	`
 )
 
 func init() {
@@ -110,10 +123,10 @@ func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
 		}
 
 		// If we end up here, the status is a failure/error.
-		// TODO(foxish): add a comment which explains what happened and how to rectify it.
 		if hasCncfYes {
 			gc.RemoveLabel(org, repo, number, claYesLabel)
 		}
+		gc.CreateComment(org, repo, number, cncfclaNotFoundMessage)
 		gc.AddLabel(org, repo, number, claNoLabel)
 	}
 	return nil

--- a/prow/plugins/cla/cla_test.go
+++ b/prow/plugins/cla/cla_test.go
@@ -147,8 +147,9 @@ func TestCLALabels(t *testing.T) {
 		}
 
 		fc := &fakegithub.FakeClient{
-			PullRequests: pullRequests,
-			Issues:       tc.issues,
+			PullRequests:  pullRequests,
+			Issues:        tc.issues,
+			IssueComments: make(map[int][]github.IssueComment),
 		}
 		se := github.StatusEvent{
 			Context: tc.context,


### PR DESCRIPTION
1. Update plugins.yaml to run cla on contrib.
2. Update cla plugin to post comment.

Will not merge till https://github.com/kubernetes/contrib/pull/2034 is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1071)
<!-- Reviewable:end -->
