### PR TITLE
Switch kubekins-e2e to use kubetest instead of hack/e2e.go

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -30,6 +30,9 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 : ${JENKINS_GCE_SSH_PRIVATE_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine'}
 : ${JENKINS_GCE_SSH_PUBLIC_KEY_FILE:='/var/lib/jenkins/gce_keys/google_compute_engine.pub'}
 
+# DO NOT CHANGE THIS VALUE. THIS FILE IS DEPRECATED.
+# Job changes requiring a new image require first updating the job to use the
+# kubernetes_e2e.py scenario, which requires setting --json for the job.
 KUBEKINS_E2E_IMAGE_TAG='v20170104-9031f1d'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -51,26 +51,38 @@ RUN apt-get update && \
 
 RUN cd /tmp && \
     git clone https://github.com/google/jsonnet.git && \
-    ( cd jsonnet && \
-      make jsonnet && \
-      cp jsonnet /bin \
-    ) && \
-    rm -rf /tmp/jsonnet
-
-RUN mkdir -p /tmp/terraform/ && \
-    ( cd /tmp/terraform && \
-      wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-      unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin \
-    ) && \
+    cd jsonnet && \
+    make jsonnet && \
+    cp jsonnet /bin && \
+    rm -rf /tmp/jsonnet && \
+    mkdir -p /tmp/terraform/ && \
+    cd /tmp/terraform && \
+    wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
     rm -rf /tmp/terraform
+
+ADD ["https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz", \
+     "/workspace/"]
+ENV PATH=/google-cloud-sdk/bin:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
+    /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false && \
+    gcloud components install beta && \
+    gcloud components install alpha && \
+    gcloud info | tee /workspace/gcloud-info.txt
 
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
+    "kubetest", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh", \
-    "https://raw.githubusercontent.com/kubernetes/test-infra/master/kubetest/e2e.go", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh", \
     "https://raw.githubusercontent.com/kubernetes/kubernetes/master/third_party/forked/shell2junit/sh2ju.sh", \
     "/workspace/"]
-RUN ["chmod", "+x", "/workspace/get-kube.sh", "/workspace/upload-to-gcs.sh", "/workspace/sh2ju.sh"]
+RUN ["chmod", "+x", "/workspace/get-kube.sh", "/workspace/sh2ju.sh"]
+WORKDIR "/workspace"
 
 ENTRYPOINT "/workspace/e2e-runner.sh"

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -17,9 +17,14 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 all: build
 
-build:
+kubetest:
+	go build -o kubetest ../../kubetest
+
+
+build: kubetest
 	docker build -t $(IMG):$(TAG) .
 	docker tag $(IMG):$(TAG) $(IMG):latest
+	rm kubetest
 	@echo Built $(IMG):$(TAG) and tagged with latest
 
 push: build

--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -488,12 +488,7 @@ if [[ -n "${KUBEKINS_TIMEOUT:-}" ]]; then
   e2e_go_args+=("--timeout=${KUBEKINS_TIMEOUT}")
 fi
 
-e2e_go="$(dirname "${0}")/e2e.go"
-if [[ ! -f "${e2e_go}" || -e "./hack/jenkins/.use_head_e2e" ]]; then
-  echo "Using HEAD version of e2e.go."
-  e2e_go="./hack/e2e.go"
-fi
-go run "${e2e_go}" ${E2E_OPT:-} "${e2e_go_args[@]}"
+"$(dirname "${0}")/kubetest" ${E2E_OPT:-} "${e2e_go_args[@]}"
 
 if [[ "${E2E_PUBLISH_GREEN_VERSION:-}" == "true" ]]; then
   # Use plaintext version file packaged with kubernetes.tar.gz


### PR DESCRIPTION
Also install gcloud in the image
Refactor the jssonnet/terraform commands to reduce caching and remove redundant parens
Stop `chmod +x`ing `upload-to-gcs.sh` (it is only sourced)
Add `--tag` to allow json e2e jobs to use a non-default image if necessary.
Update scenario to try and repull of the image in case it changed.
Add a warning to `dockerized-e2e-runner.sh` that the image tag should not change (migrate jobs to `--json` instead)
Update Makefile to build and then remove kubetest before building the image.

ref #1475