### PR TITLE
mungebot: Command.Name is always upper-cased

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	approvalNotificationName = "ApprovalNotifier"
-	approveCommand           = "approve"
+	approveCommand           = "APPROVE"
 	cancel                   = "cancel"
 	ownersFileName           = "OWNERS"
 )


### PR DESCRIPTION
This breaks the detection of approval command as the matcher always
upper-cases the command name. Let's make sure we compare apples to
apples (all upper-case).