### PR TITLE
Run workspace-cleanup at the end of a job, too.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -34,7 +34,13 @@
     - timeout:
         timeout: 700
         fail: true
-    - workspace-cleanup:
+    - workspace-cleanup:  # cleanup before the job starts, for clean build.
+        dirmatch: true
+        exclude:
+        - '**/.git/'
+        external-deletion-command: 'sudo rm -rf %s'
+    publishers:
+    - workspace-cleanup:  # cleanup after job finishes, to not waste space.
         dirmatch: true
         exclude:
         - '**/.git/'

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-dockerpush.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-dockerpush.yaml
@@ -27,10 +27,16 @@
     - timeout:
         timeout: 700
         fail: true
-    - workspace-cleanup:
+    - workspace-cleanup:  # cleanup before the job starts, for clean build.
         dirmatch: true
         exclude:
-        - 'test-infra/.git/'
+        - '**/.git/'
+        external-deletion-command: 'sudo rm -rf %s'
+    publishers:
+    - workspace-cleanup:  # cleanup after job finishes, to not waste space.
+        dirmatch: true
+        exclude:
+        - '**/.git/'
         external-deletion-command: 'sudo rm -rf %s'
 
 - project:

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -22,10 +22,16 @@
     - timeout:
         timeout: 700
         fail: true
-    - workspace-cleanup:
+    - workspace-cleanup:  # cleanup before the job starts, for clean build.
         dirmatch: true
         exclude:
-        - 'test-infra/.git/'
+        - '**/.git/'
+        external-deletion-command: 'sudo rm -rf %s'
+    publishers:
+    - workspace-cleanup:  # cleanup after job finishes, to not waste space.
+        dirmatch: true
+        exclude:
+        - '**/.git/'
         external-deletion-command: 'sudo rm -rf %s'
 
 - project:

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -25,10 +25,16 @@
     - timeout:
         timeout: 700
         fail: true
-    - workspace-cleanup:
+    - workspace-cleanup:  # cleanup before the job starts, for clean build.
         dirmatch: true
         exclude:
-        - 'test-infra/.git/'
+        - '**/.git/'
+        external-deletion-command: 'sudo rm -rf %s'
+    publishers:
+    - workspace-cleanup:  # cleanup after job finishes, to not waste space.
+        dirmatch: true
+        exclude:
+        - '**/.git/'
         external-deletion-command: 'sudo rm -rf %s'
 
 - project:


### PR DESCRIPTION
This will keep the total disk used on an agent bounded to the working
set of a job, not the sum of the working dir sizes for all jobs that run
on the agent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1206)
<!-- Reviewable:end -->
