### PR TITLE
Bump Jenkins timeout

### DIFF
--- a/jenkins/job-configs/global.yaml
+++ b/jenkins/job-configs/global.yaml
@@ -71,7 +71,7 @@
     # NOTE: this *must* be larger than recursive timeouts
     #       (like the /usr/bin/timeout command), or else the child
     #       timeouts will never fire.
-    jenkins-timeout: 700
+    jenkins-timeout: 1440
     # report-rc assumes that $rc is set to the exit status of the runner.
     report-rc: |
         if [[ ${{rc}} -eq 124 || ${{rc}} -eq 137 ]]; then


### PR DESCRIPTION
It says that it has to be larger than any other timeout - and we have larger timeout in kubemark-scale currently.