### PR TITLE
Migrate timeout handling into dockerized-e2e-runner.sh and e2e.go

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -92,12 +92,13 @@ timeout -s KILL ${DOCKER_TIMEOUT:-615m} docker run --rm \
   "gcr.io/google-containers/kubekins-e2e:${KUBEKINS_E2E_IMAGE_TAG}" && rc=$? || rc=$?
 
 echo "Exiting with code: ${rc}"
-if [[ ${rc} -eq 137 ]]; then
+if [[ ${rc} -eq 137 ]]; then  # 137 == SIGKILL, see man timeout
   local container="${CONTAINER_NAME}"
   # docker runs containers with session id being the same as the pid
   local pid=$(docker inspect --format '{{.State.Pid}}' "${container}")
   echo "Processes running under container ${container}:"
   ps wwuf --forest --sid "${pid}"
   docker stop "${container}" || true
+  sudo chmod a+rX -R "${WORKSPACE}/_artifacts/" || true
 fi
 exit ${rc}

--- a/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-aws.sh
+++ b/jobs/ci-kubernetes-e2e-aws.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-garbage-gci.sh
+++ b/jobs/ci-kubernetes-e2e-garbage-gci.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-garbage.sh
+++ b/jobs/ci-kubernetes-e2e-garbage.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster.sh
@@ -77,13 +77,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-master.sh
@@ -77,13 +77,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster.sh
@@ -77,13 +77,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master.sh
@@ -77,13 +77,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
@@ -76,18 +76,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
@@ -78,18 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-container-vm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-container-vm.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
@@ -107,18 +107,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export DOCKER_TIMEOUT="1500m"
 export KUBEKINS_TIMEOUT="1400m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.sh
@@ -105,6 +105,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="1500m"
 export KUBEKINS_TIMEOUT="1400m"
 timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 

--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
@@ -96,18 +96,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
@@ -96,18 +96,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gce-es-logging.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gce-examples.sh
@@ -67,18 +67,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
@@ -75,18 +75,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.5.sh
@@ -76,19 +76,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 # See the discussion here - https://github.com/kubernetes/test-infra/pull/1280
 # for the motivation behind the choice of this value.
+export DOCKER_TIMEOUT="750m"
 export KUBEKINS_TIMEOUT="690m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation.sh
@@ -77,18 +77,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export DOCKER_TIMEOUT="915m"
 export KUBEKINS_TIMEOUT="900m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out after ${KUBEKINS_TIMEOUT}" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation.sh
@@ -75,8 +75,9 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-readonly timeoutTime="900m"
-timeout -k 20m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
+export DOCKER_TIMEOUT="915m"
+export KUBEKINS_TIMEOUT="900m"
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
@@ -85,7 +86,7 @@ if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
         echo "Dumping logs for any remaining nodes"
         ./cluster/log-dump.sh _artifacts
     fi
-    echo "Build timed out after ${timeoutTime}" >&2
+    echo "Build timed out after ${KUBEKINS_TIMEOUT}" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2
 fi

--- a/jobs/ci-kubernetes-e2e-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gce-flaky.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
@@ -72,18 +72,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-ha-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ha-master.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-cvm-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-gci-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-cvm-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-gci-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-gci-kubectl-skew.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-cvm-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-gci-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-cvm-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-gci-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-cvm-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-gci-kubectl-skew.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
@@ -72,18 +72,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gce-multizone.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gce-proto.sh
@@ -72,18 +72,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot.sh
@@ -67,18 +67,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
@@ -93,18 +93,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability.sh
@@ -89,18 +89,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gce-statefulset.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gce.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-docker.sh
+++ b/jobs/ci-kubernetes-e2e-gci-docker.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
@@ -75,18 +75,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
@@ -76,18 +76,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="210m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
@@ -74,18 +74,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
@@ -67,18 +67,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
@@ -77,18 +77,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export DOCKER_TIMEOUT="915m"
 export KUBEKINS_TIMEOUT="900m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out after ${KUBEKINS_TIMEOUT}" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
@@ -75,8 +75,9 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-readonly timeoutTime="900m"
-timeout -k 20m "${timeoutTime}" "${runner}" && rc=$? || rc=$?
+export DOCKER_TIMEOUT="915m"
+export KUBEKINS_TIMEOUT="900m"
+timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
@@ -85,7 +86,7 @@ if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
         echo "Dumping logs for any remaining nodes"
         ./cluster/log-dump.sh _artifacts
     fi
-    echo "Build timed out after ${timeoutTime}" >&2
+    echo "Build timed out after ${KUBEKINS_TIMEOUT}" >&2
 elif [[ ${rc} -ne 0 ]]; then
     echo "Build failed" >&2
 fi

--- a/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
@@ -67,18 +67,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
@@ -91,18 +91,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
@@ -89,18 +89,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
@@ -74,18 +74,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
@@ -74,18 +74,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
@@ -72,18 +72,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
@@ -72,18 +72,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-test.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-updown.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-updown.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="30m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-cvm-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-gci-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster-new.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-master.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster-new.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-master.sh
@@ -80,13 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.2-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.2-cvm-kubectl-skew.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.2-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.2-gci-kubectl-skew.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-cvm-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-gci-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new.sh
@@ -79,13 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-master.sh
@@ -78,13 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew.sh
@@ -82,13 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew.sh
@@ -82,13 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew.sh
@@ -81,13 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew.sh
@@ -82,13 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew.sh
@@ -82,13 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster-new.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-master.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster-new.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-master.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new.sh
@@ -86,14 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new.sh
@@ -86,4 +86,5 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new.sh
@@ -87,13 +87,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gke-flaky.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster-new.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-master.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster-new.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-master.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster-new.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-master.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster-new.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-master.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new.sh
@@ -87,13 +87,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new.sh
@@ -87,13 +87,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master.sh
@@ -86,13 +86,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new.sh
@@ -85,13 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.sh
@@ -84,13 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master.sh
@@ -83,13 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
@@ -75,18 +75,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
@@ -74,18 +74,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
@@ -72,18 +72,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
@@ -74,18 +74,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gke-ingress.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
@@ -85,18 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
@@ -83,18 +83,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
@@ -81,18 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew.sh
@@ -82,13 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew.sh
@@ -82,13 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="120m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gke-multizone.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gke-pre-release.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot.sh
@@ -68,18 +68,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="180m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="150m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="80m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gke-subnet.sh
@@ -72,18 +72,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gke-test.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="480m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-updown.sh
+++ b/jobs/ci-kubernetes-e2e-gke-updown.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="30m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gke.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -64,18 +64,4 @@ export GINKGO_PARALLEL="y"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="30m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -71,18 +71,4 @@ export GINKGO_PARALLEL="y"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-kubemark-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-100-gce.sh
@@ -81,18 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="240m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
@@ -81,18 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="60m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-kubemark-5-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce.sh
@@ -80,18 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="60m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-kubemark-500-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-500-gce.sh
@@ -84,18 +84,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="60m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-kubemark-gce-scale.sh
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.sh
@@ -101,18 +101,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
@@ -85,18 +85,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="160m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.2-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.2-deploy.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.2-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.2-test.sh
@@ -79,18 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.3-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.3-deploy.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.3-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.3-test.sh
@@ -79,18 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.4-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.4-deploy.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.4-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.4-test.sh
@@ -79,18 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.5-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.5-deploy.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.5-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.5-test.sh
@@ -79,18 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-2-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-2-deploy.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-2-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-2-test.sh
@@ -79,18 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-cri-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-cri-deploy.sh
@@ -71,18 +71,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-cri-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-cri-test.sh
@@ -80,18 +80,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-deploy.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
@@ -81,18 +81,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-federation-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.sh
@@ -90,18 +90,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-gci-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-gci-deploy.sh
@@ -69,18 +69,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-gci-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-gci-test.sh
@@ -78,18 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gce-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-test.sh
@@ -78,18 +78,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.sh
@@ -75,18 +75,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-test.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-test.sh
@@ -79,18 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.sh
@@ -70,18 +70,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-test.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-test.sh
@@ -79,18 +79,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gke-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gke-deploy.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gke-gci-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gke-gci-deploy.sh
@@ -73,18 +73,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="90m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gke-gci-test.sh
+++ b/jobs/ci-kubernetes-soak-gke-gci-test.sh
@@ -82,18 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/ci-kubernetes-soak-gke-test.sh
+++ b/jobs/ci-kubernetes-soak-gke-test.sh
@@ -82,18 +82,4 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="600m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-
-### Reporting
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-    # If we timed out, make sure we collect logs anyways.
-    if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-        echo "Dumping logs for any remaining nodes"
-        ./cluster/log-dump.sh _artifacts
-    fi
-    echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-    echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kops-e2e-kubernetes-aws.sh
+++ b/jobs/pull-kops-e2e-kubernetes-aws.sh
@@ -71,18 +71,6 @@ export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 export PATH=${PATH}:/usr/local/go/bin
 
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-gce-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-cri.sh
@@ -81,17 +81,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.sh
@@ -74,17 +74,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gce-gci.sh
@@ -71,17 +71,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-gce.sh
+++ b/jobs/pull-kubernetes-e2e-gce.sh
@@ -71,17 +71,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-gke-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gke-gci.sh
@@ -84,17 +84,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-gke.sh
+++ b/jobs/pull-kubernetes-e2e-gke.sh
@@ -88,17 +88,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -89,18 +89,6 @@ export PATH=${PATH}:/usr/local/go/bin
 
 export KOPS_LATEST="latest-ci-green.txt"
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${testinfra}/jenkins/dockerized-e2e-runner.sh" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
@@ -74,17 +74,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="55m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"

--- a/jobs/pull-kubernetes-kubemark-e2e-gce.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce.sh
@@ -78,17 +78,4 @@ export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export KUBEKINS_TIMEOUT="45m"
-timeout -k 20m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
-if [[ ${rc} -ne 0 ]]; then
-  if [[ -x cluster/log-dump.sh && -d _artifacts ]]; then
-    echo "Dumping logs for any remaining nodes"
-    ./cluster/log-dump.sh _artifacts
-  fi
-fi
-if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
-  echo "Build timed out" >&2
-elif [[ ${rc} -ne 0 ]]; then
-  echo "Build failed" >&2
-fi
-echo "Exiting with code: ${rc}"
-exit ${rc}
+"${runner}"


### PR DESCRIPTION
ref #1250 

Woo! Delete 3000 lines of reporting and timeout boilerplate.

Have dockerized-e2e-runner.sh send a kill signal and delete the container after DOCKER_TIMEOUT or 615m
Ensure that e2e jobs no longer have a `### Reporting` section
Ensure that KUBEKINS_TIMEOUT is sufficiently shorter than DOCKER_TIMEOUT