### PR TITLE
cap bazel resource usage

### DIFF
--- a/jobs/pull-kubernetes-bazel.sh
+++ b/jobs/pull-kubernetes-bazel.sh
@@ -18,7 +18,9 @@ set -o nounset
 set -o pipefail
 
 #bazel test --test_output=errors --test_tag_filters '-skip' //cmd/... //pkg/... //plugin/... && rc=$? || rc=$?
-bazel build //cmd/... //pkg/... //federation/... //plugin/... //build-tools/... //test/... && rc=$? || rc=$?
+bazel build \
+  --local_resources 9500,6,1.0 \
+  //cmd/... //pkg/... //federation/... //plugin/... //build-tools/... //test/... && rc=$? || rc=$?
 case "${rc}" in
     0) echo "Success" ;;
     1) echo "Build failed" ;;


### PR DESCRIPTION
stop the bleeding. Match the pod reqs to avoid these OOMKills.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1159)
<!-- Reviewable:end -->
