### PR TITLE
Persist kubeconfig for federated clusters in GCS when only clusters are deployed without the federation control plane.

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -251,7 +251,9 @@ func complete(o *options, deployment string) error {
 	}
 
 	// Save the state if we upped a new cluster without downing it
-	if o.save != "" && !o.down && o.up {
+	// or we are turning up federated clusters without turning up
+	// the federation control plane.
+	if o.save != "" && ((!o.down && o.up) || (!o.federation && o.up && o.deployment != "none")) {
 		if err := saveState(o.save); err != nil {
 			return err
 		}
@@ -285,7 +287,9 @@ func acquireKubernetes(o *options) error {
 	if o.extract.Enabled() {
 		err := xmlWrap("Extract", func() error {
 			// Should we restore a previous state?
-			if o.save != "" && !o.up {
+			// Restore if we are not upping the cluster or we are bringing up
+			// a federation control plane without the federated clusters.
+			if o.save != "" && (!o.up || (o.federation && o.up && o.deployment == "none")) {
 				// Restore version and .kube/config from --up
 				o.extract = extractStrategies{extractStrategy{mode: load, option: o.save}}
 			}


### PR DESCRIPTION
This PR depends on #1957 which is being reviewed independently. Please review only the last commit here.