### PR TITLE
Skip reporting for the failing GCE CRI job.

### DIFF
--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -166,6 +166,7 @@ kubernetes/kubernetes:
   trigger: "@k8s-bot (node )?(e2e )?test this"
 
 - name: pull-kubernetes-e2e-gce-cri
+  skip_report: true
   always_run: true
   context: Jenkins CRI GCE e2e
   rerun_command: "@k8s-bot cri e2e test this"


### PR DESCRIPTION
This is permanently failing. Stop spamming PRs until it's passing. cc @Random-Liu 