### PR TITLE
Upload to path using k8s version instead of git sha1

### DIFF
--- a/jobs/ci-kubernetes-bazel.sh
+++ b/jobs/ci-kubernetes-bazel.sh
@@ -29,7 +29,13 @@ if [[ "${rc}" == 0 ]]; then
 fi
 
 if [[ "${rc}" == 0 ]]; then
-  bazel run //:ci-artifacts -- "gs://kubernetes-release-dev/bazel/$(git rev-parse HEAD)" && rc=$? || rc=$?
+  version=$(cat bazel-genfiles/version || true)
+  if [[ -z "${version}" ]]; then
+    echo "Kubernetes version missing; not uploading ci artifacts."
+    rc=1
+  else
+    bazel run //:ci-artifacts -- "gs://kubernetes-release-dev/bazel/${version}" && rc=$? || rc=$?
+  fi
 fi
 
 # Coalesce test results into one file for upload.


### PR DESCRIPTION
Only really has an effect once https://github.com/kubernetes/kubernetes/pull/40333 merges.