### PR TITLE
Install pip deps in the test job.

### DIFF
--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -17,6 +17,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+pip install -r gubernator/test_requirements.txt
+pip install -r jenkins/test_history/requirements.txt
+
 # Cache location.
 export TEST_TMPDIR="/root/.cache/bazel"
 


### PR DESCRIPTION
Once this is in we can enable bazel py tests and speed up travis just a tiny bit.