### PR TITLE
If the submit queue is down, it's a warning not an error.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -19,7 +19,7 @@ HOOK_VERSION   = 0.62
 LINE_VERSION   = 0.35
 SINKER_VERSION = 0.4
 DECK_VERSION   = 0.7
-SPLICE_VERSION   = 0.5
+SPLICE_VERSION   = 0.6
 
 # These are the usual GKE variables.
 PROJECT = k8s-prow

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         role: prow
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.5
+        image: gcr.io/k8s-prow/splice:0.6
         volumeMounts:
         - name: job-configs
           mountPath: /etc/jobs

--- a/prow/cmd/splice/main.go
+++ b/prow/cmd/splice/main.go
@@ -254,7 +254,7 @@ func main() {
 		queue, err := getQueuedPRs(*submitQueueURL)
 		log.Info("PRs in queue:", queue)
 		if err != nil {
-			log.WithError(err).Error("Error getting queued PRs.")
+			log.WithError(err).Warning("Error getting queued PRs. Is the submit queue down?")
 			continue
 		}
 		batchPRs, err := splicer.findMergeable(*remoteURL, queue)


### PR DESCRIPTION
I'd like the prow error stream to only show problems with prow that we need to solve. This is not one, and it happens every time we reboot the queue.