### PR TITLE
Upload started.json for debian builds.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-debian-build.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-debian-build.yaml
@@ -7,6 +7,7 @@
         num-to-keep: 200
     builders:
     - activate-gce-service-account
+    - shell: 'JENKINS_BUILD_STARTED=true bash <(curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh")'
     - shell: |
         {job-env}
         timeout -k {kill-timeout}m {timeout}m ./debian/jenkins.sh && rc=$? || rc=$?


### PR DESCRIPTION
The post-build publisher already uploads `finished.json`, but this pre-build step should also upload `started.json`, which will allow us to see the elapsed durations of builds on Gubernator.

(This one-liner is taken from [kubernetes-build.yaml](https://github.com/kubernetes/test-infra/blob/master/jenkins/job-configs/kubernetes-jenkins/kubernetes-build.yaml#L10))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1125)
<!-- Reviewable:end -->
