### PR TITLE
Bump the PR cross build timeout.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull.yaml
@@ -92,7 +92,7 @@
         job-name: pull-kubernetes-cross
         json: 1
         repo-name: 'k8s.io/kubernetes'
-        timeout: 60
+        timeout: 80
     - kubernetes-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-e2e-gce


### PR DESCRIPTION
It's been timing out pretty regularly. After https://github.com/kubernetes/kubernetes/pull/38926 went in, the post-submit job went from 50m average to 60m average, which is when this started to fail. cc @luxas 