### PR TITLE
CRI: Always run cri pr e2e test.

### DIFF
--- a/jobs/pull-kubernetes-e2e-gce-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-cri.sh
@@ -47,11 +47,12 @@ export GINKGO_TOLERATE_FLAKES="y"
 
 export E2E_NAME="cri-e2e-${NODE_NAME}-${EXECUTOR_NUMBER:-0}"
 export GINKGO_PARALLEL="y"
-# Temporarily skip the test "Network should set TCP CLOSE_WAIT timeout" because it relies
-# on host port, which is not implemented in CRI integration yet.
+# Temporarily skip the test "Network should set TCP CLOSE_WAIT timeout"
+# and "[k8s.io] Loadbalancing: L7 [k8s.io] Nginx should conform to Ingress spec"
+# because it relies on host port, which is not implemented in CRI integration yet.
 # TODO(random-liu): Re-enable the test.
 # This list should match the list in kubernetes-e2e-gce.
-export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network should set TCP CLOSE_WAIT timeout'
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network should set TCP CLOSE_WAIT timeout|Nginx should conform to Ingress spec'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="kubernetes-pr-cri-validation"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -166,9 +166,10 @@ kubernetes/kubernetes:
   trigger: "@k8s-bot (node )?(e2e )?test this"
 
 - name: pull-kubernetes-e2e-gce-cri
-  trigger: "@k8s-bot cri (e2e )?test this"
+  always_run: true
   context: Jenkins CRI GCE e2e
   rerun_command: "@k8s-bot cri e2e test this"
+  trigger: "@k8s-bot (cri e2e )?test this"
 
 - name: pull-kubernetes-node-e2e-cri
   always_run: true


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/36264.

Confirmed with @freehan that the test `[k8s.io] Loadbalancing: L7 [k8s.io] Nginx should conform to Ingress spec` failed because it relies on hostport.

Skip the test for now and make the test PR blocking.

@yujuhong 