### PR TITLE
Continue updating graph while the SQ is offline

### DIFF
--- a/queue-health/graph/graph.py
+++ b/queue-health/graph/graph.py
@@ -254,7 +254,6 @@ def output(history_lines, results):  # pylint: disable=too-many-locals,too-many-
         for moments in happy_moments.values():
             moments.append(int(bool(online and not blocked)))
 
-
         for val in real_merges.values():
             val += did_merge
         if queue or did_merge:
@@ -278,6 +277,10 @@ def output(history_lines, results):  # pylint: disable=too-many-locals,too-many-
         if start_blocked and not blocked:
             results.blocked_intervals.append((start_blocked, tick))
             start_blocked = None
+    if tick and not online:
+        tick = datetime.datetime.utcnow()
+        results.append(
+            tick, 0, pulls, queue, real_merges, active_merges, happy_moments)
     if start_blocked:
         results.blocked_intervals.append((start_blocked, tick))
     if start_offline:

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Override with production targets
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph:v20161201
+        image: gcr.io/google-containers/queue-health-graph:v20161209
         command:
         - python
         - /graph.py


### PR DESCRIPTION
Already deployed. Last night the SQ was not showing the gray bar while the SQ was crash looping because of the `if not online: continue` line (which is intended to minimize the vertical drops).