### PR TITLE
Revert KOPS_PUBLISH_GREEN_PATH settings

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-e2e-kops-aws.yaml
@@ -59,7 +59,6 @@
             job-env: |
                 export E2E_NAME="e2e-kops-aws-updown"
                 export GINKGO_TEST_ARGS="--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]"
-                export KOPS_PUBLISH_GREEN_PATH="gs://kops-ci/bin/latest-ci-updown-green.txt"
         - 'aws':  # kubernetes-e2e-kops-aws
             description: 'Run e2e tests on AWS deployed via kops using the latest successful Kubernetes build.'
             timeout: 240
@@ -70,7 +69,5 @@
             job-env: |
                 export E2E_NAME="e2e-kops-aws"
                 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector|Dashboard|Services.*functioning.*NodePort"
-                export KOPS_LATEST="latest-ci-updown-green.txt"
-                export KOPS_PUBLISH_GREEN_PATH="gs://kops-ci/bin/latest-ci-green.txt"
     jobs:
         - 'kubernetes-e2e-kops-{suffix}'


### PR DESCRIPTION
This reverts commit 82dccdfc44413b23875b5529baa1c400e2ba0a6f (in #1150). The
`KOPS_PUBLISH_GREEN_PATH` pieces are failing right now - this disables it without a full image rollback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1171)
<!-- Reviewable:end -->
