### PR TITLE
Explicitly use etcd v2 in base suites and presubmits

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gce.sh
@@ -40,6 +40,8 @@ export KUBE_NODE_OS_DISTRIBUTION="debian"
 export PROJECT="k8s-jkns-e2e-gce"
 export NUM_NODES="4"
 export GINKGO_PARALLEL_NODES="30"
+# For now explicitly test etcd v3 mode in this suite.
+export STORAGE_BACKEND="etcd2"
 
 ### post-env
 

--- a/jobs/ci-kubernetes-e2e-gci-gce.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce.sh
@@ -36,6 +36,10 @@ export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flak
 export GINKGO_PARALLEL="y"
 export KUBE_OS_DISTRIBUTION="gci"
 export PROJECT="k8s-jkns-e2e-gce-gci"
+export NUM_NODES="4"
+export GINKGO_PARALLEL_NODES="30"
+# For now explicitly test etcd v3 mode in this suite.
+export STORAGE_BACKEND="etcd2"
 
 ### post-env
 

--- a/jobs/pull-kubernetes-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gce-gci.sh
@@ -49,8 +49,10 @@ export PROJECT="k8s-jkns-pr-gci-gce"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 export NUM_NODES="4"
 export GINKGO_PARALLEL_NODES="30"
+# For now explicitly test etcd v3 mode in this suite.
+export STORAGE_BACKEND="etcd2"
 
-# Force to use container-vm.
+# Force to use GCI.
 export KUBE_NODE_OS_DISTRIBUTION="gci"
 
 # Assume we're upping, testing, and downing a cluster

--- a/jobs/pull-kubernetes-e2e-gce.sh
+++ b/jobs/pull-kubernetes-e2e-gce.sh
@@ -49,6 +49,8 @@ export PROJECT="k8s-jkns-pr-gce"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 export NUM_NODES="4"
 export GINKGO_PARALLEL_NODES="30"
+# For now explicitly test etcd v3 mode in this suite.
+export STORAGE_BACKEND="etcd2"
 
 # Force to use container-vm.
 export KUBE_NODE_OS_DISTRIBUTION="debian"


### PR DESCRIPTION
This is the preparation for changing default in k8s codebase to etcd v3 - we still want to test something with v2 API.

@timothysc 