### PR TITLE
Change period of serial and flaky node e2e suites to 2 hours.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -139,7 +139,7 @@
         timeout: 90
     - kubernetes-node-kubelet-serial:  # lantaol
         branch: master
-        frequency: 'H H/1 * * *'
+        frequency: 'H H/2 * * *'
         job-name: ci-kubernetes-node-kubelet-serial
         json: 1
         repo-name: k8s.io/kubernetes
@@ -153,7 +153,7 @@
         timeout: 90
     - kubernetes-node-kubelet-flaky:  # lantaol
         branch: master
-        frequency: 'H H/1 * * *'
+        frequency: 'H H/2 * * *'
         job-name: ci-kubernetes-node-kubelet-flaky
         json: 1
         repo-name: k8s.io/kubernetes
@@ -174,7 +174,7 @@
         timeout: 90
     - kubernetes-node-kubelet-cri-serial:  # lantaol
         branch: master
-        frequency: 'H H/1 * * *'
+        frequency: 'H H/2 * * *'
         job-name: ci-kubernetes-node-kubelet-cri-serial
         json: 1
         repo-name: k8s.io/kubernetes


### PR DESCRIPTION
Change period of serial and flaky node e2e suites to 2 hours.

Jenkins interprets `H H/1 * * *` as running per day, which is a known issue https://issues.jenkins-ci.org/browse/JENKINS-22129.

We can change the period to `H * * * *` as running per day, but I feel like that given serial suite uses 1h24m to run, 2 hour period should be enough for us.

@yujuhong 