### PR TITLE
Add more delete rules and resource types for janitor

### DIFF
--- a/jenkins/janitor.py
+++ b/jenkins/janitor.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Clean up resources from gcp projects. """
+
 import argparse
 import collections
 import datetime
@@ -21,23 +23,26 @@ import json
 import subprocess
 import sys
 
-from collections import namedtuple
-
 
 # A resource that need to be cleared.
-Resource = namedtuple('Resource', 'name condition status')
+Resource = collections.namedtuple('Resource', 'name condition managed flags')
 DEMOLISH_ORDER = [
     # Beaware of insertion order
-    Resource('instances', 'zone', None),
-    Resource('addresses', 'region', None),
-    Resource('disks', 'zone', None),
-    Resource('firewall-rules', None, None),
-    Resource('routes', None, None),
-    Resource('forwarding-rules', 'region', None),
-    Resource('backend-services', None, None),
-    Resource('target-pools', 'region', None),
-    Resource('instance-groups', 'zone', 'managed'),
-    Resource('instance-templates', None, None),
+    Resource('instances', 'zone', None, None),
+    Resource('addresses', 'region', None, None),
+    Resource('disks', 'zone', None, None),
+    Resource('firewall-rules', None, None, None),
+    Resource('routes', None, None, None),
+    Resource('forwarding-rules', 'region', None, None),
+    Resource('forwarding-rules', None, None, '--global'),
+    Resource('target-http-proxies', None, None, None),
+    Resource('url-maps', None, None, None),
+    Resource('backend-services', 'region', None, None),
+    Resource('backend-services', None, None, '--global'),
+    Resource('target-pools', 'region', None, None),
+    Resource('instance-groups', 'zone', 'Yes', None),
+    Resource('instance-groups', 'zone', 'No', None),
+    Resource('instance-templates', None, None, None),
 ]
 
 
@@ -50,7 +55,7 @@ def collect(project, age, resource, filt):
         resource: Definition of a type of gcloud resource.
         filt: Filter clause for gcloud list command.
     Returns:
-        A dict of condition : list of resource.
+        A dict of condition : list of gcloud resource object.
     """
 
     col = collections.defaultdict(list)
@@ -58,15 +63,16 @@ def collect(project, age, resource, filt):
     for item in json.loads(subprocess.check_output([
             'gcloud', 'compute', '-q',
             resource.name, 'list',
-            '--format=json(name,creationTimestamp.date(tz=UTC),zone,region)',
+            '--format=json(name,creationTimestamp.date(tz=UTC),zone,region,MANAGED)',
             '--filter=%s' % filt,
             '--project=%s' % project])):
 
-        if not item['name'] or not item['creationTimestamp']:
+        print '%s' % item
+
+        if 'name' not in item or 'creationTimestamp' not in item:
             print '[Warning] - Skip item without name or timestamp'
-            print '%s' % item
             continue
-        if resource.condition and not item[resource.condition]:
+        if resource.condition and resource.condition not in item:
             print '[Warning] - condition specified but not found'
             continue
 
@@ -75,9 +81,18 @@ def collect(project, age, resource, filt):
         else:
             colname = ''
 
+        if resource.managed:
+            if 'isManaged' not in item:
+                print '[Warning] - isManaged specified but not found'
+                continue
+            else:
+                if resource.managed != item['isManaged']:
+                    continue
+
         # Unify datetime to use utc timezone.
-        created = datetime.datetime.strptime(item['creationTimestamp'],'%Y-%m-%dT%H:%M:%S')
-        print 'Found %s, %s in %s, created time = %s' % (resource.name, item['name'], colname, item['creationTimestamp'])
+        created = datetime.datetime.strptime(item['creationTimestamp'], '%Y-%m-%dT%H:%M:%S')
+        print ('Found %s, %s in %s, created time = %s' %
+               (resource.name, item['name'], colname, item['creationTimestamp']))
         if created < age:
             print 'Added to janitor list: %s, %s' % (resource.name, item['name'])
             col[colname].append(item['name'])
@@ -97,64 +112,80 @@ def clear_resources(project, col, resource):
     """
     err = 0
     for col, items in col.items():
-        if args.dryrun:
+        if ARGS.dryrun:
             print 'Resource type %s to be deleted: %s' % (resource.name, list(items))
             continue
 
+        manage_key = {'Yes':'manage', 'No':'unmanaged'}
+
         # construct the customized gcloud commend
         base = ['gcloud', 'compute', '-q', resource.name]
-        if resource.status is not None:
-            base.append(resource.status)
+        if resource.managed:
+            base.append(manage_key[resource.managed])
         base.append('delete')
         base.append('--project=%s' % project)
+
         if resource.condition:
             base.append('--%s=%s' % (resource.condition, col))
 
-        print 'Try to kill %s - %s' % (col, list(items))
+        if resource.flags:
+            base.append(resource.flags)
+
+        print 'Call %s' % base
         try:
             subprocess.check_call(base + list(items))
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError as exc:
             err = 1
-            print >>sys.stderr, 'Error try to delete resources: %s' % e
+            print >>sys.stderr, 'Error try to delete resources: %s' % exc
     return err
 
 
 def main(project, days, hours, filt):
+    """ Clean up resources from a gcp project based on it's creation time
+
+    Args:
+        project: The name of a gcp project.
+        days/hours: days/hours of maximum lifetime of a gcp resource.
+        filt: Resource instance filters when query.
+    Returns:
+        0 if no error
+        1 if deletion command fails
+    """
+
     err = 0
     age = datetime.datetime.utcnow() - datetime.timedelta(days=days, hours=hours)
-    for r in DEMOLISH_ORDER:
-        print 'Try to search for %s with condition %s' % (r.name, r.condition)
-        col = collect(project, age, r, filt)
+    for res in DEMOLISH_ORDER:
+        print 'Try to search for %s with condition %s' % (res.name, res.condition)
+        col = collect(project, age, res, filt)
         if col:
-            err |= clear_resources(project, col, r)
+            err |= clear_resources(project, col, res)
     sys.exit(err)
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
+    PARSER = argparse.ArgumentParser(
         description='Clean up resources from an expired project')
-    parser.add_argument('--project', help='Project to clean', required=True)
-    parser.add_argument(
+    PARSER.add_argument('--project', help='Project to clean', required=True)
+    PARSER.add_argument(
         '--days', type=int,
         help='Clean items more than --days old (added to --hours)')
-    parser.add_argument(
+    PARSER.add_argument(
         '--hours', type=float,
         help='Clean items more than --hours old (added to --days)')
-    parser.add_argument(
+    PARSER.add_argument(
         '--filter',
         default='NOT tags.items:do-not-delete AND NOT name ~ ^default-route',
         help='Filter down to these instances')
-    parser.add_argument(
+    PARSER.add_argument(
         '--dryrun',
         default=False,
         action='store_true',
         help='list but not delete resources')
-    args = parser.parse_args()
+    ARGS = PARSER.parse_args()
 
     # We want to allow --days=0 and --hours=0, so check against None instead.
-    if args.days is None and args.hours is None:
+    if ARGS.days is None and ARGS.hours is None:
         print >>sys.stderr, 'must specify --days and/or --hours'
         sys.exit(1)
 
-    main(args.project, args.days or 0, args.hours or 0, args.filter)
-
+    main(ARGS.project, ARGS.days or 0, ARGS.hours or 0, ARGS.filter)

--- a/jenkins/janitor.py
+++ b/jenkins/janitor.py
@@ -56,6 +56,8 @@ def collect(project, age, resource, filt):
         filt: Filter clause for gcloud list command.
     Returns:
         A dict of condition : list of gcloud resource object.
+    Raises:
+        ValueError if json result from gcloud is invalid.
     """
 
     col = collections.defaultdict(list)
@@ -70,11 +72,10 @@ def collect(project, age, resource, filt):
         print '%s' % item
 
         if 'name' not in item or 'creationTimestamp' not in item:
-            print '[Warning] - Skip item without name or timestamp'
-            continue
+            raise ValueError('%s' % item)
+
         if resource.condition and resource.condition not in item:
-            print '[Warning] - condition specified but not found'
-            continue
+            raise ValueError(resource.condition)
 
         if resource.condition:
             colname = item[resource.condition]
@@ -83,8 +84,7 @@ def collect(project, age, resource, filt):
 
         if resource.managed:
             if 'isManaged' not in item:
-                print '[Warning] - isManaged specified but not found'
-                continue
+                raise ValueError(resource.managed)
             else:
                 if resource.managed != item['isManaged']:
                     continue

--- a/verify/verify-pylint.sh
+++ b/verify/verify-pylint.sh
@@ -20,5 +20,6 @@ set -o pipefail
 # TODO(fejta): all python files
 pylint scenarios/*.py
 pylint jenkins/bootstrap.py
+pylint jenkins/janitor.py
 pylint queue-health/graph/graph.py
 pylint queue-health/weekly_commit_stats.py


### PR DESCRIPTION
So forwarding-rules and backend-services can be either `--global` or `--region=REGION`.

And http-proxy and url-map need to be killed before shut down backend-services

```
NAME
    gcloud compute backend-services delete - delete backend services

SYNOPSIS
    gcloud compute backend-services delete NAME [NAME ...]
        [--global | --region=REGION] [GLOBAL-FLAG ...]
```
Also fixed a bunch of lint errors add it to pylint list.

#1573 