### PR TITLE
mungegithub: include client-go/examples dir in sync

### DIFF
--- a/mungegithub/mungers/publisher.go
+++ b/mungegithub/mungers/publisher.go
@@ -141,11 +141,10 @@ func construct(base, org string, src, dst coordinate) (string, error) {
 		return "", err
 	}
 	// TODO: this makes construct() specific for client-go. This keeps
-	// README.md, CHANGELOG.md, examples folder, .github folder in the
+	// README.md, CHANGELOG.md, .github folder in the
 	// client-go, rather than copying them from src.
 	if out, err := exec.Command("sh", "-c", fmt.Sprintf(`\
 find %s -depth -maxdepth 1 \( \
--name examples -o \
 -name .github -o \
 -name .git -o \
 -name README.md -o \


### PR DESCRIPTION
cc @caesarxuchao @lavalamp 

Counterpart of https://github.com/kubernetes/kubernetes/pull/40729.