### PR TITLE
Set cross build to always run and skip report.

### DIFF
--- a/prow/presubmit.yaml
+++ b/prow/presubmit.yaml
@@ -78,8 +78,8 @@ kubernetes/kubernetes:
   context: Jenkins Cross Build
   always_run: true
   skip_report: true
-  rerun_command: "@k8s-bot cross test this"
-  trigger: "@k8s-bot (cross )?test this"
+  rerun_command: "@k8s-bot cross build this"
+  trigger: "@k8s-bot (cross[ -])?(build|test) this"
 
 - name: pull-kubernetes-unit
   always_run: true

--- a/prow/presubmit.yaml
+++ b/prow/presubmit.yaml
@@ -76,8 +76,10 @@ kubernetes/kubernetes:
 
 - name: pull-kubernetes-cross
   context: Jenkins Cross Build
-  rerun_command: "@k8s-bot build this"
-  trigger: "@k8s-bot (cross )?build this"
+  always_run: true
+  skip_report: true
+  rerun_command: "@k8s-bot cross test this"
+  trigger: "@k8s-bot (cross )?test this"
 
 - name: pull-kubernetes-unit
   always_run: true


### PR DESCRIPTION
It's in silent mode so it won't comment on PRs or set a status. For the next day or two we can look at it and make sure it's not breaking unexpectedly. If it looks good then make a PR removing the skip_report line.