### PR TITLE
Correct GCI images used in gci-gci-* tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.env
@@ -1,7 +1,7 @@
 ### job-env
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-# To qualify GCI milestone 55 for k8s release-1.4.
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
+# To qualify GCI milestone 56 for k8s release-1.4.
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-1-4

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.env
@@ -1,6 +1,6 @@
 ### job-env
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-1-5

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.env
@@ -1,7 +1,7 @@
 ### job-env
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-# To qualify GCI milestone 55 for k8s release-1.4.
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
+# To qualify GCI milestone 56 for k8s release-1.4.
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=kubekins-gce-gci-ci-serial-1-4
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.env
@@ -1,6 +1,6 @@
 ### job-env
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=kubekins-gce-gci-ci-serial-1-5
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.env
@@ -1,7 +1,7 @@
 ### job-env
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-# To qualify GCI milestone 55 for k8s release-1.4.
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
+# To qualify GCI milestone 56 for k8s release-1.4.
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-slow-1-4

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.env
@@ -1,6 +1,6 @@
 ### job-env
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-slow-1-5


### PR DESCRIPTION
These jobs run the e2e tests against k8s HEAD of a branch, with GCI HEAD
of the *pinned milestone*. Since we are looking into upgrading to GCI
m56 for k8s 1.4 and 1.5, the image family used in tests should be
updated.

cc/ @kubernetes/goog-image 