### PR TITLE
Add --kops-image to choose AMI

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -40,6 +40,7 @@ var (
 	kopsNodes       = flag.Int("kops-nodes", 2, "(kops only) Number of nodes to create.")
 	kopsUpTimeout   = flag.Duration("kops-up-timeout", 20*time.Minute, "(kops only) Time limit between 'kops config / kops update' and a response from the Kubernetes API.")
 	kopsAdminAccess = flag.String("kops-admin-access", "", "(kops only) If set, restrict apiserver access to this CIDR range.")
+	kopsImage       = flag.String("kops-image", "", "(kops only) Image (AMI) for nodes to use. (Defaults to kops default, a Debian image with a custom kubernetes kernel.)")
 )
 
 type kops struct {
@@ -50,6 +51,7 @@ type kops struct {
 	nodes       int
 	adminAccess string
 	cluster     string
+	image       string
 	kubecfg     string
 }
 
@@ -113,6 +115,7 @@ func NewKops() (*kops, error) {
 		nodes:       *kopsNodes,
 		adminAccess: *kopsAdminAccess,
 		cluster:     *kopsCluster,
+		image:       *kopsImage,
 		kubecfg:     kubecfg,
 	}, nil
 }
@@ -130,6 +133,9 @@ func (k kops) Up() error {
 	}
 	if k.adminAccess != "" {
 		createArgs = append(createArgs, "--admin-access", k.adminAccess)
+	}
+	if k.image != "" {
+		createArgs = append(createArgs, "--image", k.image)
 	}
 	if err := finishRunning(exec.Command(k.path, createArgs...)); err != nil {
 		return fmt.Errorf("kops configuration failed: %v", err)

--- a/scenarios/kubernetes_kops_aws.py
+++ b/scenarios/kubernetes_kops_aws.py
@@ -149,8 +149,10 @@ def main(args):
       '-e', 'E2E_DOWN=%s' % args.down,
       # Kops
       '-e', ('E2E_OPT=--kops-cluster %s --kops-zones %s '
-             '--kops-state %s --kops-nodes=%s --kops-ssh-key=%s' %
-             (args.cluster, zones, args.state, args.nodes, aws_ssh)),
+             '--kops-state %s --kops-nodes=%s --kops-ssh-key=%s '
+             '--kops-image=%s' %
+             (args.cluster, zones, args.state, args.nodes, aws_ssh,
+              args.image)),
     ])
 
     # env blacklist.
@@ -219,6 +221,9 @@ if __name__ == '__main__':
         '--zones', default=None,
         help='Availability zones to start the cluster in. '
         'Defaults to a random zone.')
+    PARSER.add_argument(
+        '--image', default='',
+        help='Image (AMI) for nodes to use. Defaults to kops default.')
     ARGS = PARSER.parse_args()
 
     if not ARGS.cluster:


### PR DESCRIPTION
this just plumbs it though to kops's --image.

Use-case is: I want to run Feature:Volumes tests but some of those require additional packages (ceph-common). So, need to use an image with that package pre-installed. If there's other ways to achieve this, install packages before tests get run, please let me know.
