### PR TITLE
Allow "@k8s-bot test this" from non-org users after "ok to test".

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build fmt vet test
 
 
-HOOK_VERSION   = 0.66
+HOOK_VERSION   = 0.67
 LINE_VERSION   = 0.38
 SINKER_VERSION = 0.4
 DECK_VERSION   = 0.11

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.66
+        image: gcr.io/k8s-prow/hook:0.67
         imagePullPolicy: Always
         env:
         - name: LINE_IMAGE

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -35,6 +35,7 @@ func TestHandleIssueComment(t *testing.T) {
 		IsPR        bool
 		Branch      string
 		ShouldBuild bool
+		HasOkToTest bool
 	}{
 		// Not a PR.
 		{
@@ -67,6 +68,15 @@ func TestHandleIssueComment(t *testing.T) {
 			State:       "open",
 			IsPR:        true,
 			ShouldBuild: false,
+		},
+		// Non-trusted member after "ok to test".
+		{
+			Author:      "u",
+			Body:        "@k8s-bot test this",
+			State:       "open",
+			IsPR:        true,
+			HasOkToTest: true,
+			ShouldBuild: true,
 		},
 		// Trusted member's ok to test.
 		{
@@ -141,6 +151,12 @@ func TestHandleIssueComment(t *testing.T) {
 		var pr *struct{}
 		if tc.IsPR {
 			pr = &struct{}{}
+		}
+		if tc.HasOkToTest {
+			g.IssueComments[0] = []github.IssueComment{{
+				Body: "ok to test",
+				User: github.User{Login: "t"},
+			}}
 		}
 		event := github.IssueCommentEvent{
 			Action: "created",


### PR DESCRIPTION
They can already trigger a retest by pushing new code or closing and
opening the PR, so they should be able to trigger tests from comments.