### PR TITLE
Enable cache mutation detector for some PR jobs

### DIFF
--- a/jobs/pull-kubernetes-e2e-gce-etcd3.sh
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.sh
@@ -26,7 +26,7 @@ if [[ "${PULL_BASE_REF:-}" == "release-1.0" || "${PULL_BASE_REF:-}" == "release-
   exit
 fi
 
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
+export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
 export KUBE_GCS_UPDATE_LATEST=n
 export JENKINS_USE_LOCAL_BINARIES=y
@@ -44,13 +44,16 @@ export GINKGO_PARALLEL="y"
 # This list should match the list in kubernetes-e2e-gce.
 export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
-export PROJECT="k8s-jkns-pr-gce-etcd3"
+export PROJECT="${PROJECT:-k8s-jkns-pr-gce-etcd3}"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 export NUM_NODES="4"
 export GINKGO_PARALLEL_NODES="30"
 
 # Force to use container-vm.
 export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+# Panic if anything mutates a shared informer cache
+export ENABLE_CACHE_MUTATION_DETECTOR="true"
 
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"

--- a/jobs/pull-kubernetes-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gce-gci.sh
@@ -26,7 +26,7 @@ if [[ "${PULL_BASE_REF:-}" == "release-1.0" || "${PULL_BASE_REF:-}" == "release-
   exit
 fi
 
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
+export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
 export KUBE_GCS_UPDATE_LATEST=n
 export JENKINS_USE_LOCAL_BINARIES=y
@@ -45,7 +45,7 @@ export GINKGO_PARALLEL="y"
 # This list should match the list in kubernetes-e2e-gce.
 export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
-export PROJECT="k8s-jkns-pr-gci-gce"
+export PROJECT="${PROJECT:-k8s-jkns-pr-gci-gce}"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 export NUM_NODES="4"
 export GINKGO_PARALLEL_NODES="30"
@@ -56,6 +56,9 @@ export TEST_ETCD_VERSION="2.2.1"
 
 # Force to use GCI.
 export KUBE_NODE_OS_DISTRIBUTION="gci"
+
+# Panic if anything mutates a shared informer cache
+export ENABLE_CACHE_MUTATION_DETECTOR="true"
 
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"

--- a/jobs/pull-kubernetes-e2e-gce-non-cri.sh
+++ b/jobs/pull-kubernetes-e2e-gce-non-cri.sh
@@ -28,7 +28,7 @@ release-1.0|release-1.1|release-1.2|release-1.3|release-1.4)
   ;;
 esac
 
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
+export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
 export KUBE_GCS_UPDATE_LATEST=n
 export JENKINS_USE_LOCAL_BINARIES=y
@@ -47,7 +47,7 @@ export GINKGO_PARALLEL="y"
 # This list should match the list in kubernetes-e2e-gce.
 export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
-export PROJECT="kubernetes-pr-cri-validation"
+export PROJECT="${PROJECT:-kubernetes-pr-cri-validation}"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 export NUM_NODES="3"
 
@@ -56,6 +56,9 @@ export KUBE_NODE_OS_DISTRIBUTION="gci"
 
 # Enable experimental CRI integration
 export KUBELET_TEST_ARGS="--enable-cri=false"
+
+# Panic if anything mutates a shared informer cache
+export ENABLE_CACHE_MUTATION_DETECTOR="true"
 
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"

--- a/jobs/pull-kubernetes-e2e-gce.sh
+++ b/jobs/pull-kubernetes-e2e-gce.sh
@@ -26,7 +26,7 @@ if [[ "${PULL_BASE_REF:-}" == "release-1.0" || "${PULL_BASE_REF:-}" == "release-
   exit
 fi
 
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
+export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
 export KUBE_GCS_UPDATE_LATEST=n
 export JENKINS_USE_LOCAL_BINARIES=y
@@ -45,7 +45,7 @@ export GINKGO_PARALLEL="y"
 # This list should match the list in kubernetes-e2e-gce.
 export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
-export PROJECT="k8s-jkns-pr-gce"
+export PROJECT="${PROJECT:-k8s-jkns-pr-gce}"
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 export NUM_NODES="4"
 export GINKGO_PARALLEL_NODES="30"
@@ -56,6 +56,9 @@ export TEST_ETCD_VERSION="2.2.1"
 
 # Force to use container-vm.
 export KUBE_NODE_OS_DISTRIBUTION="debian"
+
+# Panic if anything mutates a shared informer cache
+export ENABLE_CACHE_MUTATION_DETECTOR="true"
 
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"

--- a/jobs/pull-kubernetes-federation-e2e-gce-gci.sh
+++ b/jobs/pull-kubernetes-federation-e2e-gce-gci.sh
@@ -28,7 +28,7 @@ fi
 
 # Federation specific params
 export FEDERATION="true"
-export PROJECT="k8s-jkns-pr-gci-bld-e2e-gce-fd"
+export PROJECT="${PROJECT:-k8s-jkns-pr-gci-bld-e2e-gce-fd}"
 export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn"
 export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
@@ -38,7 +38,7 @@ export DNS_ZONE_NAME="pr-bldr.test-f8n.k8s.io."
 export FEDERATIONS_DOMAIN_MAP="federation=pr-bldr.test-f8n.k8s.io"
 
 # Build the images.
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
+export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
 export KUBE_GCS_UPDATE_LATEST=n
 export JENKINS_USE_LOCAL_BINARIES=y
@@ -54,6 +54,8 @@ export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export NUM_NODES="3"
 # Force to use container-vm.
 export KUBE_NODE_OS_DISTRIBUTION="debian"
+# Panic if anything mutates a shared informer cache
+export ENABLE_CACHE_MUTATION_DETECTOR="true"
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"
 export E2E_TEST="true"

--- a/jobs/pull-kubernetes-federation-e2e-gce.sh
+++ b/jobs/pull-kubernetes-federation-e2e-gce.sh
@@ -27,7 +27,7 @@ if [[ "${PULL_BASE_REF:-}" == "release-1.0" || "${PULL_BASE_REF:-}" == "release-
 fi
 
 export FEDERATION="true"
-export PROJECT="k8s-jkns-pr-bldr-e2e-gce-fdrtn"
+export PROJECT="${PROJECT:-k8s-jkns-pr-bldr-e2e-gce-fdrtn}"
 export FEDERATION_PUSH_REPO_BASE="gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn"
 export GINKGO_PARALLEL="n" # We don't have namespaces yet in federation apiserver, so we need to serialize
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Feature:Federation\]"
@@ -37,7 +37,7 @@ export DNS_ZONE_NAME="pr-bldr.test-f8n.k8s.io."
 export FEDERATIONS_DOMAIN_MAP="federation=pr-bldr.test-f8n.k8s.io"
 
 # Build the images.
-export KUBE_GCS_RELEASE_BUCKET=kubernetes-release-pull
+export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
 export KUBE_GCS_UPDATE_LATEST=n
 export JENKINS_USE_LOCAL_BINARIES=y
@@ -53,6 +53,8 @@ export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export NUM_NODES="3"
 # Force to use container-vm.
 export KUBE_NODE_OS_DISTRIBUTION="debian"
+# Panic if anything mutates a shared informer cache
+export ENABLE_CACHE_MUTATION_DETECTOR="true"
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"
 export E2E_TEST="true"


### PR DESCRIPTION
Enable for e2es on gce (not gke), except kubemark, which I assume could be
negatively affected by this.

When paired with https://github.com/kubernetes/kubernetes/pull/41326, we'll be able to detect shared informer cache mutations in gce e2e PR jobs.