### PR TITLE
Make splice not re-run jobs that already succeeded.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -19,7 +19,7 @@ HOOK_VERSION   = 0.62
 LINE_VERSION   = 0.35
 SINKER_VERSION = 0.4
 DECK_VERSION   = 0.7
-SPLICE_VERSION   = 0.6
+SPLICE_VERSION   = 0.7
 
 # These are the usual GKE variables.
 PROJECT = k8s-prow

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         role: prow
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.6
+        image: gcr.io/k8s-prow/splice:0.7
         volumeMounts:
         - name: job-configs
           mountPath: /etc/jobs

--- a/prow/line/line.go
+++ b/prow/line/line.go
@@ -71,6 +71,14 @@ type BuildRequest struct {
 	Pulls []Pull
 }
 
+func (b BuildRequest) GetRefs() string {
+	rs := []string{fmt.Sprintf("%s:%s", b.BaseRef, b.BaseSHA)}
+	for _, pull := range b.Pulls {
+		rs = append(rs, fmt.Sprintf("%d:%s", pull.Number, pull.SHA))
+	}
+	return strings.Join(rs, ",")
+}
+
 func StartPRJob(k *kube.Client, jobName, context string, pr github.PullRequest, baseSHA string) error {
 	br := BuildRequest{
 		Org:  pr.Base.Repo.Owner.Login,
@@ -95,11 +103,7 @@ func StartJob(k *kube.Client, jobName, context string, br BuildRequest) error {
 }
 
 func startJob(k startClient, jobName, context string, br BuildRequest) error {
-	rs := []string{fmt.Sprintf("%s:%s", br.BaseRef, br.BaseSHA)}
-	for _, pull := range br.Pulls {
-		rs = append(rs, fmt.Sprintf("%d:%s", pull.Number, pull.SHA))
-	}
-	refs := strings.Join(rs, ",")
+	refs := br.GetRefs()
 
 	labels := map[string]string{
 		"owner":            br.Org,


### PR DESCRIPTION
This makes it less wasteful when the queue is blocked-- otherwise,
it might continuously re-run the exact same tests despite them
consistently passing.