### PR TITLE
Smiles at changes that add lines to OWNERS files

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build fmt vet test
 
 
-HOOK_VERSION   = 0.77
+HOOK_VERSION   = 0.78
 LINE_VERSION   = 0.69
 SINKER_VERSION = 0.4
 DECK_VERSION   = 0.14

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.77
+        image: gcr.io/k8s-prow/hook:0.78
         imagePullPolicy: Always
         env:
         - name: LINE_IMAGE

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -238,6 +238,23 @@ func (c *Client) CreateCommentReaction(org, repo string, ID int, reaction string
 	return nil
 }
 
+func (c *Client) CreateIssueReaction(org, repo string, ID int, reaction string) error {
+	c.log("CreateIssueReaction", org, repo, ID, reaction)
+	if c.dry {
+		return nil
+	}
+	r := Reaction{Content: reaction}
+	resp, err := c.request(http.MethodPost, fmt.Sprintf("%s/repos/%s/%s/issues/%d/reactions", c.base, org, repo, ID), r)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		return fmt.Errorf("response not 200 or 201: %s", resp.Status)
+	}
+	return nil
+}
+
 // ListIssueComments returns all comments on an issue. This may use more than
 // one API token.
 func (c *Client) ListIssueComments(org, repo string, number int) ([]IssueComment, error) {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -33,6 +33,10 @@ type FakeClient struct {
 	// org/repo#number:label
 	LabelsAdded   []string
 	LabelsRemoved []string
+
+	// org/repo#issuecommentid:reaction
+	IssueReactionsAdded   []string
+	CommentReactionsAdded []string
 }
 
 func (f *FakeClient) IsMember(org, user string) (bool, error) {
@@ -54,6 +58,16 @@ func (f *FakeClient) CreateComment(owner, repo string, number int, comment strin
 		Body: comment,
 	})
 	f.IssueCommentID++
+	return nil
+}
+
+func (f *FakeClient) CreateCommentReaction(org, repo string, ID int, reaction string) error {
+	f.CommentReactionsAdded = append(f.CommentReactionsAdded, fmt.Sprintf("%s/%s#%d:%s", org, repo, ID, reaction))
+	return nil
+}
+
+func (f *FakeClient) CreateIssueReaction(org, repo string, ID int, reaction string) error {
+	f.IssueReactionsAdded = append(f.IssueReactionsAdded, fmt.Sprintf("%s/%s#%d:%s", org, repo, ID, reaction))
 	return nil
 }
 

--- a/prow/plugins/heart/BUILD
+++ b/prow/plugins/heart/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -29,4 +30,16 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["heart_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
+    ],
 )

--- a/prow/plugins/heart/heart.go
+++ b/prow/plugins/heart/heart.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package heart
 
 import (
 	"math/rand"
+	"path/filepath"
 	"regexp"
 
 	"github.com/Sirupsen/logrus"
@@ -27,8 +28,9 @@ import (
 )
 
 const (
-	pluginName = "heart"
-	botName    = "k8s-merge-robot"
+	pluginName     = "heart"
+	botName        = "k8s-merge-robot"
+	ownersFilename = "OWNERS"
 )
 
 var mergeRe = regexp.MustCompile(`Automatic merge from submit-queue`)
@@ -42,17 +44,24 @@ var reactions = []string{
 
 func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
 type githubClient interface {
 	CreateCommentReaction(org, repo string, ID int, reaction string) error
+	CreateIssueReaction(org, repo string, ID int, reaction string) error
+	GetPullRequestChanges(pr github.PullRequest) ([]github.PullRequestChange, error)
 }
 
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, ic)
+	return handleIC(pc.GitHubClient, pc.Logger, ic)
 }
 
-func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
+func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+	return handlePR(pc.GitHubClient, pc.Logger, pre)
+}
+
+func handleIC(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
 	// Only consider new comments on PRs.
 	if !ic.Issue.IsPullRequest() || ic.Action != "created" {
 		return nil
@@ -72,4 +81,31 @@ func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) err
 		ic.Repo.Name,
 		ic.Comment.ID,
 		reactions[rand.Intn(len(reactions))])
+}
+
+func handlePR(gc githubClient, log *logrus.Entry, pre github.PullRequestEvent) error {
+	// Only consider newly opened PRs
+	if pre.Action != "opened" {
+		return nil
+	}
+
+	changes, err := gc.GetPullRequestChanges(pre.PullRequest)
+	if err != nil {
+		return err
+	}
+
+	// Smile at any change that adds to OWNERS files
+	for _, change := range changes {
+		_, filename := filepath.Split(change.Filename)
+		if filename == ownersFilename && change.Additions > 0 {
+			log.Info("Adding new OWNERS makes me happy!")
+			return gc.CreateIssueReaction(
+				pre.PullRequest.Base.Repo.Owner.Login,
+				pre.PullRequest.Base.Repo.Name,
+				pre.Number,
+				reactions[rand.Intn(len(reactions))])
+		}
+	}
+
+	return nil
 }

--- a/prow/plugins/heart/heart_test.go
+++ b/prow/plugins/heart/heart_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package heart
+
+import (
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestHandlePR(t *testing.T) {
+	basicPR := github.PullRequest{
+		Number: 1,
+		Base: github.PullRequestBranch{
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: "kubernetes",
+				},
+				Name: "kubernetes",
+			},
+		},
+	}
+
+	testcases := []struct {
+		prAction              string
+		changes               []github.PullRequestChange
+		expectedReactionAdded bool
+	}{
+		// PR opened against kubernetes/kubernetes that adds 1 line to
+		// an OWNERS file
+		{
+			prAction: "opened",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "foo/bar/OWNERS",
+					Additions: 1,
+				},
+			},
+			expectedReactionAdded: true,
+		},
+		// PR opened against kubernetes/kubernetes that deletes 1 line
+		// from an OWNERS file
+		{
+			prAction: "opened",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "foo/bar/OWNERS",
+					Deletions: 1,
+				},
+			},
+			expectedReactionAdded: false,
+		},
+		// PR opened against kubernetes/kubernetes with no changes to
+		// OWNERS
+		{
+			prAction: "opened",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "foo/bar/foo.go",
+					Additions: 1,
+				},
+			},
+			expectedReactionAdded: false,
+		},
+		// PR reopened against kubernetes/kubernetes
+		{
+			prAction: "reopened",
+			changes: []github.PullRequestChange{
+				{
+					Filename:  "foo/bar/OWNERS",
+					Additions: 1,
+				},
+			},
+			expectedReactionAdded: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		event := github.PullRequestEvent{
+			Action:      tc.prAction,
+			Number:      basicPR.Number,
+			PullRequest: basicPR,
+		}
+		fakeClient := &fakegithub.FakeClient{
+			PullRequests: map[int]*github.PullRequest{
+				basicPR.Number: &basicPR,
+			},
+			PullRequestChanges: map[int][]github.PullRequestChange{
+				basicPR.Number: tc.changes,
+			},
+		}
+		log := logrus.WithField("plugin", pluginName)
+
+		err := handlePR(fakeClient, log, event)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(fakeClient.IssueReactionsAdded) > 0 && !tc.expectedReactionAdded {
+			t.Fatalf("Expected no reactions to be added for %+v", tc)
+
+		} else if len(fakeClient.IssueReactionsAdded) == 0 && tc.expectedReactionAdded {
+			t.Fatalf("Expected reaction to be added for %+v", tc)
+		}
+	}
+}


### PR DESCRIPTION
Some caveats:
* I haven't tested this against the real GitHub API. What's the best way to do so, or what's the norm in this case?
* I only look at the changes on PRs at the time they were opened. Future work could expand this to PR `synchronize` events, but new client functions would need to be added to list and update/remove reactions.

Review :eyes: @fejta @apelisse @grodrigues3

Closes #1736