### PR TITLE
Hide error messages in PR verify jobs due to 'git remote remove'

### DIFF
--- a/jobs/pull-kubernetes-verify.sh
+++ b/jobs/pull-kubernetes-verify.sh
@@ -22,7 +22,7 @@ readonly testinfra="$(dirname "${0}")/.."
 readonly remote="bootstrap-upstream"
 
 rm -rf .gsutil  # This causes verify flags to fail...
-git remote remove "${remote}" || true
+git remote remove "${remote}" 2>/dev/null || true
 git remote add "${remote}" 'https://github.com/kubernetes/kubernetes.git'
 git remote set-url --push "${remote}" no_push
 # If .git is cached between runs this data may be stale


### PR DESCRIPTION
It seems like most pull-verification jobs have a misleading error message near the start:
```
W1122 17:30:57.584] + git remote remove bootstrap-upstream
W1122 17:30:57.588] error: Could not remove config section 'remote.bootstrap-upstream'
W1122 17:30:57.588] + true
```

We ignore the exit code (by `|| true`), so we should probably also ignore the error message so gubernator doesn't falsely highlight it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1175)
<!-- Reviewable:end -->
