### PR TITLE
Fix pathological Gubernator pod extraction regex.

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -103,9 +103,9 @@ def do_testcmd(name):
 
 def do_parse_pod_name(text):
     """Find the pod name from the failure and return the pod name."""
-    p = re.search(r'(.*) pod (.*?) .*', text)
+    p = re.search(r' pod (\S+)', text)
     if p:
-        return re.sub(r'[\'"\\:]', '', p.group(2))
+        return re.sub(r'[\'"\\:]', '', p.group(1))
     else:
         return ""
 

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -120,5 +120,13 @@ class HelperTest(unittest.TestCase):
             filters.do_gcs_browse_url('/k8s/foo'),
             'http://gcsweb.k8s.io/gcs/k8s/foo')
 
+    def test_pod_name(self):
+        self.assertEqual(filters.do_parse_pod_name("start pod 'client-c6671' to"), 'client-c6671')
+        self.assertEqual(filters.do_parse_pod_name('tripod "blah"'), '')
+
+        # exercise pathological case
+        self.assertEqual(filters.do_parse_pod_name('abcd pode ' * 10000), '')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1492,7 +1492,7 @@ class JobTest(unittest.TestCase):
         if not key in self.realjobs:
             for yaml in self.yaml_suffix:
                 self.LoadBootstrapYaml(yaml)
-        self.assertIn(key, self.realjobs)
+        self.assertIn(key, sorted(self.realjobs))  # sorted for clearer error message
         return self.realjobs.get(key)
 
     def testValidTimeout(self):


### PR DESCRIPTION
`(.*) pod (.*?) (.*)` will take O(N^3) time, which makes the build page
time out on long lines-- a failure had an 80,000 character line.