### PR TITLE
Fix kubemark scale to have a longer Jenkins timeout than bootstrap timeout.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -1381,7 +1381,7 @@
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-kubemark-gce-scale:
         job-name: ci-kubernetes-kubemark-gce-scale
-        timeout: 680
+        timeout: 760
         frequency: 'H H/12 * * *'
         json: 1
         trigger-job: ''

--- a/jobs/BUILD
+++ b/jobs/BUILD
@@ -4,6 +4,7 @@ filegroup(
     name = "jobs",
     srcs = glob([
         "*.sh",
+        "*.env",
         "config.json",
     ]),
 )


### PR DESCRIPTION
#1920 broke this, but somehow it wasn't caught in presubmit. Possibly a bad test config?