### PR TITLE
Add --publish flag to e2e.go

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -24,7 +24,7 @@ ENV E2E_UP=true \
     E2E_DOWN=true
 
 # Customize these as appropriate
-ENV E2E_PUBLISH_GREEN_VERSION=false \
+ENV E2E_PUBLISH_PATH= \
     INSTANCE_PREFIX=jenkins-e2e \
     KUBERNETES_PROVIDER=gce
 

--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -488,13 +488,11 @@ if [[ -n "${KUBEKINS_TIMEOUT:-}" ]]; then
   e2e_go_args+=("--timeout=${KUBEKINS_TIMEOUT}")
 fi
 
-"$(dirname "${0}")/kubetest" ${E2E_OPT:-} "${e2e_go_args[@]}"
-
-if [[ "${E2E_PUBLISH_GREEN_VERSION:-}" == "true" ]]; then
-  # Use plaintext version file packaged with kubernetes.tar.gz
-  echo "Publish version to ci/latest-green.txt: $(cat version)"
-  gsutil cp ./version "gs://${KUBE_GCS_DEV_RELEASE_BUCKET}/ci/latest-green.txt"
+if [[ -n "${E2E_PUBLISH_PATH:-}" ]]; then
+  e2e_go_args+=(--publish="${E2E_PUBLISH_PATH}")
 fi
+
+"$(dirname "${0}")/kubetest" ${E2E_OPT:-} "${e2e_go_args[@]}"
 
 if [[ "${JENKINS_SOAK_MODE:-}" == "y" && ${E2E_UP:-} == "true" ]]; then
   # We deployed a cluster, save state to gcs

--- a/jobs/ci-kubernetes-e2e-gce-canary.env
+++ b/jobs/ci-kubernetes-e2e-gce-canary.env
@@ -1,3 +1,4 @@
 # Everything else is the same as the other job it is testing
 KUBEKINS_TIMEOUT=40m
 GINKGO_TEST_ARGS=--ginkgo.focus=Variable.Expansion
+E2E_PUBLISH_PATH=gs://kubernetes-release-dev/ci/latest-canarygreen.txt

--- a/jobs/ci-kubernetes-e2e-gce.env
+++ b/jobs/ci-kubernetes-e2e-gce.env
@@ -1,5 +1,7 @@
 ### job-env
 # This is the *only* job that should publish the last green version.
+# TODO(fejta): switch to E2E_PUBLISH_PATH for next image
+# E2E_PUBLISH_PATH=gs://kubernetes-release-dev/ci/latest-green.txt
 E2E_PUBLISH_GREEN_VERSION=true
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]


### PR DESCRIPTION
Migrate publishing functionality out of e2e-runner.sh

Ignore the first two commits, as these are handled by #1801 #1802  (will rebase once these are in)

ref #1475 