### PR TITLE
[jenkins/gce] de-dup E2E name for gce-multizone

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gce-multizone.sh
@@ -46,7 +46,7 @@ export E2E_UP="${E2E_UP:-true}"
 export E2E_TEST="${E2E_TEST:-true}"
 export E2E_DOWN="${E2E_DOWN:-true}"
 
-export E2E_NAME='bootstrap-e2e'
+export E2E_NAME='bootstrap-e2e-gce-multizone'
 
 # Skip gcloud update checking
 export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
@@ -57,7 +57,6 @@ export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
 export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
 
 # GCE variables
-export INSTANCE_PREFIX="${E2E_NAME}"
 export KUBE_GCE_NETWORK="${E2E_NAME}"
 export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
 


### PR DESCRIPTION
Should get rid of this error that is showing up in the Jenkins logs:
```sh
W1129 18:38:57.103] ERROR: (gcloud.compute.instance-templates.delete) Some requests did not succeed:
W1129 18:38:57.103]  - The instance_template resource 'bootstrap-e2e-minion-template' is already being used by 'bootstrap-e2e-minion-group'
```

I believe this is caused by `E2E_NAME` colliding with `ci-kubernetes-e2e-gce.sh`

\cc @spxtr @fejta 