### PR TITLE
Tweak periodic job definition and add it to cmd/line.

### DIFF
--- a/prow/cmd/line/main_test.go
+++ b/prow/cmd/line/main_test.go
@@ -83,12 +83,14 @@ func TestGuberURL(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		c := &testClient{
-			IsPresubmit: tc.IsPresubmit,
-			Presubmit:   &config.Presubmit{Name: "j"},
-			Postsubmit:  &config.Postsubmit{Name: "j"},
-			PRNumber:    tc.PRNumber,
-			RepoOwner:   tc.RepoOwner,
-			RepoName:    tc.RepoName,
+			PRNumber:  tc.PRNumber,
+			RepoOwner: tc.RepoOwner,
+			RepoName:  tc.RepoName,
+		}
+		if tc.IsPresubmit {
+			c.Presubmit = &config.Presubmit{Name: "j"}
+		} else {
+			c.Postsubmit = &config.Postsubmit{Name: "j"}
 		}
 		actual := c.guberURL("1")
 		if actual != tc.ExpectedURL {

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -79,36 +79,45 @@ type Brancher struct {
 	Branches []string `json:"branches"`
 }
 
-func (c *Config) GetPresubmit(repo, job string) (bool, *Presubmit) {
+func (c *Config) GetPresubmit(repo, job string) *Presubmit {
 	return getPresubmit(c.Presubmits[repo], job)
 }
 
-func getPresubmit(jobs []Presubmit, job string) (bool, *Presubmit) {
+func getPresubmit(jobs []Presubmit, job string) *Presubmit {
 	for _, j := range jobs {
 		if j.Name == job {
-			return true, &j
+			return &j
 		}
-		if found, p := getPresubmit(j.RunAfterSuccess, job); found {
-			return true, p
+		if p := getPresubmit(j.RunAfterSuccess, job); p != nil {
+			return p
 		}
 	}
-	return false, nil
+	return nil
 }
 
-func (c *Config) GetPostsubmit(repo, job string) (bool, *Postsubmit) {
+func (c *Config) GetPostsubmit(repo, job string) *Postsubmit {
 	return getPostsubmit(c.Postsubmits[repo], job)
 }
 
-func getPostsubmit(jobs []Postsubmit, job string) (bool, *Postsubmit) {
+func getPostsubmit(jobs []Postsubmit, job string) *Postsubmit {
 	for _, j := range jobs {
 		if j.Name == job {
-			return true, &j
+			return &j
 		}
-		if found, p := getPostsubmit(j.RunAfterSuccess, job); found {
-			return true, p
+		if p := getPostsubmit(j.RunAfterSuccess, job); p != nil {
+			return p
 		}
 	}
-	return false, nil
+	return nil
+}
+
+func (c *Config) GetPeriodic(job string) *Periodic {
+	for _, j := range c.Periodics {
+		if j.Name == job {
+			return &j
+		}
+	}
+	return nil
 }
 
 func (br Brancher) RunsAgainstBranch(branch string) bool {
@@ -198,10 +207,8 @@ func (c *Config) AllJobNames() []string {
 	for _, v := range c.Postsubmits {
 		res = append(res, listPost(v)...)
 	}
-	for _, v := range c.Periodics {
-		for _, j := range v {
-			res = append(res, j.Name)
-		}
+	for _, j := range c.Periodics {
+		res = append(res, j.Name)
 	}
 	return res
 }

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -256,13 +256,13 @@ func TestGetPresubmits(t *testing.T) {
 		},
 		{Name: "b"},
 	}
-	if found, _ := getPresubmit(pres, "b"); !found {
+	if p := getPresubmit(pres, "b"); p == nil {
 		t.Error("Missed root level presubmit.")
 	}
-	if found, _ := getPresubmit(pres, "ab"); !found {
+	if p := getPresubmit(pres, "ab"); p == nil {
 		t.Error("Missed child presubmit.")
 	}
-	if found, _ := getPresubmit(pres, "c"); found {
+	if p := getPresubmit(pres, "c"); p != nil {
 		t.Error("Whaa!? Found a presubmit that shouldn't exist.")
 	}
 }


### PR DESCRIPTION
I've made it so that the config for periodic jobs is just `[]Periodic`,
rather than `map[string][]Periodic`. This makes sense because a periodic
job may not be associated with any repo at all, whereas pre and
postsubmits *must* be associated with a repo to be triggered.

I also added some more plumbing in cmd/line. Once periodic jobs are
functioning properly I will clean up that mess.