### PR TITLE
_artifacts

### DIFF
--- a/jenkins/node-dockerized.sh
+++ b/jenkins/node-dockerized.sh
@@ -45,7 +45,7 @@ GCE_USER="jenkins"
 docker run --rm=true \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
-  -v "${WORKSPACE}/_artifacts":/workspace/artifacts \
+  -v "${WORKSPACE}/_artifacts":/workspace/_artifacts \
   -v /etc/localtime:/etc/localtime:ro \
   ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:+-v "${JENKINS_GCE_SSH_PRIVATE_KEY_FILE}:/root/.ssh/google_compute_engine:ro"} \
   ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:+-v "${JENKINS_GCE_SSH_PUBLIC_KEY_FILE}:/root/.ssh/google_compute_engine.pub:ro"} \


### PR DESCRIPTION
compare with https://github.com/kubernetes/test-infra/blob/master/jenkins/dockerized-e2e-runner.sh#L79

test passed but missing all the artifacts.. I think this is the issue but not 100% sure.

#1348