### PR TITLE
Do not use existing binaries for soak

### DIFF
--- a/jobs/ci-fejta-soak-test.sh
+++ b/jobs/ci-fejta-soak-test.sh
@@ -34,7 +34,6 @@ export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 export KUBE_NODE_OS_DISTRIBUTION="debian"
 
 ### soak-env
-export JENKINS_USE_EXISTING_BINARIES="y"
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export E2E_UP="false"
 export E2E_DOWN="false"


### PR DESCRIPTION
Fix for https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-fejta-soak-test/2

tbr @kubernetes/test-infra-maintainers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1104)
<!-- Reviewable:end -->
