### PR TITLE
Reduce node-schedulable-timeout for large clusters

### DIFF
--- a/jobs/ci-kubernetes-e2e-gke-large-deploy.env
+++ b/jobs/ci-kubernetes-e2e-gke-large-deploy.env
@@ -2,7 +2,7 @@
 PROJECT=kubernetes-scale
 # TODO: Remove FAIL_ON_GCP_RESOURCE_LEAK when PROJECT changes back to gke-large-cluster-jenkins.
 FAIL_ON_GCP_RESOURCE_LEAK=false
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Empty\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=600m --system-pods-startup-timeout=60m
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Empty\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=360m --system-pods-startup-timeout=60m
 
 ZONE=us-east1-a
 NUM_NODES=5000


### PR DESCRIPTION
Too large timeout is painful when something fails in the meantime.

E.g. today, the test itself failed, but in the background all routes were created successfully, all nodes were ready, I already turned down the cluster, and the test is still running.