### PR TITLE
Reorganize some cmd/hook plumbing.

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -123,23 +123,10 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting plugins.")
 	}
 
-	prc := make(chan github.PullRequestEvent)
-	icc := make(chan github.IssueCommentEvent)
-	sec := make(chan github.StatusEvent)
 	server := &Server{
-		HMACSecret:         webhookSecret,
-		PullRequestEvents:  prc,
-		IssueCommentEvents: icc,
-		StatusEvents:       sec,
+		HMACSecret: webhookSecret,
+		Plugins:    pluginAgent,
 	}
-
-	events := &EventAgent{
-		Plugins:            pluginAgent,
-		PullRequestEvents:  prc,
-		IssueCommentEvents: icc,
-		StatusEvents:       sec,
-	}
-	events.Start()
 
 	// Return 200 on / for health checks.
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -52,6 +52,7 @@ func RegisterPullRequestHandler(name string, fn PullRequestHandler) {
 	pullRequestHandlers[name] = fn
 }
 
+// PluginClient may be used concurrently, so each entry must be thread-safe.
 type PluginClient struct {
 	GitHubClient *github.Client
 	KubeClient   *kube.Client


### PR DESCRIPTION
I had originally added these channels because it make the picture simpler when `cmd/hook` had plugins written directly in it. Now they're not necessary and only make things confusing.

This cuts some of the duplication required to listen for a new event type.