### PR TITLE
Add k8s-merge-robot to the list of bots in Gubernator.

### DIFF
--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -267,6 +267,7 @@ def distill_events(events):
     bots = [
         'k8s-bot',
         'k8s-ci-robot',
+        'k8s-merge-robot',
         'k8s-oncall',
         'k8s-reviewable',
     ]


### PR DESCRIPTION
It keeps commenting with approval status and making me look at it.