### PR TITLE
Fix automated docker validation.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gci-docker.sh
+++ b/jobs/ci-kubernetes-e2e-gci-docker.sh
@@ -33,8 +33,9 @@ export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 ### job-env
 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
 export GINKGO_PARALLEL="y"
+export KUBE_OS_DISTRIBUTION="gci"
 export PROJECT="k8s-docker-validation-gci"
-export JENKINS_GCI_IMAGE_FAMILY="gci-canary-test"
+export JENKINS_GCI_HEAD_IMAGE_FAMILY="gci-canary-test"
 
 ### post-env
 


### PR DESCRIPTION
It seems that the rename in https://github.com/kubernetes/test-infra/commit/a7d597c363be9cd2dbb9140631c165fb4034aeba missed the automated docker validation test. So cluster e2e automated docker validation is always using docker 1.11.

This PR also changes the node to use gci.

After this change, the whole automated docker validation cluster will use the newest docker version.

@wonderfly 
/cc @dchen1107 