### PR TITLE
make kubekins-node image support multiple kubekins-test version

### DIFF
--- a/jenkins/node-dockerized.sh
+++ b/jenkins/node-dockerized.sh
@@ -36,8 +36,15 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 # provided must be resolvable on the *HOST*, not the container.
 
 # default to go version 1.6 image tag
-# TODO (krzyzacy) Make one image per kubekins-image version.
-NODEIMAGE_TAG="v20161220-ead6a19"
+NODEIMAGE_TAG="1.6-latest"
+
+if [[ "${NODE_IMG_VERSION}" == *"1.2" ]] || \
+   [[ "${NODE_IMG_VERSION}" == *"1.3" ]] || \
+   [[ "${NODE_IMG_VERSION}" == *"1.4" ]]; then
+  NODEIMAGE_TAG="1.4-latest"
+elif [[ "${NODE_IMG_VERSION}" == *"1.5" ]]; then
+  NODEIMAGE_TAG="1.5-latest"
+fi
 
 docker run --rm=true \
   --privileged=true \

--- a/jenkins/node-image/Dockerfile-1.4
+++ b/jenkins/node-image/Dockerfile-1.4
@@ -1,0 +1,37 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a build environment for building and running kubernetes
+# unit and integration tests
+
+FROM gcr.io/k8s-testimages/kubekins-test:1.4-latest
+LABEL authors="Sen Lu <senlu@google.com>"
+
+# Add necessary scripts
+ADD ["node-runner.sh", \
+    "/workspace/"]
+RUN ["chmod", "+x", "/workspace/node-runner.sh"]
+
+# Install gcloud
+RUN curl -fsSL --retry 3 --keepalive-time 2 'https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz' \
+    | tar -C /workspace -xvzf-  \
+    && export CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
+    && /workspace/google-cloud-sdk/install.sh --disable-installation-options --bash-completion=false --path-update=false --usage-reporting=false
+
+ENV PATH=/workspace/google-cloud-sdk/bin:${PATH}
+
+RUN gcloud components install alpha \
+    && gcloud components install beta
+
+ENTRYPOINT "/workspace/node-runner.sh"

--- a/jenkins/node-image/Dockerfile-1.5
+++ b/jenkins/node-image/Dockerfile-1.5
@@ -1,0 +1,37 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a build environment for building and running kubernetes
+# unit and integration tests
+
+FROM gcr.io/k8s-testimages/kubekins-test:1.5-latest
+LABEL authors="Sen Lu <senlu@google.com>"
+
+# Add necessary scripts
+ADD ["node-runner.sh", \
+    "/workspace/"]
+RUN ["chmod", "+x", "/workspace/node-runner.sh"]
+
+# Install gcloud
+RUN curl -fsSL --retry 3 --keepalive-time 2 'https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz' \
+    | tar -C /workspace -xvzf-  \
+    && export CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
+    && /workspace/google-cloud-sdk/install.sh --disable-installation-options --bash-completion=false --path-update=false --usage-reporting=false
+
+ENV PATH=/workspace/google-cloud-sdk/bin:${PATH}
+
+RUN gcloud components install alpha \
+    && gcloud components install beta
+
+ENTRYPOINT "/workspace/node-runner.sh"

--- a/jenkins/node-image/Dockerfile-1.6
+++ b/jenkins/node-image/Dockerfile-1.6
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-test:1.6-v20161205-ad918bc
+FROM gcr.io/k8s-testimages/kubekins-test:1.6-latest
 LABEL authors="Sen Lu <senlu@google.com>"
 
 # Add necessary scripts

--- a/jenkins/node-image/Makefile
+++ b/jenkins/node-image/Makefile
@@ -14,15 +14,38 @@
 
 IMG = gcr.io/k8s-testimages/kubekins-node
 TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSIONS := $(wildcard ./Dockerfile-*)
+
+do_build = \
+	$(eval VERSION := $(subst ./Dockerfile-,,$(v)))\
+	docker build --pull -f ./Dockerfile-$(VERSION) -t $(IMG):$(VERSION)-$(TAG) . ;\
+	docker tag $(IMG):$(VERSION)-$(TAG) $(IMG):$(VERSION)-latest ;\
+	echo Built $(IMG):$(VERSION)-$(TAG) and tagged with $(IMG):$(VERSION)-latest ;
+
+do_push = \
+	$(eval VERSION := $(subst ./Dockerfile-,,$(v)))\
+	gcloud docker -- push $(IMG):$(VERSION)-$(TAG);\
+	gcloud docker -- push $(IMG):$(VERSION)-latest;\
+	echo Pushed $(IMG):$(VERSION)-latest and $(IMG):$(VERSION)-$(TAG);
+
+.PHONY: all build push help
 
 all: build
 
 build:
-	docker build -t $(IMG):$(TAG) .
-	docker tag $(IMG):$(TAG) $(IMG):latest
-	@echo Built $(IMG):$(TAG) and tagged with latest
+	@$(foreach v,$(VERSIONS),$(do_build))
 
 push: build
-	gcloud docker -- push $(IMG):$(TAG)
-	gcloud docker -- push $(IMG):latest
-	@echo Pushed $(IMG) with :latest and :$(TAG) tags
+	@$(foreach v,$(VERSIONS),$(do_push))
+
+help:
+	@echo "VARIABLES:"
+	@echo " VERSIONS:		Dockerfile to be built/pushed, can be either full file name or a tag"
+	@echo " 				- make build VERSIONS=./Dockerfile-1.4"
+	@echo " 				- make build VERSIONS=1.4"
+	@echo " 				are equivalent and both valid."
+	@echo ""
+	@echo "TARGETS:"
+	@echo " all:			build"
+	@echo " build:			builds all the Dockerfile-* in VERSIONS"
+	@echo " push:			builds all the Dockerfile-* in VERSIONS and pushes to k8s-testimages"

--- a/jenkins/node-image/README.md
+++ b/jenkins/node-image/README.md
@@ -1,0 +1,27 @@
+# Node Images
+
+Image for node tests, based from `kubekins-test` images.
+
+Node image contains `node-runner.sh` and pre-installed gcloud.
+
+
+# Naming:
+User can add more `Dockerfile` and name it to `Dockerfile-[VERSION]`.
+
+`[VERSION]` will be used as part of the built image tag.
+
+
+User can build one more all images by specify `VERSIONS` value, which is all `Dockerfile-*` by default.
+for example, `make push VERSIONS=1.4` will build `Dockerfile-1.4` and tag it and push it to k8s-testimages.
+
+To build multiple images, you can do something like `make build VERSIONS='1.4 1.5'`
+
+For more details, run make help, or see "Usage" below.
+
+# Usage:
+`make all:        make build`
+
+`make build:      builds all the Dockerfile-* in VERSIONS`
+
+`make push:       builds all the Dockerfile-* in VERSIONS and pushes to k8s-testimages`
+

--- a/jobs/ci-kubernetes-node-kubelet-dockerized.sh
+++ b/jobs/ci-kubernetes-node-kubelet-dockerized.sh
@@ -22,6 +22,7 @@ set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
 
+export NODE_IMG_VERSION="master"
 export NODE_TEST_SCRIPT="test/e2e_node/jenkins/e2e-node-jenkins.sh"
 export NODE_TEST_PROPERTIES="test/e2e_node/jenkins/jenkins-ci.properties"
 


### PR DESCRIPTION
To support different go versions, per comments from #1380 

Probably worth do the same thing for e2e images.

#1348 