### PR TITLE
Add /release-note and /release-note-none.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build fmt vet test
 
 
-HOOK_VERSION   = 0.62
+HOOK_VERSION   = 0.63
 LINE_VERSION   = 0.35
 SINKER_VERSION = 0.4
 DECK_VERSION   = 0.8

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.62
+        image: gcr.io/k8s-prow/hook:0.63
         imagePullPolicy: Always
         env:
         - name: LINE_IMAGE

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -36,6 +36,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/cla"
 	_ "k8s.io/test-infra/prow/plugins/close"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"
+	_ "k8s.io/test-infra/prow/plugins/releasenote"
 	_ "k8s.io/test-infra/prow/plugins/trigger"
 )
 

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -16,6 +16,7 @@ kubernetes/kops:
 
 kubernetes/kubernetes:
 - trigger
+- release-note
 
 kubernetes/test-infra:
 - trigger

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releasenote
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "release-note"
+
+const (
+	releaseNoteActionRequired = "release-note-action-required"
+	releaseNoteNone           = "release-note-none"
+	releaseNoteLabelNeeded    = "release-note-label-needed"
+	releaseNote               = "release-note"
+)
+
+var (
+	allRNLabels = []string{
+		releaseNoteNone,
+		releaseNoteActionRequired,
+		releaseNoteLabelNeeded,
+		releaseNote,
+	}
+
+	releaseNoteRe     = regexp.MustCompile(`(?mi)^\/release-note\r?$`)
+	releaseNoteNoneRe = regexp.MustCompile(`(?mi)^\/release-note-none\r?$`)
+)
+
+func init() {
+	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
+}
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+}
+
+func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
+	return handle(pc.GitHubClient, pc.Logger, ic)
+}
+
+func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
+	// Only consider PRs and new comments.
+	if !ic.Issue.IsPullRequest() || ic.Action != "created" {
+		return nil
+	}
+
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	number := ic.Issue.Number
+
+	// Which label does the comment want us to add?
+	var nl string
+	if releaseNoteRe.MatchString(ic.Comment.Body) {
+		nl = releaseNote
+	} else if releaseNoteNoneRe.MatchString(ic.Comment.Body) {
+		nl = releaseNoteNone
+	} else {
+		return nil
+	}
+
+	// Only allow authors and assignees to add labels.
+	isAssignee := ic.Issue.IsAssignee(ic.Comment.User.Login)
+	isAuthor := ic.Issue.IsAuthor(ic.Comment.User.Login)
+	if !isAssignee && !isAuthor {
+		resp := "you can only set release notes if you are the author or an assignee"
+		log.Infof("Commenting with \"%s\".", resp)
+		return gc.CreateComment(org, repo, number, plugins.FormatResponse(ic.Comment, resp))
+	}
+
+	// Add the requested label if necessary.
+	var errs []error
+	if !ic.Issue.HasLabel(nl) {
+		log.Infof("Adding %s label.", nl)
+		if err := gc.AddLabel(org, repo, number, nl); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	// Remove all other release-note-* labels if necessary.
+	for _, l := range allRNLabels {
+		if l != nl && ic.Issue.HasLabel(l) {
+			log.Infof("Removing %s label.", l)
+			if err := gc.RemoveLabel(org, repo, number, l); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("encountered %d errors setting labels: %v", len(errs), errs)
+	}
+	return nil
+}

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package releasenote
+
+import (
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestReleaseNoteComment(t *testing.T) {
+	var testcases = []struct {
+		name          string
+		action        string
+		body          string
+		isAuthor      bool
+		isReviewer    bool
+		currentLabels []string
+
+		deletedLabels []string
+		addedLabel    string
+		shouldComment bool
+	}{
+		{
+			name:          "unrelated comment",
+			action:        "created",
+			body:          "oh dear",
+			currentLabels: []string{releaseNoteLabelNeeded, "other"},
+		},
+		{
+			name:          "author release-note-none",
+			action:        "created",
+			isAuthor:      true,
+			body:          "/release-note-none",
+			currentLabels: []string{releaseNoteLabelNeeded, "other"},
+
+			deletedLabels: []string{releaseNoteLabelNeeded},
+			addedLabel:    releaseNoteNone,
+		},
+		{
+			name:          "reviewer release-note",
+			action:        "created",
+			isReviewer:    true,
+			body:          "/release-note",
+			currentLabels: []string{releaseNoteLabelNeeded, "other"},
+
+			deletedLabels: []string{releaseNoteLabelNeeded},
+			addedLabel:    releaseNote,
+		},
+		{
+			name:          "someone else release-note",
+			action:        "created",
+			body:          "/release-note",
+			currentLabels: []string{releaseNoteLabelNeeded, "other"},
+
+			shouldComment: true,
+		},
+	}
+	for _, tc := range testcases {
+		fc := &fakegithub.FakeClient{
+			IssueComments: make(map[int][]github.IssueComment),
+		}
+		ice := github.IssueCommentEvent{
+			Action: tc.action,
+			Comment: github.IssueComment{
+				Body: tc.body,
+			},
+			Issue: github.Issue{
+				User:        github.User{Login: "a"},
+				Number:      5,
+				State:       "open",
+				PullRequest: &struct{}{},
+				Assignees:   []github.User{{Login: "r"}},
+			},
+		}
+		if tc.isAuthor {
+			ice.Comment.User.Login = "a"
+		} else if tc.isReviewer {
+			ice.Comment.User.Login = "r"
+		}
+		for _, l := range tc.currentLabels {
+			ice.Issue.Labels = append(ice.Issue.Labels, github.Label{Name: l})
+		}
+		if err := handle(fc, logrus.WithField("plugin", pluginName), ice); err != nil {
+			t.Errorf("For case %s, did not expect error: %v", tc.name, err)
+		}
+		if tc.shouldComment && len(fc.IssueComments[5]) == 0 {
+			t.Errorf("For case %s, didn't comment but should have.", tc.name)
+		}
+		if len(fc.LabelsAdded) > 1 {
+			t.Errorf("For case %s, added more than one label: %v", tc.name, fc.LabelsAdded)
+		} else if len(fc.LabelsAdded) == 0 && tc.addedLabel != "" {
+			t.Errorf("For case %s, should have added %s but didn't.", tc.name, tc.addedLabel)
+		} else if len(fc.LabelsAdded) == 1 && fc.LabelsAdded[0] != "/#5:"+tc.addedLabel {
+			t.Errorf("For case %s, added wrong label. Got %s, expected %s", tc.name, fc.LabelsAdded[0], tc.addedLabel)
+		}
+		for _, dl := range tc.deletedLabels {
+			deleted := false
+			for _, lr := range fc.LabelsRemoved {
+				if lr == "/#5:"+dl {
+					deleted = true
+					break
+				}
+			}
+			if !deleted {
+				t.Errorf("For case %s, expected %s label deleted, but it wasn't.", tc.name, dl)
+			}
+		}
+	}
+}

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -87,6 +87,14 @@ func TestReleaseNoteComment(t *testing.T) {
 
 			deletedLabels: []string{releaseNoteLabelNeeded, releaseNoteNone},
 		},
+		{
+			name:       "no label present",
+			action:     "created",
+			isReviewer: true,
+			body:       "/release-note-none",
+
+			addedLabel: releaseNoteNone,
+		},
 	}
 	for _, tc := range testcases {
 		fc := &fakegithub.FakeClient{

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -72,6 +72,21 @@ func TestReleaseNoteComment(t *testing.T) {
 
 			shouldComment: true,
 		},
+		{
+			name:          "already has release-note",
+			action:        "created",
+			body:          "/release-note",
+			currentLabels: []string{releaseNote, "other"},
+		},
+		{
+			name:          "delete multiple labels",
+			action:        "created",
+			isReviewer:    true,
+			body:          "/release-note",
+			currentLabels: []string{releaseNote, releaseNoteLabelNeeded, releaseNoteNone, "other"},
+
+			deletedLabels: []string{releaseNoteLabelNeeded, releaseNoteNone},
+		},
 	}
 	for _, tc := range testcases {
 		fc := &fakegithub.FakeClient{


### PR DESCRIPTION
@kubernetes/sig-contributor-experience 

After this, authors and reviewers can write `/release-note` or `/release-note-none` in a comment and it will remove any current release-note labels and apply the correct one.