### PR TITLE
Make sure artifacts are readable on bootstrap'd builds too

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -79,7 +79,10 @@ kill-leaked-container() {
   local pid=$(docker inspect --format '{{.State.Pid}}' "${container}")
   echo "Processes running under container ${container}:"
   ps wwuf --forest --sid "${pid}"
-  docker stop "${container}"
+  docker stop "${container}" || true
+  # Make sure artifacts are readable, since we may not have run that code
+  # in e2e-runner.sh if we were killed by timeout.
+  sudo chmod a+rX -R "${WORKSPACE}/_artifacts/" || true
 }
 
 trap "kill-leaked-container ${CONTAINER_NAME}" EXIT

--- a/jenkins/job-configs/kubernetes-jenkins/global.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/global.yaml
@@ -15,8 +15,6 @@
                     mkdir -p _tmp
                     curl -fsS --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" > ./_tmp/upload-to-gcs.sh
                     chmod +x ./_tmp/upload-to-gcs.sh
-                    # Artifacts might be readable only by root if there was a timeout
-                    sudo chmod +rX -R "${WORKSPACE}/_artifacts/" || true
                     curl -fsS --retry 3 "http://jenkins-master:8080/job/${JOB_NAME}/${BUILD_NUMBER}/consoleText" > "${WORKSPACE}/build-log.txt"
                 - conditional-step:
                     condition-kind: current-status


### PR DESCRIPTION
Follow-on to #1264, applying the same fix to `bootstrap.py`. Fixes last instance of kubernetes/kubernetes#37553 I hope.

I also added an `a` to both locations to make sure that weird `umask`s won't break this.