### PR TITLE
Add upgrade CI suites for new upgrade tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -1424,6 +1424,33 @@
     # END KUBEMARK
 
     # START UPGRADE
+
+    ### Latest version upgrades #krousey
+    - kubernetes-e2e-gce-latest-upgrade-master: # upgrade master from previous version to latest
+        job-name: ci-kubernetes-e2e-gce-latest-upgrade-master
+        timeout: 110
+        frequency: 'H * * * *' # At least every hour
+        json: 1
+        trigger-job: 'ci-kubernetes-build'
+    - kubernetes-e2e-gce-latest-upgrade-cluster: # upgrade cluster from previous version to latest
+        job-name: ci-kubernetes-e2e-gce-latest-upgrade-cluster
+        timeout: 110
+        frequency: 'H * * * *' # At least every hour
+        json: 1
+        trigger-job: 'ci-kubernetes-build'
+    - kubernetes-e2e-gke-latest-upgrade-master: # upgrade master from previous version to latest
+        job-name: ci-kubernetes-e2e-gke-latest-upgrade-master
+        timeout: 110
+        frequency: 'H * * * *' # At least every hour
+        json: 1
+        trigger-job: 'ci-kubernetes-build'
+    - kubernetes-e2e-gke-latest-upgrade-cluster: # upgrade cluster from previous version to latest
+        job-name: ci-kubernetes-e2e-gke-latest-upgrade-cluster
+        timeout: 110
+        frequency: 'H * * * *' # At least every hour
+        json: 1
+        trigger-job: 'ci-kubernetes-build'
+    
     ### kubernetes-e2e-upgrades-gke #maisem
 
     - kubernetes-e2e-gke-1.3-1.4-upgrade-master:

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
@@ -1,0 +1,11 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gce-upg-lat-cluster
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
@@ -1,0 +1,11 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gce-upg-lat-master
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
@@ -1,0 +1,11 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-lat-cluster
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
@@ -1,0 +1,11 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=kube-gke-upg-lat-master
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2975,6 +2975,38 @@
     "--env-file=platforms/gke.env",
     "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.env"
   ]
+},
+
+"ci-kubernetes-e2e-gce-latest-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-latest-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-latest-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-latest-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env"
+  ]
 }
 
 }

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -871,6 +871,15 @@ test_groups:
 # kubeadm tests
 - name: kubernetes-e2e-kubeadm-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce
+# upgrade CI tests
+- name: kubernetes-e2e-gce-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-latest-upgrade-cluster
+- name: kubernetes-e2e-gce-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-latest-upgrade-master
+- name: kubernetes-e2e-gke-latest-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-latest-upgrade-cluster
+- name: kubernetes-e2e-gke-latest-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-latest-upgrade-master
 
 # Add New Testgroups Here
 
@@ -1610,6 +1619,17 @@ dashboards:
     test_group_name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new
   - name: gci-1.4-gci-latest-upgrade-master
     test_group_name: kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master
+
+- name: latest-upgrades
+  dashboard_tab:
+  - name: gce-cluster
+    test_group_name: kubernetes-e2e-gce-latest-upgrade-cluster
+  - name: gce-master
+    test_group_name: kubernetes-e2e-gce-latest-upgrade-master
+  - name: gke-cluster
+    test_group_name: kubernetes-e2e-gke-latest-upgrade-cluster
+  - name: gke-master
+    test_group_name: kubernetes-e2e-gke-latest-upgrade-master
 
 - name: google-federation
   dashboard_tab:


### PR DESCRIPTION
Creating CI tests for the manual upgrade suites. These tests intentionally don't run a second set of e2es. 