### PR TITLE
kops: Fix CLOUDSDK_CONFIG in kops-e2e-runnner

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -56,6 +56,8 @@ fi
 $(dirname "${BASH_SOURCE}")/e2e-runner.sh
 
 if [[ -n "${KOPS_PUBLISH_GREEN_PATH:-}" ]]; then
+  export CLOUDSDK_CONFIG="/workspace/.config/gcloud"
+
   if ! which gsutil; then
     export PATH=/google-cloud-sdk/bin:${PATH}
     if ! which gsutil; then

--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -61,6 +61,9 @@ export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${E2E_NAME}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/ --kops-nodes=4"
 export GINKGO_PARALLEL="y"
 
+# TODO(zmerlynn): Take this out after the e2e-image is rev'd.
+export CLOUDSDK_CONFIG="/workspace/.config/gcloud"
+
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 timeout -k 15m 20m "${runner}" && rc=$? || rc=$?

--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -68,6 +68,9 @@ export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${E2E_NAME}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/ --kops-nodes=4"
 export GINKGO_PARALLEL="y"
 
+# TODO(zmerlynn): Take this out after the e2e-image is rev'd.
+export CLOUDSDK_CONFIG="/workspace/.config/gcloud"
+
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 timeout -k 15m 240m "${runner}" && rc=$? || rc=$?


### PR DESCRIPTION
This is a more subtle breakage from #1209, and I still can't figure out where in the old path this was getting set correctly (but it was).