### PR TITLE
AWS: Disable aws-release-1.4, reorder testgrid tabs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -47,10 +47,6 @@
         job-name: ci-kubernetes-e2e-aws
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-aws-release-1.4:
-        job-name: ci-kubernetes-e2e-aws-release-1.4
-        frequency: '@daily'
-        trigger-job: 'ci-kubernetes-build-1.4'
     - kubernetes-e2e-aws-release-1.5:
         job-name: ci-kubernetes-e2e-aws-release-1.5
         frequency: '@daily'
@@ -1669,4 +1665,3 @@
         trigger-job: ''
 
     # END UPGRADE
-

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -76,8 +76,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.5
 - name: kubernetes-e2e-aws
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aws
-- name: kubernetes-e2e-aws-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aws-release-1.4
 - name: kubernetes-e2e-aws-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aws-release-1.5
 - name: ci-kubernetes-e2e-cri-gce
@@ -1044,16 +1042,14 @@ dashboards:
 
 - name: google-aws
   dashboard_tab:
-  - name: aws
-    test_group_name: kubernetes-e2e-aws
-  - name: aws-release-1.4
-    test_group_name: kubernetes-e2e-aws-release-1.4
   - name: kops-aws
     test_group_name: kubernetes-e2e-kops-aws
-  - name: aws-release-1.5
-    test_group_name: kubernetes-e2e-aws-release-1.5
   - name: kops-aws-updown
     test_group_name: kubernetes-e2e-kops-aws-updown
+  - name: aws
+    test_group_name: kubernetes-e2e-aws
+  - name: aws-release-1.5
+    test_group_name: kubernetes-e2e-aws-release-1.5
 
 - name: google-docker
   dashboard_tab:
@@ -2036,8 +2032,6 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-gci-ci-serial-release-1.4
   - name: gci-ci-release-1.4
     test_group_name: kubernetes-e2e-gce-gci-ci-release-1.4
-  - name: aws-release-1.4
-    test_group_name: kubernetes-e2e-aws-release-1.4
   - name: soak-gce-1.4-deploy
     test_group_name: kubernetes-soak-gce-1.4-deploy
   - name: soak-gci-gce-1.4-deploy


### PR DESCRIPTION
This disables support entirely for release-1.4 testing of AWS (using `kube-up.sh` - there's no `kops` test for same). There's not enough bandwidth to look at and cherry-pick failures here, and it's occasionally leaking resources still.