### PR TITLE
Adds Canonical Kubernetes e2e test results bucket

### DIFF
--- a/buckets.yaml
+++ b/buckets.yaml
@@ -23,3 +23,4 @@ gs://kopeio-kubernetes-e2e/logs/:
 gs://canonical-kubernetes-tests/logs/:
   contact: "chuckbutler"
   prefix: "juju:"
+  sequential: false

--- a/buckets.yaml
+++ b/buckets.yaml
@@ -20,3 +20,6 @@ gs://kopeio-kubernetes-e2e/logs/:
   contact: "justinsb"
   prefix: "kopeio:"
   sequential: false
+gs://canonical-kubernetes-tests/logs/:
+  contact: "chuckbutler"
+  prefix: "juju:"

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -874,6 +874,9 @@ test_groups:
 # azure
 - name: kubernetes-azure
   gcs_prefix: kube_azure_log/kubernetes.azure.nightly
+# Canonical Distribution of Kubernetes (contact: @chuckbutler on github)
+- name: canonical-kubernetes-e2e-gce
+  gcs_prefix: canonical-kubernetes-tests/logs/gce/e2e-node
 # kopeio (contact: @justinsb on github)
 - name: kopeio-kubernetes-e2e-aws
   gcs_prefix: kopeio-kubernetes-e2e/logs/kubernetes-e2e-aws
@@ -965,6 +968,11 @@ dashboards:
   dashboard_tab:
   - name: azure
     test_group_name: kubernetes-azure
+
+- name: canonical-kubernetes
+  dashboard_tab:
+  - name: cdk-gce
+    test_group_name: canonical-kubernetes-e2e-gce
 
 - name: kopeio
   dashboard_tab:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -876,7 +876,7 @@ test_groups:
   gcs_prefix: kube_azure_log/kubernetes.azure.nightly
 # Canonical Distribution of Kubernetes (contact: @chuckbutler on github)
 - name: canonical-kubernetes-e2e-gce
-  gcs_prefix: canonical-kubernetes-tests/logs/gce/e2e-node
+  gcs_prefix: canonical-kubernetes-tests/logs/gce-e2e-node
 # kopeio (contact: @justinsb on github)
 - name: kopeio-kubernetes-e2e-aws
   gcs_prefix: kopeio-kubernetes-e2e/logs/kubernetes-e2e-aws


### PR DESCRIPTION
We've just started running the e2e gambit on a regular basis with
published results to the google storage bucket. This should enable
gubernator to ingest our test results to the federated dashboard

During this dev cycle we encountered https://github.com/kubernetes/test-infra/issues/1003 

We punted on using the `upload-to-gs.sh` script in favor of a discovery in the `kubernetes/hack/lib/gubernator.sh`. At first glance this appears to be a next iteration of the `upload-to-gcs.sh` work, and was a bit more fleshed out. 

As our e2e run process diverges from what the expected integration is in the federated testing doc, if contributing those job source files would be a welcome contribution we can certainly clean those up and contribute with another PR. Let us know if thats of interest.  



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1161)
<!-- Reviewable:end -->
