### PR TITLE
Remove release-branch jobs from non-blocking list.

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -39,7 +39,6 @@ data:
     ci-kubernetes-e2e-gce-multizone,\
     ci-kubernetes-e2e-gce-scalability,\
     ci-kubernetes-e2e-gce-serial,\
-    ci-kubernetes-e2e-gci-gce-alpha-features-release-1.4,\
     ci-kubernetes-e2e-gci-gce-autoscaling,\
     ci-kubernetes-e2e-gci-gce-autoscaling-migs,\
     ci-kubernetes-e2e-gci-gce-es-logging,\
@@ -47,33 +46,22 @@ data:
     ci-kubernetes-e2e-gci-gce-examples,\
     ci-kubernetes-e2e-gci-gce-federation,\
     ci-kubernetes-e2e-gci-gce-ingress,\
-    ci-kubernetes-e2e-gci-gce-ingress-release-1.4,\
     ci-kubernetes-e2e-gci-gce-kubenet,\
     ci-kubernetes-e2e-gci-gce-petset,\
     ci-kubernetes-e2e-gci-gce-proto,\
     ci-kubernetes-e2e-gci-gce-reboot,\
-    ci-kubernetes-e2e-gci-gce-reboot-release-1.4,\
-    ci-kubernetes-e2e-gci-gce-release-1.4,\
     ci-kubernetes-e2e-gci-gce-scalability,\
-    ci-kubernetes-e2e-gci-gce-scalability-release-1.4,\
     ci-kubernetes-e2e-gci-gce-serial,\
-    ci-kubernetes-e2e-gci-gce-serial-release-1.4,\
-    ci-kubernetes-e2e-gci-gce-slow-release-1.4,\
     ci-kubernetes-e2e-gci-gke-alpha-features,\
     ci-kubernetes-e2e-gci-gke-autoscaling,\
     ci-kubernetes-e2e-gci-gke-ingress,\
-    ci-kubernetes-e2e-gci-gke-ingress-release-1.4,\
     ci-kubernetes-e2e-gci-gke-multizone,\
     ci-kubernetes-e2e-gci-gke-pre-release,\
     ci-kubernetes-e2e-gci-gke-prod,\
     ci-kubernetes-e2e-gci-gke-prod-parallel,\
     ci-kubernetes-e2e-gci-gke-prod-smoke,\
     ci-kubernetes-e2e-gci-gke-reboot,\
-    ci-kubernetes-e2e-gci-gke-reboot-release-1.4,\
-    ci-kubernetes-e2e-gci-gke-release-1.4,\
     ci-kubernetes-e2e-gci-gke-serial,\
-    ci-kubernetes-e2e-gci-gke-serial-release-1.4,\
-    ci-kubernetes-e2e-gci-gke-slow-release-1.4,\
     ci-kubernetes-e2e-gci-gke-staging,\
     ci-kubernetes-e2e-gci-gke-staging-parallel,\
     ci-kubernetes-e2e-gci-gke-subnet,\
@@ -92,73 +80,7 @@ data:
     ci-kubernetes-soak-gke-deploy,\
     ci-kubernetes-soak-gke-gci-deploy,\
     ci-kubernetes-soak-gke-gci-test,\
-    ci-kubernetes-soak-gke-test,\
-    ci-kubernetes-build-1.5,\
-    ci-kubernetes-verify-release-1.5,\
-    ci-kubernetes-test-go-release-1.5,\
-    ci-kubernetes-e2e-gce-release-1.5,\
-    ci-kubernetes-e2e-gci-gce-release-1.5,\
-    ci-kubernetes-e2e-gke-release-1.5,\
-    ci-kubernetes-e2e-gci-gke-release-1.5,\
-    ci-kubernetes-e2e-gce-slow-release-1.5,\
-    ci-kubernetes-e2e-gci-gce-slow-release-1.5,\
-    ci-kubernetes-e2e-gke-slow-release-1.5,\
-    ci-kubernetes-e2e-gci-gke-slow-release-1.5,\
-    ci-kubernetes-e2e-gce-serial-release-1.5,\
-    ci-kubernetes-e2e-gci-gce-serial-release-1.5,\
-    ci-kubernetes-e2e-gke-serial-release-1.5,\
-    ci-kubernetes-e2e-gci-gke-serial-release-1.5,\
-    ci-kubernetes-e2e-aws-release-1.5,\
-    ci-kubernetes-federation-build-1.5,\
-    ci-kubernetes-e2e-gce-federation-release-1.5,\
-    ci-kubernetes-e2e-gce-alpha-features-release-1.5,\
-    ci-kubernetes-e2e-gci-gce-alpha-features-release-1.5,\
-    ci-kubernetes-e2e-gke-alpha-features-release-1.5,\
-    ci-kubernetes-e2e-gce-scalability-release-1.5,\
-    ci-kubernetes-e2e-gci-gce-scalability-release-1.5,\
-    ci-kubernetes-e2e-gci-gce-ingress-release-1.5,\
-    ci-kubernetes-e2e-gci-gke-ingress-release-1.5,\
-    ci-kubernetes-e2e-gce-reboot-release-1.5,\
-    ci-kubernetes-e2e-gci-gce-reboot-release-1.5,\
-    ci-kubernetes-e2e-gke-reboot-release-1.5,\
-    ci-kubernetes-e2e-gci-gke-reboot-release-1.5,\
-    ci-kubernetes-soak-gce-1.5-deploy,\
-    ci-kubernetes-soak-gce-1.5-test,\
-    ci-kubernetes-soak-gci-gce-1.5-deploy,\
-    ci-kubernetes-soak-gci-gce-1.5-test,\
-    ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew,\
-    ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew,\
-    ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew,\
-    ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew,\
-    ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master,\
-    ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew,\
-    ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew,\
-    ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster,\
-    ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new,\
-    ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master"
+    ci-kubernetes-soak-gke-test"
   # SQ-Blocking Jobs
   # Please also update sq-blocking dashboard in testgrid config for test-infra presubmit to pass (@krzyzacy)
   # https://github.com/kubernetes/test-infra/blob/master/testgrid/config/config.yaml


### PR DESCRIPTION
I have [a ton of flakes assigned to me](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+is%3Aissue+assignee%3Aspxtr+label%3Akind%2Fflake), many of which are from old branches and will not be fixed. [This one](https://github.com/kubernetes/kubernetes/issues/40794) particularly annoyed me, since they don't even exist on master.