### PR TITLE
Adding kubeadm GCE e2e test.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -99,6 +99,12 @@
         repo-name: k8s.io/kubernetes
         frequency: 'H H/3 * * *'
 
+    - kubernetes-e2e-kubeadm-gce:
+        branch: master
+        job-name: ci-kubernetes-e2e-kubeadm-gce
+        repo-name: k8s.io/kubernetes-anywhere
+        frequency: 'H/5 * * * *'
+
     - kubernetes-node-kubelet:  # dawnchen
         branch: master
         job-name: ci-kubernetes-node-kubelet

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### builder
+
+### job-env
+
+export E2E_NAME="e2e-kubeadm-gce"
+export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path \"${GOPATH}/k8s.io/kubernetes-anywhere\""
+export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}.test-kubeadm.k8s.io"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+# After post-env
+export GINKGO_PARALLEL="y"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
+export KUBEKINS_TIMEOUT="120m"
+"${runner}"

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -857,6 +857,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-garbage
 - name: kubernetes-gci-garbage-collector
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-garbage-gci
+# kubeadm tests
+- name: kubernetes-e2e-kubeadm-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce
+
 # Add New Testgroups Here
 
 #
@@ -1905,6 +1909,8 @@ dashboards:
     test_group_name: kubernetes-build-debian-unstable
   - name: gke-large-teardown
     test_group_name: kubernetes-e2e-gke-large-teardown
+  - name: kubeadm-gce
+    test_group_name: kubernetes-e2e-kubeadm-gce
   - name: update-jenkins-jobs
     test_group_name: kubernetes-update-jenkins-jobs
   - name: garbage-collector


### PR DESCRIPTION
This also includes a new `kubernetes-anywhere` based e2e runner (analogous to the `kops` wrapper). I've done as much local testing as I can, so I'm at the point where I want to get it going in Jenkins to see what other failures to fix.

CC @spxtr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1118)
<!-- Reviewable:end -->
