### PR TITLE
Skipping Serial,NoCluster e2e testcases of federation

### DIFF
--- a/jobs/ci-kubernetes-e2e-cri-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-cri-gce-federation.env
@@ -4,7 +4,7 @@ KUBE_FEATURE_GATES=StreamingProxyRedirects=true
 
 # GCE project IDs are restricted to 30 characters, so this name is intentionally truncated.
 PROJECT=k8s-jkns-e2e-gce-cri-federatio
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[NoCluster\]|\[Serial\]
 
 # We don't have namespaces yet in federation apiserver, so we need to serialize
 GINKGO_PARALLEL=n

--- a/jobs/ci-kubernetes-e2e-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation.env
@@ -8,7 +8,7 @@ KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_NODE_OS_DISTRIBUTION=debian
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
 
 # We don't have namespaces yet in federation apiserver, so we need to serialize
 GINKGO_PARALLEL=n

--- a/jobs/ci-kubernetes-e2e-gci-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-federation.env
@@ -2,7 +2,7 @@
 
 # GCE project IDs are restricted to 30 characters, so this name is intentionally truncated.
 PROJECT=k8s-jkns-e2e-gce-gci-federatio
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[NoCluster\]|\[Serial\]
 
 # We don't have namespaces yet in federation apiserver, so we need to serialize
 GINKGO_PARALLEL=n


### PR DESCRIPTION
There is one test case in Slow category for federation [here](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_federation/federated-service.go#L297) and one test case in Serial category [here](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_federation/federation-apiserver.go#L38) which will be excluded by this pr.

We can include these test cases in another ci job for federation which we are planning.

cc @madhusudancs 
