### PR TITLE
kops: Pin the kuberentes-repo PR runner to latest-ci-green.txt

### DIFF
--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -87,6 +87,7 @@ export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 # Get golang into our PATH so we can run e2e.go
 export PATH=${PATH}:/usr/local/go/bin
 
+export KOPS_LATEST="latest-ci-green.txt"
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 timeout -k 15m 55m "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then


### PR DESCRIPTION
This leverages the work in
https://github.com/kubernetes/test-infra/pull/1150 (and follow-on) to
ensure that the kops build we're using in the kubernetes PR builder
has passed the same set of tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1196)
<!-- Reviewable:end -->
