### PR TITLE
Make crier only create a new comment on failure.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -22,7 +22,7 @@ DECK_VERSION   = 0.14
 SPLICE_VERSION = 0.11
 MARQUE_VERSION = 0.1
 TOT_VERSION    = 0.0
-CRIER_VERSION  = 0.3
+CRIER_VERSION  = 0.4
 
 # These are the usual GKE variables.
 PROJECT = k8s-prow

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:0.3
+        image: gcr.io/k8s-prow/crier:0.4
         args:
         - "--dry-run=false"
         - "--github-bot-name=k8s-ci-robot"

--- a/prow/crier/client_test.go
+++ b/prow/crier/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package crier
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"testing"
 
@@ -50,6 +51,16 @@ func (f *fakeGitHub) CreateComment(org, repo string, number int, comment string)
 		User: github.User{Login: "k8s-ci-robot"},
 	})
 	return nil
+}
+
+func (f *fakeGitHub) EditComment(org, repo string, ID int, comment string) error {
+	for _, ic := range f.ics {
+		if ic.ID == ID {
+			ic.Body = comment
+			return nil
+		}
+	}
+	return fmt.Errorf("issue comment not found: %d", ID)
 }
 
 func (f *fakeGitHub) DeleteComment(org, repo string, ID int) error {

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -229,6 +229,26 @@ func (c *Client) DeleteComment(org, repo string, ID int) error {
 	return nil
 }
 
+func (c *Client) EditComment(org, repo string, ID int, comment string) error {
+	c.log("EditComment", org, repo, ID, comment)
+	if c.dry {
+		return nil
+	}
+
+	ic := IssueComment{
+		Body: comment,
+	}
+	resp, err := c.request(http.MethodPatch, fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d", c.base, org, repo, ID), ic)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("response not 200: %s", resp.Status)
+	}
+	return nil
+}
+
 func (c *Client) CreateCommentReaction(org, repo string, ID int, reaction string) error {
 	c.log("CreateCommentReaction", org, repo, ID, reaction)
 	if c.dry {


### PR DESCRIPTION
For successful tests, edit the latest comment. This cuts back on
the email spam, since previously I was making a new comment every
time a test switched from failing to passing.

#1723