### PR TITLE
Default bazelbuild to test-infra.

### DIFF
--- a/images/pull_kubernetes_bazel/Makefile
+++ b/images/pull_kubernetes_bazel/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.8
+VERSION = 0.9
 
 image:
 	docker build -t "gcr.io/k8s-testimages/bazelbuild:$(VERSION)" .

--- a/images/pull_kubernetes_bazel/runner
+++ b/images/pull_kubernetes_bazel/runner
@@ -19,7 +19,7 @@ set -o pipefail
 
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
-    --repo=k8s.io/${REPO_NAME} \
+    --repo="k8s.io/${REPO_NAME:-test-infra}" \
     --job=${JOB_NAME} \
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     "$@"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -52,7 +52,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.8
+      - image: gcr.io/k8s-testimages/bazelbuild:0.9
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -170,7 +170,7 @@ presubmits:
     trigger: "@k8s-bot (bazel )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.8
+      - image: gcr.io/k8s-testimages/bazelbuild:0.9
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -198,7 +198,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.8
+      - image: gcr.io/k8s-testimages/bazelbuild:0.9
         args:
         - "--branch=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/logs"
@@ -211,7 +211,7 @@ postsubmits:
     - name: ci-kubernetes-bazel-test
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:0.8
+        - image: gcr.io/k8s-testimages/bazelbuild:0.9
           args:
           - "--branch=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/logs"
@@ -236,7 +236,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.8
+      - image: gcr.io/k8s-testimages/bazelbuild:0.9
         args:
         - "--branch=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/logs"
@@ -261,7 +261,7 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.8
+    - image: gcr.io/k8s-testimages/bazelbuild:0.9
       args:
       - "--branch=master"
       - "--upload=gs://kubernetes-jenkins/logs"


### PR DESCRIPTION
The periodic job is running correctly, but this image assumes `REPO_NAME`. For now we can default it to k/t-i, but it should really be set in the pod spec.