### PR TITLE
Move b.gcr.io/k8s-test-infra-aws/aws-janitor to gcr.io/k8s-test-infa-aws/aws-janitor

### DIFF
--- a/jenkins/aws-janitor/Makefile
+++ b/jenkins/aws-janitor/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE ?= b.gcr.io/k8s-test-infra-aws/aws-janitor
+IMAGE ?= gcr.io/k8s-test-infra-aws/aws-janitor
 VERSION ?= 0.2
 
 image:

--- a/jobs/maintenance-ci-aws-janitor.sh
+++ b/jobs/maintenance-ci-aws-janitor.sh
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-JANITOR=${AWS_JANITOR_IMAGE:-b.gcr.io/k8s-test-infra-aws/aws-janitor}
+JANITOR=${AWS_JANITOR_IMAGE:-gcr.io/k8s-test-infra-aws/aws-janitor}
 
 docker pull "${JANITOR}"
 docker run -v "${JENKINS_AWS_CREDENTIALS_FILE}:/root/.aws/credentials:ro" "${JANITOR}" \


### PR DESCRIPTION
I created an entirely new project and moved it over.

b.gcr.io will be deprecated soon: https://cloud.google.com/container-registry/docs/support/deprecation-notices