### PR TITLE
AWS: Move remaining kube-up.sh tests to us-west1-c

### DIFF
--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.sh
@@ -23,7 +23,7 @@ readonly testinfra="$(dirname "${0}")/.."
 ### provider-env
 export KUBERNETES_PROVIDER="aws"
 export E2E_MIN_STARTUP_PODS="8"
-export KUBE_AWS_ZONE="us-west-2c"
+export KUBE_AWS_ZONE="us-west-1c"
 export MASTER_SIZE="m3.medium"
 export NODE_SIZE="m3.medium"
 export NUM_NODES="3"

--- a/jobs/ci-kubernetes-e2e-aws.sh
+++ b/jobs/ci-kubernetes-e2e-aws.sh
@@ -23,7 +23,7 @@ readonly testinfra="$(dirname "${0}")/.."
 ### provider-env
 export KUBERNETES_PROVIDER="aws"
 export E2E_MIN_STARTUP_PODS="8"
-export KUBE_AWS_ZONE="us-west-2c"
+export KUBE_AWS_ZONE="us-west-1c"
 export MASTER_SIZE="m3.medium"
 export NODE_SIZE="m3.medium"
 export NUM_NODES="3"


### PR DESCRIPTION
kube-up.sh is having trouble with request limits while in the same
zone as kops, and it's leaking on error. We aren't fixing this, since
kube-up is deprecated.