### PR TITLE
Set --root to bootstrap.py.

### DIFF
--- a/images/pull-test-infra-go-test/Makefile
+++ b/images/pull-test-infra-go-test/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.1
+VERSION = 0.2
 
 image:
 	docker build -t "gcr.io/k8s-testimages/test-infra-go-test:$(VERSION)" .

--- a/images/pull-test-infra-go-test/runner
+++ b/images/pull-test-infra-go-test/runner
@@ -19,4 +19,4 @@ set -o nounset
 set -o pipefail
 
 git clone https://github.com/kubernetes/test-infra
-./test-infra/jenkins/bootstrap.py --repo=k8s.io/test-infra --pull="${PULL_NUMBER}" --job=pull-test-infra-prow-test
+./test-infra/jenkins/bootstrap.py --repo=k8s.io/test-infra --pull="${PULL_NUMBER}" --job=pull-test-infra-prow-test --root="${GOPATH}/src"


### PR DESCRIPTION
This makes it match the other PR jobs. It's almost working!

```
I1209 19:10:44.116] Bootstrap pull-test-infra-prow-test...
I1209 19:10:44.116] Check out ./k8s.io/test-infra at 947...
I1209 19:10:44.116] Call:  git init k8s.io/test-infra
I1209 19:10:44.121] Initialized empty Git repository in /workspace/k8s.io/test-infra/.git/
...
I1209 19:10:48.714] Call:  /workspace/./test-infra/jenkins/../jobs/pull-test-infra-prow-test.sh
W1209 19:10:48.716] + cd /workspace/src/k8s.io/test-infra/prow
W1209 19:10:48.717] /workspace/./test-infra/jenkins/../jobs/pull-test-infra-prow-test.sh: line 21: cd: /workspace/src/k8s.io/test-infra/prow: No such file or directory
I1209 19:10:48.717] process 400 exited with code 1
E1209 19:10:48.717] FAIL: pull-test-infra-prow-test
...
```