### PR TITLE
let client-go release-2.0 track kubernetes release-1.5

### DIFF
--- a/mungegithub/mungers/publish.sh
+++ b/mungegithub/mungers/publish.sh
@@ -18,14 +18,15 @@ set -o nounset
 set -o pipefail
 
 echo $@
-if [ ! $# -eq 4 ]; then
-    echo "usage: publish.sh destination_dir token temp_mem_dir commit_message. destination_dir and temp_mem_dir are expected to be absolute paths."
+if [ ! $# -eq 5 ]; then
+    echo "usage: publish.sh destination_dir destination_branch token netrc_dir commit_message. destination_dir and netrc_dir are expected to be absolute paths."
     exit 1
 fi
 DST="${1}"
-TOKEN="${2}"
-NETRCDIR="${3}"
-MESSAGE="${4}"
+DST_BRANCH="${2}"
+TOKEN="${3}"
+NETRCDIR="${4}"
+MESSAGE="${5}"
 # set up github token
 echo "machine github.com login ${TOKEN}" > "${NETRCDIR}"/.netrc
 rm -f ~/.netrc
@@ -42,7 +43,7 @@ if git diff --cached --exit-code &>/dev/null; then
     exit 0
 fi
 git commit -m "${MESSAGE}"
-git push origin master
+git push origin "${DST_BRANCH}"
 popd > /dev/null
 rm -f ~/.netrc
 rm -f "${NETRCDIR}"/.netrc


### PR DESCRIPTION
Refactored the robot to be able to publish to a branch other than the master branch.

After I deploy the change, the robot will publish the staging area in the **{kubernetes repo, release-1.5 branch}** to the **{client-go repo, release-2.0 branch}**.

See the last commits in my forks of client-go from for an example: https://github.com/caesarxuchao/client-go/commits/release-2.0
https://github.com/caesarxuchao/client-go/commits/master