### PR TITLE
Convert rest of the non-master gce jobs to bootstrap

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -177,174 +177,219 @@
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: 'kubernetes-build'
 
-#    # gce - 1.2
-#    - kubernetes-e2e-gce-release-1.2:
-#        job-name: ci-kubernetes-e2e-gce-release-1.2
-#        timeout: 50
-#    - kubernetes-e2e-gce-reboot-release-1.2:
-#        job-name: ci-kubernetes-e2e-gce-reboot-release-1.2
-#        timeout: 50
-#    - kubernetes-e2e-gce-slow-release-1.2:
-#        job-name: ci-kubernetes-e2e-gce-slow-release-1.2
-#        timeout: 150
-#    - kubernetes-e2e-gce-serial-release-1.2:
-#        job-name: ci-kubernetes-e2e-gce-serial-release-1.2
-#        timeout: 300
-#    - kubernetes-e2e-gce-ingress-release-1.2:
-#        job-name: ci-kubernetes-e2e-gce-ingress-release-1.2
-#        timeout: 90
+    # gce - 1.2
+    - kubernetes-e2e-gce-release-1.2:
+        job-name: ci-kubernetes-e2e-gce-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gce-reboot-release-1.2:
+        job-name: ci-kubernetes-e2e-gce-reboot-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gce-slow-release-1.2:
+        job-name: ci-kubernetes-e2e-gce-slow-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gce-serial-release-1.2:
+        job-name: ci-kubernetes-e2e-gce-serial-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gce-ingress-release-1.2:
+        job-name: ci-kubernetes-e2e-gce-ingress-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
 
-#    # gci-gce - 1.2
-#    - kubernetes-e2e-gci-gce-release-1.2:
-#        job-name: ci-kubernetes-e2e-gci-gce-release-1.2
-#        timeout: 50
-#    - kubernetes-e2e-gci-gce-reboot-release-1.2:
-#        job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.2
-#        timeout: 50
-#    - kubernetes-e2e-gci-gce-slow-release-1.2:
-#        job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.2
-#        timeout: 150
-#    - kubernetes-e2e-gci-gce-serial-release-1.2:
-#        job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.2
-#        timeout: 300
-#    - kubernetes-e2e-gci-gce-ingress-release-1.2:
-#        job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.2
-#        timeout: 90
-#
-#    # gce - 1.3
-#    - kubernetes-e2e-gce-release-1.3:
-#        job-name: ci-kubernetes-e2e-gce-release-1.3
-#        timeout: 50
-#        description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.3 branch.'
-#    - kubernetes-e2e-gce-reboot-release-1.3:
-#        job-name: ci-kubernetes-e2e-gce-reboot-release-1.3
-#        timeout: 50
-#    - kubernetes-e2e-gce-slow-release-1.3:
-#        job-name: ci-kubernetes-e2e-gce-slow-release-1.3
-#        timeout: 150
-#    - kubernetes-e2e-gce-serial-release-1.3:
-#        job-name: ci-kubernetes-e2e-gce-serial-release-1.3
-#        timeout: 300
-#    - kubernetes-e2e-gce-ingress-release-1.3:
-#        job-name: ci-kubernetes-e2e-gce-ingress-release-1.3
-#        timeout: 90
-#
-#    # gci-gce - 1.3
-#    - kubernetes-e2e-gci-gce-release-1.3:
-#        job-name: ci-kubernetes-e2e-gci-gce-release-1.3
-#        timeout: 50
-#    - kubernetes-e2e-gci-gce-reboot-release-1.3:
-#        job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.3
-#        timeout: 50
-#    - kubernetes-e2e-gci-gce-slow-release-1.3:
-#        job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.3
-#        timeout: 150
-#    - kubernetes-e2e-gci-gce-serial-release-1.3:
-#        job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.3
-#        timeout: 300
-#    - kubernetes-e2e-gci-gce-ingress-release-1.3:
-#        job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.3
-#        timeout: 90
-#
-#    # gce - 1.4
-#    - kubernetes-e2e-gce-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-release-1.4
-#      timeout: 50
-#    - kubernetes-e2e-gce-reboot-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-reboot-release-1.4
-#      timeout: 180
-#    - kubernetes-e2e-gce-slow-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-slow-release-1.4
-#     timeout: 150
-#    - kubernetes-e2e-gce-serial-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-serial-release-1.4
-#      timeout: 300
-#    - kubernetes-e2e-gce-ingress-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-ingress-release-1.4
-#      timeout: 90
-#    - kubernetes-e2e-gce-alpha-features-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-alpha-features-release-1.4
-#      timeout: 180
-#    - kubernetes-e2e-gce-scalability-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-scalability-release-1.4
-#      timeout: 120
-#    - kubernetes-e2e-gce-federation-release-1.4:
-#      job-name: ci-kubernetes-e2e-gce-federation-release-1.4
-#      timeout: 300
+    # gci-gce - 1.2
+    - kubernetes-e2e-gci-gce-release-1.2:
+        job-name: ci-kubernetes-e2e-gci-gce-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gci-gce-reboot-release-1.2:
+        job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gci-gce-slow-release-1.2:
+        job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gci-gce-serial-release-1.2:
+        job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
+    - kubernetes-e2e-gci-gce-ingress-release-1.2:
+        job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.2
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.2'
 
-#    # gci-gce - 1.4
-#    - kubernetes-e2e-gci-gce-release-1.4:
-#      job-name: ci-kubernetes-e2e-gci-gce-release-1.4
-#      timeout: 50
-#    - kubernetes-e2e-gci-gce-reboot-release-1.4:
-#      job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.4
-#      timeout: 180
-#    - kubernetes-e2e-gci-gce-slow-release-1.4:
-#      job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.4
-#      timeout: 150
-#    - kubernetes-e2e-gci-gce-serial-release-1.4:
-#      job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.4
-#      timeout: 300
-#    - kubernetes-e2e-gci-gce-ingress-release-1.4:
-#      job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.4
-#      timeout: 90
-#    - kubernetes-e2e-gci-gce-alpha-features-release-1.4:
-#      job-name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4
-#      timeout: 180
-#    - kubernetes-e2e-gci-gce-scalability-release-1.4:
-#      job-name: ci-kubernetes-e2e-gci-gce-scalability-release-1.4
-#      timeout: 120
-#
-#    # gce - 1.5
-#    - kubernetes-e2e-gce-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-release-1.5
-#      timeout: 50
-#    - kubernetes-e2e-gce-reboot-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-reboot-release-1.5
-#      timeout: 180
-#    - kubernetes-e2e-gce-slow-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-slow-release-1.5
-#      timeout: 150
-#    - kubernetes-e2e-gce-serial-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-serial-release-1.5
-#      timeout: 300
-#    - kubernetes-e2e-gce-ingress-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-ingress-release-1.5
-#      timeout: 90
-#    - kubernetes-e2e-gce-alpha-features-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-alpha-features-release-1.5
-#      timeout: 180
-#    # Uncomment when 1.4 scale tests are turned off
-#    # kubernetes-e2e-gce-scalability-release-1.5:
-#    # job-name: ci-kubernetes-e2e-gce-scalability-release-1.5
-#    # timeout: 120
-#    - kubernetes-e2e-gce-federation-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-federation-release-1.5
-#      timeout: 300
-#
-#    # gci-gce - 1.5
-#    - kubernetes-e2e-gci-gce-release-1.5:
-#      job-name: ci-kubernetes-e2e-gci-gce-release-1.5
-#      timeout: 50
-#    - kubernetes-e2e-gci-gce-reboot-release-1.5:
-#      job-name: ci-kubernetes-e2e-gce-reboot-release-1.5
-#      timeout: 180
-#    - kubernetes-e2e-gci-gce-slow-release-1.5:
-#      job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.5
-#      timeout: 150
-#    - kubernetes-e2e-gci-gce-serial-release-1.5:
-#      job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.5
-#      timeout: 300
-#    - kubernetes-e2e-gci-gce-ingress-release-1.5:
-#      job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.5
-#      timeout: 90
-#    - kubernetes-e2e-gci-gce-alpha-features-release-1.5:
-#      job-name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5
-#      timeout: 180
-#    # Uncomment when 1.4 scale tests are turned off
-#    # kubernetes-e2e-gci-gce-scalability-release-1.5:
-#    # job-name: ci-kubernetes-e2e-gci-gce-scalability-release-1.5
-#    # timeout: 120
+    # gce - 1.3
+    - kubernetes-e2e-gce-release-1.3:
+        job-name: ci-kubernetes-e2e-gce-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gce-reboot-release-1.3:
+        job-name: ci-kubernetes-e2e-gce-reboot-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gce-slow-release-1.3:
+        job-name: ci-kubernetes-e2e-gce-slow-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gce-serial-release-1.3:
+        job-name: ci-kubernetes-e2e-gce-serial-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gce-ingress-release-1.3:
+        job-name: ci-kubernetes-e2e-gce-ingress-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+
+    # gci-gce - 1.3
+    - kubernetes-e2e-gci-gce-release-1.3:
+        job-name: ci-kubernetes-e2e-gci-gce-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gci-gce-reboot-release-1.3:
+        job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gci-gce-slow-release-1.3:
+        job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gci-gce-serial-release-1.3:
+        job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+    - kubernetes-e2e-gci-gce-ingress-release-1.3:
+        job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.3
+        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        trigger-job: 'kubernetes-build-1.3'
+
+    # gce - 1.4
+    - kubernetes-e2e-gce-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gce-reboot-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-reboot-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gce-slow-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-slow-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gce-serial-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-serial-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gce-ingress-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-ingress-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gce-alpha-features-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-alpha-features-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gce-scalability-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-scalability-release-1.4
+        frequency: '@daily'
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gce-federation-release-1.4:
+        job-name: ci-kubernetes-e2e-gce-federation-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+
+    # gci-gce - 1.4
+    - kubernetes-e2e-gci-gce-release-1.4:
+        job-name: ci-kubernetes-e2e-gci-gce-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gci-gce-reboot-release-1.4:
+        job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gci-gce-slow-release-1.4:
+        job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gci-gce-serial-release-1.4:
+        job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gci-gce-ingress-release-1.4:
+        job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gci-gce-alpha-features-release-1.4:
+        job-name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.4'
+    - kubernetes-e2e-gci-gce-scalability-release-1.4:
+        job-name: ci-kubernetes-e2e-gci-gce-scalability-release-1.4
+        frequency: '@daily'
+        trigger-job: 'kubernetes-build-1.4'
+
+    # gce - 1.5
+    - kubernetes-e2e-gce-release-1.5:
+        job-name: ci-kubernetes-e2e-gce-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gce-reboot-release-1.5:
+        job-name: ci-kubernetes-e2e-gce-reboot-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gce-slow-release-1.5:
+        job-name: ci-kubernetes-e2e-gce-slow-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gce-serial-release-1.5:
+        job-name: ci-kubernetes-e2e-gce-serial-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gce-ingress-release-1.5:
+        job-name: ci-kubernetes-e2e-gce-ingress-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gce-alpha-features-release-1.5:
+        job-name: ci-kubernetes-e2e-gce-alpha-features-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    # Uncomment when 1.4 scale tests are turned off
+    # kubernetes-e2e-gce-scalability-release-1.5:
+    #   job-name: ci-kubernetes-e2e-gce-scalability-release-1.5
+    - kubernetes-e2e-gce-federation-release-1.5:
+        job-name: ci-kubernetes-e2e-gce-federation-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+
+    # gci-gce - 1.5
+    - kubernetes-e2e-gci-gce-release-1.5:
+        job-name: ci-kubernetes-e2e-gci-gce-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gci-gce-reboot-release-1.5:
+        job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gci-gce-slow-release-1.5:
+        job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gci-gce-serial-release-1.5:
+        job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gci-gce-ingress-release-1.5:
+        job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    - kubernetes-e2e-gci-gce-alpha-features-release-1.5:
+        job-name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'kubernetes-build-1.5'
+    # Uncomment when 1.4 scale tests are turned off
+    # kubernetes-e2e-gci-gce-scalability-release-1.5:
+    # job-name: ci-kubernetes-e2e-gci-gce-scalability-release-1.5
 
     # gce-features
     - kubernetes-e2e-gce-ingress:

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-gce.yaml
@@ -90,647 +90,73 @@
     jobs:
         - 'kubernetes-e2e-{suffix}'
 
-- project:
-    name: kubernetes-e2e-gce-1-2
-    trigger-job: 'kubernetes-build-1.2'
-    test-owner: 'Build Cop'
-    cron-string: '{old-cron-string}'
-    suffix:
-        - 'gce-release-1.2':  # kubernetes-e2e-gce-release-1.2
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.2 branch.'
-            timeout: 50  # See #21138
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-e2e-gce-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-reboot-release-1.2':  # kubernetes-e2e-gce-reboot-release-1.2
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.2 branch.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-e2e-gce-reboot-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-slow-release-1.2':  # kubernetes-e2e-gce-slow-release-1.2
-            description: 'Runs slow tests on GCE, sequentially on the release-1.2 branch.'
-            timeout: 150  #  See #24072
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-e2e-gce-slow-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-serial-release-1.2':  # kubernetes-e2e-gce-serial-release-1.2
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.2 branch.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
+# Convert those two when 1.4 scale tests are turned off
+# - 'gce-scalability-release-1.5':  # kubernetes-e2e-gce-scalability-release-1.5
+#     description: 'Run scalability E2E tests on GCE from the release-1.5 branch.'
+#     timeout: 120
+#     cron-string: '@daily'
+#     job-env: |
+#         export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+#         export E2E_NAME="e2e-scalability-1-5"
+#         export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+#                                  --gather-resource-usage=true \
+#                                  --gather-metrics-at-teardown=true \
+#                                  --gather-logs-sizes=true \
+#                                  --output-print-type=json"
+#         # Use the 1.1 project for now, since it has quota.
+#         # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+#         export PROJECT="k8s-e2e-gce-scalability-1-1"
+#         export FAIL_ON_GCP_RESOURCE_LEAK="false"
+#         # Override GCE defaults.
+#         export KUBE_GCE_ZONE="us-east1-b"
+#         export MASTER_SIZE="n1-standard-4"
+#         export NODE_SIZE="n1-standard-1"
+#         export NODE_DISK_SIZE="50GB"
+#         export NUM_NODES="100"
+#         export REGISTER_MASTER="true"
+#         # Reduce logs verbosity
+#         export TEST_CLUSTER_LOG_LEVEL="--v=2"
+#         # TODO: Remove when we figure out the reason for occasional failures #19048
+#         export KUBELET_TEST_LOG_LEVEL="--v=4"
+#         # Increase resync period to simulate production
+#         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+#         # Increase delete collection parallelism
+#         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+#         export KUBE_NODE_OS_DISTRIBUTION="debian"
 
-- project:
-    name: kubernetes-e2e-gci-gce-1-2
-    trigger-job: 'kubernetes-build-1.2'
-    test-owner: 'Build Cop'
-    cron-string: '{old-cron-string}'
-    suffix:
-        - 'gci-gce-release-1.2':  # kubernetes-e2e-gci-gce-release-1.2
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.2 branch, using GCI image.'
-            timeout: 50  # See #21138
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gci-gce-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-reboot-release-1.2':  # kubernetes-e2e-gci-gce-reboot-release-1.2
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.2 branch, using GCI image.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-gci-gce-reboot-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-slow-release-1.2':  # kubernetes-e2e-gci-gce-slow-release-1.2
-            description: 'Runs slow tests on GCE, sequentially on the release-1.2 branch, using GCI image.'
-            timeout: 150  #  See #24072
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gci-gce-slow-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-serial-release-1.2':  # kubernetes-e2e-gci-gce-serial-release-1.2
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.2 branch, using GCI image.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-gci-gce-serial-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
+# - 'gci-gce-scalability-release-1.5':  # kubernetes-e2e-gci-gce-scalability-release-1.5
+#     description: 'Run scalability E2E tests on GCE from the release-1.5 branch.'
+#     timeout: 120
+#     cron-string: '@daily'
+#     job-env: |
+#         export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+#         export E2E_NAME="e2e-scalability-1-5"
+#         export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+#                                  --gather-resource-usage=true \
+#                                  --gather-metrics-at-teardown=true \
+#                                  --gather-logs-sizes=true \
+#                                  --output-print-type=json"
+#         # Use the 1.1 project for now, since it has quota.
+#         # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+#         export PROJECT="k8s-e2e-gci-gce-scale-1-4"
+#         export FAIL_ON_GCP_RESOURCE_LEAK="false"
+#         # Override GCE defaults.
+#         export KUBE_GCE_ZONE="us-east1-b"
+#         export MASTER_SIZE="n1-standard-4"
+#         export NODE_SIZE="n1-standard-1"
+#         export NODE_DISK_SIZE="50GB"
+#         export NUM_NODES="100"
+#         export REGISTER_MASTER="true"
+#         # Reduce logs verbosity
+#         export TEST_CLUSTER_LOG_LEVEL="--v=2"
+#         # TODO: Remove when we figure out the reason for occasional failures #19048
+#         export KUBELET_TEST_LOG_LEVEL="--v=4"
+#         # Increase resync period to simulate production
+#         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+#         # Increase delete collection parallelism
+#         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+#         export KUBE_NODE_OS_DISTRIBUTION="gci"
 
-- project:
-    name: kubernetes-e2e-gce-1-3
-    trigger-job: 'kubernetes-build-1.3'
-    test-owner: 'Release 1.3 owner'
-    cron-string: '{old-cron-string}'
-    suffix:
-        - 'gce-release-1.3':  # kubernetes-e2e-gce-release-1.3
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.3 branch.'
-            timeout: 50  # See #21138
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gce-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-reboot-release-1.3':  # kubernetes-e2e-gce-reboot-release-1.3
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.3 branch.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-gce-reboot-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-slow-release-1.3':  # kubernetes-e2e-gce-slow-release-1.3
-            description: 'Runs slow tests on GCE, sequentially on the release-1.3 branch.'
-            timeout: 150  #  See #24072
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gce-slow-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-serial-release-1.3':  # kubernetes-e2e-gce-serial-release-1.3
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.3 branch.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-gce-serial-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-ingress-release-1.2':  # kubernetes-e2e-gce-ingress-release-1.2
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.2 branch.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="kubernetes-ingress-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-ingress-release-1.3':  # kubernetes-e2e-gce-ingress-release-1.3
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.3 branch.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="kubernetes-ingress-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gci-gce-1-3
-    trigger-job: 'kubernetes-build-1.3'
-    test-owner: 'Release 1.3 owner'
-    cron-string: '{old-cron-string}'
-    suffix:
-        - 'gci-gce-release-1.3':  # kubernetes-e2e-gci-gce-release-1.3
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.3 branch, using GCI image.'
-            timeout: 50  # See #21138
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gci-gce-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-reboot-release-1.3':  # kubernetes-e2e-gci-gce-reboot-release-1.3
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.3 branch, using GCI image.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-gci-gce-reboot-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-slow-release-1.3':  # kubernetes-e2e-gci-gce-slow-release-1.3
-            description: 'Runs slow tests on GCE, sequentially on the release-1.3 branch, using GCI image.'
-            timeout: 150  #  See #24072
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gci-gce-slow-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-serial-release-1.3':  # kubernetes-e2e-gci-gce-serial-release-1.3
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.3 branch, using GCI image.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-gci-gce-serial-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-ingress-release-1.2':  # kubernetes-e2e-gci-gce-ingress-release-1.2
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.2 branch, using GCI image.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="kubernetes-gci-ingress-1-2"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-ingress-release-1.3':  # kubernetes-e2e-gci-gce-ingress-release-1.3
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.3 branch, using GCI image.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="kubernetes-gci-ingress-1-3"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gce-1-4
-    trigger-job: 'kubernetes-build-1.4'
-    test-owner: 'pwittrock'
-    suffix:
-        - 'gce-release-1.4':  # kubernetes-e2e-gce-release-1.4
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.4 branch.'
-            timeout: 50  # See kubernetes/kubernetes#21138
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gce-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-reboot-release-1.4':  # kubernetes-e2e-gce-reboot-release-1.4
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.4 branch.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-gce-reboot-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-slow-release-1.4':  # kubernetes-e2e-gce-slow-release-1.4
-            description: 'Runs slow tests on GCE, sequentially on the release-1.4 branch.'
-            timeout: 150  #  See kubernetes/kubernetes#24072
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-jkns-gce-slow-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-serial-release-1.4':  # kubernetes-e2e-gce-serial-release-1.4
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.4 branch.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-jkns-gce-serial-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-ingress-release-1.4':  # kubernetes-e2e-gce-ingress-release-1.4
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.4 branch.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="k8s-jkns-gce-ingress1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-alpha-features-release-1.4': # kubernetes-e2e-gce-alpha-features-release-1.4
-            description: 'Run alpha feature tests on GCE on the release-1.4 branch.'
-            timeout: 180
-            job-env: |
-                export PROJECT="k8s-jkns-e2e-gce-alpha1-4"
-                export KUBE_FEATURE_GATES="AllAlpha=true"
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
-                export PROJECT="k8s-jkns-e2e-gce-alpha1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-scalability-release-1.4':  # kubernetes-e2e-gce-scalability-release-1.4
-            description: 'Run scalability E2E tests on GCE from the release-1.4 branch.'
-            timeout: 120
-            cron-string: '@daily'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export E2E_NAME="e2e-scalability-1-4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
-                                         --gather-resource-usage=true \
-                                         --gather-metrics-at-teardown=true \
-                                         --gather-logs-sizes=true \
-                                         --output-print-type=json"
-                # Use the 1.1 project for now, since it has quota.
-                # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
-                export PROJECT="k8s-e2e-gce-scalability-1-1"
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                # Override GCE defaults.
-                export KUBE_GCE_ZONE="us-east1-b"
-                export MASTER_SIZE="n1-standard-4"
-                export NODE_SIZE="n1-standard-1"
-                export NODE_DISK_SIZE="50GB"
-                export NUM_NODES="100"
-                export REGISTER_MASTER="true"
-                # Reduce logs verbosity
-                export TEST_CLUSTER_LOG_LEVEL="--v=2"
-                # TODO: Remove when we figure out the reason for occasional failures #19048
-                export KUBELET_TEST_LOG_LEVEL="--v=4"
-                # Increase resync period to simulate production
-                export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
-                # Increase delete collection parallelism
-                export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-federation-release-1.4':  # kubernetes-e2e-gce-federation-1.4
-            # This test depends on the artifacts generated by the trigger-job. Be careful while changing this test.
-            trigger-job: 'kubernetes-federation-build-1.4'
-            description: 'Run all federation e2e tests.'
-            timeout: 300
-            emails: 'quinton@google.com, colin.hom@coreos.com, madhusudancs@google.com'
-            test-owner: 'madhusudancs'
-            job-env: |
-                export PROJECT="k8s-jkns-e2e-gce-f8n-1-4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
-                export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
-                export FEDERATION="true"
-                export DNS_ZONE_NAME="release1-4.test-f8n.k8s.io."
-                export FEDERATIONS_DOMAIN_MAP="federation=release1-4.test-f8n.k8s.io"
-                export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
-                export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-f8n-1-4"
-                export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-4
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-4
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gce-1-5
-    trigger-job: 'kubernetes-build-1.5'
-    test-owner: 'saad-ali'
-    suffix:
-        - 'gce-release-1.5':  # kubernetes-e2e-gce-release-1.5
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.5 branch.'
-            timeout: 50  # See kubernetes/kubernetes#21138
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-gce-1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-reboot-release-1.5':  # kubernetes-e2e-gce-reboot-release-1.5
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.5 branch.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-gce-reboot-1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-slow-release-1.5':  # kubernetes-e2e-gce-slow-release-1.5
-            description: 'Runs slow tests on GCE, sequentially on the release-1.5 branch.'
-            timeout: 150  #  See kubernetes/kubernetes#24072
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="k8s-gce-slow-1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-serial-release-1.5':  # kubernetes-e2e-gce-serial-release-1.5
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.5 branch.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="k8s-gce-serial-1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-ingress-release-1.5':  # kubernetes-e2e-gce-ingress-release-1.5
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.5 branch.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="k8s-gce-ingress1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-alpha-features-release-1.5': # kubernetes-e2e-gce-alpha-features-release-1.5
-            description: 'Run alpha feature tests on GCE on the release-1.5 branch.'
-            timeout: 180
-            job-env: |
-                export KUBE_FEATURE_GATES="AllAlpha=true"
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
-                export PROJECT="k8s-e2e-gce-alpha1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="debian"
-        # Uncomment when 1.4 scale tests are turned off
-        # - 'gce-scalability-release-1.5':  # kubernetes-e2e-gce-scalability-release-1.5
-        #     description: 'Run scalability E2E tests on GCE from the release-1.5 branch.'
-        #     timeout: 120
-        #     cron-string: '@daily'
-        #     job-env: |
-        #         export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-        #         export E2E_NAME="e2e-scalability-1-5"
-        #         export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
-        #                                  --gather-resource-usage=true \
-        #                                  --gather-metrics-at-teardown=true \
-        #                                  --gather-logs-sizes=true \
-        #                                  --output-print-type=json"
-        #         # Use the 1.1 project for now, since it has quota.
-        #         # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
-        #         export PROJECT="k8s-e2e-gce-scalability-1-1"
-        #         export FAIL_ON_GCP_RESOURCE_LEAK="false"
-        #         # Override GCE defaults.
-        #         export KUBE_GCE_ZONE="us-east1-b"
-        #         export MASTER_SIZE="n1-standard-4"
-        #         export NODE_SIZE="n1-standard-1"
-        #         export NODE_DISK_SIZE="50GB"
-        #         export NUM_NODES="100"
-        #         export REGISTER_MASTER="true"
-        #         # Reduce logs verbosity
-        #         export TEST_CLUSTER_LOG_LEVEL="--v=2"
-        #         # TODO: Remove when we figure out the reason for occasional failures #19048
-        #         export KUBELET_TEST_LOG_LEVEL="--v=4"
-        #         # Increase resync period to simulate production
-        #         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
-        #         # Increase delete collection parallelism
-        #         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
-        #         export KUBE_NODE_OS_DISTRIBUTION="debian"
-        - 'gce-federation-release-1.5':  # kubernetes-e2e-gce-federation-1.5
-            # This test depends on the artifacts generated by the trigger-job. Be careful while changing this test.
-            trigger-job: 'kubernetes-federation-build-1.5'
-            description: 'Run all federation e2e tests.'
-            timeout: 300
-            emails: 'quinton@google.com, colin.hom@coreos.com, madhusudancs@google.com'
-            test-owner: 'madhusudancs'
-            job-env: |
-                export PROJECT="k8s-e2e-gce-f8n-1-5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
-                export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
-                export FEDERATION="true"
-                export DNS_ZONE_NAME="release1-5.test-f8n.k8s.io."
-                export FEDERATIONS_DOMAIN_MAP="federation=release1-5.test-f8n.k8s.io"
-                export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
-                export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-e2e-gce-f8n-1-5"
-                export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
-                export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-5
-                export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-5
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gci-gce-1-5
-    trigger-job: 'kubernetes-build-1.5'
-    test-owner: 'saad-ali'
-    suffix:
-        - 'gci-gce-release-1.5':  # kubernetes-e2e-gci-gce-release-1.5
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.5 branch, using GCI image.'
-            timeout: 50
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-1-5"
-                export KUBE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-reboot-release-1.5':  # kubernetes-e2e-gci-gce-reboot-release-1.5
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.5 branch.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-gci-gce-reboot-1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-slow-release-1.5':  # kubernetes-e2e-gci-gce-slow-release-1.5
-            description: 'Runs slow tests on GCE, sequentially on the release-1.5 branch, using GCI image.'
-            timeout: 150
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-slow-1-5"
-                export KUBE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-serial-release-1.5':  # kubernetes-e2e-gci-gce-serial-release-1.5
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.5 branch, using GCI image.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-ci-serial-1-5"
-                export KUBE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-ingress-release-1.5':  # kubernetes-e2e-gci-gce-ingress-release-1.5
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.5 branch.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="k8s-gci-gce-ingress1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-alpha-features-release-1.5': # kubernetes-e2e-gci-gce-alpha-features-release-1.5
-            description: 'Run alpha feature tests on GCE on the release-1.5 branch.'
-            timeout: 180
-            job-env: |
-                export KUBE_FEATURE_GATES="AllAlpha=true"
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
-                export PROJECT="k8s-e2e-gci-gce-alpha1-5"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        # Uncomment when 1.4 scale tests are turned off
-        # - 'gci-gce-scalability-release-1.5':  # kubernetes-e2e-gci-gce-scalability-release-1.5
-        #     description: 'Run scalability E2E tests on GCE from the release-1.5 branch.'
-        #     timeout: 120
-        #     cron-string: '@daily'
-        #     job-env: |
-        #         export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
-        #         export E2E_NAME="e2e-scalability-1-5"
-        #         export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
-        #                                  --gather-resource-usage=true \
-        #                                  --gather-metrics-at-teardown=true \
-        #                                  --gather-logs-sizes=true \
-        #                                  --output-print-type=json"
-        #         # Use the 1.1 project for now, since it has quota.
-        #         # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
-        #         export PROJECT="k8s-e2e-gci-gce-scale-1-4"
-        #         export FAIL_ON_GCP_RESOURCE_LEAK="false"
-        #         # Override GCE defaults.
-        #         export KUBE_GCE_ZONE="us-east1-b"
-        #         export MASTER_SIZE="n1-standard-4"
-        #         export NODE_SIZE="n1-standard-1"
-        #         export NODE_DISK_SIZE="50GB"
-        #         export NUM_NODES="100"
-        #         export REGISTER_MASTER="true"
-        #         # Reduce logs verbosity
-        #         export TEST_CLUSTER_LOG_LEVEL="--v=2"
-        #         # TODO: Remove when we figure out the reason for occasional failures #19048
-        #         export KUBELET_TEST_LOG_LEVEL="--v=4"
-        #         # Increase resync period to simulate production
-        #         export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
-        #         # Increase delete collection parallelism
-        #         export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
-        #         export KUBE_NODE_OS_DISTRIBUTION="gci"
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
-
-- project:
-    name: kubernetes-e2e-gci-gce-1-4
-    trigger-job: 'kubernetes-build-1.4'
-    test-owner: 'pwittrock'
-    suffix:
-        - 'gci-gce-release-1.4':  # kubernetes-e2e-gci-gce-release-1.4
-            description: 'Runs all non-slow, non-serial, non-flaky, tests on GCE in parallel on the release-1.4 branch, using GCI image.'
-            timeout: 50
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-1-4"
-                export KUBE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-reboot-release-1.4':  # kubernetes-e2e-gci-gce-reboot-release-1.4
-            description: 'Run [Feature:Reboot] tests on GCE on the release-1.4 branch.'
-            timeout: 180
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
-                export PROJECT="k8s-jkns-gci-gce-reboot-1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-slow-release-1.4':  # kubernetes-e2e-gci-gce-slow-release-1.4
-            description: 'Runs slow tests on GCE, sequentially on the release-1.4 branch, using GCI image.'
-            timeout: 150
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
-                                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
-                export GINKGO_PARALLEL="y"
-                export PROJECT="e2e-gce-gci-ci-slow-1-4"
-                export KUBE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-serial-release-1.4':  # kubernetes-e2e-gci-gce-serial-release-1.4
-            description: 'Run [Serial], [Disruptive], tests on GCE on the release-1.4 branch, using GCI image.'
-            timeout: 300
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
-                                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
-                export PROJECT="e2e-gce-gci-ci-serial-1-4"
-                export KUBE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-ingress-release-1.4':  # kubernetes-e2e-gci-gce-ingress-release-1.4
-            description: 'Run [Feature:Ingress] tests on GCE on the release-1.4 branch.'
-            timeout: 90
-            emails: 'beeps@google.com'
-            test-owner: 'beeps'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
-                export PROJECT="k8s-jkns-gci-gce-ingress1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-alpha-features-release-1.4': # kubernetes-e2e-gci-gce-alpha-features-release-1.4
-            description: 'Run alpha feature tests on GCE on the release-1.4 branch.'
-            timeout: 180
-            job-env: |
-                export PROJECT="k8s-jkns-e2e-gce-alpha1-4"
-                export KUBE_FEATURE_GATES="AllAlpha=true"
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
-                export PROJECT="k8s-jkns-e2e-gci-gce-alpha1-4"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-        - 'gci-gce-scalability-release-1.4':  # kubernetes-e2e-gci-gce-scalability-release-1.4
-            description: 'Run scalability E2E tests on GCE from the release-1.4 branch.'
-            timeout: 120
-            cron-string: '@daily'
-            job-env: |
-                export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
-                export E2E_NAME="e2e-scalability-1-4"
-                export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
-                                         --gather-resource-usage=true \
-                                         --gather-metrics-at-teardown=true \
-                                         --gather-logs-sizes=true \
-                                         --output-print-type=json"
-                # Use the 1.1 project for now, since it has quota.
-                # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
-                export PROJECT="k8s-e2e-gci-gce-scale-1-4"
-                export FAIL_ON_GCP_RESOURCE_LEAK="false"
-                # Override GCE defaults.
-                export KUBE_GCE_ZONE="us-east1-b"
-                export MASTER_SIZE="n1-standard-4"
-                export NODE_SIZE="n1-standard-1"
-                export NODE_DISK_SIZE="50GB"
-                export NUM_NODES="100"
-                export REGISTER_MASTER="true"
-                # Reduce logs verbosity
-                export TEST_CLUSTER_LOG_LEVEL="--v=2"
-                # TODO: Remove when we figure out the reason for occasional failures #19048
-                export KUBELET_TEST_LOG_LEVEL="--v=4"
-                # Increase resync period to simulate production
-                export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
-                # Increase delete collection parallelism
-                export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
-                export KUBE_NODE_OS_DISTRIBUTION="gci"
-    jobs:
-        - 'kubernetes-e2e-{suffix}'
 
 - project:
     name: kubernetes-e2e-gce-enormous-cluster

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export KUBE_FEATURE_GATES="AllAlpha=true"
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
+export PROJECT="k8s-jkns-e2e-gce-alpha1-4"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export KUBE_FEATURE_GATES="AllAlpha=true"
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
+export PROJECT="k8s-e2e-gce-alpha1-5"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export PROJECT="k8s-jkns-e2e-gce-f8n-1-4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
+export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
+export FEDERATION="true"
+export DNS_ZONE_NAME="release1-4.test-f8n.k8s.io."
+export FEDERATIONS_DOMAIN_MAP="federation=release1-4.test-f8n.k8s.io"
+export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
+export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-f8n-1-4"
+export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
+export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-4
+export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-4
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export PROJECT="k8s-e2e-gce-f8n-1-5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
+export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
+export FEDERATION="true"
+export DNS_ZONE_NAME="release1-5.test-f8n.k8s.io."
+export FEDERATIONS_DOMAIN_MAP="federation=release1-5.test-f8n.k8s.io"
+export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
+export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-e2e-gce-f8n-1-5"
+export KUBE_GCE_ZONE="us-central1-f" #TODO(colhom): This should be generalized out to plural case
+export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-5
+export KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-5
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-ingress-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress-release-1.2.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="kubernetes-ingress-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-ingress-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress-release-1.3.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="kubernetes-ingress-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress-release-1.4.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="k8s-jkns-gce-ingress1-4"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress-release-1.5.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="k8s-gce-ingress1-5"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-jkns-e2e-gce-reboot-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-jkns-gce-reboot-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-jkns-gce-reboot-1-4"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-gce-reboot-1-5"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-e2e-gce-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gce-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gce-1-4"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-gce-1-5"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.4.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export E2E_NAME="e2e-scalability-1-4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+                         --gather-resource-usage=true \
+                         --gather-metrics-at-teardown=true \
+                         --gather-logs-sizes=true \
+                         --output-print-type=json"
+# Use the 1.1 project for now, since it has quota.
+# TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+export PROJECT="k8s-e2e-gce-scalability-1-1"
+export FAIL_ON_GCP_RESOURCE_LEAK="false"
+# Override GCE defaults.
+export KUBE_GCE_ZONE="us-east1-b"
+export MASTER_SIZE="n1-standard-4"
+export NODE_SIZE="n1-standard-1"
+export NODE_DISK_SIZE="50GB"
+export NUM_NODES="100"
+export REGISTER_MASTER="true"
+# Reduce logs verbosity
+export TEST_CLUSTER_LOG_LEVEL="--v=2"
+# TODO: Remove when we figure out the reason for occasional failures #19048
+export KUBELET_TEST_LOG_LEVEL="--v=4"
+# Increase resync period to simulate production
+export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+# Increase delete collection parallelism
+export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 120m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="k8s-jkns-e2e-gce-serial-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="k8s-jkns-gce-serial-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="k8s-jkns-gce-serial-1-4"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="k8s-gce-serial-1-5"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-e2e-gce-slow-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gce-slow-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gce-slow-1-4"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-gce-slow-1-5"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export KUBE_FEATURE_GATES="AllAlpha=true"
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
+export PROJECT="k8s-jkns-e2e-gci-gce-alpha1-4"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export KUBE_FEATURE_GATES="AllAlpha=true"
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob"
+export PROJECT="k8s-e2e-gci-gce-alpha1-5"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.2.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="kubernetes-gci-ingress-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.3.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="kubernetes-gci-ingress-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="k8s-jkns-gci-gce-ingress1-4"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Ingress\]"
+export PROJECT="k8s-gci-gce-ingress1-5"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-jkns-gci-gce-reboot-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-jkns-gci-gce-reboot-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-jkns-gci-gce-reboot-1-4"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Reboot\]"
+export PROJECT="k8s-gci-gce-reboot-1-5"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gci-gce-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gci-gce-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="e2e-gce-gci-ci-1-4"
+export KUBE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="e2e-gce-gci-ci-1-5"
+export KUBE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.4.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export E2E_NAME="e2e-scalability-1-4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Performance\] \
+                         --gather-resource-usage=true \
+                         --gather-metrics-at-teardown=true \
+                         --gather-logs-sizes=true \
+                         --output-print-type=json"
+# Use the 1.1 project for now, since it has quota.
+# TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+export PROJECT="k8s-e2e-gci-gce-scale-1-4"
+export FAIL_ON_GCP_RESOURCE_LEAK="false"
+# Override GCE defaults.
+export KUBE_GCE_ZONE="us-east1-b"
+export MASTER_SIZE="n1-standard-4"
+export NODE_SIZE="n1-standard-1"
+export NODE_DISK_SIZE="50GB"
+export NUM_NODES="100"
+export REGISTER_MASTER="true"
+# Reduce logs verbosity
+export TEST_CLUSTER_LOG_LEVEL="--v=2"
+# TODO: Remove when we figure out the reason for occasional failures #19048
+export KUBELET_TEST_LOG_LEVEL="--v=4"
+# Increase resync period to simulate production
+export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
+# Increase delete collection parallelism
+export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 120m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="k8s-jkns-gci-gce-serial-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="k8s-jkns-gci-gce-serial-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="e2e-gce-gci-ci-serial-1-4"
+export KUBE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Serial\]|\[Disruptive\] \
+                         --ginkgo.skip=\[Flaky\]|\[Feature:.+\]"
+export PROJECT="e2e-gce-gci-ci-serial-1-5"
+export KUBE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.2"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gci-gce-slow-1-2"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.3"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="k8s-jkns-gci-gce-slow-1-3"
+export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.4"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="e2e-gce-gci-ci-slow-1-4"
+export KUBE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+
+### project-env
+# expected empty
+
+### job-env
+export JENKINS_PUBLISHED_VERSION="ci/latest-1.5"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Slow\] \
+                         --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+export PROJECT="e2e-gce-gci-ci-slow-1-5"
+export KUBE_OS_DISTRIBUTION="gci"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -89,13 +89,13 @@ test_groups:
 - name: kubernetes-e2e-gci-gce-alpha-features
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-features
 - name: kubernetes-e2e-gce-alpha-features-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-alpha-features-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-features-release-1.4
 - name: kubernetes-e2e-gce-alpha-features-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-alpha-features-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-features-release-1.5
 - name: kubernetes-e2e-gci-gce-alpha-features-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4
 - name: kubernetes-e2e-gci-gce-alpha-features-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-alpha-features-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5
 - name: kubernetes-e2e-gce-autoscaling
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-autoscaling
 - name: kubernetes-e2e-gci-gce-autoscaling
@@ -121,9 +121,9 @@ test_groups:
 - name: kubernetes-e2e-gce-federation
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-federation
 - name: kubernetes-e2e-gce-federation-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-federation-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-federation-release-1.4
 - name: kubernetes-e2e-gce-federation-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-federation-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-federation-release-1.5
 - name: kubernetes-soak-weekly-deploy-gce-federation
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-soak-weekly-deploy-gce-federation
 - name: kubernetes-soak-continuous-e2e-gce-federation
@@ -199,43 +199,43 @@ test_groups:
 - name: kubernetes-e2e-gce-gci-qa-slow-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-slow-master
 - name: kubernetes-e2e-gci-gce-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-release-1.4
 - name: kubernetes-e2e-gci-gce-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-release-1.5
 - name: kubernetes-e2e-gci-gce-scalability
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability
 - name: kubernetes-e2e-gci-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
 - name: kubernetes-e2e-gci-gce-serial-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1.4
 - name: kubernetes-e2e-gci-gce-serial-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1.5
 - name: kubernetes-e2e-gci-gce-slow
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow
 - name: kubernetes-e2e-gci-gce-slow-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-slow-release-1.4
 - name: kubernetes-e2e-gci-gce-slow-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-slow-release-1.5
 - name: kubernetes-e2e-gce-ingress
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ingress
 - name: kubernetes-e2e-gci-gce-ingress
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress
 - name: kubernetes-e2e-gce-ingress-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ingress-release-1.2
 - name: kubernetes-e2e-gci-gce-ingress-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-release-1.2
 - name: kubernetes-e2e-gce-ingress-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ingress-release-1.3
 - name: kubernetes-e2e-gci-gce-ingress-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-release-1.3
 - name: kubernetes-e2e-gce-ingress-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ingress-release-1.4
 - name: kubernetes-e2e-gce-ingress-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-ingress-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ingress-release-1.5
 - name: kubernetes-e2e-gci-gce-ingress-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4
 - name: kubernetes-e2e-gci-gce-ingress-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-ingress-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5
 - name: kubernetes-e2e-gce-kubenet
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-kubenet
 - name: kubernetes-e2e-gci-gce-kubenet
@@ -261,73 +261,73 @@ test_groups:
 - name: kubernetes-e2e-gci-gce-reboot
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-reboot
 - name: kubernetes-e2e-gce-reboot-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-reboot-release-1.2
 - name: kubernetes-e2e-gci-gce-reboot-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2
 - name: kubernetes-e2e-gce-reboot-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-reboot-release-1.3
 - name: kubernetes-e2e-gci-gce-reboot-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3
 - name: kubernetes-e2e-gce-reboot-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-reboot-release-1.4
 - name: kubernetes-e2e-gce-reboot-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-reboot-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-reboot-release-1.5
 - name: kubernetes-e2e-gci-gce-reboot-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4
 - name: kubernetes-e2e-gci-gce-reboot-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-reboot-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5
 - name: kubernetes-e2e-gce-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-release-1.2
 - name: kubernetes-e2e-gci-gce-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-release-1.2
 - name: kubernetes-e2e-gce-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-release-1.3
 - name: kubernetes-e2e-gci-gce-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-release-1.3
 - name: kubernetes-e2e-gce-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-release-1.4
 - name: kubernetes-e2e-gce-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-release-1.5
 - name: kubernetes-e2e-gce-scalability
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability
 - name: kubernetes-e2e-gce-scalability-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-scalability-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability-release-1.4
 # Uncomment when 1.4 scale tests are turned off
 # - name: kubernetes-e2e-gce-scalability-release-1.5
-#   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-scalability-release-1.5
+#   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability-release-1.5
 - name: kubernetes-e2e-gci-gce-scalability-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-scalability-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-release-1.4
 # Uncomment when 1.4 scale tests are turned off
 # - name: kubernetes-e2e-gci-gce-scalability-release-1.5
-#   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-scalability-release-1.5
+#   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5
 - name: kubernetes-e2e-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial
 - name: kubernetes-e2e-gce-serial-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-serial-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial-release-1.2
 - name: kubernetes-e2e-gci-gce-serial-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1.2
 - name: kubernetes-e2e-gce-serial-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-serial-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial-release-1.3
 - name: kubernetes-e2e-gci-gce-serial-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-serial-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1.3
 - name: kubernetes-e2e-gce-serial-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-serial-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial-release-1.4
 - name: kubernetes-e2e-gce-serial-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-serial-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial-release-1.5
 - name: kubernetes-e2e-gce-slow
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-slow
 - name: kubernetes-e2e-gce-slow-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-slow-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-slow-release-1.2
 - name: kubernetes-e2e-gci-gce-slow-release-1.2
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-slow-release-1.2
 - name: kubernetes-e2e-gce-slow-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-slow-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-slow-release-1.3
 - name: kubernetes-e2e-gci-gce-slow-release-1.3
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gci-gce-slow-release-1.3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-slow-release-1.3
 - name: kubernetes-e2e-gce-slow-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-slow-release-1.4
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-slow-release-1.4
 - name: kubernetes-e2e-gce-slow-release-1.5
-  gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gce-slow-release-1.5
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-slow-release-1.5
 - name: kubernetes-e2e-gke
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-e2e-gke
 - name: kubernetes-e2e-gke-alpha-features


### PR DESCRIPTION
github is not very smart when comparing the changes..

#1025 

only manual and blocking jobs stays there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1075)
<!-- Reviewable:end -->
