### PR TITLE
Pull e2e.go from test-infra

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -67,7 +67,7 @@ RUN mkdir -p /tmp/terraform/ && \
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh", \
-    "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/e2e.go", \
+    "https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest/e2e.go", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/forked/shell2junit/sh2ju.sh", \
     "/workspace/"]


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/pull/40374
ref kubernetes/test-infra#1475

We'll soon start compiling kubetest and using multiple files. So I'll need to further adjust this, but this will do for now.