### PR TITLE
Revert "Explicitly set storage backen in large deploy"

### DIFF
--- a/jobs/ci-kubernetes-e2e-gke-large-deploy.env
+++ b/jobs/ci-kubernetes-e2e-gke-large-deploy.env
@@ -17,8 +17,6 @@ GKE_CREATE_FLAGS=--max-nodes-per-pool=1000
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=True
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
 KUBE_GKE_IMAGE_TYPE=gci
-# TODO: This should be removed once we fix the problem of etcd size.
-STORAGE_BACKEND=etcd3
 E2E_DOWN=false
 
 KUBEKINS_TIMEOUT=1200m


### PR DESCRIPTION
Reverts kubernetes/test-infra#1815

This doesn't make sense in GKE clusters.