### PR TITLE
Add deployment instructions and link to release managers to oncall dashboard

### DIFF
--- a/jenkins/oncall.html
+++ b/jenkins/oncall.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- To "deploy": gsutil cp -Z oncall.html gs://kubernetes-jenkins/ -->
 <html>
 <script>
 // extracted/modified from kubernetes/test-infra/gubernator/static/build.js
@@ -56,6 +57,7 @@ img { padding-left: 10px; }
 <h1>Kubernetes Oncall Rotation</h1>
 <p>Updated: <span id="updated">Never</span></a>
 <div id="oncall">Loading...</div>
+<div><h2>release managers: <a href="https://github.com/kubernetes/community/wiki#release-managers">see wiki</a></h2></div>
 <sub><a href="https://storage.googleapis.com/kubernetes-jenkins/oncall.json">data source</a></sub>
 </body>
 </html>

--- a/jenkins/oncall.html
+++ b/jenkins/oncall.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<script>
+// extracted/modified from kubernetes/test-infra/gubernator/static/build.js
+function get(uri, callback) {
+	if (uri[0] === '/') {
+		// Matches /bucket/file/path -> [..., "bucket", "file/path"]
+		var groups = uri.match(/([^/:]+)\/(.*)/);
+		var bucket = groups[1], path = groups[2];
+		var url = 'https://www.googleapis.com/storage/v1/b/' + bucket + '/o/' +
+			encodeURIComponent(path) + '?alt=media';
+	} else {
+		var url = uri;
+	}
+	var req = new XMLHttpRequest();
+	req.open('GET', url);
+	req.onload = function(resp) {
+		callback(req);
+	}
+	req.send();
+}
+
+function build_table(req) {
+	var data = req.response;
+	var oncall = JSON.parse(data).Oncall;
+	var keys = Object.keys(oncall).sort();
+
+	var html = ''
+	for (var i = 0; i < keys.length; i++) {
+		var key = keys[i];
+		var person = oncall[key];
+		html += '<h2>' + key + ': ';
+		if (person) {
+			html += '<a href="https://github.com/' + person + '">';
+			html += person + '<img src="https://github.com/' + person + '.png?size=125"></a>';
+		} else {
+			html += 'None'
+		}
+		html += '</h2>';
+	}
+
+	// trivial XSS, but storage.googleapis.com is even more trivial XSS!
+	document.getElementById('oncall').innerHTML = html;
+
+	document.getElementById('updated').innerText = req.getResponseHeader('date');
+}
+
+get('/kubernetes-jenkins/oncall.json', build_table);
+</script>
+<title>K8S Oncall Rotation</title>
+<style>
+body { background-color: #eee; padding-left: 30%; }
+img { padding-left: 10px; }
+</style>
+<body>
+<h1>Kubernetes Oncall Rotation</h1>
+<p>Updated: <span id="updated">Never</span></a>
+<div id="oncall">Loading...</div>
+<sub><a href="https://storage.googleapis.com/kubernetes-jenkins/oncall.json">data source</a></sub>
+</body>
+</html>


### PR DESCRIPTION
I don't think this is checked in to git anywhere yet.

I haven't "deployed" this yet, but I tested locally and it seems to work.