### PR TITLE
AWS: Add maintenance-pull-aws-janitor job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-maintenance-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-maintenance-pull.yaml
@@ -44,7 +44,6 @@
         repo-name: 'k8s.io/test-infra'
     - janitor:
         branch: master
-        frequency: '0 */3 * * *'
+        frequency: 'H */3 * * *'
         job-name: maintenance-pull-janitor
         repo-name: 'k8s.io/test-infra'
-

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-maintenance-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-maintenance-ci.yaml
@@ -43,3 +43,8 @@
         job-name: maintenance-ci-testgrid-config-upload
         frequency: '*/10 * * * *' # every 10min, till we have scm in prow
         repo-name: 'k8s.io/test-infra'
+    - aws-janitor:
+        branch: master
+        frequency: 'H * * * *'
+        job-name: maintenance-ci-aws-janitor
+        repo-name: 'k8s.io/test-infra'

--- a/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.4.sh
@@ -70,6 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-export DOCKER_TIMEOUT="260m"
-export KUBEKINS_TIMEOUT="240m"
+export DOCKER_TIMEOUT="140m"
+export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
@@ -70,6 +70,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-export DOCKER_TIMEOUT="260m"
-export KUBEKINS_TIMEOUT="240m"
+export DOCKER_TIMEOUT="140m"
+export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-aws.sh
+++ b/jobs/ci-kubernetes-e2e-aws.sh
@@ -69,6 +69,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-export DOCKER_TIMEOUT="260m"
-export KUBEKINS_TIMEOUT="240m"
+export DOCKER_TIMEOUT="140m"
+export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -70,6 +70,6 @@ export GINKGO_PARALLEL="y"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-export DOCKER_TIMEOUT="260m"
-export KUBEKINS_TIMEOUT="240m"
+export DOCKER_TIMEOUT="140m"
+export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/jobs/maintenance-ci-aws-janitor.sh
+++ b/jobs/maintenance-ci-aws-janitor.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+JANITOR=${AWS_JANITOR_IMAGE:-b.gcr.io/k8s-test-infra-aws/aws-janitor}
+
+docker pull "${JANITOR}"
+docker run -v "${JENKINS_AWS_CREDENTIALS_FILE}:/root/.aws/credentials:ro" "${JANITOR}" \
+  --path s3://janitor-jenkins/objs.json\
+  --ttl 2h30m # Aggressive, but all of our jobs are <2h right now.

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -863,6 +863,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/maintenance-all-hourly
 - name: maintenance-ci-clean-projects
   gcs_prefix: kubernetes-jenkins/logs/maintenance-ci-clean-projects
+- name: maintenance-ci-aws-janitor
+  gcs_prefix: kubernetes-jenkins/logs/maintenance-ci-aws-janitor
 - name: kubernetes-build-debian-unstable
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-debian-unstable
 - name: kubernetes-e2e-gke-gci-staging-parallel-release-1.2
@@ -2144,3 +2146,5 @@ dashboards:
     test_group_name: testgrid-config-upload
   - name: test-history
     test_group_name: test-infra-test-history
+  - name: aws-janitor
+    test_group_name: maintenance-ci-aws-janitor


### PR DESCRIPTION
Continuation of #1320. I've already pushed the image, so it can actually go in separately (and given that I'm out until Monday, it's not a horrible idea).

* Add the `maintenance-pull-aws-janitor` script
* Drop AWS timeouts down to ~2h (when succeeding, these jobs *should* be <30m)