### PR TITLE
kops: Allow kops jobs to be run outside Jenkins

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,7 +30,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
-KUBEKINS_E2E_IMAGE_TAG='v20161213-64a59fc'
+KUBEKINS_E2E_IMAGE_TAG='v20161214-42db426'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -53,9 +53,12 @@ if [[ "${KOPS_DEPLOY_LATEST_KUBE:-}" =~ ^[yY]$ ]]; then
   export E2E_OPT="${E2E_OPT} --kops-kubernetes-version ${KOPS_KUBE_RELEASE_URL}/${KOPS_KUBE_LATEST}"
 fi
 
-EXTERNAL_IP=$(curl -SsL -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip')
+EXTERNAL_IP=$(curl -SsL -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip' || true)
 if [[ -z "${EXTERNAL_IP}" ]]; then
   # Running outside GCE
+  echo
+  echo "WARNING: Getting external IP from instance metadata failed, assuming not running on GCE."
+  echo
   EXTERNAL_IP=$(curl 'http://v4.ifconfig.co')
 fi
 export E2E_OPT="${E2E_OPT} --kops-admin-access ${EXTERNAL_IP}/32"

--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -20,6 +20,21 @@ set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
 
+if [[ -z "${JENKINS_AWS_SSH_PRIVATE_KEY_FILE:-}" ]]; then
+  echo "JENKINS_AWS_SSH_PRIVATE_KEY_FILE not set, assuming ${HOME}/.ssh/kube_aws_rsa"
+  export JENKINS_AWS_SSH_PRIVATE_KEY_FILE="${HOME}/.ssh/kube_aws_rsa"
+fi
+
+if [[ -z "${JENKINS_AWS_SSH_PUBLIC_KEY_FILE:-}" ]]; then
+  echo "JENKINS_AWS_SSH_PUBLIC_KEY_FILE not set, assuming ${HOME}/.ssh/kube_aws_rsa.pub"
+  export JENKINS_AWS_SSH_PUBLIC_KEY_FILE="${HOME}/.ssh/kube_aws_rsa.pub"
+fi
+
+if [[ -z "${JENKINS_AWS_CREDENTIALS_FILE:-}" ]]; then
+  echo "JENKINS_AWS_CREDENTIALS_FILE not set, assuming ${HOME}/.aws/credentials"
+  export JENKINS_AWS_CREDENTIALS_FILE="${HOME}/.aws/credentials"
+fi
+
 ### builder
 
 # Fake provider to trick e2e-runner.sh
@@ -35,9 +50,27 @@ export LOG_DUMP_SSH_USER=admin
 export LOG_DUMP_SAVE_LOGS=cloud-init-output
 
 ### job-env
-export E2E_NAME="e2e-kops-aws-updown"
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]"
-export KOPS_PUBLISH_GREEN_PATH="gs://kops-ci/bin/latest-ci-updown-green.txt"
+if [[ -n "${JOB_NAME:-}" ]]; then
+  # Running on Jenkins
+  export KOPS_E2E_CLUSTER_NAME="e2e-kops-aws-updown.test-aws.k8s.io"
+  export KOPS_E2E_STATE_STORE="s3://k8s-kops-jenkins/"
+  export KOPS_PUBLISH_GREEN_PATH="gs://kops-ci/bin/latest-ci-updown-green.txt"
+else
+  if [[ -z "${KOPS_E2E_CLUSTER_NAME:-}" ]]; then
+    echo "KOPS_E2E_CLUSTER_NAME not set!" >&2
+    exit 1
+  fi
+  if [[ -z "${KOPS_E2E_STATE_STORE:-}" ]]; then
+    echo "KOPS_E2E_STATE_STORE not set!" >&2
+    exit 1
+  fi
+  export WORKSPACE="${WORKSPACE:-$PWD}"
+  echo "E2Es results will be output to ${WORKSPACE}/_artifacts"
+
+  export JOB_NAME="${USER}"
+  export BUILD_NUMBER=$(date +%s)
+fi
 
 ### post-env
 
@@ -57,8 +90,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 # After post-env
 export KOPS_DEPLOY_LATEST_KUBE=y
 export KUBE_E2E_RUNNER="/workspace/kops-e2e-runner.sh"
-# TODO(zmerlynn): Take out --kops-ssh-key after fixing kops-e2e-runner again.
-export E2E_OPT="--kops-ssh-key /workspace/.ssh/kube_aws_rsa --kops-cluster ${E2E_NAME}.test-aws.k8s.io --kops-state s3://k8s-kops-jenkins/ --kops-nodes=4"
+export E2E_OPT="--kops-cluster ${KOPS_E2E_CLUSTER_NAME} --kops-state ${KOPS_E2E_STATE_STORE} --kops-nodes=4"
 export GINKGO_PARALLEL="y"
 
 ### Runner


### PR DESCRIPTION
This lets you do e.g.

```
KOPS_E2E_STATE_STORE=s3://your-state-store \
KOPS_E2E_CLUSTER_NAME=e2e.your.domain \
jobs/ci-kubernetes-e2e-kops-aws.sh
```
