### PR TITLE
Strip invalid XML characters when coalescing bazel results.

### DIFF
--- a/images/pull_kubernetes_bazel/coalesce_test.py
+++ b/images/pull_kubernetes_bazel/coalesce_test.py
@@ -63,6 +63,13 @@ something bad'''
 		result = coalesce.result(pkg)
 		self.assertEqual(result.find('failure').text, 'something bad')
 
+	def test_sanitize_bad(self):
+		self.assertEqual(coalesce.sanitize('foo\033\x00\x08'), 'foo')
+
+	def test_sanitize_ansi(self):
+		self.assertEqual(coalesce.sanitize('foo\033[1mbar\033[1mbaz'),
+						 'foobarbaz')
+
 	def test_package_names(self):
 		os.chdir(self.tmpdir)
 		os.symlink('.', 'bazel-testlogs')


### PR DESCRIPTION
These characters cannot appear in an XML document, even encoded:

    >>> import xml.etree.ElementTree as ET
    >>> ET.fromstring('<a>&#x1F;</a>')
    xml.etree.ElementTree.ParseError: reference to invalid character
    number: line 1, column 3

Strip the full ANSI escape codes before getting other invalid
characters, to keep the output clean.

Came up in kubernetes/kubernetes#40878