### PR TITLE
Test gcloud credentials on gke-alpha-features.sh

### DIFF
--- a/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
@@ -49,6 +49,8 @@ export E2E_NAME='bootstrap-e2e'
 export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 # Use default component update behavior
 export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+# Use gcloud credentials for authentication
+export CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=false
 
 # AWS variables
 export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"


### PR DESCRIPTION
If all looks good, will expand to other jobs that test gke with k8s HEAD.

This flag tells gcloud to write a kubeconfig entry that lets kubectl use gcloud's credentials. We currently use application default credentials; we're changing to use gcloud credentials to avoid the confusion that results when gcloud and adc are using different service accounts - resulting in `gcloud container clusters create` succeeding, but `kubectl ...` failing.