### PR TITLE
Split ENV in two, since it's not as smart as I thought it was.

### DIFF
--- a/images/pull-test-infra-go-test/Dockerfile
+++ b/images/pull-test-infra-go-test/Dockerfile
@@ -31,7 +31,8 @@ RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     rm google-cloud-sdk-136.0.0-linux-x86_64.tar.gz && \
     ./google-cloud-sdk/install.sh
 
-ENV GOROOT=/go GOPATH=/workspace PATH="${PATH}:${GOROOT}/bin:${GOPATH}/bin:/google-cloud-sdk/bin"
+ENV GOROOT=/go GOPATH=/workspace
+ENV PATH="${PATH}:${GOROOT}/bin:${GOPATH}/bin:/google-cloud-sdk/bin"
 
 RUN mkdir -p /workspace
 WORKDIR /workspace

--- a/images/pull-test-infra-go-test/Makefile
+++ b/images/pull-test-infra-go-test/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.2
+VERSION = 0.3
 
 image:
 	docker build -t "gcr.io/k8s-testimages/test-infra-go-test:$(VERSION)" .

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -199,7 +199,7 @@ kubernetes/test-infra:
       role: build
     containers:
     - name: builder
-      image: gcr.io/k8s-testimages/test-infra-go-test:0.1
+      image: gcr.io/k8s-testimages/test-infra-go-test:0.3
       volumeMounts:
       - name: service
         mountPath: /etc/service-account


### PR DESCRIPTION
You can't do `ENV GOPATH=/bla PATH=${GOPATH}/bin`. `PATH` will end up being `/bin`... 😠 