### PR TITLE
Bump e2e tag to v20161213-326cf17, restrict kops masters to agent IP

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,7 +30,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20161212-aeea862'
+KUBEKINS_E2E_IMAGE_TAG='v20161213-326cf17'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -53,6 +53,13 @@ if [[ "${KOPS_DEPLOY_LATEST_KUBE:-}" =~ ^[yY]$ ]]; then
   export E2E_OPT="${E2E_OPT} --kops-kubernetes-version ${KOPS_KUBE_RELEASE_URL}/${KOPS_KUBE_LATEST}"
 fi
 
+EXTERNAL_IP=$(curl -SsL -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip')
+if [[ -z "${EXTERNAL_IP}" ]]; then
+  # Running outside GCE
+  EXTERNAL_IP=$(curl 'http://v4.ifconfig.co')
+fi
+export E2E_OPT="${E2E_OPT} --kops-admin-access ${EXTERNAL_IP}/32"
+
 # Define a custom instance lister for cluster/log-dump.sh.
 function log_dump_custom_get_instances() {
   local -r role=$1


### PR DESCRIPTION
This picks up kubernetes/kubernetes#38672, and the code to enable it (which was built into the tag bump to v20161213-326cf17).

Context: Until kubernetes/kops#1144 went in because of a breaking change to defaults, all the `kops` AWS clusters were being created with wide open apiservers. It's easy enough to restrict this at the cloud level as well, so do it.