### PR TITLE
Change registry to pickup image for federation soak tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -61,7 +61,7 @@
     - kubernetes-soak-gce-federation-deploy:
         blocker: ci-kubernetes-soak-gce-federation-test
         job-name: ci-kubernetes-soak-gce-federation-deploy
-        frequency: 'H 0 * * 2'
+        frequency: 'H 0 * * *'
         scan: DISABLED
     - kubernetes-soak-gce-federation-test:
         blocker: ci-kubernetes-soak-gce-federation-deploy

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
@@ -47,7 +47,7 @@ export FEDERATION="true"
 export DNS_ZONE_NAME="soak.test-f8n.k8s.io."
 export FEDERATIONS_DOMAIN_MAP="federation=soak.test-f8n.k8s.io"
 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-gce-federation-soak"
+export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
 
 ### post-env
 

--- a/jobs/ci-kubernetes-soak-gce-federation-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.sh
@@ -56,7 +56,7 @@ export FEDERATION="true"
 export DNS_ZONE_NAME="soak.test-f8n.k8s.io."
 export FEDERATIONS_DOMAIN_MAP="federation=soak.test-f8n.k8s.io"
 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-gce-federation-soak"
+export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
 
 ### post-env
 


### PR DESCRIPTION
`federation-soak-deployment` job should be linked to a `federation-build` job which has succeeded recently. Unfortunately i am not finding a way to link them. So changing the FEDERATION_PUSH_REPO_BASE in `federation-soak-deployment` job to use the `federation-build` project registry, assuming the images are publicly accessible.

Also changed the frequency of soak deployment from 1 week to 1 day to correct the CI issue. once it succeeds we shall change it back.

@madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1143)
<!-- Reviewable:end -->
