### PR TITLE
Set critical kubemark job to v20170223-43ce8f86

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1388,6 +1388,7 @@
     "--env-file=jobs/ci-kubernetes-kubemark-500-gce.env",
     "--docker-in-docker",
     "--cluster=kubemark-500",
+    "--tag=v20170223-43ce8f86",
     "--test=false"
   ]
 },


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/2012 https://github.com/kubernetes/test-infra/pull/2009

Reverting this job to the previous image. Kubemark does not like the change from --check_version_skew to --check-version-skew