### PR TITLE
Re-enable tests using host ports in CRI builds

### DIFF
--- a/jobs/ci-kubernetes-e2e-cri-gce.env
+++ b/jobs/ci-kubernetes-e2e-cri-gce.env
@@ -3,12 +3,7 @@ KUBELET_TEST_ARGS=--experimental-cri=true
 KUBE_FEATURE_GATES=StreamingProxyRedirects=true
 
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
-# Temporarily skip the test "Network should set TCP CLOSE_WAIT timeout"
-# and "[k8s.io] Loadbalancing: L7 [k8s.io] Nginx should conform to Ingress spec"
-# because it relies on host port, which is not implemented in CRI integration yet.
-# yet.
-# TODO(random-liu): Re-enable the test.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|Nginx\sshould\sconform\sto\sIngress\sspec
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 KUBE_OS_DISTRIBUTION=gci
 PROJECT=kubernetes-e2e-cri-validation

--- a/jobs/pull-kubernetes-e2e-gce-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-cri.sh
@@ -47,12 +47,8 @@ export GINKGO_TOLERATE_FLAKES="y"
 
 export E2E_NAME="cri-e2e-${NODE_NAME}-${EXECUTOR_NUMBER:-0}"
 export GINKGO_PARALLEL="y"
-# Temporarily skip the test "Network should set TCP CLOSE_WAIT timeout"
-# and "[k8s.io] Loadbalancing: L7 [k8s.io] Nginx should conform to Ingress spec"
-# because it relies on host port, which is not implemented in CRI integration yet.
-# TODO(random-liu): Re-enable the test.
 # This list should match the list in kubernetes-e2e-gce.
-export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|Nginx\sshould\sconform\sto\sIngress\sspec'
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="kubernetes-pr-cri-validation"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.


### PR DESCRIPTION
The docker-CRI implementation now supports the host port feature.