### PR TITLE
Run jobs that build on build nodes

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -6,7 +6,7 @@
         './test-infra/jenkins/bootstrap.py' --job='{job-name}' --repo='{repo-name}' --branch='{branch}' --root="${{GOPATH}}/src"
     disabled: false
     name: 'ci-{repo-suffix}'
-    node: 'e2e'
+    node: 'build'
     properties:
     - build-discarder:
         days-to-keep: 7


### PR DESCRIPTION
verify/test-go jobs are running on the wrong nodes

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1077)
<!-- Reviewable:end -->
