### PR TITLE
Remove duplicated KUBE_GCE_ZONE setting for high-density kubemark

### DIFF
--- a/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
@@ -43,7 +43,6 @@ export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export NUM_NODES="8"
 export MASTER_SIZE="n1-standard-2"
 export NODE_SIZE="n1-standard-8"
-export KUBE_GCE_ZONE="us-east1-d"
 export KUBEMARK_MASTER_SIZE="n1-standard-4"
 export KUBEMARK_NUM_NODES="600"
 # The kubemark scripts build a Docker image


### PR DESCRIPTION
I added quota in us-central, as this was a zone I noticed first in the file. @fejta

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1099)
<!-- Reviewable:end -->
