### PR TITLE
Make bootstrap.py accept batch commits.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
     - pylint jenkins/bootstrap.py  # TODO(fejta): all python files
     - pylint queue-health/graph/graph.py  # TODO(fejta): all python files
     - ./jenkins/bootstrap_test.py
+    - nosetests --with-doctest jenkins/bootstrap.py
     - ./jenkins/diff-job-config-patch.sh
     - ./jenkins/diff-e2e-runner.sh
     - make -C gcsweb test

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -97,9 +97,43 @@ def call(cmd, stdin=None, check=True, output=None):
     return lines
 
 
+def pull_has_shas(pull):
+    """Determine if a pull reference specifies shas (contains ':')
+
+    >>> pull_has_shas('master:abcd')
+    True
+    >>> pull_has_shas('123')
+    False
+    >>> pull_has_shas(123)
+    False
+    >>> pull_has_shas(None)
+    False
+    """
+    return isinstance(pull, basestring) and ':' in pull
+
+
 def pull_ref(pull):
-    """Return the tag associated with the PR."""
-    return '+refs/pull/%d/merge' % pull
+    """Turn a PR number of list of refs into specific refs to fetch and check out.
+
+    >>> pull_ref('123')
+    (['+refs/pull/123/merge'], ['FETCH_HEAD'])
+    >>> pull_ref('master:abcd,123:effe')
+    (['master', '+refs/pull/123/head:refs/pr/123'], ['abcd', 'effe'])
+    """
+    if pull_has_shas(pull):
+        refs = []
+        checkouts = []
+        for name, sha in (x.split(':') for x in pull.split(',')):
+            if len(refs) == 0:
+                # first entry is the branch spec ("master")
+                refs.append(name)
+            else:
+                num = int(name)
+                refs.append('+refs/pull/%d/head:refs/pr/%d' % (num, num))
+            checkouts.append(sha)
+        return refs, checkouts
+    else:
+        return ['+refs/pull/%d/merge' % int(pull)], ['FETCH_HEAD']
 
 
 def repository(repo):
@@ -118,20 +152,24 @@ def checkout(repo, branch, pull):
     """Fetch and checkout the repository at the specified branch/pull."""
     if bool(branch) == bool(pull):
         raise ValueError('Must specify one of --branch or --pull')
+
     if pull:
-        ref = pull_ref(pull)
+        refs, checkouts = pull_ref(pull)
     else:
-        ref = branch
+        refs, checkouts = [branch], ['FETCH_HEAD']
 
     git = 'git'
     call([git, 'init', repo])
     os.chdir(repo)
+
+    # To make a merge commit, a user needs to be set. It's okay to use a dummy
+    # user here, since we're not exporting the history.
+    call([git, 'config', '--local', 'user.name', 'K8S Bootstrap'])
+    call([git, 'config', '--local', 'user.email', 'k8s_bootstrap@localhost'])
     retries = 3
     for attempt in range(retries):
         try:
-            call([
-                git, 'fetch', '--tags', repository(repo), ref,
-            ])
+            call([git, 'fetch', '--tags', repository(repo)] + refs)
             break
         except subprocess.CalledProcessError as cpe:
             if attempt >= retries - 1:
@@ -140,10 +178,12 @@ def checkout(repo, branch, pull):
                 raise
             logging.warning('git fetch failed')
             random_sleep(attempt)
-    call([git, 'checkout', 'FETCH_HEAD'])
+    call([git, 'checkout', '-B', 'test', checkouts[0]])
+    for ref, head in zip(refs, checkouts)[1:]:
+        call(['git', 'merge', '--no-ff', '-m', 'Merge %s' % ref, head])
 
 
-def start(gsutil, paths, stamp, node_name, version):
+def start(gsutil, paths, stamp, node_name, version, pull):
     """Construct and upload started.json."""
     data = {
         'timestamp': stamp,
@@ -153,6 +193,8 @@ def start(gsutil, paths, stamp, node_name, version):
     if version:
         data['repo-version'] = version
         data['version'] = version  # TODO(fejta): retire
+    if pull_has_shas(pull):
+        data['pull'] = pull
     gsutil.upload_json(paths.started, data)
 
 
@@ -432,7 +474,10 @@ def pr_paths(repo, job, build, pull):
     else:
         prefix = repo.replace('/', '_')
     base = 'gs://kubernetes-jenkins/pr-logs'
-    pull = os.path.join(prefix, pull)
+    if pull_has_shas(pull):
+        pull = os.path.join(prefix, 'batch')
+    else:
+        pull = os.path.join(prefix, pull)
     pr_path = os.path.join(base, 'pull', pull, job, build)
     result_cache = os.path.join(
             base, 'directory', job, 'jobResultsCache.json')
@@ -607,7 +652,7 @@ def bootstrap(job, repo, branch, pull, root):
         paths = ci_paths(job, build)
     gsutil = GSUtil()
     logging.info('Start %s at %s...', build, version)
-    start(gsutil, paths, started, node(), version)
+    start(gsutil, paths, started, node(), version, pull)
     success = False
     try:
         cmd = [job_script(job)]
@@ -634,7 +679,8 @@ if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(
         'Checks out a github PR/branch to <basedir>/<repo>/')
     PARSER.add_argument('--root', default='.', help='Root dir to work with')
-    PARSER.add_argument('--pull', type=int, help='PR number')
+    PARSER.add_argument('--pull',
+        help='PR number, or list of PR:sha pairs like master:abcd,12:ef12,45:ff65')
     PARSER.add_argument('--branch', help='Checkout the following branch')
     PARSER.add_argument('--repo', help='The repository to fetch from')
     PARSER.add_argument('--bare', action='store_true', help='Do not check out a repository')


### PR DESCRIPTION
They include the SHAs for each ref involved, e.g.:

    --pull master:18d1cdf822518a55916dfd44c24311e0ba5ddbbb,123:2f97295852f6ece2af499849aa1d8830f37db313,456:40ddfd89205f79338f1d9784eea667091a696ee5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1090)
<!-- Reviewable:end -->
