### PR TITLE
Increase cross-build timeout to 100m. It takes ~45m.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -82,7 +82,7 @@
         giturl: 'https://github.com/kubernetes/kubernetes'
         job-name: ci-kubernetes-cross-build
         repo-name: k8s.io/kubernetes
-        timeout: 50
+        timeout: 100
 
     - kubernetes-build-1.3:
         branch: release-1.3


### PR DESCRIPTION
There have been a few spurious timeout failures recently due to this.

https://k8s-testgrid.appspot.com/misc#cross-build&width=20&graph-metrics=test-duration-minutes