### PR TITLE
Brackets are hard

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -15,7 +15,7 @@
     scm:  # TODO(fejta): migrate scm monitoring to prow.
     - git:
         url: '{giturl}'
-        basedir: '${{GOPATH}}/src/{repo-name}'
+        basedir: 'go/src/{repo-name}'  # Must match GOPATH below
         branches:
         - '{branch}'
         skip-tag: true

--- a/jenkins/job-configs/kubernetes-jenkins/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/global.yaml
@@ -24,7 +24,7 @@
                     steps:
                         - shell: |
                             export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
-                            export HOME="{WORKSPACE}"
+                            export HOME="${WORKSPACE}"
                             export JENKINS_BUILD_FINISHED=SUCCESS
                             ./_tmp/upload-to-gcs.sh
                 - conditional-step:
@@ -34,7 +34,7 @@
                     steps:
                         - shell: |
                             export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
-                            export HOME="{WORKSPACE}"
+                            export HOME="${WORKSPACE}"
                             export JENKINS_BUILD_FINISHED=UNSTABLE
                             ./_tmp/upload-to-gcs.sh
                 - conditional-step:
@@ -44,7 +44,7 @@
                     steps:
                         - shell: |
                             export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
-                            export HOME="{WORKSPACE}"
+                            export HOME="${WORKSPACE}"
                             export JENKINS_BUILD_FINISHED=FAILURE
                             ./_tmp/upload-to-gcs.sh
                 - conditional-step:
@@ -54,7 +54,7 @@
                     steps:
                         - shell: |
                             export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
-                            export HOME="{WORKSPACE}"
+                            export HOME="${WORKSPACE}"
                             export JENKINS_BUILD_FINISHED=ABORTED
                             ./_tmp/upload-to-gcs.sh
             script-only-if-succeeded: False


### PR DESCRIPTION
git basedir will not expand `${GOPATH}` into `go` so do it directly.
Also fix `{WORKSPACE}` bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1208)
<!-- Reviewable:end -->
