### PR TITLE
kops: Disable on release-1.4 as well

### DIFF
--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -22,7 +22,7 @@ readonly testinfra="$(dirname "${0}")/.."
 
 # TODO(fejta): remove this
 case "${ghprbTargetBranch:-}" in
-  "release-1.0"|"release-1.1"|"release-1.2"|"release-1.3")
+  "release-1.0"|"release-1.1"|"release-1.2"|"release-1.3"|"release-1.4")
     echo "PR AWS kops job disabled for legacy branches."
     exit
     ;;


### PR DESCRIPTION
c.f. https://github.com/kubernetes/kubernetes/pull/37336

The deflaking and most of the e2e works weren't done until
release-1.5, and I'm not going to backport everything at this point.

TBR @kubernetes/test-infra-maintainers 