### PR TITLE
Reduce DOCKER_TIMEOUT to 60m

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -74,7 +74,7 @@ fi
 CONTAINER_NAME="${JOB_NAME}-${BUILD_NUMBER}"
 
 echo "Starting..."
-timeout -s KILL ${DOCKER_TIMEOUT:-120m} docker run --rm \
+timeout -s KILL ${DOCKER_TIMEOUT:-60m} docker run --rm \
   --name="${CONTAINER_NAME}" \
   -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
   -v /etc/localtime:/etc/localtime:ro \

--- a/jobs/ci-kubernetes-e2e-gce-container-vm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-container-vm.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gce-es-logging.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gce-examples.sh
@@ -66,5 +66,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-master.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m52.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m53.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m54.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m55.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-master.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ingress.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
+++ b/jobs/ci-kubernetes-e2e-gce-master-on-cvm.sh
@@ -71,5 +71,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gce-proto.sh
@@ -71,5 +71,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gce-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gce-statefulset.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gce.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-docker.sh
+++ b/jobs/ci-kubernetes-e2e-gci-docker.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-cri.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-es-logging.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
@@ -73,5 +73,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-examples.sh
@@ -66,5 +66,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.4.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.5.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-proto.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1.5.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-statefulset.sh
@@ -67,5 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.sh
@@ -73,5 +73,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.sh
@@ -73,5 +73,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.3.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.4.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gci-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gke.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-prod-parallel-release-1.2.sh
@@ -74,5 +74,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-staging-parallel-release-1.2.sh
@@ -73,5 +73,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-ingress.sh
+++ b/jobs/ci-kubernetes-e2e-gke-ingress.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-parallel.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
+++ b/jobs/ci-kubernetes-e2e-gke-prod-smoke.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.2.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.3.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.4.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.5.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
+++ b/jobs/ci-kubernetes-e2e-gke-staging-parallel.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="100m"
 export KUBEKINS_TIMEOUT="80m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-gke.sh
+++ b/jobs/ci-kubernetes-e2e-gke.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
 export KUBEKINS_TIMEOUT="50m"
 "${runner}"

--- a/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce-1.5.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="80m"
 export KUBEKINS_TIMEOUT="60m"
 "${runner}"

--- a/jobs/ci-kubernetes-kubemark-5-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-5-gce.sh
@@ -79,5 +79,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="80m"
 export KUBEKINS_TIMEOUT="60m"
 "${runner}"

--- a/jobs/ci-kubernetes-kubemark-500-gce.sh
+++ b/jobs/ci-kubernetes-kubemark-500-gce.sh
@@ -83,5 +83,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="80m"
 export KUBEKINS_TIMEOUT="60m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.2-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.2-deploy.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.3-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.3-deploy.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.4-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.4-deploy.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-1.5-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-1.5-deploy.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-2-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-2-deploy.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-cri-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-cri-deploy.sh
@@ -70,5 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-deploy.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.sh
@@ -80,5 +80,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gce-gci-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-gci-deploy.sh
@@ -68,5 +68,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.sh
@@ -74,5 +74,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.sh
@@ -69,5 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gke-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gke-deploy.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/ci-kubernetes-soak-gke-gci-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gke-gci-deploy.sh
@@ -72,5 +72,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="110m"
 export KUBEKINS_TIMEOUT="90m"
 "${runner}"

--- a/jobs/pull-kops-e2e-kubernetes-aws.sh
+++ b/jobs/pull-kops-e2e-kubernetes-aws.sh
@@ -72,5 +72,6 @@ export PATH=${PATH}:/usr/local/go/bin
 
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-e2e-gce-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-cri.sh
@@ -80,5 +80,6 @@ export KUBE_GCE_INSTANCE_PREFIX=${E2E_NAME}
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.sh
@@ -73,5 +73,6 @@ export KUBE_GCE_INSTANCE_PREFIX=${E2E_NAME}
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gce-gci.sh
@@ -70,5 +70,6 @@ export KUBE_GCE_INSTANCE_PREFIX=${E2E_NAME}
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-e2e-gce.sh
+++ b/jobs/pull-kubernetes-e2e-gce.sh
@@ -70,5 +70,6 @@ export KUBE_GCE_INSTANCE_PREFIX=${E2E_NAME}
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-e2e-gke-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gke-gci.sh
@@ -83,5 +83,6 @@ export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-e2e-gke.sh
+++ b/jobs/pull-kubernetes-e2e-gke.sh
@@ -87,5 +87,6 @@ export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -90,5 +90,6 @@ export PATH=${PATH}:/usr/local/go/bin
 export KOPS_LATEST="latest-ci-green.txt"
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce-gci.sh
@@ -73,5 +73,6 @@ export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="75m"
 export KUBEKINS_TIMEOUT="55m"
 "${runner}"

--- a/jobs/pull-kubernetes-kubemark-e2e-gce.sh
+++ b/jobs/pull-kubernetes-kubemark-e2e-gce.sh
@@ -77,5 +77,6 @@ export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 export PATH=${PATH}:/usr/local/go/bin
 
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="65m"
 export KUBEKINS_TIMEOUT="45m"
 "${runner}"


### PR DESCRIPTION
DOCKER_TIMEOUT now defaults to 60m
Ensure DOCKER_TIMEOUT is at least 20m more than KUBEKINS_TIMEOUT. If not, override DOCKER_TIMEOUT in the job.sh