### PR TITLE
Change build log link to go to Gubernator instead of GCS HTTPS endpoint

### DIFF
--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -7,8 +7,10 @@ https://k8s-gubernator.appspot.com/
 For development:
 
 - Install the Google App Engine Python SDK
-- Set the GAE_ROOT environment variable to your GAE SDK directory.
+- Set the GAE_ROOT environment variable to your GAE SDK directory (e.g.
+  `export GAE_ROOT=~/google-cloud-sdk/platform/google_appengine`)
 - Run locally using dev_appserver.py and visit http://localhost:8080
+- Install libraries needed for testing: `pip install webtest nosegae`
 - Test using `./test.sh`. Arguments are passed to the test runner, so `./test.sh log_parser_test.py`
   only runs the tests for the log parser. See `./test.sh -h` for more options.
 - Lint using `./lint.sh`.

--- a/gubernator/static/build.js
+++ b/gubernator/static/build.js
@@ -87,6 +87,7 @@ function expand_skipped(els) {
 		parent.normalize();  // merge adjacent text nodes
 		fix_escape_codes();  // colorize new segments
 	});
+	document.querySelector('h2#log').innerHTML = 'Build Log';
 }
 
 function expand_all(btn) {

--- a/gubernator/static/style.css
+++ b/gubernator/static/style.css
@@ -2,6 +2,7 @@ body {
     font-family: sans-serif;
     padding: 0;
     margin: 0;
+    scroll-behavior: smooth;
 }
 #header {
     background-color: #3f51b5;
@@ -151,3 +152,23 @@ h3.pr-section {
 .ansi-13 { color: #f935f8; }  /* Magenta */
 .ansi-14 { color: #14f0f0; }  /* Cyan */
 .ansi-15 { color: #e9ebeb; }  /* White */
+ul.nav {
+    list-style-type:none;
+}
+li.nav {
+    padding: 5px 20px 5px 20px;
+    display: inline-block;
+    background-color: #eee;
+}
+div#log {
+    padding: 0 0 0 10px;
+}
+ul.log {
+    list-style-type:none;
+    margin: 0px;
+    padding: 0px;
+}
+li.log {
+    padding: 5px;
+    display: inline-block;
+}

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -19,7 +19,7 @@
 % block content
 <div id="summary">
 	<table border=0 align="center" style="text-align: left;">
-	<style>tr:nth-child(even){background:#ddd}</style>
+	<style>tr:nth-child(even){background:#ddd} td{padding:2px 5px 2px 5px}</style>
 	% if pr and pr_digest
 		% set pl = pr_digest.payload
 		<tr><td>PR<td><a href="/pr/{{pl['author']}}">{{pl['author']}}</a>: {{pl['title']}}
@@ -47,8 +47,10 @@
 		% endif
 	% endif
 	</table>
-	<p><a href="{{build_dir | gcs_browse_url}}">artifacts</a>
-	<a href="https://storage.googleapis.com{{build_dir}}/build-log.txt">build-log.txt</a>
+	<ul class="nav">
+		<li class="nav"><a href="{{build_dir | gcs_browse_url}}">artifacts</a></li>
+		<li class="nav"><a href="?log#log">build log</a></li>
+	</ul>
 	</div>
 	<div id="failures">
 	% if issues
@@ -86,13 +88,17 @@
 	% else
 		<h2>{{"No Test Failures!" if finished else "Build Still Running!"}}</h2>
 	% endif
-	<hr>
-	% if not build_log
-		<a href="?log"><button>Load build log</button></a>
-	% else
-		<button onclick="javascript:expand_all(this)">Expand Skipped Lines</button>
-		<h3>Error lines from build-log.txt</h3>
+	</div>
+	% if build_log
+	<div id="log">
+		<a name="log"></a>
+		<hr>
+		<h2 id="log">Error lines from build-log.txt</h2>
+		<ul class="log">
+			<li class="log"><button onclick="javascript:expand_all(this.parentElement)">Expand Skipped Lines</button></li>
+			<li class="log"><a href="https://storage.googleapis.com{{build_dir}}/build-log.txt">Raw build-log.txt</a></li>
+		</ul>
 		<pre data-src="{{build_dir}}/build-log.txt">{{build_log | safe}}</pre>
+	</div>
 	% endif
-</div>
 % endblock

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -160,10 +160,12 @@ class BuildTest(main_test.TestBase):
     def test_build_optional_log(self):
         write(self.BUILD_DIR + 'build-log.txt', 'error or timeout or something')
         response = self.get_build_page()
-        self.assertIn('<a href="?log">', response)
+        self.assertIn('<a href="?log#log">', response)
         self.assertNotIn('timeout', response)
+        self.assertNotIn('build-log.txt', response)
         response = self.get_build_page('?log')
         self.assertIn('timeout', response)
+        self.assertIn('build-log.txt', response)
 
     def test_build_testgrid_links(self):
         response = self.get_build_page()


### PR DESCRIPTION
It seems like Chrome doesn't yet support the `scroll-behavior` CSS property, but it might some day!

As as result, the anchor link `#log` jumps to the log instantly, which is less than ideal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1156)
<!-- Reviewable:end -->
