### PR TITLE
kops-e2e-runner.sh: Publish green without caching, remove TODOs

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -20,9 +20,6 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-# TODO(zmerlynn): Remove this after all jobs are using KOPS_BASE_URL
-export KOPS_BASE_URL="${KOPS_BASE_URL:-${KOPS_URL:-}}"
-
 if [[ -z "${KOPS_BASE_URL:-}" ]]; then
   readonly KOPS_LATEST=${KOPS_LATEST:-"latest-ci.txt"}
   readonly LATEST_URL="https://storage.googleapis.com/kops-ci/bin/${KOPS_LATEST}"
@@ -35,8 +32,6 @@ fi
 
 curl -fsS --retry 3 -o "${WORKSPACE}/kops" "${KOPS_BASE_URL}/linux/amd64/kops"
 chmod +x "${WORKSPACE}/kops"
-# TODO(zmerlynn): Remove this when kubernetes/kops#1318 goes back in
-export NODEUP_URL="${KOPS_BASE_URL}/linux/amd64/nodeup"
 
 # Get kubectl on the path (works after e2e-runner.sh:unpack_binaries)
 export PRIORITY_PATH="/workspace/kubernetes/platforms/linux/amd64"
@@ -99,5 +94,5 @@ if [[ -n "${KOPS_PUBLISH_GREEN_PATH:-}" ]]; then
     fi
   fi
   echo "Publish version to ${KOPS_PUBLISH_GREEN_PATH}: ${KOPS_BASE_URL}"
-  echo "${KOPS_BASE_URL}" | gsutil cp - "${KOPS_PUBLISH_GREEN_PATH}"
+  echo "${KOPS_BASE_URL}" | gsutil -h "Cache-Control:private, max-age=0, no-transform" cp - "${KOPS_PUBLISH_GREEN_PATH}"
 fi


### PR DESCRIPTION
TODOs should be safe after https://github.com/kubernetes/kops/pull/1349 and #1483 

Not bumping e2e-image yet. This can go in leisurely.