### PR TITLE
Make sure artifacts are readable in legacy Jenkins jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/global.yaml
@@ -15,7 +15,8 @@
                     mkdir -p _tmp
                     curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" > ./_tmp/upload-to-gcs.sh
                     chmod +x ./_tmp/upload-to-gcs.sh
-
+                    # Artifacts might be readable only by root if there was a timeout
+                    sudo chmod +rX -R "${WORKSPACE}/_artifacts/" || true
                     curl -fsS --retry 3 "http://jenkins-master:8080/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" > "${WORKSPACE}/build-log.txt"
                 - conditional-step:
                     condition-kind: current-status


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/37553 for non-bootstrap jobs.

cc @krousey 