### PR TITLE
Extend the default timeout to 300, and all other jobs use 30

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-maintenance-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-maintenance-ci.yaml
@@ -31,7 +31,7 @@
         - 'test-infra/.git/'
         external-deletion-command: 'sudo rm -rf %s'
     - timeout:
-        timeout: 30
+        timeout: 300
         fail: true
     triggers:
     - timed: '{frequency}'
@@ -47,14 +47,14 @@
         json: 0
         frequency: 'H H/3 * * *'
         repo-name: 'k8s.io/test-infra'
-        timeout: 0
+        timeout: 30
     - aws-janitor:
         branch: master
         frequency: 'H * * * *'
         job-name: maintenance-ci-aws-janitor
         json: 0
         repo-name: 'k8s.io/test-infra'
-        timeout: 0
+        timeout: 30
     - janitor:
         branch: master
         frequency: '@daily'


### PR DESCRIPTION
```
Build timed out (after 30 minutes). Marking the build as failed.
Build was aborted
```

:cry: more fix follow #1907 