### PR TITLE
Increase kill timeout to 20m for e2e and kubemark jobs

### DIFF
--- a/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-aws.sh
+++ b/jobs/ci-kubernetes-e2e-aws.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-garbage-gci.sh
+++ b/jobs/ci-kubernetes-e2e-garbage-gci.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-garbage.sh
+++ b/jobs/ci-kubernetes-e2e-garbage.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
@@ -76,7 +76,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
@@ -78,7 +78,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-container-vm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-container-vm.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
@@ -106,7 +106,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="1400m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
@@ -96,7 +96,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
@@ -96,7 +96,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gce-es-logging.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gce-examples.sh
@@ -67,7 +67,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
@@ -75,7 +75,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
@@ -75,7 +75,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation.sh
@@ -76,7 +76,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 readonly timeoutTime="900m"
-timeout -k 15m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gce-flaky.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
@@ -72,7 +72,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-ha-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ha-master.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-kubenet.sh
+++ b/jobs/ci-kubernetes-e2e-gce-kubenet.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
@@ -72,7 +72,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gce-multizone.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gce-proto.sh
@@ -72,7 +72,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot.sh
@@ -67,7 +67,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
@@ -93,7 +93,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability.sh
@@ -89,7 +89,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gce-statefulset.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gce.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-docker.sh
+++ b/jobs/ci-kubernetes-e2e-gci-docker.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
@@ -75,7 +75,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
@@ -76,7 +76,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
@@ -74,7 +74,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
@@ -67,7 +67,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
@@ -76,7 +76,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 readonly timeoutTime="900m"
-timeout -k 15m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-kubenet.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-kubenet.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
@@ -67,7 +67,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
@@ -91,7 +91,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
@@ -89,7 +89,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
@@ -74,7 +74,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
@@ -74,7 +74,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
@@ -72,7 +72,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
@@ -72,7 +72,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-test.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke-updown.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-updown.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="30m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gci-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gke-flaky.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
@@ -75,7 +75,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
@@ -74,7 +74,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
@@ -72,7 +72,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
@@ -74,7 +74,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gke-ingress.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
@@ -85,7 +85,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
@@ -83,7 +83,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
@@ -81,7 +81,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gke-multizone.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gke-pre-release.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot.sh
@@ -68,7 +68,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
@@ -71,7 +71,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
@@ -73,7 +73,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging.sh
@@ -70,7 +70,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gke-subnet.sh
@@ -72,7 +72,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gke-test.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke-updown.sh
+++ b/jobs/ci-kubernetes-e2e-gke-updown.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="30m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gke.sh
@@ -69,7 +69,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -64,7 +64,7 @@ export GINKGO_PARALLEL="y"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="30m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -71,7 +71,7 @@ export GINKGO_PARALLEL="y"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-kubemark-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-100-gce.sh
@@ -81,7 +81,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
@@ -81,7 +81,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="60m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-kubemark-5-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce.sh
@@ -80,7 +80,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="60m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-kubemark-500-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-500-gce.sh
@@ -84,7 +84,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="60m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-kubemark-gce-scale.sh
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.sh
@@ -101,7 +101,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
@@ -85,7 +85,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="160m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/pull-kops-e2e-kubernetes-aws.sh
+++ b/jobs/pull-kops-e2e-kubernetes-aws.sh
@@ -72,7 +72,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-e2e-gce-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-cri.sh
@@ -81,7 +81,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.sh
@@ -74,7 +74,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gce-gci.sh
@@ -71,7 +71,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-e2e-gce.sh
+++ b/jobs/pull-kubernetes-e2e-gce.sh
@@ -71,7 +71,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-e2e-gke-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gke-gci.sh
@@ -84,7 +84,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-e2e-gke.sh
+++ b/jobs/pull-kubernetes-e2e-gke.sh
@@ -88,7 +88,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -90,7 +90,7 @@ export PATH=${PATH}:/usr/local/go/bin
 export KOPS_LATEST="latest-ci-green.txt"
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-federation-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-federation-e2e-gce-gci.sh
@@ -70,7 +70,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-federation-e2e-gce.sh
+++ b/jobs/pull-kubernetes-federation-e2e-gce.sh
@@ -69,7 +69,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
@@ -74,7 +74,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"

--- a/jobs/pull-kubernetes-kubemark-e2e-gce.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce.sh
@@ -78,7 +78,7 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="45m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 if [[ ${rc} -ne 0 ]]; then
   if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
     echo "Dumping logs for any remaining nodes"


### PR DESCRIPTION
ref #1250 

Once #1276 goes in we expect e2e.go to terminate itself after 15m so allow 5 more minutes before we kill the container. 

```
sed -i -e 's/timeout -k 15m/timeout -k 20m/' *-kubemark-*.sh *-e2e-*.sh
```