### PR TITLE
gci-qa-master: Add JENKINS_USE_GCI_VERSION=y back

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-master.env
@@ -1,3 +1,6 @@
+# Use GCI builtin k8s version.
+JENKINS_USE_GCI_VERSION=y
+
 ### job-env
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]


### PR DESCRIPTION
This was left out during the refacor in #1742