### PR TITLE
Use dockerized version of conformance, since it's working now

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -165,13 +165,6 @@
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 90
-    - kubernetes-node-kubelet-conformance-dockerized:  # senlu, temp
-        branch: master
-        frequency: 'H/30 * * * *'
-        job-name: ci-kubernetes-node-kubelet-conformance-dockerized
-        json: 1
-        repo-name: k8s.io/kubernetes
-        timeout: 90
     - kubernetes-node-kubelet-cri:  # yjhong
         branch: master
         frequency: 'H/30 * * * *'

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -126,15 +126,6 @@
 },
 
 "ci-kubernetes-node-kubelet-conformance": {
-  "scenario": "execute",
-  "todo": "Merge with -dockerized",
-  "args": [
-    "test/e2e_node/jenkins/conformance/conformance-jenkins.sh",
-    "test/e2e_node/jenkins/conformance/jenkins-conformance.properties"
-  ]
-},
-
-"ci-kubernetes-node-kubelet-conformance-dockerized": {
   "scenario": "kubernetes_kubelet",
   "args": [
     "--properties=test/e2e_node/jenkins/conformance/jenkins-conformance.properties",

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -756,8 +756,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-flaky
 - name: ci-kubernetes-node-kubelet-conformance
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-conformance
-- name: ci-kubernetes-node-kubelet-conformance-dockerized
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-conformance-dockerized
 - name: kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
 - name: kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master
@@ -1301,8 +1299,6 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet-flaky
   - name: kubelet-conformance-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-conformance
-  - name: kubelet-conformance-gce-e2e-dockerized
-    test_group_name: ci-kubernetes-node-kubelet-conformance-dockerized
   - name: kubelet-1.4
     test_group_name: ci-kubernetes-node-kubelet-1.4
   - name: kubelet-1.5


### PR DESCRIPTION
It's [green](http://k8s-testgrid.appspot.com/google-node#kubelet-conformance-gce-e2e-dockerized) now after fix https://github.com/kubernetes/kubernetes/pull/40250

Plus the old one is failing due to old go version on Jenkins.