### PR TITLE
Fix test-infra path

### DIFF
--- a/jobs/maintenance-ci-testgrid-config-upload.sh
+++ b/jobs/maintenance-ci-testgrid-config-upload.sh
@@ -23,7 +23,7 @@ set -o xtrace
 # GOPATH should point to /go here
 mkdir -p $GOPATH/src/k8s.io/test-infra
 export TEST_INFRA=$GOPATH/src/k8s.io/test-infra
-cp -r $WORKSPACE/test-infra $TEST_INFRA
+cp -r $WORKSPACE $TEST_INFRA
 
 # Export config
 export CONFIGDIR=$TEST_INFRA/testgrid/config


### PR DESCRIPTION

`W0113 21:29:15.610] + cp -r /workspace/k8s.io/test-infra/test-infra /go/src/k8s.io/test-infra`
`W0113 21:29:15.615] cp: cannot stat '/workspace/k8s.io/test-infra/test-infra': No such file or directory`


#1559 