### PR TITLE
The serial job just reuses the main federation build job, so we should use the same release bucket.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-federation-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-serial.env
@@ -4,8 +4,8 @@ USE_KUBEFED=true
 
 PROJECT=k8s-jkns-e2e-gce-f8n-serial
 KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-federation
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-serial
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-serial
+KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
+KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 # Note: this only works if [Feature:Federation] is before all


### PR DESCRIPTION
cc @kubernetes/sig-federation-pr-reviews @shashidharatd 