### PR TITLE
Explicitly specify host cluster.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-federation-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-serial.env
@@ -23,4 +23,10 @@ FEDERATION_DNS_ZONE_NAME=gce-serial.test-f8n.k8s.io.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
 FEDERATIONS_DOMAIN_MAP=federation=gce-serial.test-f8n.k8s.io
 
+# TODO: Replace this with FEDERATION_HOST_CLUSTER, but do it in
+# lock steps. First make current the scripts understand the host
+# parameters. Then make the necessary changes to make them more
+# accurate.
+FEDERATION_HOST_CLUSTER_ZONE=us-central1-f
+
 KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation.env
@@ -17,4 +17,10 @@ FEDERATION_DNS_ZONE_NAME=test-f8n.k8s.io.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
 FEDERATIONS_DOMAIN_MAP=federation=test-f8n.k8s.io
 
+# TODO: Replace this with FEDERATION_HOST_CLUSTER, but do it in
+# lock steps. First make current the scripts understand the host
+# parameters. Then make the necessary changes to make them more
+# accurate.
+FEDERATION_HOST_CLUSTER_ZONE=us-central1-f
+
 KUBEKINS_TIMEOUT=900m


### PR DESCRIPTION
We still track the names of the clusters through their GCE zone names in the core repository's test scripts. So we are using the cluster zone as a proxy to identify the cluster. In the future we are going to have a way to directly identify clusters through their names.