### PR TITLE
Create kubernetes_build scenario, migrate build jobs

### DIFF
--- a/jobs/ci-kops-build.sh
+++ b/jobs/ci-kops-build.sh
@@ -19,13 +19,16 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export GCS_LOCATION="gs://kops-ci/bin"
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --script='make gcs-publish-ci'
+  --kops='gs://kops-ci/bin'
+)
 
 ### Runner
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="20m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" make gcs-publish-ci && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-build-1.3.sh
+++ b/jobs/ci-kubernetes-build-1.3.sh
@@ -19,13 +19,14 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-build-1.4.sh
+++ b/jobs/ci-kubernetes-build-1.4.sh
@@ -19,13 +19,14 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-build-1.5.sh
+++ b/jobs/ci-kubernetes-build-1.5.sh
@@ -19,13 +19,14 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-build-debian-unstable.sh
+++ b/jobs/ci-kubernetes-build-debian-unstable.sh
@@ -19,14 +19,16 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export DEB_CHANNEL="unstable"
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --script='./debian/jenkins.sh'
+  --unstable
+)
 
 ### Runner
-readonly runner="./debian/jenkins.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="300m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-build.sh
+++ b/jobs/ci-kubernetes-build.sh
@@ -19,14 +19,15 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export KUBE_FASTBUILD=true
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --fast
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="30m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-cross-build.sh
+++ b/jobs/ci-kubernetes-cross-build.sh
@@ -19,15 +19,16 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export KUBE_FASTBUILD=false
-export KUBE_GCS_RELEASE_SUFFIX=-cross  # to avoid colliding with 'kubernetes-build'
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --suffix=-cross
+  # --slow
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-federation-build-1.4.sh
+++ b/jobs/ci-kubernetes-federation-build-1.4.sh
@@ -19,19 +19,17 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export PROJECT="k8s-jkns-e2e-gce-f8n-1-4"
-export FEDERATION=true
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-f8n-1-4"
-export KUBE_FASTBUILD=true
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-4
-export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release-1-4
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --federation=k8s-jkns-e2e-gce-f8n-1-4
+  --fast
+  --release=kubernetes-federation-release-1-4
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-federation-build-1.5.sh
+++ b/jobs/ci-kubernetes-federation-build-1.5.sh
@@ -19,19 +19,17 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export PROJECT="k8s-e2e-gce-f8n-1-5"
-export FEDERATION=true
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-e2e-gce-f8n-1-5"
-export KUBE_FASTBUILD=true
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-5
-export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release-1-5
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --federation=k8s-e2e-gce-f8n-1-5
+  --fast
+  --release=kubernetes-federation-release-1-5
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-federation-build-soak.sh
+++ b/jobs/ci-kubernetes-federation-build-soak.sh
@@ -19,19 +19,17 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export PROJECT="k8s-jkns-gce-federation-soak"
-export FEDERATION=true
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-gce-federation-soak"
-export KUBE_FASTBUILD=true
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
-export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --federation=k8s-jkns-gce-federation-soak
+  --fast
+  --release=kubernetes-federation-release
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/jobs/ci-kubernetes-federation-build.sh
+++ b/jobs/ci-kubernetes-federation-build.sh
@@ -19,19 +19,17 @@ set -o pipefail
 set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
-
-### job-env
-export PROJECT="k8s-jkns-e2e-gce-federation"
-export FEDERATION=true
-export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-e2e-gce-federation"
-export KUBE_FASTBUILD=true
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
-export KUBE_GCS_RELEASE_BUCKET_MIRROR=kubernetes-federation-release
+readonly scenario='kubernetes_build.py'
+readonly scenario_args=(
+  --federation=k8s-jkns-e2e-gce-federation
+  --fast
+  --release=kubernetes-federation-release
+)
 
 ### Runner
-readonly runner="./hack/jenkins/build.sh"
+readonly runner="${testinfra}/scenarios/${scenario}"
 export KUBEKINS_TIMEOUT="50m"
-timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" && rc=$? || rc=$?
+timeout -k 15m "${KUBEKINS_TIMEOUT}" "${runner}" "${scenario_args[@]}" && rc=$? || rc=$?
 
 ### Reporting
 if [[ ${rc} -eq 124 || ${rc} -eq 137 ]]; then

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -1,0 +1,41 @@
+# Test scenarios
+
+Place scripts to run test scenarios inside this location.
+
+Test jobs are composed of two things:
+1) A scenario to test
+2) Configuration options for the scenario.
+
+Three example scenarios are:
+
+* Unit tests
+* Node e2e tests
+* e2e tests
+
+Example configurations are:
+
+* Parallel tests on gce
+* Build all platforms
+
+The assumption is that each scenario will be called a variety of times with
+different configuration options. For example at the time of this writing there
+are over 300 e2e jobs, each run with a slightly different set of options.
+
+## Contract
+
+The scenario assumes the calling process (bootstrap.py) has setup all
+prerequisites, such as checking out the right repository, setting pwd,
+activiating service accounts, etc.
+
+The scenario also assumes that the calling process will handle all post-job
+works, such as recording log output, copying logs to gcs, etc.
+
+The scenario should exit 0 if and only on success.
+
+The calling process can configure the scenario by calling the scenario
+with different arguments. For example: `kubernetes\_build.py --fast`
+configures the scenario to do a fast build (one platform) and/or
+`kubernetes\_build.py --federation=random-project` configures the scenario
+to do a federation build using the random-project.
+
+Call the scenario with `-h` to see configuration options.

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Need to figure out why this only fails on travis
+# pylint: disable=bad-continuation
+
+"""Builds kubernetes with specified config"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def check(*cmd):
+    """Log and run the command, raising on errors."""
+    print >>sys.stderr, 'Run:', cmd
+    subprocess.check_call(cmd)
+
+
+def main(args):
+    """Build kubernetes."""
+    env = {}
+    if args.kops:
+        env['GCS_LOCATION'] = args.kops
+    if args.unstable:
+        env['DEB_CHANNEL'] = 'unstable'
+    if args.suffix:
+        env['KUBE_GCS_RELEASE_SUFFIX'] = args.suffix
+    env['KUBE_FASTBUILD'] = 'true' if args.fast else 'false'
+    if args.federation:
+        env['PROJECT'] = args.federation
+        env['FEDERATION'] = 'true'
+        env['FEDERATION_PUSH_REPO_BASE'] = 'gcr.io/%s' % args.federation
+    if args.release:
+        env['KUBE_GCS_RELEASE_BUCKET'] = args.release
+        env['KUBE_GCS_RELEASE_BUCKET_MIRROR'] = args.release
+
+
+    for key, value in env.items():
+        os.environ[key] = value
+
+    if args.script == 'make gcs-publish-ci':
+        # TODO(fejta): fix this hack
+        check('make', 'gcs-publish-ci')
+    else:
+        check(args.script)
+
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser(
+        'Runs verification checks on the kubernetes repo')
+    PARSER.add_argument(
+        '--script',
+        default='./hack/jenkins/build.sh',
+        help='Script relative to repo which builds')
+    PARSER.add_argument('--fast', action='store_true', help='Build quickly')
+    PARSER.add_argument(
+        '--release', help='Upload binaries to the specified gs:// path')
+    PARSER.add_argument(
+        '--suffix', help='Append suffix to the upload path if set')
+    PARSER.add_argument(
+        '--unstable',
+        action='store_true',
+        help='Use the unstable debian channel')
+    PARSER.add_argument(
+        '--federation',
+        help='Enable federation with the specified project')
+    PARSER.add_argument(
+        '--kops', help='Upload kops to the specified gs:// path')
+    ARGS = PARSER.parse_args()
+    main(ARGS)


### PR DESCRIPTION
ref #1227 #1225 

* Create scenarios/kubernetes_build.py
* Update all build jobs to use this scenario.

In a subsequent PR will:
* migrate the jobs to use a .yaml config instead of .sh 
* migrate timeout inside kubernetes_build.py