### PR TITLE
Update io_bazel_rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "2c6fa767100b95799043451aa3ee221d9a9bbb55",
+    commit = "bfa3601d9ab664b448ddb4cc7e48eea511217aaf",
 )
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 


### PR DESCRIPTION
Needed for latest bazel release:
```
ERROR: [...]/external/io_bazel_rules_go/go/toolchain/BUILD:15:1: no such package '@io_bazel_rules_go_toolchain//': Not a file: [...]/external/golang_linux_amd64/BUILD and referenced by '@io_bazel_rules_go//go/toolchain:go_include'.
ERROR: Analysis of target '//vendor:google.golang.org/grpc/codes' failed; build aborted.
```