### PR TITLE
Purge the bazel cache so that we can use git cache.

### DIFF
--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -48,4 +48,8 @@ esac
 
 ./images/pull-kubernetes-bazel/coalesce.py
 
+# TODO(spxtr): Remove this once we've purged the cache on all nodes.
+bazel clean
+rm -rf /root/.cache
+
 exit "${rc}"

--- a/prow/presubmit.yaml
+++ b/prow/presubmit.yaml
@@ -185,9 +185,10 @@ kubernetes/test-infra:
       args:
       - "--pull=$(PULL_REFS)"
       - "--upload=gs://kubernetes-jenkins/pr-logs"
+      - "--git-cache=/root/.cache/git"
       volumeMounts:
       - name: cache-ssd
-        mountPath: /root/.cache/bazel
+        mountPath: /root/.cache
       # We only want one of these to run per node. Once pod affinity is GA, use
       # that. Until then, use a hostPort. This must match other bazel jobs.
       ports:


### PR DESCRIPTION
This is going to make bazel builds slower, but it prepares us for them to get much faster.

It should be safe, but I'll keep an eye on it.