### PR TITLE
Only remove bootstrap-upstream remote if it exists

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -12,3 +12,4 @@ max-args=12
 
 [SIMILARITIES]
 ignore-imports=yes
+min-similarity-lines=100

--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -39,6 +39,12 @@ VERSION_TAG = {
 }
 
 
+def check_output(*cmd):
+    """Log and run the command, return output, raising on errors."""
+    print >>sys.stderr, 'Run:', cmd
+    return subprocess.check_output(cmd)
+
+
 def check(*cmd):
     """Log and run the command, raising on errors."""
     print >>sys.stderr, 'Run:', cmd
@@ -61,10 +67,10 @@ def main(branch, script, force):
     check('rm', '-rf', '.gsutil')
     remote = 'bootstrap-upstream'
     uri = 'https://github.com/kubernetes/kubernetes.git'
-    try:
+
+    current_remotes = check_output(['git', 'remote'])
+    if re.search('^%s$' % remote, current_remotes, flags=re.MULTILINE):
         check('git', 'remote', 'remove', remote)
-    except subprocess.CalledProcessError:
-        pass
     check('git', 'remote', 'add', remote, uri)
     check('git', 'remote', 'set-url', '--push', remote, 'no_push')
     # If .git is cached between runs this data may be stale


### PR DESCRIPTION
The verify job is pretty much always printing
```
W0124 15:37:03.721] Run: ('git', 'remote', 'remove', 'bootstrap-upstream')
W0124 15:37:03.794] error: Could not remove config section 'remote.bootstrap-upstream'
```

which confuses Gubernator and developers alike.

cc @zmerlynn 