### PR TITLE
Add SIGs to testowners munger

### DIFF
--- a/mungegithub/mungers/sync/issue-sync.go
+++ b/mungegithub/mungers/sync/issue-sync.go
@@ -62,6 +62,9 @@ func (p Priority) Priority() int {
 type OwnerMapper interface {
 	// TestOwner returns a GitHub username for a test, or "" if none are found.
 	TestOwner(testName string) string
+
+	// TestSIG returns the name of the Special Interest Group (SIG) which owns the test , or "" if none are found.
+	TestSIG(testName string) string
 }
 
 // IssueFinder finds an issue for a given key.


### PR DESCRIPTION
This adds support for parsing the SIG column added in kubernetes/kubernetes#40031. It should not be merged until that PR is.

Later PRs will label flakes with the appropriate SIG.