### PR TITLE
Cleanup etcd3 configuration in tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.sh
@@ -49,10 +49,7 @@ export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
 # Increase delete collection parallelism
 export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
 # =========================================
-# Configuration we are targetting in 1.5
-export TEST_ETCD_IMAGE="3.0.14-experimental.1"
-export TEST_ETCD_VERSION="3.0.14"
-export STORAGE_BACKEND="etcd3"
+# Configuration we are targetting in 1.6
 export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
 export KUBE_NODE_OS_DISTRIBUTION="gci"
 

--- a/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-teardown.sh
@@ -49,10 +49,7 @@ export TEST_CLUSTER_RESYNC_PERIOD="--min-resync-period=12h"
 # Increase delete collection parallelism
 export TEST_CLUSTER_DELETE_COLLECTION_WORKERS="--delete-collection-workers=16"
 # =========================================
-# Configuration we are targetting in 1.5
-export TEST_ETCD_IMAGE="3.0.14-experimental.1"
-export TEST_ETCD_VERSION="3.0.14"
-export STORAGE_BACKEND="etcd3"
+# Configuration we are targetting in 1.6
 export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
 export KUBE_NODE_OS_DISTRIBUTION="gci"
 

--- a/jobs/ci-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3.sh
@@ -34,12 +34,7 @@ export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
 export GINKGO_PARALLEL="y"
 export PROJECT="k8s-jkns-e2e-etcd3"
-# Use etcd3 as storage backend.
-export STORAGE_BACKEND="etcd3"
 export KUBE_NODE_OS_DISTRIBUTION="debian"
-# Use new image for etcd.
-export TEST_ETCD_IMAGE="3.0.14-experimental.1"
-export TEST_ETCD_VERSION="3.0.14"
 
 ### post-env
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
+++ b/jobs/ci-kubernetes-e2e-gci-gce-etcd3.sh
@@ -35,12 +35,7 @@ export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 export GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
 export GINKGO_PARALLEL="y"
 export PROJECT="k8s-jkns-gci-etcd3"
-# Use etcd3 as storage backend.
-export STORAGE_BACKEND="etcd3"
 export KUBE_NODE_OS_DISTRIBUTION="gci"
-# Use new image for etcd.
-export TEST_ETCD_IMAGE="3.0.14-experimental.1"
-export TEST_ETCD_VERSION="3.0.14"
 
 ### post-env
 

--- a/jobs/ci-kubernetes-kubemark-gce-scale.sh
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.sh
@@ -56,10 +56,7 @@ export MASTER_DISK_SIZE="100GB"
 export KUBEMARK_NUM_NODES="5000"
 export KUBE_GCE_ZONE="us-central1-b"
 # =========================================
-# Configuration we are targetting in 1.5
-export TEST_ETCD_IMAGE="3.0.14-experimental.1"
-export TEST_ETCD_VERSION="3.0.14"
-export STORAGE_BACKEND="etcd3"
+# Configuration we are targetting in 1.6
 export TEST_CLUSTER_STORAGE_CONTENT_TYPE="--storage-media-type=application/vnd.kubernetes.protobuf"
 # The kubemark scripts build a Docker image
 export JENKINS_ENABLE_DOCKER_IN_DOCKER="y"

--- a/jobs/pull-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.sh
@@ -48,10 +48,6 @@ export PROJECT="k8s-jkns-pr-gce-etcd3"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 export NUM_NODES="4"
 export GINKGO_PARALLEL_NODES="30"
-# Use etcd3 as storage backend.
-export STORAGE_BACKEND="etcd3"
-export TEST_ETCD_IMAGE="3.0.14-experimental.1"
-export TEST_ETCD_VERSION="3.0.14"
 
 # Force to use container-vm.
 export KUBE_NODE_OS_DISTRIBUTION="debian"


### PR DESCRIPTION
Etcd v3 is now a default, so there is no need to specify it explicitly.