### PR TITLE
Add system-out/err from junit into the gubernator build display

### DIFF
--- a/gubernator/static/build.js
+++ b/gubernator/static/build.js
@@ -105,6 +105,15 @@ function expand_all(btn) {
 	btn.remove();
 }
 
+function expand_element(els) {
+	var parent = els[0].parentElement;
+	var hidden = parent.querySelectorAll(".hidden");
+	for (var i = 0; i < hidden.length; i++) {
+		hidden[i].classList.toggle("hidden");
+	}
+	els[0].classList.add("hidden");
+}
+
 /* given a string containing ansi formatting directives, return a new one
    with designated regions of text marked with the appropriate color directives,
    and with all unknown directives stripped */
@@ -149,13 +158,30 @@ function fix_escape_codes() {
 	}
 }
 
+/* Remove unicode sequences caused by colorized output in junit.xml */
+function remove_unicode_escape_codes() {
+	var errors = document.querySelectorAll('pre.error')
+	for (var i = 0; i < errors.length; i++) {
+		var orig = errors[i].innerHTML
+		var newer = orig.replace(/\ufffd\[\d+m/g, "")
+		if (orig !== newer) {
+			errors[i].innerHTML = newer;
+		}
+	}
+}
+
 function init() {
 	fix_timestamps();
 	fix_escape_codes();
+	remove_unicode_escape_codes();
 	document.body.onclick = function(evt) {
 		var target = evt.target;
-		if (target.nodeName === 'SPAN' && target.className === 'skip') {
+		if (target.nodeName === 'SPAN' && target.classList.contains('skip')) {
 			expand_skipped([target]);
+			evt.preventDefault();
+		}
+		if (target.nodeName === 'SPAN' && target.classList.contains('expand')) {
+			expand_element([target]);
 			evt.preventDefault();
 		}
 	}

--- a/gubernator/static/style.css
+++ b/gubernator/static/style.css
@@ -82,6 +82,17 @@ span.time {
     font-weight: lighter;
     font-family: monospace;
 }
+span.inset-expand {
+    float: left;
+    color: #777;
+    text-decoration: underline;
+}
+.hidden {
+    display: none;
+}
+span.expand:hover {
+    cursor: pointer;
+}
 a.anchor, pre.error>a {
     color: inherit;
 }

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -68,14 +68,20 @@
 	% endif
 	% if failures
 		<h2>Test Failures</h2>
-		% for name, time, text, filename in failures
+		% for name, time, text, filename, output in failures
 			<hr>
 			<h3><a class="anchor" id="{{name|slugify}}" href="#{{name|slugify}}">{{name}}<span class="time"> {{time|duration}}</span></h3></a>
 			% if 'junit_runner' not in filename
 				<pre class="cmd" onclick="select(this)">{{name | testcmd}}</pre>
 			% endif
 			% if text
-				<pre class="error">{{text|linkify_stacktrace(commit)}}<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span></pre>
+				<pre class="error">{{text|linkify_stacktrace(commit)}}
+				% if output
+				<div class="hidden"><hr>{{output|linkify_stacktrace(commit)}}</div>
+				<span class="expand inset-expand">Click to see stdout/stderr</span><span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span></pre>
+				% else
+				<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span></pre>
+				% endif
 				% set pod_name = text|parse_pod_name
 				% if pod_name
 					<p>Find <tt>{{pod_name}}</tt> mentions in <a id="{{pod_name|slugify}}" href="/build{{build_dir}}/nodelog?pod={{pod_name}}&junit={{filename|basename}}&wrap=on">log files</a>

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -38,7 +38,7 @@ class ParseJunitTest(unittest.TestCase):
     def test_normal(self):
         failures = self.parse(main_test.JUNIT_SUITE)
         stack = '/go/src/k8s.io/kubernetes/test.go:123\nError Goes Here'
-        self.assertEqual(failures, [('Third', 96.49, stack, "fp")])
+        self.assertEqual(failures, [('Third', 96.49, stack, "fp", "")])
 
     def test_testsuites(self):
         failures = self.parse('''
@@ -49,11 +49,16 @@ class ParseJunitTest(unittest.TestCase):
                     </properties>
                     <testcase name="TestBad" time="0.1">
                         <failure>something bad</failure>
+                        <system-out>out: first line</system-out>
+                        <system-err>err: first line</system-err>
+                        <system-out>out: second line</system-out>
                     </testcase>
                 </testsuite>
             </testsuites>''')
-        self.assertEqual(failures,
-                         [('k8s.io/suite TestBad', 0.1, 'something bad', "fp")])
+        self.assertEqual(failures, [(
+            'k8s.io/suite TestBad', 0.1, 'something bad', "fp",
+            "out: first line\nout: second line\nerr: first line",
+            )])
 
     def test_bad_xml(self):
         self.assertEqual(self.parse('''<body />'''), [])
@@ -68,7 +73,7 @@ class ParseJunitTest(unittest.TestCase):
                     </testcase>
                 </testsuite>
             </testsuites>''')
-        self.assertEqual(failures, [('a Corrupt', 0.0, 'something bad ?', 'fp')])
+        self.assertEqual(failures, [('a Corrupt', 0.0, 'something bad ?', 'fp', '')])
 
     def test_not_xml(self):
         failures = self.parse('\x01')


### PR DESCRIPTION
kubernetes/kubernetes#41954 adds system-out capture from junit for
ginkgo tests, which enables e2e tests to display their log snipped
directly inline (for easier browsing). This commit adds simple display
of the system-out / system-err fields from junit (of which their can be
many) by aggregating them and then emitting the aggregate for each
failure that is yielded. For multiple failure test cases this may lead
to redundant output, but it simplifies the output setup.

Not tested yet