### PR TITLE
Use k8s version instead of git sha1 for PR bazel builds too

### DIFF
--- a/jobs/pull-kubernetes-bazel.sh
+++ b/jobs/pull-kubernetes-bazel.sh
@@ -30,7 +30,13 @@ if [[ "${rc}" == 0 ]]; then
 fi
 
 if [[ "${rc}" == 0 ]]; then
-  bazel run //:ci-artifacts -- "gs://kubernetes-release-dev/bazel/$(git rev-parse HEAD)" && rc=$? || rc=$?
+  version=$(cat bazel-genfiles/version || true)
+  if [[ -z "${version}" ]]; then
+    echo "Kubernetes version missing; not uploading ci artifacts."
+    rc=1
+  else
+    bazel run //:ci-artifacts -- "gs://kubernetes-release-dev/bazel/${version}" && rc=$? || rc=$?
+  fi
 fi
 
 # Coalesce test results into one file for upload.


### PR DESCRIPTION
I forgot that CI and PR use separate scripts.

Do we want to use a different GCS path for CI vs. PR? Right now they're sharing the same location.
(Should we even be uploading artifacts for PRs?)

cc @mikedanese @pipejakob 