### PR TITLE
Add default kubeadm version to kubetest.

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -51,6 +51,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase2.docker_registry="gcr.io/google-containers"
 .phase2.kubernetes_version="v1.4.1"
 .phase2.provider="{{.Phase2Provider}}"
+.phase2.kubeadm.version="stable"
 
 .phase3.run_addons=y
 .phase3.kube_proxy=y


### PR DESCRIPTION
Upstream changes in kubernetes-anywhere now require this field to be set, so default it to "stable" (which was the previous behavior). I will follow up by adding CLI plumbing to override this value.