### PR TITLE
Mark a group of cri suites to submit queue non-blocking

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -69,6 +69,10 @@ data:
     ci-kubernetes-e2e-gci-gke-subnet,\
     ci-kubernetes-e2e-gci-gke-test,\
     ci-kubernetes-e2e-gci-gke-updown,\
+    ci-kubernetes-e2e-cri-gce,\
+    ci-kubernetes-e2e-cri-gce-slow,\
+    ci-kubernetes-e2e-cri-gke,\
+    ci-kubernetes-e2e-cri-gke-slow,\
     ci-kubernetes-e2e-gke-large-cluster,\
     ci-kubernetes-e2e-gke-serial,\
     ci-kubernetes-e2e-gke-staging,\


### PR DESCRIPTION
This helps us track the failures.