### PR TITLE
Add --email for docker 1.9.x

### DIFF
--- a/jobs/ci-cadvisor-canarypush.sh
+++ b/jobs/ci-cadvisor-canarypush.sh
@@ -24,9 +24,15 @@ TARGET="google/cadvisor:canary"
 FILE="deploy/canary/Dockerfile"
 docker build -t "${TARGET}" --no-cache=true --pull=true --file="${FILE}" .
 docker inspect "${TARGET}"
+if [[ "$(docker version --format='{{.Client.Version}}')" =~ ^1.9 ]]; then
+  DOCKER_EMAIL="--email=not@val.id"
+else
+  DOCKER_EMAIL=
+fi
 set +o xtrace  # Do not log credentials
-docker login --username="${DOCKER_USER}" --password="${DOCKER_PASSWORD}"
-unset DOCKER_USER DOCKER_PASSWORD
+echo "Logging in as ${DOCKER_USER}..."
+docker login ${DOCKER_EMAIL:-} --username="${DOCKER_USER}" --password="${DOCKER_PASSWORD}"
 set -o xtrace
+unset DOCKER_USER DOCKER_PASSWORD DOCKER_EMAIL
 docker push "${TARGET}"
 docker logout

--- a/jobs/ci-heapster-canarypush.sh
+++ b/jobs/ci-heapster-canarypush.sh
@@ -24,9 +24,15 @@ TARGET="kubernetes/heapster:canary"
 FILE="deploy/docker/canary/Dockerfile"
 docker build -t "${TARGET}" --no-cache=true --pull=true --file="${FILE}" .
 docker inspect "${TARGET}"
+if [[ "$(docker version --format='{{.Client.Version}}')" =~ ^1.9 ]]; then
+  DOCKER_EMAIL="--email=not@val.id"
+else
+  DOCKER_EMAIL=
+fi
 set +o xtrace  # Do not log credentials
-docker login --username="${DOCKER_USER}" --password="${DOCKER_PASSWORD}"
-unset DOCKER_USER DOCKER_PASSWORD
+echo "Logging in as ${DOCKER_USER}..."
+docker login ${DOCKER_EMAIL:-} --username="${DOCKER_USER}" --password="${DOCKER_PASSWORD}"
 set -o xtrace
+unset DOCKER_USER DOCKER_PASSWORD DOCKER_EMAIL
 docker push "${TARGET}"
 docker logout


### PR DESCRIPTION
ref #1021 #1108 
tbr @krzyzacy @kubernetes/test-infra-admins 

Docker 1.9 requires an --email flag, docker 1.12 deprecates it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1127)
<!-- Reviewable:end -->
