### PR TITLE
Add timeout log collection to postsubmit jobs

### DIFF
--- a/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
@@ -74,6 +74,11 @@ timeout -k 15m 240m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
@@ -74,6 +74,11 @@ timeout -k 15m 240m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-aws.sh
+++ b/jobs/ci-kubernetes-e2e-aws.sh
@@ -73,6 +73,11 @@ timeout -k 15m 240m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-garbage-gci.sh
+++ b/jobs/ci-kubernetes-e2e-garbage-gci.sh
@@ -73,6 +73,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-garbage.sh
+++ b/jobs/ci-kubernetes-e2e-garbage.sh
@@ -73,6 +73,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
@@ -79,6 +79,11 @@ timeout -k 15m 210m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
@@ -81,6 +81,11 @@ timeout -k 15m 210m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-container-vm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-container-vm.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
@@ -109,6 +109,11 @@ timeout -k 15m 1400m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
@@ -99,6 +99,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
@@ -99,6 +99,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gce-es-logging.sh
@@ -71,6 +71,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3.sh
@@ -76,6 +76,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gce-examples.sh
@@ -70,6 +70,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
@@ -78,6 +78,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
@@ -78,6 +78,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation.sh
@@ -80,6 +80,11 @@ timeout -k 15m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out after ${timeoutTime}" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gce-flaky.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
@@ -71,6 +71,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
@@ -71,6 +71,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
@@ -71,6 +71,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
@@ -71,6 +71,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
@@ -72,6 +72,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
@@ -71,6 +71,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
@@ -73,6 +73,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
@@ -75,6 +75,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-ha-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ha-master.sh
@@ -71,6 +71,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress.sh
@@ -72,6 +72,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-kubenet.sh
+++ b/jobs/ci-kubernetes-e2e-gce-kubenet.sh
@@ -72,6 +72,11 @@ timeout -k 15m 120m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
@@ -75,6 +75,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gce-multizone.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gce-proto.sh
@@ -75,6 +75,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot.sh
@@ -70,6 +70,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
@@ -96,6 +96,11 @@ timeout -k 15m 120m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability.sh
@@ -92,6 +92,11 @@ timeout -k 15m 120m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gce-statefulset.sh
@@ -71,6 +71,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gce.sh
@@ -76,6 +76,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-docker.sh
+++ b/jobs/ci-kubernetes-e2e-gci-docker.sh
@@ -71,6 +71,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
@@ -78,6 +78,11 @@ timeout -k 15m 210m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
@@ -79,6 +79,11 @@ timeout -k 15m 210m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
@@ -74,6 +74,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
@@ -76,6 +76,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
@@ -71,6 +71,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
@@ -77,6 +77,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
@@ -70,6 +70,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
@@ -80,6 +80,11 @@ timeout -k 15m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out after ${timeoutTime}" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
@@ -71,6 +71,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
@@ -71,6 +71,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
@@ -72,6 +72,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-kubenet.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-kubenet.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
@@ -76,6 +76,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
@@ -70,6 +70,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
@@ -94,6 +94,11 @@ timeout -k 15m 120m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
@@ -92,6 +92,11 @@ timeout -k 15m 120m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
@@ -71,6 +71,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
@@ -74,6 +74,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
@@ -74,6 +74,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
@@ -73,6 +73,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
@@ -73,6 +73,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
@@ -72,6 +72,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
@@ -77,6 +77,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
@@ -77,6 +77,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
@@ -75,6 +75,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
@@ -73,6 +73,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
@@ -74,6 +74,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
@@ -73,6 +73,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
@@ -74,6 +74,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
@@ -74,6 +74,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
@@ -75,6 +75,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
@@ -76,6 +76,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
@@ -74,6 +74,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
@@ -76,6 +76,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-test.sh
@@ -73,6 +73,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke-updown.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-updown.sh
@@ -73,6 +73,11 @@ timeout -k 15m 30m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gci-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
@@ -73,6 +73,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gke-flaky.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
@@ -78,6 +78,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
@@ -76,6 +76,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
@@ -77,6 +77,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
@@ -75,6 +75,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
@@ -77,6 +77,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
@@ -74,6 +74,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gke-ingress.sh
@@ -72,6 +72,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
@@ -88,6 +88,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
@@ -86,6 +86,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
@@ -84,6 +84,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gke-multizone.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gke-pre-release.sh
@@ -71,6 +71,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
@@ -76,6 +76,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
@@ -76,6 +76,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod.sh
@@ -74,6 +74,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
@@ -72,6 +72,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot.sh
@@ -71,6 +71,11 @@ timeout -k 15m 180m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
@@ -73,6 +73,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
@@ -73,6 +73,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial.sh
@@ -72,6 +72,11 @@ timeout -k 15m 300m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
@@ -74,6 +74,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow.sh
@@ -73,6 +73,11 @@ timeout -k 15m 150m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
@@ -76,6 +76,11 @@ timeout -k 15m 80m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging.sh
@@ -73,6 +73,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gke-subnet.sh
@@ -75,6 +75,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gke-test.sh
@@ -72,6 +72,11 @@ timeout -k 15m 480m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke-updown.sh
+++ b/jobs/ci-kubernetes-e2e-gke-updown.sh
@@ -72,6 +72,11 @@ timeout -k 15m 30m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gke.sh
@@ -72,6 +72,11 @@ timeout -k 15m 50m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -67,6 +67,11 @@ timeout -k 15m 30m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -74,6 +74,11 @@ timeout -k 15m 240m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-kubemark-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-100-gce.sh
@@ -84,6 +84,11 @@ timeout -k 15m 240m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
@@ -84,6 +84,11 @@ timeout -k 15m 60m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-kubemark-5-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce.sh
@@ -83,6 +83,11 @@ timeout -k 15m 60m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-kubemark-500-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-500-gce.sh
@@ -87,6 +87,11 @@ timeout -k 15m 60m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-kubemark-gce-scale.sh
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.sh
@@ -108,6 +108,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
@@ -88,6 +88,11 @@ timeout -k 15m 160m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.2-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.2-deploy.sh
@@ -73,6 +73,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.2-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.2-test.sh
@@ -82,6 +82,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.3-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.3-deploy.sh
@@ -73,6 +73,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.3-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.3-test.sh
@@ -82,6 +82,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.4-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.4-deploy.sh
@@ -73,6 +73,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.4-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.4-test.sh
@@ -82,6 +82,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.5-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.5-deploy.sh
@@ -73,6 +73,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-1.5-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.5-test.sh
@@ -82,6 +82,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-2-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-2-deploy.sh
@@ -73,6 +73,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-2-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-2-test.sh
@@ -82,6 +82,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-cri-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-cri-deploy.sh
@@ -74,6 +74,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-cri-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-cri-test.sh
@@ -83,6 +83,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-deploy.sh
@@ -72,6 +72,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
@@ -84,6 +84,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-federation-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.sh
@@ -93,6 +93,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-gci-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-gci-deploy.sh
@@ -72,6 +72,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-gci-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-gci-test.sh
@@ -81,6 +81,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gce-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-test.sh
@@ -81,6 +81,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.sh
@@ -78,6 +78,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-test.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-test.sh
@@ -82,6 +82,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.sh
@@ -73,6 +73,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-test.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-test.sh
@@ -82,6 +82,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gke-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gke-deploy.sh
@@ -76,6 +76,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gke-gci-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gke-gci-deploy.sh
@@ -76,6 +76,11 @@ timeout -k 15m 90m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gke-gci-test.sh
+++ b/jobs/ci-kubernetes-soak-gke-gci-test.sh
@@ -85,6 +85,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2

--- a/jobs/ci-kubernetes-soak-gke-test.sh
+++ b/jobs/ci-kubernetes-soak-gke-test.sh
@@ -85,6 +85,11 @@ timeout -k 15m 600m "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    # If we timed out, make sure we collect logs anyways.
+    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
+        echo "Dumping logs for any remaining nodes"
+        ./cluster/log-dump.sh _artifacts
+    fi
     echo "Build timed out" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2


### PR DESCRIPTION
Add timeout log collection to postsubmit jobs

This was done using the following script, which I'm sure could be
better but gets the job done:

```
grep -lR "timeout -k" ci-kubernetes* | while read file; do
  if ! grep "dockerized-e2e-runner.sh" "${file}" > /dev/null; then
    continue
  fi
  sed -i '/-eq 137/r fix-timeouts.txt' "${file}"
done
```

Quick fix for kubernetes/kubernetes#37553

cc @kubernetes/test-infra-maintainers