### PR TITLE
Add support for soak mode

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1020,10 +1020,14 @@ class JobTest(unittest.TestCase):
             self.assertTrue(os.access(job_path, os.X_OK|os.R_OK), job_path)
 
     def testAllProjectAreUnique(self):
-        allowed_list = {  # TODO(fejta): remove these (found while migrating jobs)
+        allowed_list = {
+            # TODO(fejta): remove these (found while migrating jobs)
             'ci-kubernetes-kubemark-100-gce.sh': 'ci-kubernetes-kubemark-*',
             'ci-kubernetes-kubemark-5-gce.sh': 'ci-kubernetes-kubemark-*',
             'ci-kubernetes-kubemark-high-density-100-gce.sh': 'ci-kubernetes-kubemark-*',
+            # TODO(fejta): will deal with these test jobs later
+            'ci-fejta-soak-test.sh': 'ci-fejta-soak-*',
+            'ci-fejta-soak-deploy.sh': 'ci-fejta-soak-*',
         }
         projects = collections.defaultdict(set)
         for job, job_path in self.jobs:

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -19,7 +19,7 @@ all: build
 
 build:
 	docker build -t $(IMG):$(TAG) .
-	docker tag -f $(IMG):$(TAG) $(IMG):latest
+	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with latest
 
 push: build

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -596,3 +596,11 @@
         frequency: 'H H/12 * * *'
         trigger-job: 'kubernetes-build'
     # END KUBEMARK
+    - fejta-soak-deploy:
+        job-name: ci-fejta-soak-deploy
+        frequency: '@daily'
+        trigger-job: 'kubernetes-build-1.2'  # Simulate manual triggering
+    - fejta-soak-test:
+        job-name: ci-fejta-soak-test
+        frequency: '@daily'
+        trigger-job: 'kubernetes-build-1.2'  # Simulate manual triggering

--- a/jobs/ci-fejta-soak-deploy.sh
+++ b/jobs/ci-fejta-soak-deploy.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# Hack to test use a test image
+OVERRIDE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
+mkdir -p $(dirname "${OVERRIDE}")
+echo v20161116-fc014f3 > "${OVERRIDE}"
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### soak-env
+export FAIL_ON_GCP_RESOURCE_LEAK="false"
+export E2E_TEST="false"
+export E2E_DOWN="false"
+
+### job-env
+export PROJECT="fejta-prod"
+export JENKINS_SOAK_MODE="y"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-fejta-soak-test.sh
+++ b/jobs/ci-fejta-soak-test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# Hack to test use a test image
+OVERRIDE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
+mkdir -p $(dirname "${OVERRIDE}")
+echo v20161116-fc014f3 > "${OVERRIDE}"
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+export KUBERNETES_PROVIDER="gce"
+export E2E_MIN_STARTUP_PODS="8"
+export KUBE_GCE_ZONE="us-central1-f"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
+export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+### soak-env
+export JENKINS_USE_EXISTING_BINARIES="y"
+export FAIL_ON_GCP_RESOURCE_LEAK="false"
+export E2E_UP="false"
+export E2E_DOWN="false"
+# Clear out any orphaned namespaces in case previous run was interrupted.
+export E2E_CLEAN_START="true"
+# TODO: Remove when we figure out #22166 and other docker potential slowness.
+export DOCKER_TEST_LOG_LEVEL="--log-level=warn"
+# We should be testing the reliability of a long-running cluster. The
+# [Disruptive] tests kill/restart components or nodes in the cluster,
+# defeating the purpose of a soak cluster. (#15722)
+export GINKGO_TEST_ARGS="--ginkgo.focus=ResourceQuota"
+
+### job-env
+export PROJECT="fejta-prod"
+export JENKINS_SOAK_MODE="y"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -914,6 +914,10 @@ test_groups:
 - name: kubernetes-gci-garbage-collector
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-garbagecollector-gci-feature
 # Add New Testgroups Here
+- name: fejta-soak-deploy
+  gcs_prefix: kubernetes-jenkins/logs/ci-fejta-soak-deploy
+- name: fejta-soak-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-fejta-soak-test
 
 #
 # Start dashboards
@@ -2153,6 +2157,10 @@ dashboards:
   dashboard_tab:
   - name: ci-kubernetes-e2e-gce-etcd3
     test_group_name: ci-kubernetes-e2e-gce-etcd3
+  - name: fejta-soak-deploy
+    test_group_name: fejta-soak-deploy
+  - name: fejta-soak-test
+    test_group_name: fejta-soak-test
 
 - name: maintenance
   dashboard_tab:


### PR DESCRIPTION
Add two new modes for e2e-runner.sh:
* `JENKINS_SOAK_MODE==true && E2E_UP == true`:
    - we deployed a soak cluster, copy .kube/config and KUBERNETES_RELEASE to gcs
* `JENKINS_SOAK_MODE==true && E2E_UP != true`:
    - we are testing a previously deployed cluster, copy `.kube/config` and `KUBERNETES_RELEASE` from gcs

We copy kubernetes release to ensure we continue using the same version of the tests we deployed with.
We copy kube/config to ensure we have credentials for the cluster.

This will allow soak jobs to run on any available agent as opposed binding them to the master like we do today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1088)
<!-- Reviewable:end -->
