### PR TITLE
Remove some unneeded envs for enormous jobs

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
@@ -22,9 +22,6 @@ readonly testinfra="$(dirname "${0}")/.."
 
 ### provider-env
 export KUBERNETES_PROVIDER="gce"
-export E2E_MIN_STARTUP_PODS="8"
-export KUBE_GCE_ZONE="us-central1-f"
-export FAIL_ON_GCP_RESOURCE_LEAK="true"
 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 
 ### project-env

--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
@@ -22,9 +22,6 @@ readonly testinfra="$(dirname "${0}")/.."
 
 ### provider-env
 export KUBERNETES_PROVIDER="gce"
-export E2E_MIN_STARTUP_PODS="8"
-export KUBE_GCE_ZONE="us-central1-f"
-export FAIL_ON_GCP_RESOURCE_LEAK="true"
 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 
 ### project-env

--- a/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
@@ -22,9 +22,6 @@ readonly testinfra="$(dirname "${0}")/.."
 
 ### provider-env
 export KUBERNETES_PROVIDER="gce"
-export E2E_MIN_STARTUP_PODS="8"
-export KUBE_GCE_ZONE="us-central1-f"
-export FAIL_ON_GCP_RESOURCE_LEAK="true"
 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 
 ### project-env


### PR DESCRIPTION
@wojtek-t you mentioned you don't want `E2E_MIN_STARTUP_PODS="8"` so I've removed it however it was there before. The other two line are overwritten anyway. Feel free to change more on the jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1200)
<!-- Reviewable:end -->
