### PR TITLE
Bump e2e image to v20161129-79a2508, remove associated TODOs

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,7 +30,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20161122-748fef7'
+KUBEKINS_E2E_IMAGE_TAG='v20161129-79a2508'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -61,9 +61,6 @@ export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${E2E_NAME}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/ --kops-nodes=4"
 export GINKGO_PARALLEL="y"
 
-# TODO(zmerlynn): Take this out after the e2e-image is rev'd.
-export CLOUDSDK_CONFIG="/workspace/.config/gcloud"
-
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 timeout -k 15m 20m "${runner}" && rc=$? || rc=$?

--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -68,9 +68,6 @@ export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${E2E_NAME}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/ --kops-nodes=4"
 export GINKGO_PARALLEL="y"
 
-# TODO(zmerlynn): Take this out after the e2e-image is rev'd.
-export CLOUDSDK_CONFIG="/workspace/.config/gcloud"
-
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 timeout -k 15m 240m "${runner}" && rc=$? || rc=$?


### PR DESCRIPTION
Removes TODOs from #1218, since the bump will obviate the exports. Also picks up #1217/#1221.

Testing in kubernetes/kubernetes#37298.