### PR TITLE
Revert "Enable secrets in kubemark-scale"

### DIFF
--- a/jobs/ci-kubernetes-kubemark-gce-scale.sh
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.sh
@@ -64,6 +64,8 @@ export KUBE_NODE_OS_DISTRIBUTION="gci"
 
 # TODO: revert after running experiments.
 export EVENT_PD="true"
+# TODO remove after #19188 is fixed
+export CUSTOM_ADMISSION_PLUGINS="NamespaceLifecycle,LimitRanger,ResourceQuota"
 # TODO: Reduce this once we have log rotation in Kubemark.
 export KUBEMARK_MASTER_ROOT_DISK_SIZE="100GB"
 


### PR DESCRIPTION
Temporarily disable secrets in kubemark-scale, until improvements are merge in the main repo.
This is to allow me for more profiling.