### PR TITLE
kops: Rely on JENKINS_PUBLISHED_VERSION instead, keeping redundancy

### DIFF
--- a/jobs/pull-kops-e2e-kubernetes-aws.sh
+++ b/jobs/pull-kops-e2e-kubernetes-aws.sh
@@ -28,11 +28,8 @@ make gcs-publish-ci "VERSION=${KOPS_VERSION}"
 # TODO(zmerlynn): Change this to stable.txt (which is kops default
 # anyways) after 1.5 becomes stable.txt. (Some AWS test deflaking was
 # in 1.5.)
-export KUBERNETES_RELEASE=$(gsutil cat "gs://kubernetes-release/release/latest-1.5.txt")
-export KUBERNETES_RELEASE_URL="https://storage.googleapis.com/kubernetes-release/release"
-KUBERNETES_SKIP_CONFIRM=y KUBERNETES_SKIP_CREATE_CLUSTER=y KUBERNETES_DOWNLOAD_TESTS=y \
-  "/workspace/get-kube.sh"
-export JENKINS_USE_EXISTING_BINARIES=y
+export JENKINS_PUBLISHED_VERSION=release/latest-1.5
+export KUBERNETES_RELEASE=$(gsutil cat "gs://kubernetes-release/${JENKINS_PUBLISHED_VERSION}.txt")
 
 export KUBERNETES_PROVIDER="kops-aws"
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1193)
<!-- Reviewable:end -->
