### PR TITLE
Make the mungegithub/mungers tests go faster.

### DIFF
--- a/mungegithub/mungers/stale-green-ci_test.go
+++ b/mungegithub/mungers/stale-green-ci_test.go
@@ -70,6 +70,9 @@ func OldStatus() *github.CombinedStatus {
 func TestOldUnitTestMunge(t *testing.T) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
+	// Avoid a 5 second delay
+	github_util.SetCombinedStatusLifetime(time.Millisecond)
+
 	tests := []struct {
 		name     string
 		tested   bool
@@ -128,9 +131,11 @@ func TestOldUnitTestMunge(t *testing.T) {
 			w.Write(data)
 		})
 
-		config := &github_util.Config{}
-		config.Org = "o"
-		config.Project = "r"
+		config := &github_util.Config{
+			Org:          "o",
+			Project:      "r",
+			BaseWaitTime: time.Nanosecond, // Avoid a 30 second delay
+		}
 		config.SetClient(client)
 
 		s := StaleGreenCI{}

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -207,7 +207,7 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 	sq.BlockingJobNames = []string{"foo"}
 	sq.WeakStableJobNames = []string{"bar"}
 	sq.githubE2EQueue = map[int]*github_util.MungeObject{}
-	sq.githubE2EPollTime = 50 * time.Millisecond
+	sq.githubE2EPollTime = time.Millisecond
 
 	sq.clock = utilclock.NewFakeClock(time.Time{})
 	sq.lastMergeTime = sq.clock.Now()


### PR DESCRIPTION
There's no need to sleep for 5 seconds\*6 or 50 milliseconds\*30 in tests.

Fixes #1682.