### PR TITLE
refactor gcloud download/install/auth out, and apply it for node test

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,7 +30,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20161213-64a59fc'
+KUBEKINS_E2E_IMAGE_TAG='v20161213-d446e91'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -45,6 +45,7 @@ ENV FAIL_ON_GCP_RESOURCE_LEAK=true \
 
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
+    "gcloud-common.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/e2e.go", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh", \

--- a/jenkins/e2e-image/gcloud-common.sh
+++ b/jenkins/e2e-image/gcloud-common.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# This script downloads, installs cloud sdk and activates the service account.
+# USAGE:
+#   gcloud-common.sh [--download] -t|--tar [gcloud-tarball-dir] -d|--dir [install-dir]
+#       --download - if need download gcloud tarball from web
+#       -t|--tar - where to find/fetch gcloud tarball
+#       -d|--dir - where to install gcloud to
+#
+
+
+# default
+DOWNLOAD=false
+TARBALL="${WORKSPACE}/google-cloud-sdk.tar.gz"
+INSTALL_DIR="/"
+
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    --download)
+    DOWNLOAD=true # past argument
+    ;;
+    -t|--tar)
+    TARBALL="$2"
+    shift # past argument
+    ;;
+    -i|--install)
+    INSTALL_DIR="$2"
+    shift # past argument
+    ;;
+    *)
+    # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+if [[ "$DOWNLOAD"==true ]]; then
+  curl -fsSL --retry 3 --keepalive-time 2 -o "${TARBALL}" 'https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz'
+fi
+
+mkdir -p "${INSTALL_DIR}"
+tar xzf "${TARBALL}" -C "${INSTALL_DIR}"
+
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+"${INSTALL_DIR}/google-cloud-sdk/install.sh" --disable-installation-options --bash-completion=false --path-update=false --usage-reporting=false
+export PATH=${INSTALL_DIR}/google-cloud-sdk/bin:${PATH}
+gcloud components install alpha
+gcloud components install beta
+gcloud info
+
+# activate gcloud
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
+

--- a/jenkins/node-runner.sh
+++ b/jenkins/node-runner.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+GCLOUD_SCRIPT=$1
+NODE_SCRIPT=$2
+NODE_PROPERTY=$3
+
+"${GCLOUD_SCRIPT}"
+"${NODE_SCRIPT} ${NODE_PROPERTY}"

--- a/jobs/ci-kubernetes-node-kubelet-dockerized.sh
+++ b/jobs/ci-kubernetes-node-kubelet-dockerized.sh
@@ -23,7 +23,7 @@ set -o xtrace
 readonly testinfra="$(dirname "${0}")/.."
 
 export KUBE_VERIFY_GIT_BRANCH='master'
-export KUBE_TEST_SCRIPT="test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-ci.properties"
+export KUBE_TEST_SCRIPT="${testinfra}/jenkins/node-runner.sh ${testinfra}/jenkins/e2e-image/gcloud-common.sh test/e2e_node/jenkins/e2e-node-jenkins.sh test/e2e_node/jenkins/jenkins-ci.properties"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/gotest-dockerized.sh"


### PR DESCRIPTION
#1355 #1348  did not work as perfect due to gcloud permission issues.. this might help..

cc @krousey 

Also moved e2e image to k8s-testimages project 

test is here: https://github.com/kubernetes/kubernetes/pull/38729