### PR TITLE
Add gci-gce testing against the GCI canary image

### DIFF
--- a/jobs/ci-kubernetes-e2e-gke-gci-ci-master.sh
+++ b/jobs/ci-kubernetes-e2e-gke-gci-ci-master.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### provider-env
+# Use GKE's test endpoint
+export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
+# Pull Kubernetes artifacts from this bucket instead of kubernetes-release
+export CLOUDSDK_BUCKET="gs://cloud-sdk-testing/ci/staging"
+export E2E_MIN_STARTUP_PODS="8"
+export FAIL_ON_GCP_RESOURCE_LEAK="true"
+export KUBERNETES_PROVIDER="gke"
+export ZONE="us-central1-f"
+
+### project-env
+# expected empty
+
+### job-env
+# Use Google credentials to authenticate to the cluster API server
+export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
+export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
+export GINKGO_PARALLEL="y"
+# The master branch will always use GCI images built from its
+# tip of tree, categorized in family `gci-canary`.
+export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary"
+export PROJECT="e2e-gke-gci-ci-master"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+export E2E_TEST="${E2E_TEST:-true}"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+export E2E_NAME='bootstrap-e2e'
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# AWS variables
+export KUBE_AWS_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GCE variables
+export INSTANCE_PREFIX="${E2E_NAME}"
+export KUBE_GCE_NETWORK="${E2E_NAME}"
+export KUBE_GCE_INSTANCE_PREFIX="${E2E_NAME}"
+
+# GKE variables
+export CLUSTER_NAME="${E2E_NAME}"
+export KUBE_GKE_NETWORK="${E2E_NAME}"
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+### Runner
+readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+export DOCKER_TIMEOUT="70m"
+export KUBEKINS_TIMEOUT="50m"
+"${runner}"


### PR DESCRIPTION
This should add testing against the latest GCI canary image. I am adding
one job first, to see if the way I did this works properly. The plan is
to add just a few more (gke and slow equivs) so we have some basic
signals from the very tip of GCI development.

Note that this depends on https://github.com/kubernetes/kubernetes/pull/38640 and should not be merged until that goes in.