### PR TITLE
Remove quoting of path.

### DIFF
--- a/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
@@ -26,7 +26,7 @@ readonly testinfra="$(dirname "${0}")/.."
 
 export PROJECT="k8s-jkns-e2e-kubeadm-gce-ci"
 export E2E_NAME="e2e-kubeadm-gce"
-export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path \"${GOPATH}/k8s.io/kubernetes-anywhere\""
+export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path ${GOPATH}/k8s.io/kubernetes-anywhere"
 export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}.test-kubeadm.k8s.io"
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
 


### PR DESCRIPTION
This was causing failures in Jenkins, where the path was actually getting double quoted, making the quotes part of the path string itself (see [failure log](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce/71)).