### PR TITLE
Move e2e-image from google-containers to k8s-testimages

### DIFF
--- a/jenkins/diff-e2e-runner.sh
+++ b/jenkins/diff-e2e-runner.sh
@@ -19,7 +19,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly KUBEKINS_IMAGE="gcr.io/google-containers/kubekins-e2e"
+readonly KUBEKINS_IMAGE="gcr.io/k8s-testimages/kubekins-e2e"
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd)
 

--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,7 +30,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20161213-326cf17'
+KUBEKINS_E2E_IMAGE_TAG='v20161213-64a59fc'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")
@@ -89,7 +89,7 @@ timeout -s KILL ${DOCKER_TIMEOUT:-60m} docker run --rm \
   -e "WORKSPACE=/workspace" \
   ${GOOGLE_APPLICATION_CREDENTIALS:+-e "GOOGLE_APPLICATION_CREDENTIALS=/service-account.json"} \
   "${docker_extra_args[@]:+${docker_extra_args[@]}}" \
-  "gcr.io/google-containers/kubekins-e2e:${KUBEKINS_E2E_IMAGE_TAG}" && rc=$? || rc=$?
+  "gcr.io/k8s-testimages/kubekins-e2e:${KUBEKINS_E2E_IMAGE_TAG}" && rc=$? || rc=$?
 
 echo "Exiting with code: ${rc}"
 if [[ ${rc} -eq 137 ]]; then  # 137 == SIGKILL, see man timeout

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMG = gcr.io/google-containers/kubekins-e2e
+IMG = gcr.io/k8s-testimages/kubekins-e2e
 TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 all: build


### PR DESCRIPTION
Do this before #1361, let e2e-image reside next to kubekins-image