### PR TITLE
Add retry loop to finding commits by sha.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build fmt vet test
 
 
-HOOK_VERSION   = 0.62
+HOOK_VERSION   = 0.63
 LINE_VERSION   = 0.35
 SINKER_VERSION = 0.4
 DECK_VERSION   = 0.8

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.62
+        image: gcr.io/k8s-prow/hook:0.63
         imagePullPolicy: Always
         env:
         - name: LINE_IMAGE

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -46,6 +46,7 @@ Once you've signed, please reply here (e.g. "I signed it!") and we'll verify.  T
 <!-- need_sender_cla -->
 
 <details>
+
 %s
 </details>
 	`


### PR DESCRIPTION
Retry every 10 seconds till the commit starts showing up.
The github search api has slowed sufficiently that we need to now retry for PR's like: https://github.com/kubernetes/kubernetes/pull/38409 to get the CLA label.

