### PR TITLE
Actually, put the install step in the image.

### DIFF
--- a/images/pull-test-infra-py-test/Dockerfile
+++ b/images/pull-test-infra-py-test/Dockerfile
@@ -20,16 +20,31 @@ RUN apt-get update && apt-get install -y \
     git \
     wget \
     python \
-    python-pip && \
+    python-pip \
+    unzip && \
     apt-get clean
 
-RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-136.0.0-linux-x86_64.tar.gz && \
-    tar xf google-cloud-sdk-136.0.0-linux-x86_64.tar.gz && \
-    rm google-cloud-sdk-136.0.0-linux-x86_64.tar.gz && \
-    ./google-cloud-sdk/install.sh
-ENV PATH="/google-cloud-sdk/bin:${PATH}"
+ENV GCLOUD_TAR="google-cloud-sdk-136.0.0-linux-x86_64.tar.gz" \
+    GAE_ZIP="google_appengine_1.9.40.zip" \
+    GAE_ROOT="/workspace/google_appengine" \
+    PATH="/google-cloud-sdk/bin:${PATH}"
 
 RUN mkdir -p /workspace
+
+RUN wget "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TAR}" && \
+    tar xf "${GCLOUD_TAR}" && \
+    rm "${GCLOUD_TAR}" && \
+    ./google-cloud-sdk/install.sh
+
+RUN wget -nv "https://storage.googleapis.com/appengine-sdks/featured/${GAE_ZIP}" && \
+    unzip -q "${GAE_ZIP}" -d /workspace
+
+RUN pip install webtest nosegae pylint==1.6.4 coverage requests jinja2 pyyaml
+
+# We need these set for a few test cases.
+RUN git config --global user.email "you@example.com" && \
+    git config --global user.name "Your Name"
+
 WORKDIR /workspace
 ADD runner /
 ENTRYPOINT ["/bin/bash", "/runner"]

--- a/images/pull-test-infra-py-test/Makefile
+++ b/images/pull-test-infra-py-test/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.5
+VERSION = 0.7
 
 image:
 	docker build -t "gcr.io/k8s-testimages/test-infra-py-test:$(VERSION)" .

--- a/jobs/pull-test-infra-py-test.sh
+++ b/jobs/pull-test-infra-py-test.sh
@@ -18,14 +18,6 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# Based on https://github.com/travis-ci/travis-ci/issues/738#issuecomment-11179888
-readonly GAE_ZIP=google_appengine_1.9.40.zip
-readonly GAE_ROOT=${HOME}/google_appengine
-wget -nv https://storage.googleapis.com/appengine-sdks/featured/${GAE_ZIP}
-unzip -q ${GAE_ZIP} -d ${HOME}
-pip install -r gubernator/test_requirements.txt
-pip install -r jenkins/test-history/requirements.txt
-
 ./verify/verify-boilerplate.py
 python -m unittest discover -s jenkins/test-history -p "*_test.py"
 pylint jenkins/bootstrap.py

--- a/prow/jobs.yaml
+++ b/prow/jobs.yaml
@@ -188,4 +188,4 @@ kubernetes/test-infra:
   trigger: "@k8s-bot (py )?test this"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/test-infra-py-test:0.5
+    - image: gcr.io/k8s-testimages/test-infra-py-test:0.7


### PR DESCRIPTION
I had a few surprises when bootstrap behaves strangely. It does things like setting `$HOME` to the checkout path, or not setting the git config for its own unit tests. I think this one should finally work, though.