### PR TITLE
Trigger cross-build on changes to build/ or hack/lib instead of all shell

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -66,7 +66,7 @@ presubmits:
     context: Jenkins Cross Build
     rerun_command: "@k8s-bot cross build this"
     trigger: "@k8s-bot (cross[ -])?build this"
-    run_if_changed: '(Makefile|\.sh|_(windows|linux|osx|unsupported)(_test)?\.go)$'
+    run_if_changed: '^(build/|hack/lib/)|(Makefile|_(windows|linux|osx|unsupported)(_test)?\.go)$'
 
   - name: pull-kubernetes-unit
     always_run: true


### PR DESCRIPTION
Directories like `cluster/` contain a lot of shell scripts, but they shouldn't trigger the cross-build.
Conversely, changes to the cross-build image in `build/build-image/` don't necessarily touch shell.