### PR TITLE
Add dependencies to the e2e-image required by kubernetes-anywhere.

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -43,6 +43,27 @@ ENV FAIL_ON_GCP_RESOURCE_LEAK=true \
 # JENKINS_AWS_SSH_PUBLIC_KEY_FILE
 # JENKINS_AWS_CREDENTIALS_FILE
 
+# Add kubernetes-anywhere dependencies: jsonnet, terraform
+ENV TERRAFORM_VERSION 0.7.2
+
+RUN apt-get update && \
+    apt-get install -y unzip
+
+RUN cd /tmp && \
+    git clone https://github.com/google/jsonnet.git && \
+    ( cd jsonnet && \
+      make jsonnet && \
+      cp jsonnet /bin \
+    ) && \
+    rm -rf /tmp/jsonnet
+
+RUN mkdir -p /tmp/terraform/ && \
+    ( cd /tmp/terraform && \
+      wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+      unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin \
+    ) && \
+    rm -rf /tmp/terraform
+
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh", \


### PR DESCRIPTION
As part of https://github.com/kubernetes/test-infra/pull/1118, we also need to add a few dependencies to the e2e image to support using the `kubernetes-anywhere` e2e runner.

CC @spxtr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1121)
<!-- Reviewable:end -->
