### PR TITLE
Add python tests as a new prow job.

### DIFF
--- a/images/pull-test-infra-py-test/Dockerfile
+++ b/images/pull-test-infra-py-test/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+MAINTAINER spxtr@google.com
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    wget \
+    python \
+    pylint \
+    python-nose && \
+    apt-get clean
+
+RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-136.0.0-linux-x86_64.tar.gz && \
+    tar xf google-cloud-sdk-136.0.0-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-136.0.0-linux-x86_64.tar.gz && \
+    ./google-cloud-sdk/install.sh
+
+RUN mkdir -p /workspace
+WORKDIR /workspace
+ADD runner /
+ENTRYPOINT ["/bin/bash", "/runner"]

--- a/images/pull-test-infra-py-test/Makefile
+++ b/images/pull-test-infra-py-test/Makefile
@@ -1,0 +1,23 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION = 0.0
+
+image:
+	docker build -t "gcr.io/k8s-testimages/test-infra-py-test:$(VERSION)" .
+
+push:
+	gcloud docker -- push "gcr.io/k8s-testimages/test-infra-py-test:$(VERSION)"
+
+.PHONY: image push

--- a/images/pull-test-infra-py-test/runner
+++ b/images/pull-test-infra-py-test/runner
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+git clone https://github.com/kubernetes/test-infra
+./test-infra/jenkins/bootstrap.py --repo=k8s.io/test-infra --pull="${PULL_NUMBER}" --job=pull-test-infra-py-test --root="${GOPATH}/src"

--- a/jobs/pull-test-infra-py-test.sh
+++ b/jobs/pull-test-infra-py-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+./verify/verify-boilerplate.py
+python -m unittest discover -s jenkins/test-history -p "*_test.py"
+pylint jenkins/bootstrap.py
+pylint queue-health/graph/graph.py
+./jenkins/bootstrap_test.py
+nosetests --with-doctest jenkins/bootstrap.py

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -178,3 +178,13 @@ kubernetes/test-infra:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/test-infra-go-test:0.4
+
+- name: pull-test-infra-py-test
+  always_run: true
+  skip_report: true
+  context: py test
+  rerun_command: "@k8s-bot py test this"
+  trigger: "@k8s-bot (py )?test this"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/test-infra-py-test:0.0


### PR DESCRIPTION
#1342. We have two options here. We can either

1. put all of our tests in one job, or
1. try to find a logical grouping of tests and have several jobs, or
1. use bazel for everything.

Both are pretty good. In this PR I add `pull-test-infra-py-test`, as a step down the second path. There is some duplication in `/images/`, and I'd like to clean that up in a future PR if we go down this route. I'm partial to bazel, but that's a bit trickier.