### PR TITLE
Approval Persists

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -97,8 +97,7 @@ func (h *ApprovalHandler) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	comments, ok := getCommentsAfterLastModified(obj)
-
+	comments, ok := obj.ListComments()
 	if !ok {
 		return
 	}
@@ -409,18 +408,4 @@ func (h ApprovalHandler) getApprovedOwners(files []*githubapi.CommitFile, approv
 		ownersApprovers[fn] = sets.NewString()
 	}
 	return ownersApprovers
-}
-
-// gets the comments since the obj was last changed.  If we can't figure out when the object was last changed
-// return all the comments on the issue
-func getCommentsAfterLastModified(obj *github.MungeObject) ([]*githubapi.IssueComment, bool) {
-	comments, ok := obj.ListComments()
-	if !ok {
-		return comments, ok
-	}
-	lastModified, ok := obj.LastModifiedTime()
-	if !ok {
-		return comments, ok
-	}
-	return c.FilterComments(comments, c.CreatedAfter(*lastModified)), true
 }

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -874,7 +874,6 @@ const (
 	noLGTM                  = "PR does not have " + lgtmLabel + " label."
 	noApproved              = "PR does not have " + approvedLabel + " label."
 	lgtmEarly               = "The PR was changed after the " + lgtmLabel + " label was added."
-	approvedEarly           = "The PR was changed after the " + approvedLabel + " label was added."
 	unmergeable             = "PR is unable to be automatically merged. Needs rebase."
 	undeterminedMergability = "Unable to determine is PR is mergeable. Will try again later."
 	noMerge                 = "Will not auto merge because " + doNotMergeLabel + " is present"
@@ -981,14 +980,6 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 	if sq.GateApproved {
 		if !obj.HasLabel(approvedLabel) {
 			sq.SetMergeStatus(obj, noApproved)
-			return false
-		}
-		// PR cannot change since approvedLabel was added
-		if after, ok := obj.ModifiedAfterLabeled(approvedLabel); !ok {
-			sq.SetMergeStatus(obj, unknown)
-			return false
-		} else if after {
-			sq.SetMergeStatus(obj, approvedEarly)
 			return false
 		}
 	}

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -845,14 +845,24 @@ func TestSubmitQueue(t *testing.T) {
 			state:           "pending",
 		},
 		{
-			name:     "Fail because changed after approval",
-			pr:       ValidPR(),
-			issue:    LGTMApprovedIssue(),
-			events:   OldApprovedEvents(),
-			commits:  Commits(), // Modified at time.Unix(7), 8, and 9
-			ciStatus: SuccessStatus(),
-			reason:   approvedEarly,
-			state:    "pending",
+			name:            "Approval Can Happen Before Code Changes",
+			pr:              ValidPR(),
+			issue:           LGTMApprovedIssue(),
+			events:          OldApprovedEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			weakResults:     map[int]utils.FinishedFile{LastBuildNumber(): SuccessGCS()},
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			retest1Pass:     true,
+			retest2Pass:     true,
+			reason:          merged,
+			state:           "success",
+			isMerged:        true,
+			retestsAvoided:  1,
+			imHeadSHA:       "mysha", // Set by ValidPR
+			imBaseSHA:       "mastersha",
+			masterCommit:    MasterCommit(),
 		},
 
 		// // Should pass even though last 'weakStable' build failed, as it wasn't "strong" failure


### PR DESCRIPTION

- if a person approves, it doesn't matter if code was pushed, PR was
changed
- if the approved label was applied, it doesn't matter to SQ if PR
changed (can still merge if approved prior to approved label added)
- has no effect on LGTM behavior (lgtm stil not persistent)

Fixes #1743 