### PR TITLE
aws-janitor: Don't sweep default-looking DHCP Option Sets

### DIFF
--- a/jenkins/aws-janitor/Makefile
+++ b/jenkins/aws-janitor/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 IMAGE ?= b.gcr.io/k8s-test-infra-aws/aws-janitor
-VERSION ?= 0.1
+VERSION ?= 0.2
 
 image:
 	CGO_ENABLED=0 go build k8s.io/test-infra/jenkins/aws-janitor


### PR DESCRIPTION
Replaces kubernetes/kops#1336