### PR TITLE
Default DOCKER_TIMEOUT to 120m

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -74,7 +74,7 @@ fi
 CONTAINER_NAME="${JOB_NAME}-${BUILD_NUMBER}"
 
 echo "Starting..."
-timeout -s KILL ${DOCKER_TIMEOUT:-615m} docker run --rm \
+timeout -s KILL ${DOCKER_TIMEOUT:-120m} docker run --rm \
   --name="${CONTAINER_NAME}" \
   -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
   -v /etc/localtime:/etc/localtime:ro \

--- a/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="260m"
 export KUBEKINS_TIMEOUT="240m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="260m"
 export KUBEKINS_TIMEOUT="240m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-aws.sh
+++ b/jobs/ci-kubernetes-e2e-aws.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="260m"
 export KUBEKINS_TIMEOUT="240m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-garbage-gci.sh
+++ b/jobs/ci-kubernetes-e2e-garbage-gci.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-garbage.sh
+++ b/jobs/ci-kubernetes-e2e-garbage.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster.sh
@@ -76,5 +76,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.3-1.4-upgrade-master.sh
@@ -76,5 +76,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster.sh
@@ -76,5 +76,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master.sh
@@ -76,5 +76,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.sh
@@ -75,5 +75,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="230m"
 export KUBEKINS_TIMEOUT="210m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="230m"
 export KUBEKINS_TIMEOUT="210m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
@@ -95,5 +95,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
@@ -95,5 +95,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.4.sh
@@ -74,5 +74,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gce-federation.sh
@@ -76,5 +76,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export DOCKER_TIMEOUT="915m"
+export DOCKER_TIMEOUT="920m"
 export KUBEKINS_TIMEOUT="900m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gce-flaky.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.2.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m52.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m53.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m54.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m55.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m52.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m53.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m54.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.sh
@@ -71,5 +71,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-ha-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ha-master.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-cvm-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-gci-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-cvm-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-gci-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-gci-kubectl-skew.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-cvm-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-gci-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-cvm-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.3-gci-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-cvm-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gce-latest-latest-1.4-gci-kubectl-skew.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gce-multizone.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.2.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.3.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1.5.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gce-reboot.sh
@@ -66,5 +66,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.sh
@@ -92,5 +92,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gce-scalability.sh
@@ -88,5 +88,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gce-serial.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.2.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.3.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1.5.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gce-slow.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.sh
@@ -74,5 +74,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="230m"
 export KUBEKINS_TIMEOUT="210m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.sh
@@ -75,5 +75,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="230m"
 export KUBEKINS_TIMEOUT="210m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri-serial.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-federation.sh
@@ -76,5 +76,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
 export DOCKER_TIMEOUT="915m"
+export DOCKER_TIMEOUT="920m"
 export KUBEKINS_TIMEOUT="900m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-flaky.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.2.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.3.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.4.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1.5.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot.sh
@@ -66,5 +66,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.sh
@@ -90,5 +90,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability.sh
@@ -88,5 +88,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.2.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.3.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.5.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-flaky.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-multizone.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-pre-release.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.sh
@@ -71,5 +71,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.3.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.3.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.4.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.sh
@@ -71,5 +71,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-subnet.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-test.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-cvm-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-gci-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster-new.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-cluster.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.3-upgrade-master.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster-new.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-cluster.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.2-1.4-upgrade-master.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.2-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.2-cvm-kubectl-skew.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.2-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.2-gci-kubectl-skew.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-cvm-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-gci-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.3-1.4-upgrade-master.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
+++ b/jobs/ci-kubernetes-e2e-gke-autoscaling.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster-new.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-cluster.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.3-upgrade-master.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster-new.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-cluster.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.2-gci-1.4-upgrade-master.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new.sh
@@ -86,5 +86,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new.sh
@@ -86,5 +86,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-flaky.sh
+++ b/jobs/ci-kubernetes-e2e-gke-flaky.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster-new.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-cluster.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.3-upgrade-master.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster-new.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-cluster.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-container_vm-1.4-upgrade-master.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster-new.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-cluster.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.3-upgrade-master.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster-new.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-cluster.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.2-gci-1.4-upgrade-master.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new.sh
@@ -86,5 +86,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new.sh
@@ -86,5 +86,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master.sh
@@ -85,5 +85,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-release-1.2.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-release-1.2.sh
@@ -71,5 +71,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-subnet-release-1.2.sh
@@ -73,5 +73,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-test-release-1.2.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-cluster.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-deploy.sh
@@ -82,5 +82,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gke-large-teardown.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-latest-1.4-cvm-kubectl-skew.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew.sh
+++ b/jobs/ci-kubernetes-e2e-gke-latest-1.4-gci-kubectl-skew.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-multizone.sh
+++ b/jobs/ci-kubernetes-e2e-gke-multizone.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-pre-release.sh
+++ b/jobs/ci-kubernetes-e2e-gke-pre-release.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-prod.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.3.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.4.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-reboot.sh
+++ b/jobs/ci-kubernetes-e2e-gke-reboot.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="200m"
 export KUBEKINS_TIMEOUT="180m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-serial.sh
+++ b/jobs/ci-kubernetes-e2e-gke-serial.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="320m"
 export KUBEKINS_TIMEOUT="300m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.2.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.3.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-slow.sh
+++ b/jobs/ci-kubernetes-e2e-gke-slow.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="170m"
 export KUBEKINS_TIMEOUT="150m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-staging.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-subnet.sh
+++ b/jobs/ci-kubernetes-e2e-gke-subnet.sh
@@ -71,5 +71,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-test.sh
+++ b/jobs/ci-kubernetes-e2e-gke-test.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="500m"
 export KUBEKINS_TIMEOUT="480m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -70,5 +70,6 @@ export GINKGO_PARALLEL="y"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="260m"
 export KUBEKINS_TIMEOUT="240m"
 "${runner}"

--- a/jobs/ci-kubernetes-kubemark-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-100-gce.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="260m"
 export KUBEKINS_TIMEOUT="240m"
 "${runner}"

--- a/jobs/ci-kubernetes-kubemark-gce-scale.sh
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.sh
@@ -100,5 +100,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-high-density-100-gce.sh
@@ -84,5 +84,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="180m"
 export KUBEKINS_TIMEOUT="160m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.2-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.2-test.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.3-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.3-test.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.4-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.4-test.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.5-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.5-test.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-2-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-2-test.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-cri-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-cri-test.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-federation-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.sh
@@ -89,5 +89,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-gci-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-gci-test.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-test.sh
@@ -77,5 +77,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-test.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-test.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-test.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-test.sh
@@ -78,5 +78,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gke-gci-test.sh
+++ b/jobs/ci-kubernetes-soak-gke-gci-test.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gke-test.sh
+++ b/jobs/ci-kubernetes-soak-gke-test.sh
@@ -81,5 +81,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="620m"
 export KUBEKINS_TIMEOUT="600m"
 "${runner}"


### PR DESCRIPTION
ref #1226
Reduce default in dockerized-e2e-runner.sh to 120m
Set DOCKER_TIMEOUT to at least 20m more than its KUBEKINS_TIMEOUT value