### PR TITLE
Soak jobs cleanup

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1361,8 +1361,6 @@ class JobTest(unittest.TestCase):
             self.assertNotIn('repo-name', job)
             self.assertNotIn('branch', job)
             self.assertIn('timeout', job)
-            self.assertIn('json', job)
-            self.assertTrue(job['json'], name)
             self.assertGreater(job['timeout'], 0, name)
 
             return job_name

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -143,6 +143,20 @@
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
+    - kubernetes-soak-gce-1.3-deploy:
+        blocker: ci-kubernetes-soak-gce-1.3-test
+        job-name: ci-kubernetes-soak-gce-1.3-deploy
+        json: 1
+        frequency: 'H 0 * * 2'
+        scan: DISABLED
+        timeout: 110
+    - kubernetes-soak-gce-1.3-test:
+        blocker: ci-kubernetes-soak-gce-1.3-deploy
+        job-name: ci-kubernetes-soak-gce-1.3-test
+        json: 1
+        frequency: 'H/30 * * * *'
+        scan: ALL
+        timeout: 620
     - kubernetes-soak-gci-gce-1.5-deploy:
         blocker: ci-kubernetes-soak-gci-gce-1.5-test
         job-name: ci-kubernetes-soak-gci-gce-1.5-deploy
@@ -167,20 +181,6 @@
     - kubernetes-soak-gci-gce-1.4-test:
         blocker: ci-kubernetes-soak-gci-gce-1.4-deploy
         job-name: ci-kubernetes-soak-gci-gce-1.4-test
-        json: 1
-        frequency: 'H/30 * * * *'
-        scan: ALL
-        timeout: 620
-    - kubernetes-soak-gce-1.3-deploy:
-        blocker: ci-kubernetes-soak-gce-1.3-test
-        job-name: ci-kubernetes-soak-gce-1.3-deploy
-        json: 1
-        frequency: 'H 0 * * 2'
-        scan: DISABLED
-        timeout: 110
-    - kubernetes-soak-gce-1.3-test:
-        blocker: ci-kubernetes-soak-gce-1.3-deploy
-        job-name: ci-kubernetes-soak-gce-1.3-test
         json: 1
         frequency: 'H/30 * * * *'
         scan: ALL

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -6,7 +6,7 @@
         './test-infra/jenkins/bootstrap.py' \
             --bare \
             --job='{job-name}' \
-            --json='{json}' \
+            --json=1 \
             --root="${{GOPATH}}/src/k8s.io" \
             --service-account="${{GOOGLE_APPLICATION_CREDENTIALS}}" \
             --timeout='{timeout}' \
@@ -48,168 +48,144 @@
     - kubernetes-soak-gce-deploy:
         blocker: ci-kubernetes-soak-gce-test
         job-name: ci-kubernetes-soak-gce-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-test:
         blocker: ci-kubernetes-soak-gce-deploy
         job-name: ci-kubernetes-soak-gce-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gce-non-cri-deploy:
         blocker: ci-kubernetes-soak-gce-non-cri-test
         job-name: ci-kubernetes-soak-gce-non-cri-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-non-cri-test:
         blocker: ci-kubernetes-soak-gce-non-cri-deploy
         job-name: ci-kubernetes-soak-gce-non-cri-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gce-federation-deploy:
         blocker: ci-kubernetes-soak-gce-federation-test
         job-name: ci-kubernetes-soak-gce-federation-deploy
-        json: 1
         frequency: 'H 0 * * *'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-federation-test:
         blocker: ci-kubernetes-soak-gce-federation-deploy
         job-name: ci-kubernetes-soak-gce-federation-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gce-gci-deploy:
         blocker: ci-kubernetes-soak-gce-gci-test
         job-name: ci-kubernetes-soak-gce-gci-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-gci-test:
         blocker: ci-kubernetes-soak-gce-gci-deploy
         job-name: ci-kubernetes-soak-gce-gci-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gce-2-deploy:
         blocker: ci-kubernetes-soak-gce-2-test
         job-name: ci-kubernetes-soak-gce-2-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-2-test:
         blocker: ci-kubernetes-soak-gce-2-deploy
         job-name: ci-kubernetes-soak-gce-2-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gce-1.5-deploy:
         blocker: ci-kubernetes-soak-gce-1.5-test
         job-name: ci-kubernetes-soak-gce-1.5-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-1.5-test:
         blocker: ci-kubernetes-soak-gce-1.5-deploy
         job-name: ci-kubernetes-soak-gce-1.5-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gce-1.4-deploy:
         blocker: ci-kubernetes-soak-gce-1.4-test
         job-name: ci-kubernetes-soak-gce-1.4-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-1.4-test:
         blocker: ci-kubernetes-soak-gce-1.4-deploy
         job-name: ci-kubernetes-soak-gce-1.4-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gce-1.3-deploy:
         blocker: ci-kubernetes-soak-gce-1.3-test
         job-name: ci-kubernetes-soak-gce-1.3-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gce-1.3-test:
         blocker: ci-kubernetes-soak-gce-1.3-deploy
         job-name: ci-kubernetes-soak-gce-1.3-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gci-gce-1.5-deploy:
         blocker: ci-kubernetes-soak-gci-gce-1.5-test
         job-name: ci-kubernetes-soak-gci-gce-1.5-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gci-gce-1.5-test:
         blocker: ci-kubernetes-soak-gci-gce-1.5-deploy
         job-name: ci-kubernetes-soak-gci-gce-1.5-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gci-gce-1.4-deploy:
         blocker: ci-kubernetes-soak-gci-gce-1.4-test
         job-name: ci-kubernetes-soak-gci-gce-1.4-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gci-gce-1.4-test:
         blocker: ci-kubernetes-soak-gci-gce-1.4-deploy
         job-name: ci-kubernetes-soak-gci-gce-1.4-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gke-deploy:
         blocker: ci-kubernetes-soak-gke-test
         job-name: ci-kubernetes-soak-gke-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gke-test:
         blocker: ci-kubernetes-soak-gke-deploy
         job-name: ci-kubernetes-soak-gke-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
     - kubernetes-soak-gke-gci-deploy:
         blocker: ci-kubernetes-soak-gke-gci-test
         job-name: ci-kubernetes-soak-gke-gci-deploy
-        json: 1
         frequency: 'H 0 * * 2'
         scan: DISABLED
         timeout: 110
     - kubernetes-soak-gke-gci-test:
         blocker: ci-kubernetes-soak-gke-gci-deploy
         job-name: ci-kubernetes-soak-gke-gci-test
-        json: 1
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2054,6 +2054,27 @@
   ]
 },
 
+"ci-kubernetes-soak-gce-federation-deploy": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gce-federation-deploy.env",
+    "--test=false",
+    "--down=false"
+  ]
+},
+
+"ci-kubernetes-soak-gce-federation-test": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gce-federation-test.env",
+    "--soak-test",
+    "--up=false",
+    "--down=false"
+  ]
+},
+
 "ci-kubernetes-soak-gce-gci-deploy": {
   "scenario": "kubernetes_e2e",
   "args": [
@@ -2138,6 +2159,27 @@
   ]
 },
 
+"ci-kubernetes-soak-gce-1.3-deploy": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gce-1.3-deploy.env",
+    "--test=false",
+    "--down=false"
+  ]
+},
+
+"ci-kubernetes-soak-gce-1.3-test": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gce-1.3-test.env",
+    "--soak-test",
+    "--up=false",
+    "--down=false"
+  ]
+},
+
 "ci-kubernetes-soak-gci-gce-1.5-deploy": {
   "scenario": "kubernetes_e2e",
   "args": [
@@ -2174,48 +2216,6 @@
   "args": [
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.4-test.env",
-    "--soak-test",
-    "--up=false",
-    "--down=false"
-  ]
-},
-
-"ci-kubernetes-soak-gce-1.3-deploy": {
-  "scenario": "kubernetes_e2e",
-  "args": [
-    "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-soak-gce-1.3-deploy.env",
-    "--test=false",
-    "--down=false"
-  ]
-},
-
-"ci-kubernetes-soak-gce-1.3-test": {
-  "scenario": "kubernetes_e2e",
-  "args": [
-    "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-soak-gce-1.3-test.env",
-    "--soak-test",
-    "--up=false",
-    "--down=false"
-  ]
-},
-
-"ci-kubernetes-soak-gce-federation-deploy": {
-  "scenario": "kubernetes_e2e",
-  "args": [
-    "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-soak-gce-federation-deploy.env",
-    "--test=false",
-    "--down=false"
-  ]
-},
-
-"ci-kubernetes-soak-gce-federation-test": {
-  "scenario": "kubernetes_e2e",
-  "args": [
-    "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-soak-gce-federation-test.env",
     "--soak-test",
     "--up=false",
     "--down=false"


### PR DESCRIPTION
#1230 #1938 

This PR:
a. sort soak jobs in `bootstrap-ci-soak.yaml` and `config.json` to keep consistent.
b. kill json flag.

cc @krzyzacy 