### PR TITLE
Set e2e image to v20170207-9bbd5f41

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce.env
+++ b/jobs/ci-kubernetes-e2e-gce.env
@@ -1,8 +1,6 @@
 ### job-env
 # This is the *only* job that should publish the last green version.
-# TODO(fejta): switch to E2E_PUBLISH_PATH for next image
-# E2E_PUBLISH_PATH=gs://kubernetes-release-dev/ci/latest-green.txt
-E2E_PUBLISH_GREEN_VERSION=true
+E2E_PUBLISH_PATH=gs://kubernetes-release-dev/ci/latest-green.txt
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -174,17 +174,17 @@ if __name__ == '__main__':
 
     # Assume we're upping, testing, and downing a cluster by default
     PARSER.add_argument(
-        '--up', default='true', help='If we need to set --up in e2e.go')
+        '--cluster', default='bootstrap-e2e', help='Name of the cluster')
     PARSER.add_argument(
-        '--test', default='true', help='If we need to set --test in e2e.go')
+        '--docker-in-docker', action='store_true', help='Enable run docker within docker')
     PARSER.add_argument(
         '--down', default='true', help='If we need to set --down in e2e.go')
     PARSER.add_argument(
-        '--cluster', default='bootstrap-e2e', help='Name of the cluster')
+        '--tag', default='v20170207-9bbd5f41', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
-        '--tag', default='v20170206-dbc6dd2a', help='Use a specific kubekins-e2e tag if set')
+        '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(
-        '--docker-in-docker', action='store_true', help='Enable run docker within docker')
+        '--up', default='true', help='If we need to set --up in e2e.go')
     ARGS = PARSER.parse_args()
 
     CONTAINER = '%s-%s' % (os.environ.get('JOB_NAME'), os.environ.get('BUILD_NUMBER'))


### PR DESCRIPTION
Canary result: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-canary/6

Adds support for --publish flag to e2e.go, enabled via the `E2E_PUBLISH_PATH` var.