### PR TITLE
kops: Move kops-aws-updown job to its own isolated account

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -33,7 +33,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 # DO NOT CHANGE THIS VALUE. THIS FILE IS DEPRECATED.
 # Job changes requiring a new image require first updating the job to use the
 # kubernetes_e2e.py scenario, which requires setting --json for the job.
-KUBEKINS_E2E_IMAGE_TAG='v20170104-9031f1d'
+KUBEKINS_E2E_IMAGE_TAG='v20170208-a2139fbc'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")

--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -81,6 +81,18 @@ function log_dump_custom_get_instances() {
 pip install awscli # Only needed for log_dump_custom_get_instances
 export -f log_dump_custom_get_instances # Export to cluster/log-dump.sh
 
+if [[ -z "${KOPS_E2E_ROLE_ARN:-}" ]]; then
+  export AWS_CONFIG_FILE="/workspace/.aws/tmp-config"
+  cat > "${AWS_CONFIG_FILE}" <<EOF
+[profile jenkins-assumed-role]
+role_arn = ${KOPS_ROLE_ARN}
+source_profile = ${AWS_PROFILE:-default}
+EOF
+  export AWS_SDK_LOAD_CONFIG=true
+  export AWS_PROFILE="jenkins-assumed-role"
+  export AWS_DEFAULT_PROFILE="${AWS_PROFILE}"
+fi
+
 $(dirname "${BASH_SOURCE}")/e2e-runner.sh
 
 if [[ -n "${KOPS_PUBLISH_GREEN_PATH:-}" ]]; then

--- a/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
+++ b/jobs/ci-kubernetes-e2e-kops-aws-updown.sh
@@ -39,10 +39,6 @@ fi
 
 # Fake provider to trick e2e-runner.sh
 export KUBERNETES_PROVIDER="kops-aws"
-export AWS_CONFIG_FILE="/workspace/.aws/credentials"
-# This is needed to be able to create PD from the e2e test
-export AWS_SHARED_CREDENTIALS_FILE="/workspace/.aws/credentials"
-# TODO(zmerlynn): Eliminate the other uses of this env variable
 export KUBE_SSH_USER=admin
 export LOG_DUMP_USE_KUBECTL=yes
 export LOG_DUMP_SSH_KEY=/workspace/.ssh/kube_aws_rsa
@@ -55,8 +51,9 @@ DEFAULT_GINKGO_TEST_ARGS="--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 export GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-${DEFAULT_GINKGO_TEST_ARGS}}"
 if [[ -n "${JOB_NAME:-}" ]]; then
   # Running on Jenkins
-  export KOPS_E2E_CLUSTER_NAME="e2e-kops-aws-updown.test-aws.k8s.io"
-  export KOPS_E2E_STATE_STORE="s3://k8s-kops-jenkins/"
+  export KOPS_E2E_ROLE_ARN="arn:aws:iam::660757973107:role/job-kops-aws-updown"
+  export KOPS_E2E_CLUSTER_NAME="${BUILD_NUMBER}.kops-aws-updown.test-aws.k8s.io"
+  export KOPS_E2E_STATE_STORE="s3://kops-aws-updown-store"
   export KOPS_PUBLISH_GREEN_PATH="gs://kops-ci/bin/latest-ci-updown-green.txt"
 else
   if [[ -z "${KOPS_E2E_CLUSTER_NAME:-}" ]]; then

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--down', default='true', help='If we need to set --down in e2e.go')
     PARSER.add_argument(
-        '--tag', default='v20170207-9bbd5f41', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170208-a2139fbc', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(


### PR DESCRIPTION
Relies on the Jenkins IAM account having AssumeRole for the other account.

TODO: After this, we could run aws-janitor directly after the test job
to ensure all resources were clean.