### PR TITLE
Use a shorter name for the GCE project and use that name consistently for the release buckets.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-federation-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-serial.env
@@ -2,10 +2,10 @@
 FEDERATION=true
 USE_KUBEFED=true
 
-PROJECT=k8s-jkns-e2e-gce-federation-serial
+PROJECT=k8s-jkns-e2e-gce-f8n-serial
 KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-federation
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-serial
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-serial
+KUBE_GCS_RELEASE_BUCKET=kubernetes-f8n-release-serial
+KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-f8n-release-serial
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 # Note: this only works if [Feature:Federation] is before all


### PR DESCRIPTION
GCE project names have a 30 characters limit which did not occur to me yesterday.

cc @kubernetes/sig-federation-pr-reviews @shashidharatd @kubernetes/test-infra-reviewers 