### PR TITLE
Add a new job to deploy federated clusters for federation pull job.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -189,3 +189,12 @@
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
+    # Although this job is a dependency for a pull job, this is
+    # being deployed as a CI soak job to periodically bring up
+    # and tear down the clusters for the federation pull job.
+    - kubernetes-pull-gce-federation-deploy:
+        blocker: pull-kubernetes-federation-e2e-gce
+        job-name: ci-kubernetes-pull-gce-federation-deploy
+        frequency: 'H 0 * * *'
+        scan: DISABLED
+        timeout: 90

--- a/jobs/ci-kubernetes-pull-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-pull-gce-federation-deploy.env
@@ -1,0 +1,23 @@
+# NOTE: Although this job is a dependency for a pull job, this is
+# being deployed as a CI job because we want this to run this job
+# periodically to bring up and tear down the clusters.
+
+### job-env
+FEDERATION=true
+
+PROJECT=k8s-jkns-pr-bldr-e2e-gce-fdrtn
+KUBE_REGISTRY=gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn
+KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
+KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+FAIL_ON_GCP_RESOURCE_LEAK=false
+
+# Where the clusters will be created. Federation components are now deployed to the last one.
+E2E_ZONES=us-central1-a us-central1-b us-central1-f
+FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
+
+FEDERATION_UP=false
+FEDERATION_DOWN=false
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2036,6 +2036,16 @@
   ]
 },
 
+"ci-kubernetes-pull-gce-federation-deploy": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy.env",
+    "--test=false",
+    "--down=false"
+  ]
+},
+
 "ci-kubernetes-soak-gce-deploy": {
   "scenario": "kubernetes_e2e",
   "args": [

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -188,6 +188,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-federation-deploy
 - name: kubernetes-soak-gce-federation-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-federation-test
+- name: kubernetes-pull-gce-federation-deploy
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-pull-gce-federation-deploy
 - name: kubernetes-federation-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build
 - name: kubernetes-federation-build-1.4
@@ -1625,6 +1627,8 @@ dashboards:
     test_group_name: kubernetes-soak-gce-federation-deploy
   - name: soak-gce-test
     test_group_name: kubernetes-soak-gce-federation-test
+  - name: pull-gce-deploy
+    test_group_name: kubernetes-pull-gce-federation-deploy
   - name: build
     test_group_name: kubernetes-federation-build
   - name: build-1.4


### PR DESCRIPTION
We still need some kind of a blocking/synchronization mechanism to ensure that the pull job doesn't run when this deploy job is running. I will think about it. But in this mean time, let's try to get this in.