### PR TITLE
Add jobs for testing kubernetes-security org pull requests

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -684,6 +684,11 @@ def setup_magic_environment(job):
         'JENKINS_AWS_SSH_PUBLIC_KEY_FILE',
         os.path.join(home, '.ssh/kube_aws_rsa.pub'),
     )
+    os.environ.setdefault(
+        'K8S_SECURITY_SSH_PRIVATE_KEY_FILE',
+        os.path.join(home, '.ssh/id_ed25519'),
+    )
+
 
     cwd = os.getcwd()
     # TODO(fejta): jenkins sets WORKSPACE and pieces of our infra expect this

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1350,6 +1350,7 @@ class JobTest(unittest.TestCase):
         'job-configs/kubernetes-jenkins-pull/bootstrap-maintenance-pull.yaml' : 'suffix',
         'job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml' : 'suffix',
         'job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml' : 'jsonsuffix',
+        'job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml' : 'suffix',
         'job-configs/kubernetes-jenkins/bootstrap-ci.yaml' : 'suffix',
         'job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml' : 'commit-suffix',
         'job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml' : 'repo-suffix',
@@ -1461,6 +1462,26 @@ class JobTest(unittest.TestCase):
             'job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml',
             Check, use_json=is_modern)
 
+    def testBootstrapSecurityPullYaml(self):
+        bads = ['kubernetes-e2e', 'kops-e2e', 'federation-e2e', 'kubemark-e2e']
+        is_modern = lambda n: all(b not in n for b in bads)
+        def Check(job, name):
+            job_name = 'pull-%s' % name
+            self.assertIn('max-total', job)
+            self.assertIn('repo-name', job)
+            self.assertIn('.', job['repo-name'])  # Has domain
+            self.assertIn('timeout', job)
+            self.assertIn('json', job)
+            modern = is_modern(name)
+            self.assertEquals(modern, job['json'])
+            if is_modern(name):
+                self.assertGreater(job['timeout'], 0)
+            return job_name
+
+        self.CheckBootstrapYaml(
+            'job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml',
+            Check, use_json=is_modern)
+
     def testBootstrapCIYaml(self):
         def Check(job, name):
             job_name = 'ci-%s' % name
@@ -1555,7 +1576,9 @@ class JobTest(unittest.TestCase):
             self.fail(tmpl)
         self.assertIn('--service-account=', cmd)
         self.assertIn('--upload=', cmd)
-        if '${{PULL_REFS}}' in cmd:
+        if 'kubernetes-security' in cmd:
+            self.assertIn('--upload=\'gs://kubernetes-security-jenkins/pr-logs\'', cmd)
+        elif '${{PULL_REFS}}' in cmd:
             self.assertIn('--upload=\'gs://kubernetes-jenkins/pr-logs\'', cmd)
         else:
             self.assertIn('--upload=\'gs://kubernetes-jenkins/logs\'', cmd)

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1482,6 +1482,22 @@ class JobTest(unittest.TestCase):
             'job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml',
             Check, use_json=is_modern)
 
+    def testBootstrapSecurityPullYamlJobsMatch(self):
+        jobs1 = self.LoadBootstrapYaml('job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml')
+        jobs2 = self.LoadBootstrapYaml('job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml')
+        for name, job in jobs1.iteritems():
+            if job['repo-name'] == 'k8s.io/kubernetes':
+                job2 = jobs2[name]
+                for attr in job:
+                    if attr != 'repo-name':
+                        self.assertEquals(job[attr], job2[attr])
+        for name, job in jobs2.iteritems():
+            job2 = jobs1[name]
+            for attr in job:
+                if attr != 'repo-name':
+                    self.assertEquals(job[attr], job2[attr])
+
+
     def testBootstrapCIYaml(self):
         def Check(job, name):
             job_name = 'ci-%s' % name

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
@@ -31,6 +31,13 @@
         name: buildId
     wrappers:
     - e2e-credentials-binding
+    - credentials-binding:
+      - file:
+          credential-id: 'k8s-security-gcp-service-account'
+          variable: 'K8S_SECURITY_GCP_SERVICE_ACCOUNT'
+      - file:
+          credential-id: 'k8s-security-repo-git-ssh-key'
+          variable: 'K8S_SECURITY_SSH_PRIVATE_KEY_FILE'
     - inject:
         properties-content: |
             GOROOT=/usr/local/go

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
@@ -1,0 +1,162 @@
+- job-template:
+    name: 'pull-security-{suffix}'
+    concurrent: true
+    properties:
+    - build-discarder:
+        days-to-keep: 7
+    - throttle:
+        max-total: '{max-total}'
+        max-per-node: 2
+        option: project
+    - raw:
+        xml: |
+            <com.cloudbees.plugins.JobPrerequisites plugin="slave-prerequisites@1.0">
+                <script>docker version; gcloud version</script>
+                <interpreter>shell script</interpreter>
+            </com.cloudbees.plugins.JobPrerequisites>
+    parameters:
+    # TODO(spxtr): Delete these two.
+    - string:
+        name: ghprbPullId
+    - string:
+        name: ghprbTargetBranch
+    - string:
+        name: PULL_REFS
+    - string:
+        name: PULL_NUMBER
+    - string:
+        name: PULL_BASE_REF
+    # The test job tracks a run through the queue using the buildId parameter.
+    - string:
+        name: buildId
+    wrappers:
+    - e2e-credentials-binding
+    - inject:
+        properties-content: |
+            GOROOT=/usr/local/go
+            GOPATH=$WORKSPACE/go
+            PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
+    - workspace-cleanup:
+        dirmatch: true
+        exclude:
+        - 'go/src/{repo-name}/.git/'
+        - 'test-infra/.git/'
+        external-deletion-command: 'sudo rm -rf %s'
+    - timeout:
+        timeout: 90
+        fail: true
+    builders:
+    - shell: |
+        # TODO(fejta): consider a stable tag instead of master
+        git clone https://github.com/kubernetes/test-infra -b master
+        './test-infra/jenkins/bootstrap.py' \
+            --job='{job-name}' \
+            --json='{json}' \
+            --pull="${{PULL_REFS}}" \
+            --repo='{repo-name}' \
+            --root="${{GOPATH}}/src" \
+            --service-account="${{K8S_SECURITY_GCP_SERVICE_ACCOUNT}}" \
+            --timeout='{timeout}' \
+            --upload='gs://kubernetes-security-jenkins/pr-logs' \
+            --ssh
+- project:
+    name: bootstrap-security-pull-jobs
+    jobs:
+    - 'pull-security-{suffix}'
+    suffix:  # pull-<repo>-<suffix> is the expected format
+    - kubernetes-cross:
+        max-total: 12
+        job-name: pull-kubernetes-cross
+        json: 1
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 80
+    - kubernetes-e2e-gce:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gce
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-e2e-gce-non-cri:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gce-non-cri
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-e2e-gce-gci:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gce-gci
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-e2e-gce-etcd3:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gce-etcd3
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-e2e-gke:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gke
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-e2e-gke-gci:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gke-gci
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-e2e-kops-aws:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-kops-aws
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-federation-e2e-gce:
+        max-total: 12
+        job-name: pull-kubernetes-federation-e2e-gce
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-federation-e2e-gce-gci:
+        max-total: 12
+        job-name: pull-kubernetes-federation-e2e-gce-gci
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-kubemark-e2e-gce:
+        max-total: 12
+        job-name: pull-kubernetes-kubemark-e2e-gce
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-kubemark-e2e-gce-gci:
+        max-total: 12
+        job-name: pull-kubernetes-kubemark-e2e-gce-gci
+        json: 0
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 0
+    - kubernetes-node-e2e:
+        max-total: 12
+        job-name: pull-kubernetes-node-e2e
+        json: 1
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 90
+    - kubernetes-node-e2e-non-cri:
+        max-total: 12
+        job-name: pull-kubernetes-node-e2e-non-cri
+        json: 1
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 90
+    - kubernetes-verify:
+        max-total: 12
+        job-name: pull-kubernetes-verify
+        json: 1
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 60
+    - kubernetes-unit:
+        max-total: 12
+        job-name: pull-kubernetes-unit
+        json: 1
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 60

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
@@ -112,12 +112,6 @@
         json: 0
         repo-name: 'github.com/kubernetes-security/kubernetes'
         timeout: 0
-    - kubernetes-federation-e2e-gce:
-        max-total: 12
-        job-name: pull-kubernetes-federation-e2e-gce
-        json: 0
-        repo-name: 'github.com/kubernetes-security/kubernetes'
-        timeout: 0
     - kubernetes-federation-e2e-gce-gci:
         max-total: 12
         job-name: pull-kubernetes-federation-e2e-gce-gci

--- a/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
@@ -6,6 +6,9 @@
                 credential-id: 'gcp-service-account'
                 variable: 'GOOGLE_APPLICATION_CREDENTIALS'
             - file:
+                credential-id: 'k8s-security-gcp-service-account'
+                variable: 'K8S_SECURITY_GCP_SERVICE_ACCOUNT'
+            - file:
                 credential-id: 'aws-ssh-public-key'
                 variable: 'JENKINS_AWS_SSH_PUBLIC_KEY_FILE'
             - file:

--- a/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
@@ -6,12 +6,6 @@
                 credential-id: 'gcp-service-account'
                 variable: 'GOOGLE_APPLICATION_CREDENTIALS'
             - file:
-                credential-id: 'k8s-security-gcp-service-account'
-                variable: 'K8S_SECURITY_GCP_SERVICE_ACCOUNT'
-            - file:
-                credential-id: 'k8s-security-repo-git-ssh-key'
-                variable: 'K8S_SECURITY_SSH_PRIVATE_KEY_FILE'
-            - file:
                 credential-id: 'aws-ssh-public-key'
                 variable: 'JENKINS_AWS_SSH_PUBLIC_KEY_FILE'
             - file:

--- a/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/credentials.yaml
@@ -9,6 +9,9 @@
                 credential-id: 'k8s-security-gcp-service-account'
                 variable: 'K8S_SECURITY_GCP_SERVICE_ACCOUNT'
             - file:
+                credential-id: 'k8s-security-repo-git-ssh-key'
+                variable: 'K8S_SECURITY_SSH_PRIVATE_KEY_FILE'
+            - file:
                 credential-id: 'aws-ssh-public-key'
                 variable: 'JENKINS_AWS_SSH_PUBLIC_KEY_FILE'
             - file:

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -162,6 +162,10 @@ func (ps Presubmit) RunsAgainstChanges(changes []string) bool {
 func (c *Config) MatchingPresubmits(fullRepoName, body string, testAll *regexp.Regexp) []Presubmit {
 	var result []Presubmit
 	ott := testAll.MatchString(body)
+	// copy the jobs from k8s.io/kubernetes to kubernetes-security/kubernetes
+	if fullRepoName == "kubernetes-security/kubernetes" {
+		fullRepoName = "kubernetes/kubernetes"
+	}
 	if jobs, ok := c.Presubmits[fullRepoName]; ok {
 		for _, job := range jobs {
 			if job.re.MatchString(body) || (ott && job.AlwaysRun) {


### PR DESCRIPTION
Things to do:

- [x] Add webhook to the repo itself, I was going to give @spxtr access rights.. but it looks like we need to add more seats to the org so idk if you can just email me what should be added for the hook in the meantime.
- [x] Add the service account file to the jenkins credentials so it matches `credentials.yaml` 
- [x] Add an ssh key with access to the repo to the jenkins instance for it to use for cloning
- [x] Give k8s-ci-robot access to the repo (requires buying another seat as well)

This only changes kubernetes jenkins pulls, I figured I would add the master/branch jobs in another step.