### PR TITLE
Disable Google Cloud Storage bucket for Azure

### DIFF
--- a/buckets.yaml
+++ b/buckets.yaml
@@ -10,9 +10,9 @@
 gs://kubernetes-jenkins/logs/:
   contact: "fejta"
   prefix: ""
-gs://kube_azure_log/:
-  contact: "travisnewhouse"
-  prefix: "azure:"
+#gs://kube_azure_log/:
+#  contact: "travisnewhouse"
+#  prefix: "azure:"
 gs://rktnetes-jenkins/logs/:
   contact: "euank"
   prefix: "rktnetes:"

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -842,8 +842,8 @@ test_groups:
 - name: kubernetes-rktnetes
   gcs_prefix: rktnetes-jenkins/logs/kubernetes-e2e-gce
 # azure
-- name: kubernetes-azure
-  gcs_prefix: kube_azure_log/kubernetes.azure.nightly
+#- name: kubernetes-azure
+#  gcs_prefix: kube_azure_log/kubernetes.azure.nightly
 # Canonical Distribution of Kubernetes (contact: @chuckbutler on github)
 - name: canonical-kubernetes-e2e-gce
   gcs_prefix: canonical-kubernetes-tests/logs/kubernetes-gce-e2e-node
@@ -877,10 +877,10 @@ test_groups:
 #
 
 dashboards:
-- name: azure
-  dashboard_tab:
-  - name: azure
-    test_group_name: kubernetes-azure
+#- name: azure
+#  dashboard_tab:
+#  - name: azure
+#    test_group_name: kubernetes-azure
 
 - name: canonical-kubernetes
   dashboard_tab:


### PR DESCRIPTION
AppFormix has been acquired by Juniper.  The existing Google Cloud
Storage bucket that hosts the Azure test results will be migrated
to a new bucket.  Disable in the interim.