### PR TITLE
kops: Re-enable reporting in Kubernetes repo

### DIFF
--- a/prow/presubmit.yaml
+++ b/prow/presubmit.yaml
@@ -123,7 +123,6 @@ kubernetes/kubernetes:
   context: Jenkins kops AWS e2e
   rerun_command: "@k8s-bot kops aws e2e test this"
   trigger: "@k8s-bot (kops )?(aws )?(e2e )?test this"
-  skip_report: true
 
 - name: pull-kubernetes-federation-e2e-gce
   context: Jenkins Federation GCE e2e


### PR DESCRIPTION
I'll wait on merging this until the existing `kops` breakage has flowed through the system, but we have to get the PR builder back talking. It's been reliable for a while (previous to this incident): https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kops-aws?before=5795

cc @chrislovecnm @justinsb @kris-nova