### PR TITLE
Extend janitor timeout, till it becomes stable

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-maintenance-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-maintenance-ci.yaml
@@ -31,7 +31,7 @@
         - 'test-infra/.git/'
         external-deletion-command: 'sudo rm -rf %s'
     - timeout:
-        timeout: 300
+        timeout: 700
         fail: true
     triggers:
     - timed: '{frequency}'
@@ -61,4 +61,4 @@
         job-name: maintenance-ci-janitor
         json: 1
         repo-name: 'k8s.io/test-infra'
-        timeout: 300
+        timeout: 600


### PR DESCRIPTION
300m is not enough (might due to too many old dirts to cycle through in the first run), and it's killed by Jenkins so it does not upload any logs.

Give it some more room, and will update it again once the time consumption is stabilized.