### PR TITLE
kops: Re-enable NodeProblemDetector tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-kops-aws.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws.sh
@@ -53,11 +53,10 @@ export LOG_DUMP_SAVE_SERVICES="protokube"
 ### job-env
 
 # See https://github.com/kubernetes/kubernetes/issues/30312 for why HPA is disabled.
-# See https://github.com/kubernetes/node-problem-detector/issues/28 for why NPD is disabled.
 # See https://github.com/kubernetes/kops/issues/774 for why the Dashboard is disabled
 # See https://github.com/kubernetes/kops/issues/775 for why NodePort is disabled
 
-DEFAULT_GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector|Dashboard|Services.*functioning.*NodePort"
+DEFAULT_GINKGO_TEST_ARGS="--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort"
 export GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-${DEFAULT_GINKGO_TEST_ARGS}}"
 if [[ -n "${JOB_NAME:-}" ]]; then
   # Running on Jenkins

--- a/jobs/pull-kops-e2e-kubernetes-aws.sh
+++ b/jobs/pull-kops-e2e-kubernetes-aws.sh
@@ -74,9 +74,9 @@ export LOG_DUMP_SAVE_SERVICES="protokube"
 # Flake detection. Individual tests get a second chance to pass.
 export GINKGO_TOLERATE_FLAKES="y"
 export GINKGO_PARALLEL="y"
-# This list should match the list in kubernetes-e2e-kops-aws.
-export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector|Dashboard|Services.*functioning.*NodePort'
-# GINKGO_PARALLEL_NODES should match kubernetes-e2e-kops-aws.
+# This list should match the list in ci-kubernetes-e2e-kops-aws.
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort'
+# GINKGO_PARALLEL_NODES should match ci-kubernetes-e2e-kops-aws.
 export GINKGO_PARALLEL_NODES="30"
 
 # Assume we're upping, testing, and downing a cluster

--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -86,9 +86,9 @@ export LOG_DUMP_SAVE_SERVICES="protokube"
 # Flake detection. Individual tests get a second chance to pass.
 export GINKGO_TOLERATE_FLAKES="y"
 export GINKGO_PARALLEL="y"
-# This list should match the list in kubernetes-e2e-kops-aws.
-export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector|Dashboard|Services.*functioning.*NodePort'
-# GINKGO_PARALLEL_NODES should match kubernetes-e2e-kops-aws.
+# This list should match the list in ci-kubernetes-e2e-kops-aws.
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort'
+# GINKGO_PARALLEL_NODES should match ci-kubernetes-e2e-kops-aws.
 export GINKGO_PARALLEL_NODES="30"
 
 # Assume we're upping, testing, and downing a cluster


### PR DESCRIPTION
Finally verified that https://github.com/kubernetes/node-problem-detector/issues/28 is fixed.