### PR TITLE
Make Gubernator track "needs attention" times

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -149,6 +149,8 @@ def do_render_status(payload, user):
         text = 'LGTM'
     elif user in payload.get('attn', {}):
         text = payload['attn'][user].title()
+        if '#' in text:  # strip start/end attn timestamps
+            text = text[:text.index('#')]
 
     for ctx, (state, _url, desc) in payload.get('status', {}).items():
         if ctx == 'Submit Queue' and state == 'pending':

--- a/gubernator/github/app.yaml
+++ b/gubernator/github/app.yaml
@@ -11,6 +11,7 @@ handlers:
   script: admin.app
 - url: /admin.*
   script: admin.app
+  login: admin
 - url: .*
   script: main.app
 

--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -14,7 +14,6 @@
 
 import logging
 import re
-import json
 
 import models
 
@@ -40,7 +39,7 @@ def classify_issue(repo, number):
     events = list(models.GithubWebhookRaw.query(ancestor=ancestor))
     events.sort(key=lambda e: e.timestamp)
     logging.debug('classifying %s %s (%d events)', repo, number, len(events))
-    event_tuples = [(event.event, json.loads(event.body), event.timestamp) for event in events]
+    event_tuples = [event.to_tuple() for event in events]
 
     last_event_timestamp = events[-1].timestamp
     merged = get_merged(event_tuples)
@@ -243,62 +242,80 @@ def distill_events(events):
     skip_comments = get_skip_comments(events, bots)
 
     output = []
-    for event, body, _timestamp in events:
+    for event, body, timestamp in events:
         action = body.get('action')
         user = body.get('sender', {}).get('login')
         if event in ('issue_comment', 'pull_request_review_comment'):
             if body['comment']['id'] in skip_comments:
                 continue
             if action == 'created':
-                output.append(('comment', user))
+                output.append(('comment', user, timestamp))
         if event == 'pull_request':
             if action in ('opened', 'reopened', 'synchronize'):
-                output.append(('push', user))
+                output.append(('push', user, timestamp))
             if action == 'labeled' and 'label' in body:
-                output.append(('label ' + body['label']['name'].lower(), user))
+                output.append(('label ' + body['label']['name'].lower(), user, timestamp))
     return output
+
+
+def evaluate_fsm(events, start, transitions):
+    '''
+    Given a series of event tuples and a start state, execute the list of transitions
+    and return the resulting state, the time it entered that state, and the last time
+    the state would be entered (self-transitions are allowed).
+
+    transitions is a list of tuples
+    (state_before str, state_after str, condition str or callable)
+
+    The transition occurs if condition equals the action (as a str), or if
+    condition(action, user) is True.
+    '''
+    state = start
+    state_start = 0 # time that we entered this state
+    state_last = 0  # time of last transition into this state
+    for action, user, timestamp in events:
+        for state_before, state_after, condition in transitions:
+            if state_before is None or state_before == state:
+                if condition == action or (callable(condition) and condition(action, user)):
+                    if state_after != state:
+                        state_start = timestamp
+                    state = state_after
+                    state_last = timestamp
+                    break
+    return state, state_start, state_last
 
 
 def get_author_state(author, distilled_events):
     '''
     Determine the state of the author given a series of distilled events.
     '''
-    state = 'waiting'
-    for action, user in distilled_events:
-        if state == 'waiting':
-            if action == 'comment' and user != author:
-                state = 'address comments'
-        elif state == 'address comments':
-            if action == 'push':
-                state = 'waiting'
-            elif action == 'comment' and user == author:
-                state = 'waiting'
-    return state
+    return evaluate_fsm(distilled_events, start='waiting', transitions=[
+        # before, after, condition
+        (None, 'address comments', lambda a, u: a == 'comment' and u != author),
+        ('address comments', 'waiting', 'push'),
+        ('address comments', 'waiting', lambda a, u: a == 'comment' and u == author),
+    ])
 
 
 def get_assignee_state(assignee, author, distilled_events):
     '''
     Determine the state of an assignee given a series of distilled events.
     '''
-    state = 'needs review'
-    for action, user in distilled_events:
-        if state == 'needs review':
-            if user == assignee:
-                if action == 'comment':
-                    state = 'waiting'
-                if action == 'label lgtm':
-                    state = 'waiting'
-        elif state == 'waiting':
-            if action == 'push':
-                state = 'needs review'
-            elif action == 'comment' and user == author:
-                state = 'needs review'
-    return state
+    return evaluate_fsm(distilled_events, start='needs review', transitions=[
+        # before, after, condition
+        ('needs review', 'waiting', lambda a, u: u == assignee and a in ('comment', 'label lgtm')),
+        (None, 'needs review', 'push'),
+        (None, 'needs review', lambda a, u: a == 'comment' and u == author),
+    ])
 
 
 def calculate_attention(distilled_events, payload):
     '''
     Given information about an issue, determine who should look at it.
+
+    It can include start and last update time for various states --
+    "address comments#123#456" means that something has been in 'address comments' since
+    123, and there was some other event that put it in 'address comments' at 456.
     '''
     author = payload['author']
     assignees = payload['assignees']
@@ -312,13 +329,13 @@ def calculate_attention(distilled_events, payload):
         notify(author, 'fix tests')
 
     for assignee in assignees:
-        assignee_state = get_assignee_state(assignee, author, distilled_events)
+        assignee_state, first, last = get_assignee_state(assignee, author, distilled_events)
         if assignee_state != 'waiting':
-            notify(assignee, assignee_state)
+            notify(assignee, '%s#%s#%s' % (assignee_state, first, last))
 
-    author_state = get_author_state(author, distilled_events)
+    author_state, first, last = get_author_state(author, distilled_events)
     if author_state != 'waiting':
-        notify(author, author_state)
+        notify(author, '%s#%s#%s' % (author_state, first, last))
 
     if payload.get('needs_rebase'):
         notify(author, 'needs rebase')

--- a/gubernator/github/classifier_test.py
+++ b/gubernator/github/classifier_test.py
@@ -27,7 +27,7 @@ class MergedTest(unittest.TestCase):
             {'c': 4},
             {'issue': {'n': 3, 'd': 4},
              'pull_request': {'n': 4, 'e': 5}}
-        ])), {'n': 4, 'a': 2, 'b': 3, 'd': 4, 'e': 5})
+        ], [0] * 4)), {'n': 4, 'a': 2, 'b': 3, 'd': 4, 'e': 5})
 
 
 def diffs_to_events(*diffs):
@@ -40,7 +40,7 @@ def diffs_to_events(*diffs):
             action = 'unlabeled'
         events.append(('pull_request',
                        {'action': action,
-                        'label': label}))
+                        'label': label}, 0))
     return events
 
 
@@ -50,13 +50,13 @@ class LabelsTest(unittest.TestCase):
         self.assertEqual(sorted(labels.keys()), sorted(names))
 
     def test_empty(self):
-        self.expect_labels([('comment', {'body': 'no labels here'})], [])
+        self.expect_labels([('comment', {'body': 'no labels here'}, 0)], [])
 
     def test_colors(self):
         self.assertEqual(classifier.get_labels(
                 [('c', {'issue':
                         {'labels': [{'name': 'foo', 'color': '#abc'}]}
-            })]),
+                        }, 0)]),
             {'foo': '#abc'})
 
     def test_labeled_action(self):
@@ -68,10 +68,10 @@ class LabelsTest(unittest.TestCase):
     def test_issue_overrides_action(self):
         labels = [{'name': 'x', 'color': 'y'}]
         self.expect_labels(diffs_to_events('+a') +
-            [('other_event', {'issue': {'labels': labels}})], ['x'])
+            [('other_event', {'issue': {'labels': labels}}, 0)], ['x'])
 
     def test_labeled_action_missing_label(self):
-        self.expect_labels([('pull_request', {'action': 'labeled'})], [])
+        self.expect_labels([('pull_request', {'action': 'labeled'}, 0)], [])
 
 
 def make_comment_event(num, name, msg='', event='issue_comment',
@@ -85,7 +85,7 @@ def make_comment_event(num, name, msg='', event='issue_comment',
             'body': msg,
             'created_at': ts,
         }
-    }
+    }, 0
 
 
 class CalculateTest(unittest.TestCase):
@@ -103,13 +103,13 @@ class CalculateTest(unittest.TestCase):
                         'additions': 1,
                         'deletions': 1,
                     }
-                }),
+                }, 0),
                 make_comment_event(1, 'k8s-bot',
                     'failure in https://k8s-gubernator.appspot.com/build/bucket/job/123/'),
                 ('pull_request', {
                     'action': 'labeled',
                     'label': {'name': 'release-note-none', 'color': 'orange'},
-                })
+                }, 0)
             ], {'e2e': ['failure', None, 'stuff is broken']}
         ),
         (True, True, ['a', 'b'],
@@ -134,9 +134,9 @@ class CalculateTest(unittest.TestCase):
             make_comment_event(1, 'a', action='deleted'),
             make_comment_event(3, 'c', event='pull_request_review_comment'),
             make_comment_event(4, 'k8s-bot'),
-            ('pull_request', {'action': 'synchronize', 'sender': {'login': 'auth'}}),
+            ('pull_request', {'action': 'synchronize', 'sender': {'login': 'auth'}}, 0),
             ('pull_request', {'action': 'labeled', 'sender': {'login': 'rev'},
-                'label': {'name': 'lgtm'}}),
+                'label': {'name': 'lgtm'}}, 0),
         ]),
         [
             ('comment', 'b'),

--- a/gubernator/github/classifier_test.py
+++ b/gubernator/github/classifier_test.py
@@ -85,7 +85,7 @@ def make_comment_event(num, name, msg='', event='issue_comment',
             'body': msg,
             'created_at': ts,
         }
-    }, 0
+    }, ts
 
 
 class CalculateTest(unittest.TestCase):
@@ -103,13 +103,13 @@ class CalculateTest(unittest.TestCase):
                         'additions': 1,
                         'deletions': 1,
                     }
-                }, 0),
+                }, 1),
                 make_comment_event(1, 'k8s-bot',
-                    'failure in https://k8s-gubernator.appspot.com/build/bucket/job/123/'),
+                    'failure in https://k8s-gubernator.appspot.com/build/bucket/job/123/', ts=2),
                 ('pull_request', {
                     'action': 'labeled',
                     'label': {'name': 'release-note-none', 'color': 'orange'},
-                }, 0)
+                }, 3)
             ], {'e2e': ['failure', None, 'stuff is broken']}
         ),
         (True, True, ['a', 'b'],
@@ -118,7 +118,7 @@ class CalculateTest(unittest.TestCase):
             'assignees': ['b'],
             'additions': 1,
             'deletions': 1,
-            'attn': {'a': 'fix tests', 'b': 'needs review'},
+            'attn': {'a': 'fix tests', 'b': 'needs review#0#0'},
             'title': 'some fix',
             'labels': {'release-note-none': 'orange'},
             'head': 'abcdef',
@@ -129,20 +129,20 @@ class CalculateTest(unittest.TestCase):
 
     def test_distill(self):
         self.assertEqual(classifier.distill_events([
-            make_comment_event(1, 'a'),
-            make_comment_event(2, 'b'),
-            make_comment_event(1, 'a', action='deleted'),
-            make_comment_event(3, 'c', event='pull_request_review_comment'),
-            make_comment_event(4, 'k8s-bot'),
-            ('pull_request', {'action': 'synchronize', 'sender': {'login': 'auth'}}, 0),
+            make_comment_event(1, 'a', ts=1),
+            make_comment_event(2, 'b', ts=2),
+            make_comment_event(1, 'a', action='deleted', ts=3),
+            make_comment_event(3, 'c', event='pull_request_review_comment', ts=4),
+            make_comment_event(4, 'k8s-bot', ts=4),
+            ('pull_request', {'action': 'synchronize', 'sender': {'login': 'auth'}}, 5),
             ('pull_request', {'action': 'labeled', 'sender': {'login': 'rev'},
-                'label': {'name': 'lgtm'}}, 0),
+                'label': {'name': 'lgtm'}}, 6),
         ]),
         [
-            ('comment', 'b'),
-            ('comment', 'c'),
-            ('push', 'auth'),
-            ('label lgtm', 'rev'),
+            ('comment', 'b', 2),
+            ('comment', 'c', 4),
+            ('push', 'auth', 5),
+            ('label lgtm', 'rev', 6),
         ])
 
     def test_calculate_attention(self):
@@ -162,35 +162,38 @@ class CalculateTest(unittest.TestCase):
         expect(make_payload('gamma', status={'ci': ['failure', '', '']}), [],
             {'gamma': 'fix tests'})
         expect(make_payload('gamma', status={'ci': ['failure', '', '']}),
-            [('comment', 'other')],
-            {'gamma': 'address comments'})
+            [('comment', 'other', 1)],
+            {'gamma': 'address comments#1#1'})
         expect(make_payload('delta', ['epsilon']), [],
-            {'epsilon': 'needs review'})
+            {'epsilon': 'needs review#0#0'})
 
-        expect(make_payload('alpha', ['alpha']), [('comment', 'other')],
-            {'alpha': 'address comments'})
+        expect(make_payload('alpha', ['alpha']), [('comment', 'other', 1)],
+            {'alpha': 'address comments#1#1'})
 
     def test_author_state(self):
         def expect(events, result):
             self.assertEqual(classifier.get_author_state('author', events),
                              result)
-        expect([], 'waiting')
-        expect([('comment', 'author')], 'waiting')
-        expect([('comment', 'other')], 'address comments')
-        expect([('comment', 'other'), ('push', 'author')], 'waiting')
-        expect([('comment', 'other'), ('comment', 'author')], 'waiting')
+        expect([], ('waiting', 0, 0))
+        expect([('comment', 'author', 1)], ('waiting', 0, 0))
+        expect([('comment', 'other', 1)], ('address comments', 1, 1))
+        expect([('comment', 'other', 1), ('push', 'author', 2)], ('waiting', 2, 2))
+        expect([('comment', 'other', 1), ('comment', 'author', 2)], ('waiting', 2, 2))
+        expect([('comment', 'other', 1), ('comment', 'other', 2)], ('address comments', 1, 2))
 
     def test_assignee_state(self):
         def expect(events, result):
             self.assertEqual(classifier.get_assignee_state('me', 'author', events),
                              result)
-        expect([], 'needs review')
-        expect([('comment', 'other')], 'needs review')
-        expect([('comment', 'me')], 'waiting')
-        expect([('label lgtm', 'other')], 'needs review')
-        expect([('label lgtm', 'me')], 'waiting')
-        expect([('comment', 'me'), ('push', 'author')], 'needs review')
-        expect([('comment', 'me'), ('comment', 'author')], 'needs review')
+        expect([], ('needs review', 0, 0))
+        expect([('comment', 'other', 1)], ('needs review', 0, 0))
+        expect([('comment', 'me', 1)], ('waiting', 1, 1))
+        expect([('label lgtm', 'other', 1)], ('needs review', 0, 0))
+        expect([('label lgtm', 'me', 1)], ('waiting', 1, 1))
+        expect([('comment', 'me', 1), ('push', 'author', 2)], ('needs review', 2, 2))
+        expect([('comment', 'me', 1), ('comment', 'author', 2)], ('needs review', 2, 2))
+        expect([('comment', 'me', 1), ('comment', 'author', 2), ('comment', 'author', 3)],
+               ('needs review', 2, 3))
 
     def test_xrefs(self):
         def expect(body, comments, result):

--- a/gubernator/github/handlers.py
+++ b/gubernator/github/handlers.py
@@ -201,9 +201,9 @@ class Timeline(BaseHandler):
 
         self.response.write('<h3>Distilled Events</h3>')
         self.response.write('<pre>')
-        event_pairs = [(event.event, json.loads(event.body)) for event in events]
+        event_pairs = [event.to_tuple() for event in events]
         for ev in classifier.distill_events(event_pairs):
-            self.response.write(cgi.escape('%s, %s\n' % ev))
+            self.response.write(cgi.escape('%s, %s %s\n' % ev))
         self.response.write('</pre>')
 
         self.response.write('<h3>%d Raw Events</h3>' % (len(events)))

--- a/gubernator/github/models.py
+++ b/gubernator/github/models.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import json
 
 import google.appengine.ext.ndb as ndb
 
@@ -31,6 +32,9 @@ class GithubWebhookRaw(ndb.Model):
     event = ndb.StringProperty()
     timestamp = ndb.DateTimeProperty(auto_now_add=True)
     body = ndb.TextProperty(compressed=True)
+
+    def to_tuple(self):
+        return (self.event, json.loads(self.body), int(self.timestamp.strftime('%s')))
 
 
 def from_iso8601(t):


### PR DESCRIPTION
This is the half the backend work needed to support acks-- the user interface for clicking an ack button and having it hide something is still in progress.