### PR TITLE
Rename cri to non-cri jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml
@@ -99,9 +99,9 @@
         json: 0
         repo-name: 'k8s.io/kubernetes'
         timeout: 0
-    - kubernetes-e2e-gce-cri:
+    - kubernetes-e2e-gce-non-cri:
         max-total: 12
-        job-name: pull-kubernetes-e2e-gce-cri
+        job-name: pull-kubernetes-e2e-gce-non-cri
         json: 0
         repo-name: 'k8s.io/kubernetes'
         timeout: 0
@@ -165,9 +165,9 @@
         json: 1
         repo-name: 'k8s.io/kubernetes'
         timeout: 90
-    - kubernetes-node-e2e-cri:
+    - kubernetes-node-e2e-non-cri:
         max-total: 12
-        job-name: pull-kubernetes-node-e2e-cri
+        job-name: pull-kubernetes-node-e2e-non-cri
         json: 1
         repo-name: 'k8s.io/kubernetes'
         timeout: 90

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -165,24 +165,24 @@
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 90
-    - kubernetes-node-kubelet-cri:  # yjhong
+    - kubernetes-node-kubelet-non-cri:  # yjhong
         branch: master
         frequency: 'H/30 * * * *'
-        job-name: ci-kubernetes-node-kubelet-cri
+        job-name: ci-kubernetes-node-kubelet-non-cri
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 90
-    - kubernetes-node-kubelet-cri-serial:  # lantaol
+    - kubernetes-node-kubelet-non-cri-serial:  # lantaol
         branch: master
         frequency: 'H H/2 * * *'
-        job-name: ci-kubernetes-node-kubelet-cri-serial
+        job-name: ci-kubernetes-node-kubelet-non-cri-serial
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 240
-    - kubernetes-node-kubelet-cri-benchmark:  # lantaol
+    - kubernetes-node-kubelet-non-cri-benchmark:  # lantaol
         branch: master
         frequency: 'H H/2 * * *'
-        job-name: ci-kubernetes-node-kubelet-cri-benchmark
+        job-name: ci-kubernetes-node-kubelet-non-cri-benchmark
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 90

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -59,16 +59,16 @@
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 0
-    - kubernetes-soak-gce-cri-deploy:
-        blocker: ci-kubernetes-soak-gce-cri-test
-        job-name: ci-kubernetes-soak-gce-cri-deploy
+    - kubernetes-soak-gce-non-cri-deploy:
+        blocker: ci-kubernetes-soak-gce-non-cri-test
+        job-name: ci-kubernetes-soak-gce-non-cri-deploy
         json: 0
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 0
-    - kubernetes-soak-gce-cri-test:
-        blocker: ci-kubernetes-soak-gce-cri-deploy
-        job-name: ci-kubernetes-soak-gce-cri-test
+    - kubernetes-soak-gce-non-cri-test:
+        blocker: ci-kubernetes-soak-gce-non-cri-deploy
+        job-name: ci-kubernetes-soak-gce-non-cri-test
         json: 0
         frequency: 'H/30 * * * *'
         scan: ALL

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -293,81 +293,81 @@
         json: 1
         trigger-job: 'ci-kubernetes-build'
 
-    # gce-master with cri
-    - kubernetes-e2e-cri-gce:
-        job-name: ci-kubernetes-e2e-cri-gce
+    # gce-master with non-cri
+    - kubernetes-e2e-non-cri-gce:
+        job-name: ci-kubernetes-e2e-non-cri-gce
         timeout: 110
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-slow:
-        job-name: ci-kubernetes-e2e-cri-gce-slow
+    - kubernetes-e2e-non-cri-gce-slow:
+        job-name: ci-kubernetes-e2e-non-cri-gce-slow
         timeout: 170
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-serial:
-        job-name: ci-kubernetes-e2e-cri-gce-serial
+    - kubernetes-e2e-non-cri-gce-serial:
+        job-name: ci-kubernetes-e2e-non-cri-gce-serial
         timeout: 320
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-reboot:
-        job-name: ci-kubernetes-e2e-cri-gce-reboot
+    - kubernetes-e2e-non-cri-gce-reboot:
+        job-name: ci-kubernetes-e2e-non-cri-gce-reboot
         timeout: 200
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-autoscaling:
-        job-name: ci-kubernetes-e2e-cri-gce-autoscaling
+    - kubernetes-e2e-non-cri-gce-autoscaling:
+        job-name: ci-kubernetes-e2e-non-cri-gce-autoscaling
         timeout: 230
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-autoscaling-migs:
-        job-name: ci-kubernetes-e2e-cri-gce-autoscaling-migs
+    - kubernetes-e2e-non-cri-gce-autoscaling-migs:
+        job-name: ci-kubernetes-e2e-non-cri-gce-autoscaling-migs
         timeout: 230
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-alpha-features:
-        job-name: ci-kubernetes-e2e-cri-gce-alpha-features
+    - kubernetes-e2e-non-cri-gce-alpha-features:
+        job-name: ci-kubernetes-e2e-non-cri-gce-alpha-features
         timeout: 200
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-flaky:
-        job-name: ci-kubernetes-e2e-cri-gce-flaky
+    - kubernetes-e2e-non-cri-gce-flaky:
+        job-name: ci-kubernetes-e2e-non-cri-gce-flaky
         timeout: 200
         trigger-job: 'ci-kubernetes-build'
         json: 1
         frequency: 'H/5 * * * *' # At least every 30m
-    - kubernetes-e2e-cri-gce-scalability:
-        job-name: ci-kubernetes-e2e-cri-gce-scalability
+    - kubernetes-e2e-non-cri-gce-scalability:
+        job-name: ci-kubernetes-e2e-non-cri-gce-scalability
         timeout: 140
         frequency: 'H H/12 * * *'
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-etcd3:
-        job-name: ci-kubernetes-e2e-cri-gce-etcd3
+    - kubernetes-e2e-non-cri-gce-etcd3:
+        job-name: ci-kubernetes-e2e-non-cri-gce-etcd3
         timeout: 70
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-proto:
-        job-name: ci-kubernetes-e2e-cri-gce-proto
+    - kubernetes-e2e-non-cri-gce-proto:
+        job-name: ci-kubernetes-e2e-non-cri-gce-proto
         timeout: 70
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-examples:
-        job-name: ci-kubernetes-e2e-cri-gce-examples
+    - kubernetes-e2e-non-cri-gce-examples:
+        job-name: ci-kubernetes-e2e-non-cri-gce-examples
         timeout: 110
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-federation:
-        job-name: ci-kubernetes-e2e-cri-gce-federation
+    - kubernetes-e2e-non-cri-gce-federation:
+        job-name: ci-kubernetes-e2e-non-cri-gce-federation
         timeout: 920
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
@@ -653,26 +653,26 @@
         trigger-job: ''
 
     # cri-gce-features
-    - kubernetes-e2e-cri-gce-ingress:
-        job-name: ci-kubernetes-e2e-cri-gce-ingress
+    - kubernetes-e2e-non-cri-gce-ingress:
+        job-name: ci-kubernetes-e2e-non-cri-gce-ingress
         timeout: 110
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-es-logging:
-        job-name: ci-kubernetes-e2e-cri-gce-es-logging
+    - kubernetes-e2e-non-cri-gce-es-logging:
+        job-name: ci-kubernetes-e2e-non-cri-gce-es-logging
         timeout: 110
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-statefulset:
-        job-name: ci-kubernetes-e2e-cri-gce-statefulset
+    - kubernetes-e2e-non-cri-gce-statefulset:
+        job-name: ci-kubernetes-e2e-non-cri-gce-statefulset
         timeout: 110
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gce-garbage:
-        job-name: ci-kubernetes-e2e-cri-gce-garbage
+    - kubernetes-e2e-non-cri-gce-garbage:
+        job-name: ci-kubernetes-e2e-non-cri-gce-garbage
         timeout: 620
         frequency: 'H H/6 * * *'
         json: 1
@@ -1032,62 +1032,62 @@
         trigger-job: 'ci-kubernetes-build'
 
     # cri-gke-master with CRI
-    - kubernetes-e2e-cri-gke:
-        job-name: ci-kubernetes-e2e-cri-gke
+    - kubernetes-e2e-non-cri-gke:
+        job-name: ci-kubernetes-e2e-non-cri-gke
         timeout: 70
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-slow:
-        job-name: ci-kubernetes-e2e-cri-gke-slow
+    - kubernetes-e2e-non-cri-gke-slow:
+        job-name: ci-kubernetes-e2e-non-cri-gke-slow
         timeout: 170
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-multizone:
-        job-name: ci-kubernetes-e2e-cri-gke-multizone
+    - kubernetes-e2e-non-cri-gke-multizone:
+        job-name: ci-kubernetes-e2e-non-cri-gke-multizone
         timeout: 170
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-alpha-features:
-        job-name: ci-kubernetes-e2e-cri-gke-alpha-features
+    - kubernetes-e2e-non-cri-gke-alpha-features:
+        job-name: ci-kubernetes-e2e-non-cri-gke-alpha-features
         timeout: 200
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-autoscaling:
-        job-name: ci-kubernetes-e2e-cri-gke-autoscaling
+    - kubernetes-e2e-non-cri-gke-autoscaling:
+        job-name: ci-kubernetes-e2e-non-cri-gke-autoscaling
         timeout: 320
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-flaky:
-        job-name: ci-kubernetes-e2e-cri-gke-flaky
+    - kubernetes-e2e-non-cri-gke-flaky:
+        job-name: ci-kubernetes-e2e-non-cri-gke-flaky
         timeout: 320
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-reboot:
-        job-name: ci-kubernetes-e2e-cri-gke-reboot
+    - kubernetes-e2e-non-cri-gke-reboot:
+        job-name: ci-kubernetes-e2e-non-cri-gke-reboot
         timeout: 200
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-serial:
-        job-name: ci-kubernetes-e2e-cri-gke-serial
+    - kubernetes-e2e-non-cri-gke-serial:
+        job-name: ci-kubernetes-e2e-non-cri-gke-serial
         timeout: 320
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-updown:
-        job-name: ci-kubernetes-e2e-cri-gke-updown
+    - kubernetes-e2e-non-cri-gke-updown:
+        job-name: ci-kubernetes-e2e-non-cri-gke-updown
         timeout: 50
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build'
-    - kubernetes-e2e-cri-gke-ingress:
-        job-name: ci-kubernetes-e2e-cri-gke-ingress
+    - kubernetes-e2e-non-cri-gke-ingress:
+        job-name: ci-kubernetes-e2e-non-cri-gke-ingress
         timeout: 320
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-alpha-features.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 PROJECT=k8s-jkns-e2e-cri-gce-alpha
 KUBE_FEATURE_GATES=AllAlpha=true

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-autoscaling-migs.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-autoscaling-migs.env
@@ -1,14 +1,13 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\]
-PROJECT=k8s-jkns-cri-autoscaling
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
+PROJECT=k8s-jkns-cri-autoscaling-migs
 
 # Override GCE default for cluster size autoscaling purposes.
-ENABLE_CUSTOM_METRICS=true
 KUBE_ENABLE_CLUSTER_AUTOSCALER=true
 NUM_NODES=3
+MAX_INSTANCES_PER_MIG=2
 KUBE_AUTOSCALER_MIN_NODES=3
 KUBE_AUTOSCALER_MAX_NODES=5
 KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-autoscaling.env
@@ -1,14 +1,13 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
-PROJECT=k8s-jkns-cri-autoscaling-migs
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\]
+PROJECT=k8s-jkns-cri-autoscaling
 
 # Override GCE default for cluster size autoscaling purposes.
+ENABLE_CUSTOM_METRICS=true
 KUBE_ENABLE_CLUSTER_AUTOSCALER=true
 NUM_NODES=3
-MAX_INSTANCES_PER_MIG=2
 KUBE_AUTOSCALER_MIN_NODES=3
 KUBE_AUTOSCALER_MAX_NODES=5
 KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-es-logging.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-es-logging.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 PROJECT=k8s-jkns-cri-es-logging
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Elasticsearch\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-etcd3.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-etcd3.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-examples.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-examples.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Example\]
 PROJECT=k8s-jkns-e2e-cri-examples

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-federation.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 # GCE project IDs are restricted to 30 characters, so this name is intentionally truncated.
 PROJECT=k8s-jkns-e2e-gce-cri-federatio

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-flaky.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-flaky.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 JENKINS_USE_GET_KUBE_SCRIPT=y
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-garbage.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-garbage.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 # Start the gc in controller plane
 ENABLE_GARBAGE_COLLECTOR=true

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-ingress.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-ingress.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-jkns-cri-ingress

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-proto.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-proto.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kube-api-content-type=application/vnd.kubernetes.protobuf

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-reboot.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-reboot.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-scalability.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-scalability.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-serial.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-serial.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 ENABLE_GARBAGE_COLLECTOR=true
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-slow.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-slow.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-statefulset.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-statefulset.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StatefulSet\]
 PROJECT=k8s-jkns-cri-petset

--- a/jobs/ci-kubernetes-e2e-non-cri-gce.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-alpha-features.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 PROJECT=k8s-jkns-e2e-cri-gke-alpha
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-autoscaling.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-flaky.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-flaky.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 JENKINS_USE_GET_KUBE_SCRIPT=y
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-ingress.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-ingress.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-jkns-cri-gke-ingress

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-multizone.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-multizone.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 ADDITIONAL_ZONES=us-central1-a,us-central1-b
 GINKGO_PARALLEL=y

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-reboot.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-reboot.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-serial.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-serial.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 ENABLE_GARBAGE_COLLECTOR=true
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-slow.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-slow.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-updown.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-updown.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y

--- a/jobs/ci-kubernetes-e2e-non-cri-gke.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke.env
@@ -1,6 +1,5 @@
 ### job-env
-KUBELET_TEST_ARGS=--experimental-cri=true
-KUBE_FEATURE_GATES=StreamingProxyRedirects=true
+KUBELET_TEST_ARGS=--enable-cri=false
 
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y

--- a/jobs/ci-kubernetes-soak-gce-non-cri-deploy.sh
+++ b/jobs/ci-kubernetes-soak-gce-non-cri-deploy.sh
@@ -27,7 +27,6 @@ export KUBE_GCE_ZONE="us-central1-f"
 export FAIL_ON_GCP_RESOURCE_LEAK="true"
 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 export KUBE_OS_DISTRIBUTION="gci"
-export KUBE_FEATURE_GATES="StreamingProxyRedirects=true"
 
 ### soak-env
 export JENKINS_SOAK_MODE="y"
@@ -37,7 +36,7 @@ export E2E_DOWN="false"
 
 ### job-env
 export PROJECT="k8s-jkns-gce-cri-soak"
-export KUBELET_TEST_ARGS="--experimental-cri=true"
+export KUBELET_TEST_ARGS="--enable-cri=false"
 
 ### post-env
 

--- a/jobs/ci-kubernetes-soak-gce-non-cri-test.sh
+++ b/jobs/ci-kubernetes-soak-gce-non-cri-test.sh
@@ -27,7 +27,6 @@ export KUBE_GCE_ZONE="us-central1-f"
 export FAIL_ON_GCP_RESOURCE_LEAK="true"
 export CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS="1"
 export KUBE_OS_DISTRIBUTION="gci"
-export KUBE_FEATURE_GATES="StreamingProxyRedirects=true"
 
 ### soak-env
 export JENKINS_SOAK_MODE="y"
@@ -46,7 +45,7 @@ export GINKGO_TEST_ARGS="--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]"
 
 ### job-env
 export PROJECT="k8s-jkns-gce-cri-soak"
-export KUBELET_TEST_ARGS="--experimental-cri=true"
+export KUBELET_TEST_ARGS="--enable-cri=false"
 
 ### post-env
 

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -132,24 +132,24 @@
   ]
 },
 
-"ci-kubernetes-node-kubelet-cri-benchmark": {
+"ci-kubernetes-node-kubelet-non-cri-benchmark": {
   "scenario": "kubernetes_kubelet",
   "args": [
-    "--properties=test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties"
+    "--properties=test/e2e_node/jenkins/non-cri_validation/jenkins-benchmark.properties"
   ]
 },
 
-"ci-kubernetes-node-kubelet-cri-serial": {
+"ci-kubernetes-node-kubelet-non-cri-serial": {
   "scenario": "kubernetes_kubelet",
   "args": [
-    "--properties=test/e2e_node/jenkins/cri_validation/jenkins-serial.properties"
+    "--properties=test/e2e_node/jenkins/non-cri_validation/jenkins-serial.properties"
   ]
 },
 
-"ci-kubernetes-node-kubelet-cri": {
+"ci-kubernetes-node-kubelet-non-cri": {
   "scenario": "kubernetes_kubelet",
   "args": [
-    "--properties=test/e2e_node/jenkins/cri_validation/jenkins-validation.properties"
+    "--properties=test/e2e_node/jenkins/non-cri_validation/jenkins-validation.properties"
   ]
 },
 
@@ -282,7 +282,7 @@
   ]
 },
 
-"pull-kubernetes-node-e2e-cri": {
+"pull-kubernetes-node-e2e-non-cri": {
   "scenario": "kubernetes_kubelet",
   "args": [
     "--properties=test/e2e_node/jenkins/cri_validation/jenkins-pull.properties"
@@ -315,140 +315,140 @@
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce": {
+"ci-kubernetes-e2e-non-cri-gce": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-slow": {
+"ci-kubernetes-e2e-non-cri-gce-slow": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-slow.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-slow.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-serial": {
+"ci-kubernetes-e2e-non-cri-gce-serial": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-serial.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-serial.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-reboot": {
+"ci-kubernetes-e2e-non-cri-gce-reboot": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-reboot.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-reboot.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-autoscaling": {
+"ci-kubernetes-e2e-non-cri-gce-autoscaling": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-autoscaling.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-autoscaling.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-autoscaling-migs": {
+"ci-kubernetes-e2e-non-cri-gce-autoscaling-migs": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-autoscaling-migs.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-autoscaling-migs.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-alpha-features": {
+"ci-kubernetes-e2e-non-cri-gce-alpha-features": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-alpha-features.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-alpha-features.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-flaky": {
+"ci-kubernetes-e2e-non-cri-gce-flaky": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-flaky.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-flaky.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-scalability": {
+"ci-kubernetes-e2e-non-cri-gce-scalability": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-scalability.env",
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-scalability.env",
     "--cluster=e2e-scalability"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-etcd3": {
+"ci-kubernetes-e2e-non-cri-gce-etcd3": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-etcd3.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-etcd3.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-proto": {
+"ci-kubernetes-e2e-non-cri-gce-proto": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-proto.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-proto.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-examples": {
+"ci-kubernetes-e2e-non-cri-gce-examples": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-examples.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-examples.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-federation": {
+"ci-kubernetes-e2e-non-cri-gce-federation": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-federation.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-federation.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-ingress": {
+"ci-kubernetes-e2e-non-cri-gce-ingress": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-ingress.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-ingress.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-es-logging": {
+"ci-kubernetes-e2e-non-cri-gce-es-logging": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-es-logging.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-es-logging.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-statefulset": {
+"ci-kubernetes-e2e-non-cri-gce-statefulset": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-statefulset.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-statefulset.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gce-garbage": {
+"ci-kubernetes-e2e-non-cri-gce-garbage": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gce-garbage.env",
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gce-garbage.env",
     "--cluster=gc-feature"
   ]
 },
@@ -1980,83 +1980,83 @@
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke": {
+"ci-kubernetes-e2e-non-cri-gke": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-slow": {
+"ci-kubernetes-e2e-non-cri-gke-slow": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-slow.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-slow.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-multizone": {
+"ci-kubernetes-e2e-non-cri-gke-multizone": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-multizone.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-multizone.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-alpha-features": {
+"ci-kubernetes-e2e-non-cri-gke-alpha-features": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-alpha-features.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-alpha-features.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-autoscaling": {
+"ci-kubernetes-e2e-non-cri-gke-autoscaling": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-autoscaling.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-autoscaling.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-flaky": {
+"ci-kubernetes-e2e-non-cri-gke-flaky": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-flaky.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-flaky.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-reboot": {
+"ci-kubernetes-e2e-non-cri-gke-reboot": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-reboot.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-reboot.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-serial": {
+"ci-kubernetes-e2e-non-cri-gke-serial": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-serial.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-serial.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-updown": {
+"ci-kubernetes-e2e-non-cri-gke-updown": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-updown.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-updown.env"
   ]
 },
 
-"ci-kubernetes-e2e-cri-gke-ingress": {
+"ci-kubernetes-e2e-non-cri-gke-ingress": {
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gke.env",
-    "--env-file=jobs/ci-kubernetes-e2e-cri-gke-ingress.env"
+    "--env-file=jobs/ci-kubernetes-e2e-non-cri-gke-ingress.env"
   ]
 },
 

--- a/jobs/pull-kubernetes-e2e-gce-non-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-non-cri.sh
@@ -39,9 +39,6 @@ export KUBERNETES_PROVIDER="gce"
 export E2E_MIN_STARTUP_PODS="1"
 export KUBE_GCE_ZONE="us-central1-f"
 
-# Required for CRI exec/attach/port-forward.
-export KUBE_FEATURE_GATES="StreamingProxyRedirects=true"
-
 # Flake detection. Individual tests get a second chance to pass.
 export GINKGO_TOLERATE_FLAKES="y"
 
@@ -58,7 +55,7 @@ export NUM_NODES="3"
 export KUBE_NODE_OS_DISTRIBUTION="gci"
 
 # Enable experimental CRI integration
-export KUBELET_TEST_ARGS="--experimental-cri=true"
+export KUBELET_TEST_ARGS="--enable-cri=false"
 
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"

--- a/prow/presubmit.yaml
+++ b/prow/presubmit.yaml
@@ -149,15 +149,15 @@ kubernetes/kubernetes:
   rerun_command: "@k8s-bot node e2e test this"
   trigger: "@k8s-bot (node )?(e2e )?test this"
 
-- name: pull-kubernetes-e2e-gce-cri
+- name: pull-kubernetes-e2e-gce-non-cri
   branches:
   - master
   always_run: true
-  context: Jenkins CRI GCE e2e
-  rerun_command: "@k8s-bot cri e2e test this"
-  trigger: "@k8s-bot (cri e2e )?test this"
+  context: Jenkins non-CRI GCE e2e
+  rerun_command: "@k8s-bot non-cri e2e test this"
+  trigger: "@k8s-bot (non-cri e2e )?test this"
 
-- name: pull-kubernetes-node-e2e-cri
+- name: pull-kubernetes-node-e2e-non-cri
   skip_branches:
   - release-1.0
   - release-1.1
@@ -165,9 +165,9 @@ kubernetes/kubernetes:
   - release-1.3
   - release-1.4
   always_run: true
-  context: Jenkins CRI GCE Node e2e
-  rerun_command: "@k8s-bot cri node e2e test this"
-  trigger: "@k8s-bot (cri node e2e )?test this"
+  context: Jenkins non-CRI GCE Node e2e
+  rerun_command: "@k8s-bot non-cri node e2e test this"
+  trigger: "@k8s-bot (non-cri node e2e )?test this"
 
 kubernetes/test-infra:
 - name: pull-test-infra-bazel

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -54,12 +54,12 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-test-history
 - name: ci-kubernetes-node-kubelet-benchmark
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-benchmark
-- name: ci-kubernetes-node-kubelet-cri
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-cri
-- name: ci-kubernetes-node-kubelet-cri-serial
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-cri-serial
-- name: ci-kubernetes-node-kubelet-cri-benchmark
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-cri-benchmark
+- name: ci-kubernetes-node-kubelet-non-cri
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-non-cri
+- name: ci-kubernetes-node-kubelet-non-cri-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-non-cri-serial
+- name: ci-kubernetes-node-kubelet-non-cri-benchmark
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-non-cri-benchmark
 - name: ci-kubernetes-node-kubelet
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet
 - name: ci-kubernetes-node-kubelet-serial
@@ -76,60 +76,60 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aws
 - name: kubernetes-e2e-aws-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aws-release-1.5
-- name: ci-kubernetes-e2e-cri-gce
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce
-- name: ci-kubernetes-e2e-cri-gce-alpha-features
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-alpha-features
-- name: ci-kubernetes-e2e-cri-gce-autoscaling
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-autoscaling
-- name: ci-kubernetes-e2e-cri-gce-autoscaling-migs
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-autoscaling-migs
-- name: ci-kubernetes-e2e-cri-gce-es-logging
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-es-logging
-- name: ci-kubernetes-e2e-cri-gce-etcd3
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-etcd3
-- name: ci-kubernetes-e2e-cri-gce-examples
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-examples
-- name: ci-kubernetes-e2e-cri-gce-federation
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-federation
-- name: ci-kubernetes-e2e-cri-gce-flaky
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-flaky
-- name: ci-kubernetes-e2e-cri-gce-ingress
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-ingress
-- name: ci-kubernetes-e2e-cri-gce-proto
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-proto
-- name: ci-kubernetes-e2e-cri-gce-reboot
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-reboot
-- name: ci-kubernetes-e2e-cri-gce-scalability
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-scalability
-- name: ci-kubernetes-e2e-cri-gce-serial
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-serial
-- name: ci-kubernetes-e2e-cri-gce-slow
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-slow
-- name: ci-kubernetes-e2e-cri-gce-statefulset
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-statefulset
-- name: ci-kubernetes-e2e-cri-gke
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke
-- name: ci-kubernetes-e2e-cri-gke-alpha-features
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-alpha-features
-- name: ci-kubernetes-e2e-cri-gke-autoscaling
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-autoscaling
-- name: ci-kubernetes-e2e-cri-gke-flaky
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-flaky
-- name: ci-kubernetes-e2e-cri-gke-ingress
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-ingress
-- name: ci-kubernetes-e2e-cri-gke-multizone
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-multizone
-- name: ci-kubernetes-e2e-cri-gke-reboot
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-reboot
-- name: ci-kubernetes-e2e-cri-gke-serial
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-serial
-- name: ci-kubernetes-e2e-cri-gke-slow
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-slow
-- name: ci-kubernetes-e2e-cri-gke-updown
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gke-updown
-- name: ci-kubernetes-e2e-cri-gce-garbage
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-cri-gce-garbage
+- name: ci-kubernetes-e2e-non-cri-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce
+- name: ci-kubernetes-e2e-non-cri-gce-alpha-features
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-alpha-features
+- name: ci-kubernetes-e2e-non-cri-gce-autoscaling
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-autoscaling
+- name: ci-kubernetes-e2e-non-cri-gce-autoscaling-migs
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-autoscaling-migs
+- name: ci-kubernetes-e2e-non-cri-gce-es-logging
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-es-logging
+- name: ci-kubernetes-e2e-non-cri-gce-etcd3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-etcd3
+- name: ci-kubernetes-e2e-non-cri-gce-examples
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-examples
+- name: ci-kubernetes-e2e-non-cri-gce-federation
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-federation
+- name: ci-kubernetes-e2e-non-cri-gce-flaky
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-flaky
+- name: ci-kubernetes-e2e-non-cri-gce-ingress
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-ingress
+- name: ci-kubernetes-e2e-non-cri-gce-proto
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-proto
+- name: ci-kubernetes-e2e-non-cri-gce-reboot
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-reboot
+- name: ci-kubernetes-e2e-non-cri-gce-scalability
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-scalability
+- name: ci-kubernetes-e2e-non-cri-gce-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-serial
+- name: ci-kubernetes-e2e-non-cri-gce-slow
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-slow
+- name: ci-kubernetes-e2e-non-cri-gce-statefulset
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-statefulset
+- name: ci-kubernetes-e2e-non-cri-gke
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke
+- name: ci-kubernetes-e2e-non-cri-gke-alpha-features
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-alpha-features
+- name: ci-kubernetes-e2e-non-cri-gke-autoscaling
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-autoscaling
+- name: ci-kubernetes-e2e-non-cri-gke-flaky
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-flaky
+- name: ci-kubernetes-e2e-non-cri-gke-ingress
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-ingress
+- name: ci-kubernetes-e2e-non-cri-gke-multizone
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-multizone
+- name: ci-kubernetes-e2e-non-cri-gke-reboot
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-reboot
+- name: ci-kubernetes-e2e-non-cri-gke-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-serial
+- name: ci-kubernetes-e2e-non-cri-gke-slow
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-slow
+- name: ci-kubernetes-e2e-non-cri-gke-updown
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gke-updown
+- name: ci-kubernetes-e2e-non-cri-gce-garbage
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-non-cri-gce-garbage
 - name: kubernetes-e2e-kops-aws
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws
 - name: kubernetes-e2e-kops-aws-updown
@@ -524,8 +524,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gke-test
 - name: kubernetes-soak-gke-gci-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gke-gci-test
-- name: kubernetes-soak-gce-cri-test
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-cri-test
+- name: kubernetes-soak-gce-non-cri-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-non-cri-test
 - name: kubernetes-soak-gce-deploy
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-deploy
 - name: kubernetes-soak-gce-1.3-deploy
@@ -546,8 +546,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gke-deploy
 - name: kubernetes-soak-gke-gci-deploy
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gke-gci-deploy
-- name: kubernetes-soak-gce-cri-deploy
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-cri-deploy
+- name: kubernetes-soak-gce-non-cri-deploy
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-non-cri-deploy
 - name: kubernetes-test-go
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-test-go
   days_of_results: 4
@@ -1305,12 +1305,12 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet
   - name: kubelet-serial-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-serial
-  - name: kubelet-cri-gce-e2e
-    test_group_name: ci-kubernetes-node-kubelet-cri
-  - name: kubelet-cri-serial-gce-e2e
-    test_group_name: ci-kubernetes-node-kubelet-cri-serial
-  - name: kubelet-cri-benchmark-gce-e2e
-    test_group_name: ci-kubernetes-node-kubelet-cri-benchmark
+  - name: kubelet-non-cri-gce-e2e
+    test_group_name: ci-kubernetes-node-kubelet-non-cri
+  - name: kubelet-non-cri-serial-gce-e2e
+    test_group_name: ci-kubernetes-node-kubelet-non-cri-serial
+  - name: kubelet-non-cri-benchmark-gce-e2e
+    test_group_name: ci-kubernetes-node-kubelet-non-cri-benchmark
   - name: kubelet-flaky-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-flaky
   - name: kubelet-conformance-gce-e2e
@@ -1349,8 +1349,8 @@ dashboards:
     test_group_name: kubernetes-soak-gke-test
   - name: gke-gci-test
     test_group_name: kubernetes-soak-gke-gci-test
-  - name: gce-cri-test
-    test_group_name: kubernetes-soak-gce-cri-test
+  - name: gce-non-cri-test
+    test_group_name: kubernetes-soak-gce-non-cri-test
   - name: gce-deploy
     test_group_name: kubernetes-soak-gce-deploy
   - name: gce-1.3-deploy
@@ -1371,8 +1371,8 @@ dashboards:
     test_group_name: kubernetes-soak-gke-deploy
   - name: gke-gci-deploy
     test_group_name: kubernetes-soak-gke-gci-deploy
-  - name: gce-cri-deploy
-    test_group_name: kubernetes-soak-gce-cri-deploy
+  - name: gce-non-cri-deploy
+    test_group_name: kubernetes-soak-gce-non-cri-deploy
 
 - name: google-unit
   dashboard_tab:
@@ -1992,59 +1992,59 @@ dashboards:
   - name: verify 
     test_group_name: kubernetes-verify-master
 
-- name: google-cri
+- name: google-non-cri
   dashboard_tab:
   - name: gce
-    test_group_name: ci-kubernetes-e2e-cri-gce
+    test_group_name: ci-kubernetes-e2e-non-cri-gce
   - name: gce-alpha-features
-    test_group_name: ci-kubernetes-e2e-cri-gce-alpha-features
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-alpha-features
   - name: gce-autoscaling
-    test_group_name: ci-kubernetes-e2e-cri-gce-autoscaling
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-autoscaling
   - name: gce-autoscaling-migs
-    test_group_name: ci-kubernetes-e2e-cri-gce-autoscaling-migs
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-autoscaling-migs
   - name: gce-es-logging
-    test_group_name: ci-kubernetes-e2e-cri-gce-es-logging
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-es-logging
   - name: gce-etcd3
-    test_group_name: ci-kubernetes-e2e-cri-gce-etcd3
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-etcd3
   - name: gce-examples
-    test_group_name: ci-kubernetes-e2e-cri-gce-examples
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-examples
   - name: gce-federation
-    test_group_name: ci-kubernetes-e2e-cri-gce-federation
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-federation
   - name: gce-flaky
-    test_group_name: ci-kubernetes-e2e-cri-gce-flaky
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-flaky
   - name: gce-ingress
-    test_group_name: ci-kubernetes-e2e-cri-gce-ingress
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-ingress
   - name: gce-proto
-    test_group_name: ci-kubernetes-e2e-cri-gce-proto
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-proto
   - name: gce-reboot
-    test_group_name: ci-kubernetes-e2e-cri-gce-reboot
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-reboot
   - name: gce-scalability
-    test_group_name: ci-kubernetes-e2e-cri-gce-scalability
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-scalability
   - name: gce-serial
-    test_group_name: ci-kubernetes-e2e-cri-gce-serial
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-serial
   - name: gce-slow
-    test_group_name: ci-kubernetes-e2e-cri-gce-slow
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-slow
   - name: gce-statefulset
-    test_group_name: ci-kubernetes-e2e-cri-gce-statefulset
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-statefulset
   - name: gce-garbage
-    test_group_name: ci-kubernetes-e2e-cri-gce-garbage
+    test_group_name: ci-kubernetes-e2e-non-cri-gce-garbage
   - name: gke
-    test_group_name: ci-kubernetes-e2e-cri-gke
+    test_group_name: ci-kubernetes-e2e-non-cri-gke
   - name: gke-alpha-features
-    test_group_name: ci-kubernetes-e2e-cri-gke-alpha-features
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-alpha-features
   - name: gke-autoscaling
-    test_group_name: ci-kubernetes-e2e-cri-gke-autoscaling
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-autoscaling
   - name: gke-flaky
-    test_group_name: ci-kubernetes-e2e-cri-gke-flaky
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-flaky
   - name: gke-ingress
-    test_group_name: ci-kubernetes-e2e-cri-gke-ingress
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-ingress
   - name: gke-multizone
-    test_group_name: ci-kubernetes-e2e-cri-gke-multizone
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-multizone
   - name: gke-reboot
-    test_group_name: ci-kubernetes-e2e-cri-gke-reboot
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-reboot
   - name: gke-serial
-    test_group_name: ci-kubernetes-e2e-cri-gke-serial
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-serial
   - name: gke-slow
-    test_group_name: ci-kubernetes-e2e-cri-gke-slow
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-slow
   - name: gke-updown
-    test_group_name: ci-kubernetes-e2e-cri-gke-updown
+    test_group_name: ci-kubernetes-e2e-non-cri-gke-updown


### PR DESCRIPTION
We have already enabled CRI in all builds. This change repurposes the
CRI jobs to test the original non-CRI implementation. We keep the
original gce project (and job names) to avoid recreating all the
projects. This could be misleading at times, so this change also renames
the test-grid dashboard "google-cri" to "google-non-cri" to improve
readability.