### PR TITLE
Add a separate job for federation soak build task

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1135,6 +1135,8 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-e2e-gce-federation-release-1.5.sh': 'ci-kubernetes-federation-1.5-*',
             'ci-kubernetes-federation-build-1.4.sh': 'ci-kubernetes-federation-1.4-*',
             'ci-kubernetes-e2e-gce-federation-release-1.4.sh': 'ci-kubernetes-federation-1.4-*',
+            'ci-kubernetes-federation-build-soak.sh': 'ci-kubernetes-federation-soak-*',
+            'ci-kubernetes-soak-gce-federation-*.sh': 'ci-kubernetes-federation-soak-*',
         }
         projects = collections.defaultdict(set)
         for job, job_path in self.jobs:

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -121,6 +121,13 @@
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
 
+    - kubernetes-federation-build-soak:
+        branch: master
+        giturl: 'https://github.com/kubernetes/kubernetes'
+        job-name: ci-kubernetes-federation-build-soak
+        repo-name: k8s.io/kubernetes
+        commit-frequency: 'H 23 * * *'
+
     - kubernetes-build-debian-unstable:
         branch: master
         giturl: 'https://github.com/kubernetes/release'

--- a/jobs/ci-kubernetes-federation-build-soak.sh
+++ b/jobs/ci-kubernetes-federation-build-soak.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### job-env
+export PROJECT="k8s-jkns-gce-federation-soak"
+export FEDERATION=true
+export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-gce-federation-soak"
+export KUBE_FASTBUILD=true
+export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
+export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release
+
+### Runner
+readonly runner="./hack/jenkins/build.sh"
+export KUBEKINS_TIMEOUT="50m"
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+
+### Reporting
+if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then
+    echo "Build timed out" >&2
+elif [[ ${rc} -ne 0 ]]; then
+    echo "Build failed" >&2
+fi
+echo "Exiting with code: ${rc}"
+exit ${rc}

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
@@ -47,7 +47,7 @@ export FEDERATION="true"
 export DNS_ZONE_NAME="soak.test-f8n.k8s.io."
 export FEDERATIONS_DOMAIN_MAP="federation=soak.test-f8n.k8s.io"
 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
+export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-gce-federation-soak"
 
 ### post-env
 

--- a/jobs/ci-kubernetes-soak-gce-federation-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.sh
@@ -56,7 +56,7 @@ export FEDERATION="true"
 export DNS_ZONE_NAME="soak.test-f8n.k8s.io."
 export FEDERATIONS_DOMAIN_MAP="federation=soak.test-f8n.k8s.io"
 export E2E_ZONES="us-central1-a us-central1-b us-central1-f" # Where the clusters will be created. Federation components are now deployed to the last one.
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
+export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-gce-federation-soak"
 
 ### post-env
 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -126,6 +126,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-1.4
 - name: kubernetes-federation-build-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-1.5
+- name: kubernetes-federation-build-soak
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-soak
 - name: kubernetes-e2e-gce-federation
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-federation
 - name: kubernetes-e2e-gci-gce-federation
@@ -1779,6 +1781,8 @@ dashboards:
     test_group_name: kubernetes-federation-build-1.4
   - name: federation-build-1.5
     test_group_name: kubernetes-federation-build-1.5
+  - name: federation-build-soak
+    test_group_name: kubernetes-federation-build-soak
   - name: gce-federation
     test_group_name: kubernetes-e2e-gce-federation
   - name: gci-federation


### PR DESCRIPTION
federation-soak-deploy job cannot access the gcr images of k8s-jkns-e2e-gce-federation project, so adding another separate build for federation soak tests.
The trigger frequency is currently kept as every day and later will be changed to a week as recorded in #1260. federation-soak-build job will get triggered one hour before the federation-soak-deploy job.

@madhusudancs @fejta 