### PR TITLE
Make Gubernator handle corrupt JUnit files better.

### DIFF
--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -30,7 +30,15 @@ import view_base
 
 def parse_junit(xml, filename):
     """Generate failed tests as a series of (name, duration, text, filename) tuples."""
-    tree = ET.fromstring(xml)
+    try:
+        tree = ET.fromstring(xml)
+    except ET.ParseError, e:
+        logging.exception('parse_junit failed for %s', filename)
+        try:
+            tree = ET.fromstring(re.sub(r'[\x00\x80-\xFF]+', '?', xml))
+        except ET.ParseError, e:
+            yield 'Gubernator Internal Fatal XML Parse Error', 0.0, str(e), filename
+            return
     if tree.tag == 'testsuite':
         for child in tree:
             name = child.attrib['name']

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -58,6 +58,22 @@ class ParseJunitTest(unittest.TestCase):
     def test_bad_xml(self):
         self.assertEqual(self.parse('''<body />'''), [])
 
+    def test_corrupt_xml(self):
+        self.assertEqual(self.parse('<a>\xff</a>'), [])
+        failures = self.parse('''
+            <testsuites>
+                <testsuite name="a">
+                    <testcase name="Corrupt" time="0">
+                        <failure>something bad \xff</failure>
+                    </testcase>
+                </testsuite>
+            </testsuites>''')
+        self.assertEqual(failures, [('a Corrupt', 0.0, 'something bad ?', 'fp')])
+
+    def test_not_xml(self):
+        failures = self.parse('\x01')
+        self.assertEqual(failures,
+            [(failures[0][0], 0.0, 'not well-formed (invalid token): line 1, column 0', 'fp')])
 
 class BuildTest(main_test.TestBase):
     # pylint: disable=too-many-public-methods


### PR DESCRIPTION
If parsing fails, try to remove all the bad characters from the XML
file-- UTF-8 characters all have the high bit set.

See also kubernetes/kubernetes#41591