### PR TITLE
bootstrap build jobs: Remove timed-frequency

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -969,7 +969,6 @@ class JobTest(unittest.TestCase):
             self.assertTrue('commit-frequency', job.get('commit-frequency'))
             self.assertIn('giturl', job)
             self.assertIn('repo-name', job)
-            self.assertIn('timed-frequency', job)
             return job_name
 
         self.CheckBootstrapYaml(

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -23,7 +23,6 @@
     triggers:
     - pollscm:
         cron: '{commit-frequency}'
-    - timed: '{timed-frequency}'
     wrappers:
     - e2e-credentials-binding
     - inject:
@@ -58,7 +57,6 @@
         job-name: ci-kops-build
         repo-name: k8s.io/kops
         commit-frequency: 'H/2 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-build:
         branch: master
@@ -66,7 +64,6 @@
         job-name: ci-kubernetes-build
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/2 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-cross-build:
         branch: master
@@ -74,7 +71,6 @@
         job-name: ci-kubernetes-cross-build
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-build-1.2:
         branch: release-1.2
@@ -82,7 +78,6 @@
         job-name: ci-kubernetes-build-1.2
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-build-1.3:
         branch: release-1.3
@@ -90,7 +85,6 @@
         job-name: ci-kubernetes-build-1.3
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-build-1.4:
         branch: release-1.4
@@ -98,7 +92,6 @@
         job-name: ci-kubernetes-build-1.4
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-build-1.5:
         branch: release-1.5
@@ -106,7 +99,6 @@
         job-name: ci-kubernetes-build-1.5
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-federation-build:
         branch: master
@@ -114,7 +106,6 @@
         job-name: ci-kubernetes-federation-build
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-federation-build-1.4:
         branch: release-1.4
@@ -122,7 +113,6 @@
         job-name: ci-kubernetes-federation-build-1.4
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-federation-build-1.5:
         branch: release-1.5
@@ -130,7 +120,6 @@
         job-name: ci-kubernetes-federation-build-1.5
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'
 
     - kubernetes-build-debian-unstable:
         branch: master
@@ -138,4 +127,3 @@
         job-name: ci-kubernetes-build-debian-unstable
         repo-name: k8s.io/release
         commit-frequency: 'H/5 * * * *'
-        timed-frequency: 'H * * * *'


### PR DESCRIPTION
None of the migrated jobs in #1182 would previously build unnecessarily. Remove it. This actually destabilized the kops jobs because new binaries for the same build were getting sliced in continuously (and c.f. https://github.com/kubernetes/kops/pull/1011).

Fixes #1212 

(Assigning to original author/reviewer to respond to review comment.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/test-infra/1213)
<!-- Reviewable:end -->
