### PR TITLE
error strings should not end with punctuation

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -519,13 +519,13 @@ type kops struct {
 
 func NewKops() (*kops, error) {
 	if *kopsPath == "" {
-		return nil, fmt.Errorf("--kops must be set to a valid binary path for kops deployment.")
+		return nil, fmt.Errorf("--kops must be set to a valid binary path for kops deployment")
 	}
 	if *kopsCluster == "" {
-		return nil, fmt.Errorf("--kops-cluster must be set to a valid cluster name for kops deployment.")
+		return nil, fmt.Errorf("--kops-cluster must be set to a valid cluster name for kops deployment")
 	}
 	if *kopsState == "" {
-		return nil, fmt.Errorf("--kops-state must be set to a valid S3 path for kops deployment.")
+		return nil, fmt.Errorf("--kops-state must be set to a valid S3 path for kops deployment")
 	}
 	sshKey := *kopsSSHKey
 	if sshKey == "" {


### PR DESCRIPTION
Pull https://github.com/kubernetes/kubernetes/pull/36734 into test-infra

```
git format-patch -o /tmp/erick 50c4b28..96cfe7b hack/e2e.go
sed -e 's/hack.e2e.go/kubetest\/e2e.go/g' -i /tmp/erick/*
cd ../test-infra
git am -3 /tmp/erick/0001-error-strings-should-not-end-with-punctuation.patch
```