### PR TITLE
Remove references to build-tools/

### DIFF
--- a/jobs/pull-kubernetes-e2e-gke-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gke-gci.sh
@@ -33,14 +33,9 @@ export JENKINS_USE_LOCAL_BINARIES=y
 export KUBE_FASTBUILD=true
 ./hack/jenkins/build.sh
 
-# TODO(spxtr): once https://github.com/kubernetes/kubernetes/pull/35453 is in,
-# remove the first branch here.
-if [[ -e build/util.sh ]]; then
-  version=$(source build/util.sh && echo $(kube::release::semantic_version))
-elif [[ -e build-tools/util.sh ]]; then
-  version=$(source build-tools/util.sh && echo $(kube::release::semantic_version))
-else
-  echo "Could not find build/util.sh or build-tools/util.sh." >&2
+readonly version=$(source build/util.sh && echo $(kube::release::semantic_version))
+if [[ -z "${version:-}" ]]; then
+  echo "Could not find build/util.sh, or kube::release::semantic_version failed." >&2
   exit 1
 fi
 gsutil -m rsync -r "gs://kubernetes-release-pull/ci/${JOB_NAME}/${version}" "gs://kubernetes-release-dev/ci/${version}-pull-gke-gci"

--- a/jobs/pull-kubernetes-e2e-gke.sh
+++ b/jobs/pull-kubernetes-e2e-gke.sh
@@ -33,14 +33,9 @@ export JENKINS_USE_LOCAL_BINARIES=y
 export KUBE_FASTBUILD=true
 ./hack/jenkins/build.sh
 
-# TODO(spxtr): once https://github.com/kubernetes/kubernetes/pull/35453 is in,
-# remove the first branch here.
-if [[ -e build/util.sh ]]; then
-  version=$(source build/util.sh && echo $(kube::release::semantic_version))
-elif [[ -e build-tools/util.sh ]]; then
-  version=$(source build-tools/util.sh && echo $(kube::release::semantic_version))
-else
-  echo "Could not find build/util.sh or build-tools/util.sh." >&2
+readonly version=$(source build/util.sh && echo $(kube::release::semantic_version))
+if [[ -z "${version:-}" ]]; then
+  echo "Could not find build/util.sh, or kube::release::semantic_version failed." >&2
   exit 1
 fi
 gsutil -m rsync -r "gs://kubernetes-release-pull/ci/${JOB_NAME}/${version}" "gs://kubernetes-release-dev/ci/${version}-pull-gke"

--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -38,14 +38,9 @@ if [[ -z "${SKIP_BUILD:-}" ]]; then
   ./hack/jenkins/build.sh
 fi
 
-# TODO(spxtr): Revert back to build/
-if [[ -e build/util.sh ]]; then
-  readonly version=$(source build/util.sh && echo $(kube::release::semantic_version))
-elif [[ -e build-tools/util.sh ]]; then
-  readonly version=$(source build-tools/util.sh && echo $(kube::release::semantic_version))
-fi
+readonly version=$(source build/util.sh && echo $(kube::release::semantic_version))
 if [[ -z "${version:-}" ]]; then
-  echo "Could not find build/util.sh or build-tools/util.sh, or kube::release::semantic_version failed." >&2
+  echo "Could not find build/util.sh, or kube::release::semantic_version failed." >&2
   exit 1
 fi
 export KUBERNETES_PROVIDER="kops-aws"


### PR DESCRIPTION
None of the kubernetes branches have `build-tools/` anymore, so we can remove all references to it.

x-ref https://github.com/kubernetes/kubernetes/issues/38126