### PR TITLE
mungegithub: Replace AssignPR with AddAssignee

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -143,7 +143,7 @@ func assignApprovers(obj *github.MungeObject, suggestedApprovers sets.String) {
 
 	for approver := range suggestedApprovers {
 		if !assignees.Has(approver) {
-			obj.AssignPR(approver)
+			obj.AddAssignee(approver)
 		}
 	}
 }

--- a/mungegithub/mungers/assign-fixes.go
+++ b/mungegithub/mungers/assign-fixes.go
@@ -87,9 +87,8 @@ func (a *AssignFixesMunger) Munge(obj *github.MungeObject) {
 			glog.V(6).Infof("skipping %v: reassign: %v assignee: %v", *issue.Number, a.AssignfixesReassign, github.DescribeUser(issue.Assignee))
 			continue
 		}
-		glog.Infof("Assigning %v to %v (previously assigned to %v)", *issue.Number, prOwner, github.DescribeUser(issue.Assignee))
-		// although it says "AssignPR" it's more generic than that and is really just an issue.
-		issueObj.AssignPR(prOwner)
+		glog.Infof("Assigning %v to %v", *issue.Number, prOwner)
+		issueObj.AddAssignee(prOwner)
 	}
 
 }

--- a/mungegithub/mungers/assign-unassign-handler.go
+++ b/mungegithub/mungers/assign-unassign-handler.go
@@ -87,9 +87,9 @@ func (h AssignUnassignHandler) Munge(obj *github.MungeObject) {
 
 	toAssign, toUnassign := h.getAssigneesAndUnassignees(obj, comments, fileList, potentialOwners)
 	for _, username := range toAssign.List() {
-		obj.AssignPR(username)
+		obj.AddAssignee(username)
 	}
-	obj.UnassignPR(toUnassign.List()...)
+	obj.RemoveAssignees(toUnassign.List()...)
 }
 
 // getAssigneesAndUnassignees checks to see when someone comments "/assign" or "/unassign"

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -170,5 +170,5 @@ func (b *BlunderbussMunger) Munge(obj *github.MungeObject) {
 	}
 	c := chance(potentialOwners[owner], weightSum)
 	glog.Infof("Assigning %v to %v who had a %02.2f%% chance to be assigned (previously assigned to %v)", *issue.Number, owner, c, github.DescribeUser(issue.Assignee))
-	obj.AssignPR(owner)
+	obj.AddAssignee(owner)
 }


### PR DESCRIPTION
AssignPR has a very bad semantic: does it replace the current list of
assignees with only one person? Does it add a new assignee. Turns out it
does the former, and this unassigned a ton of people on all issues.

Let's make it more straightforward by using the non-deprecated function
AddAssignee