### PR TITLE
Add a --mode=local flag to kubernetes_e2e scenario

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -810,8 +810,7 @@ def bootstrap(
 
 def parse_args(arguments=None):
     """Parse arguments or sys.argv[1:]."""
-    parser = argparse.ArgumentParser(
-        'Checks out a github PR/branch to <basedir>/<repo>/')
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         '--json',
         nargs='?', const=1, default=0,


### PR DESCRIPTION
`kubernetes_e2e.py --mode=docker # the default` runs the scenario via `docker run kubekins`
`kubernetes_e2e.py --mode=local` runs the scenario by starting a e2e-runner.sh subprocess.

Also:
* fix the binary name in bootstrap.py -h
* Delete unused cp /var/lib/jenkins gce keys (we always run on docker now in jenkins)
* Delete non bootstrap migration mode (everything uses bootstrap now)
