### PR TITLE
Convert kubeadm e2e Jenkins job to prow.

### DIFF
--- a/images/ci-kubernetes-e2e-kubeadm/Dockerfile
+++ b/images/ci-kubernetes-e2e-kubeadm/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170217-47d95907
+MAINTAINER beacham@google.com
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    unzip \
+    bash-completion \
+    git \
+    wget && \
+    apt-get clean
+
+# Add kubernetes-anywhere dependencies: jsonnet, terraform
+ENV TERRAFORM_VERSION 0.7.2
+
+RUN cd /tmp && \
+    git clone https://github.com/google/jsonnet.git && \
+    ( cd jsonnet && \
+      make jsonnet && \
+      cp jsonnet /bin \
+    ) && \
+    rm -rf /tmp/jsonnet
+
+RUN mkdir -p /tmp/terraform/ && \
+    ( cd /tmp/terraform && \
+      wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+      unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin \
+    ) && \
+    rm -rf /tmp/terraform
+
+WORKDIR /workspace
+ADD runner /
+ENTRYPOINT ["/bin/bash", "/runner"]

--- a/images/ci-kubernetes-e2e-kubeadm/Makefile
+++ b/images/ci-kubernetes-e2e-kubeadm/Makefile
@@ -1,0 +1,23 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION = 0.1
+
+image:
+	docker build -t "gcr.io/k8s-testimages/e2e-kubeadm:$(VERSION)" .
+
+push:
+	gcloud docker -- push "gcr.io/k8s-testimages/e2e-kubeadm:$(VERSION)"
+
+.PHONY: image push

--- a/images/ci-kubernetes-e2e-kubeadm/runner
+++ b/images/ci-kubernetes-e2e-kubeadm/runner
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+git clone https://github.com/kubernetes/test-infra
+git clone https://github.com/kubernetes/kubernetes-anywhere
+
+# This is required until https://github.com/kubernetes/kubernetes-anywhere/issues/332
+# is implemented.
+ln -s "${GOOGLE_APPLICATION_CREDENTIALS}" kubernetes-anywhere/phase1/gce/account.json
+
+./test-infra/jenkins/bootstrap.py \
+    --repo="k8s.io/${REPO_NAME}" \
+    --job="${JOB_NAME}" \
+    --service-account="${GOOGLE_APPLICATION_CREDENTIALS}" \
+    "$@"

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -43,24 +43,6 @@ ENV FAIL_ON_GCP_RESOURCE_LEAK=true \
 # JENKINS_AWS_SSH_PUBLIC_KEY_FILE
 # JENKINS_AWS_CREDENTIALS_FILE
 
-# Add kubernetes-anywhere dependencies: jsonnet, terraform
-ENV TERRAFORM_VERSION 0.7.2
-
-RUN apt-get update && \
-    apt-get install -y unzip
-
-RUN cd /tmp && \
-    git clone https://github.com/google/jsonnet.git && \
-    cd jsonnet && \
-    make jsonnet && \
-    cp jsonnet /bin && \
-    rm -rf /tmp/jsonnet && \
-    mkdir -p /tmp/terraform/ && \
-    cd /tmp/terraform && \
-    wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
-    rm -rf /tmp/terraform
-
 ADD ["https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz", \
      "/workspace/"]
 ENV PATH=/google-cloud-sdk/bin:${PATH} \

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -122,14 +122,6 @@
         repo-name: k8s.io/kubernetes
         timeout: 100
 
-    - kubernetes-e2e-kubeadm-gce:
-        branch: master
-        job-name: ci-kubernetes-e2e-kubeadm-gce
-        json: 0  # TODO(fejta): so sad!
-        repo-name: k8s.io/kubernetes-anywhere
-        frequency: 'H/5 * * * *'
-        timeout: 0
-
     - kubernetes-node-kubelet:  # dawnchen
         branch: master
         frequency: 'H/30 * * * *'

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
@@ -25,9 +25,10 @@ readonly testinfra="$(dirname "${0}")/.."
 ### job-env
 
 export PROJECT="k8s-jkns-e2e-kubeadm-gce-ci"
+export KUBERNETES_PROVIDER=kubernetes-anywhere
 export E2E_NAME="e2e-kubeadm-gce"
-export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path ${GOPATH}/src/k8s.io/kubernetes-anywhere"
-export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}.test-kubeadm.k8s.io"
+export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path /workspace/kubernetes-anywhere"
+export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}"
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
 
 ### post-env
@@ -49,7 +50,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 export GINKGO_PARALLEL="y"
 
 ### Runner
-readonly runner="${testinfra}/jenkins/dockerized-e2e-runner.sh"
+readonly runner="/workspace/e2e-runner.sh"
 export DOCKER_TIMEOUT="140m"
 export KUBEKINS_TIMEOUT="120m"
 "${runner}"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -219,6 +219,16 @@ postsubmits:
           - "--clean"
           securityContext:
             privileged: true
+      run_after_success:
+      - name: ci-kubernetes-e2e-kubeadm-gce
+        spec:
+          containers:
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.1
+            args:
+            - "--branch=$(PULL_REFS)"
+            - "--upload=gs://kubernetes-jenkins/logs"
+            - "--git-cache=/root/.cache/git"
+            - "--clean"
 
   kubernetes/test-infra:
   - name: ci-test-infra-bazel


### PR DESCRIPTION
After encountering a lot of problems getting this to work as a Jenkins job, I'm converting it to prow per EngProd's advice. This also allowed me to move the kubernetes-anywhere dependencies out of the Jenkins e2e image and into a new image specific to this job.

This is just the postsubmit CI job to start with. After testing, I'll add a presubmit job next.

CC @dmmcquay @mikedanese 