### PR TITLE
Split k8s bazel postsubmit in two.

### DIFF
--- a/jobs/ci-kubernetes-bazel-build.sh
+++ b/jobs/ci-kubernetes-bazel-build.sh
@@ -25,10 +25,6 @@ bazel clean --expunge
 make bazel-build && rc=$? || rc=$?
 
 if [[ "${rc}" == 0 ]]; then
-  make bazel-test && rc=$? || rc=$?
-fi
-
-if [[ "${rc}" == 0 ]]; then
   make bazel-release && rc=$? || rc=$?
 fi
 

--- a/jobs/ci-kubernetes-bazel-test.sh
+++ b/jobs/ci-kubernetes-bazel-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Cache location.
+export TEST_TMPDIR="/root/.cache/bazel"
+
+bazel clean --expunge
+
+make bazel-test && rc=$? || rc=$?
+
+# Coalesce test results into one file for upload.
+"$(dirname "${0}")/../images/pull_kubernetes_bazel/coalesce.py"
+
+exit "${rc}"

--- a/prow/postsubmit.yaml
+++ b/prow/postsubmit.yaml
@@ -1,6 +1,6 @@
 ---
 kubernetes/kubernetes:
-- name: ci-kubernetes-bazel
+- name: ci-kubernetes-bazel-build
   branches:
   - master
   spec:
@@ -14,6 +14,18 @@ kubernetes/kubernetes:
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
+  run_after_success:
+  - name: ci-kubernetes-bazel-test
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:0.8
+        args:
+        - "--branch=$(PULL_REFS)"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--git-cache=/root/.cache/git"
+        - "--clean"
+        securityContext:
+          privileged: true
 
 kubernetes/test-infra:
 - name: ci-test-infra-bazel

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -832,8 +832,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubernetes-update-jenkins-jobs
 # Manual, federated groups
 # bazel, run on prow
-- name: ci-kubernetes-bazel
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel
+- name: ci-kubernetes-bazel-build
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-build
+- name: ci-kubernetes-bazel-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test
 - name: ci-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-bazel
 # rktnetes
@@ -1380,8 +1382,10 @@ dashboards:
     test_group_name: kubernetes-build-1.4
   - name: build-1.5
     test_group_name: kubernetes-build-1.5
-  - name: bazel
-    test_group_name: ci-kubernetes-bazel
+  - name: bazel-build
+    test_group_name: ci-kubernetes-bazel-build
+  - name: bazel-test
+    test_group_name: ci-kubernetes-bazel-test
   - name: test-go
     test_group_name: kubernetes-test-go
   - name: test-go-1.3


### PR DESCRIPTION
In preparation for making an e2e job, I need the build job to run separate from the test job.