### PR TITLE
CRI: Fix CRI e2e skip.

### DIFF
--- a/jobs/ci-kubernetes-e2e-cri-gce.sh
+++ b/jobs/ci-kubernetes-e2e-cri-gce.sh
@@ -36,10 +36,11 @@ export KUBE_FEATURE_GATES="StreamingProxyRedirects=true"
 
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
 # Temporarily skip the test "Network should set TCP CLOSE_WAIT timeout"
-# because it relies on host port, which is not implemented in CRI integration
+# and "[k8s.io] Loadbalancing: L7 [k8s.io] Nginx should conform to Ingress spec"
+# because it relies on host port, which is not implemented in CRI integration yet.
 # yet.
 # TODO(random-liu): Re-enable the test.
-export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network should set TCP CLOSE_WAIT timeout"
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|Nginx\sshould\sconform\sto\sIngress\sspec"
 export GINKGO_PARALLEL="y"
 export KUBE_OS_DISTRIBUTION="gci"
 export PROJECT="kubernetes-e2e-cri-validation"

--- a/jobs/pull-kubernetes-e2e-gce-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-cri.sh
@@ -52,7 +52,7 @@ export GINKGO_PARALLEL="y"
 # because it relies on host port, which is not implemented in CRI integration yet.
 # TODO(random-liu): Re-enable the test.
 # This list should match the list in kubernetes-e2e-gce.
-export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network should set TCP CLOSE_WAIT timeout|Nginx.*should conform to Ingress spec'
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|Nginx\sshould\sconform\sto\sIngress\sspec'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="kubernetes-pr-cri-validation"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.


### PR DESCRIPTION
Sorry for the confusion, but the quote logic of ginkgo focus/skip is really confusing.

It turns out that:
1. `./e2e.test "--ginkgo.skip=Network should set TCP CLOSE_WAIT timeout|Nginx should conform to Ingress spec"` will skip the 2 tests.
2. `go run hack/e2e.go -v -test --test_args="--ginkgo.skip=Network should set TCP CLOSE_WAIT timeout|Nginx should conform to Ingress spec"` will only skip all tests contain the word "Network". And it didn't throw out error surprisingly. (`GINKGO_TEST_ARGS` is used in this way.)
3. `go run hack/e2e.go -v -test --test_args="--ginkgo.skip=Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|Nginx\sshould\sconform\sto\sIngress\sspec"` will skip the 2 tests.

In PR https://github.com/kubernetes/test-infra/pull/1345, I was verifying with 1.

In fact, we are skipping all tests containing the word `Network`, rather than the test `Network should set TCP CLOSE_WAIT timeout`. This PR fixed it.

@yujuhong 

