### PR TITLE
Prefix FEDERATION_ to the DNS_ZONE_NAME environment variable name to make it consistent with other federation environment variables.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation.env
@@ -13,7 +13,7 @@ GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\]
 # We don't have namespaces yet in federation apiserver, so we need to serialize
 GINKGO_PARALLEL=n
 
-DNS_ZONE_NAME=test-f8n.k8s.io.
+FEDERATION_DNS_ZONE_NAME=test-f8n.k8s.io.
 # Where the clusters will be created. Federation components are now deployed to the last one.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
 FEDERATIONS_DOMAIN_MAP=federation=test-f8n.k8s.io


### PR DESCRIPTION
cc @kubernetes/sig-federation-pr-reviews 