### PR TITLE
Increase nodes for kubemark-gce-scale CI test to 60 from 59

### DIFF
--- a/jobs/ci-kubernetes-kubemark-gce-scale.sh
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.sh
@@ -44,9 +44,9 @@ export TEST_CLUSTER_MAX_REQUESTS_INFLIGHT="--max-requests-inflight=1500"
 export LOAD_TEST_THROUGHPUT=25
 # Override defaults to be independent from GCE defaults and set kubemark parameters
 # We need 11 so that we won't hit max-pods limit (set to 100). TODO: do it in a nicer way.
-export NUM_NODES="59"
+export NUM_NODES="60"
 export MASTER_SIZE="n1-standard-4"
-# Note: can fit about 17 hollow nodes per core so NUM_NODES x
+# Note: can fit about ~10 hollow nodes per core so NUM_NODES x
 # cores_per_node should be set accordingly.
 export NODE_SIZE="n1-standard-8"
 export KUBEMARK_MASTER_SIZE="n1-standard-32"


### PR DESCRIPTION
Ref issue kubernetes/kubernetes#39134

@kubernetes/sig-scalability-misc @wojtek-t @gmarek