### PR TITLE
Added missing 'm' to ha e2e test timeout.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-ha-master.sh
+++ b/jobs/ci-kubernetes-e2e-gce-ha-master.sh
@@ -67,6 +67,6 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 ### Runner
 readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
-export DOCKER_TIMEOUT="240"
-export KUBEKINS_TIMEOUT="220"
+export DOCKER_TIMEOUT="240m"
+export KUBEKINS_TIMEOUT="220m"
 "${runner}"


### PR DESCRIPTION
Added missing 'm' to ha e2e test timeout (the problem was introduced in #1467).