### PR TITLE
Force dangling image deletion in maintenance.

### DIFF
--- a/jenkins/hourly_maintenance.py
+++ b/jenkins/hourly_maintenance.py
@@ -124,7 +124,7 @@ def RemoveImages(skip, ancient):
     dangling = subprocess.check_output([
         'docker', 'images', '-q', '-f', 'dangling=true'])
     if dangling:
-        err |= subprocess.call(['docker', 'rmi'] + dangling.split())
+        err |= subprocess.call(['docker', 'rmi', '-f'] + dangling.split())
 
     if err:
         print >>sys.stderr, 'RemoveImages failed'


### PR DESCRIPTION
1. a kube-build image is created, then a container which runs, finishes in 20 minutes, and exits
1. 20 minutes later, this is repeated
1. hourly maintenance runs, doesn't delete the old container because it's not *that* old, but fails when it tries to delete the dangling image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1096)
<!-- Reviewable:end -->
