### PR TITLE
Overwrite JOB_NAME for soak-test jobs

### DIFF
--- a/jobs/ci-kubernetes-soak-gce-1.3-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.3-test.env
@@ -2,7 +2,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 
 ### soak-env
 JENKINS_SOAK_MODE=y
-JOB_NAME=ci-kubernetes-soak-gce-1.3-deploy
 FAIL_ON_GCP_RESOURCE_LEAK=false
 # Clear out any orphaned namespaces in case previous run was interrupted.
 E2E_CLEAN_START=true

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2064,6 +2064,7 @@
   "args": [
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-soak-gce-1.3-test.env",
+    "--soak-test",
     "--up=false",
     "--down=false"
   ]

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -150,6 +150,10 @@ def main(args):
         if key not in docker_env_ignore:
             cmd.extend(['-e', '%s=%s' % (key, value)])
 
+    # Overwrite JOB_NAME for soak-*-test jobs
+    if args.soak_test and os.environ.get('JOB_NAME'):
+        cmd.extend(['-e', 'JOB_NAME=%s' % os.environ.get('JOB_NAME').replace('-test', '-deploy')])
+
     cmd.append(kubekins(args.tag))
 
     signal.signal(signal.SIGTERM, sig_handler)
@@ -184,6 +188,8 @@ if __name__ == '__main__':
         '--docker-in-docker', action='store_true', help='Enable run docker within docker')
     PARSER.add_argument(
         '--down', default='true', help='If we need to set --down in e2e.go')
+    PARSER.add_argument(
+        '--soak-test', action='store_true', help='If the test is a soak test job')
     PARSER.add_argument(
         '--tag', default='v20170207-9bbd5f41', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(


### PR DESCRIPTION
#1886 was not enough..

Here tries to handle things like https://github.com/kubernetes/test-infra/blob/master/jobs/ci-kubernetes-soak-gce-1.4-test.sh#L33, which now the original flag would tramp over `--env-file` in docker.