### PR TITLE
mungegithub: Run approval-handler before submit-queue

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -7,7 +7,9 @@ data:
   config.http-cache-dir: /cache/httpcache
   config.organization: kubernetes
   config.project: contrib
-  config.pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,needs-rebase,approval-handler
+  # Make sure approval-handler and blunderbuss run before submit-queue.
+  # Otherwise it's going to take an extra-cycle to detect the label change.
+  config.pr-mungers: approval-handler,blunderbuss,lgtm-after-commit,submit-queue,needs-rebase
   config.state: open
   config.token-file: /etc/secret-volume/token
   gitrepo.repo-dir: /gitrepos

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -7,7 +7,9 @@ data:
   config.http-cache-dir: /cache/httpcache
   config.organization: kubernetes
   config.project: kubernetes
-  config.pr-mungers: blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,path-label,size,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter,close-stale-pr,docs-need-no-retest,approval-handler
+  # Make sure approval-handler and blunderbuss run before submit-queue.
+  # Otherwise it's going to take an extra-cycle to detect the label change.
+  config.pr-mungers: approval-handler,blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,path-label,size,stale-green-ci,block-path,release-note-label,comment-deleter,submit-queue,issue-cacher,flake-manager,old-test-getter,close-stale-pr,docs-need-no-retest
   config.state: open
   config.token-file: /etc/secret-volume/token
 


### PR DESCRIPTION
The goal is to be able to merge a pull-request that has just been
approved in only one cycle rather than two. Right now, the submit-queue
will read the approved label one cycle later because the mungers runs
after all others. Change the order of mungers to fix that.