### PR TITLE
kops-updown: Bump timeout to 30m

### DIFF
--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -63,7 +63,7 @@ export GINKGO_PARALLEL="y"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-timeout -k 15m 20m "${runner}" && rc=$? || rc=$?
+timeout -k 15m 30m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then


### PR DESCRIPTION
The natural hack/e2e.go timeout for cluster up is 20m, and we keep
racing as to whether that pops or the entire container is killed. If
the latter happens, we get no logs. Sad!