### PR TITLE
Revert the logs bucket name for the federation GCE serial test job.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-federation-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-serial.env
@@ -4,8 +4,8 @@ USE_KUBEFED=true
 
 PROJECT=k8s-jkns-e2e-gce-f8n-serial
 KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-federation
-KUBE_GCS_RELEASE_BUCKET=kubernetes-f8n-release-serial
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-f8n-release-serial
+KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-serial
+KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-serial
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 # Note: this only works if [Feature:Federation] is before all


### PR DESCRIPTION
It is better to have bucket names consistent with other bucket names
than the project name.

cc @shashidharatd @kubernetes/sig-federation-pr-reviews 