### PR TITLE
Allow people to add routing labels with commands

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -6,6 +6,9 @@ Command | Implemented By | Who can run it | Description
 --- | --- | --- | ---
 `/assign [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | kubernetes org members | Assigns specified people (or yourself if no one is specified)
 `/unassign [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | kubernetes org members | Unassigns specified people (or yourself if no one is specified)
+`/area` | prow [label](./prow/plugins/label) | anyone | adds an area/<> label if it exists
+`/kind` | prow [label](./prow/plugins/label) | anyone | adds a kind/<> label if it exists
+`/priority` | prow [label](./prow/plugins/label) | anyone | adds a priority/<> label if it exists
 `/lgtm` | prow [lgtm](./prow/plugins/lgtm) | assignees | adds the `lgtm` label
 `/lgtm cancel` | prow [lgtm](./prow/plugins/lgtm) | authors and assignees | removes the `lgtm` label
 `/approve` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | approve all the files for which you are an approver
@@ -13,6 +16,7 @@ Command | Implemented By | Who can run it | Description
 `/close` | prow [close](./prow/plugins/close) | authors and assignees | closes the issue
 `/release-note` | prow [releasenote](./prow/plugins/releasenote) | authors and assignees | adds the `release-note` label
 `/release-note-none` | prow [releasenote](./prow/plugins/releasenote) | authors and assignees | adds the `release-note-none` label
+`/sig-<some-github-team>` | prow [label](./prow/plugins/label) | kubernetes org members| adds the corresponding `sig` label
 `@k8s-bot test this` | prow [trigger](./prow/plugins/trigger) | kubernetes org members | runs tests defined in [config.yaml](./config.yaml)
 `@k8s-bot ok to test` | prow [trigger](./prow/plugins/trigger) | kubernetes org members | allows the PR author to `@k8s-bot test this`
 `@k8s-bot tell me a joke` | prow [yuks](./prow/plugins/yuks) | anyone | tells a bad joke, sometimes

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.91
+HOOK_VERSION       = 0.93
 LINE_VERSION       = 0.85
 SINKER_VERSION     = 0.5
 DECK_VERSION       = 0.18

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.91
+        image: gcr.io/k8s-prow/hook:0.93
         imagePullPolicy: Always
         args:
         - "--github-bot-name=k8s-ci-robot"

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -49,6 +49,7 @@ go_library(
         "//prow/plugins/cla:go_default_library",
         "//prow/plugins/close:go_default_library",
         "//prow/plugins/heart:go_default_library",
+        "//prow/plugins/label:go_default_library",
         "//prow/plugins/lgtm:go_default_library",
         "//prow/plugins/releasenote:go_default_library",
         "//prow/plugins/trigger:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -37,6 +37,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/cla"
 	_ "k8s.io/test-infra/prow/plugins/close"
 	_ "k8s.io/test-infra/prow/plugins/heart"
+	_ "k8s.io/test-infra/prow/plugins/label"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"
 	_ "k8s.io/test-infra/prow/plugins/releasenote"
 	_ "k8s.io/test-infra/prow/plugins/trigger"

--- a/prow/cmd/phony/examples/test_comment.json
+++ b/prow/cmd/phony/examples/test_comment.json
@@ -133,7 +133,7 @@
     },
     "created_at": "2016-11-24T05:34:50Z",
     "updated_at": "2016-11-24T05:34:50Z",
-    "body": "@k8s-bot go test this"
+    "body": "/area kubectl"
   },
   "repository": {
     "id": 57333709,

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -397,6 +397,24 @@ func (c *Client) CreateStatus(org, repo, ref string, s Status) error {
 	return err
 }
 
+func (c *Client) GetLabels(org, repo string) ([]string, error) {
+	c.log("GetLabel", org, repo)
+	var res struct {
+		Object []map[string]string `json:"object"`
+	}
+	_, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      fmt.Sprintf("%s/repos/%s/%s/labels", c.base, org, repo),
+		exitCodes: []int{200},
+	}, &res)
+	var labels []string
+	for _, lab := range res.Object {
+		labels = append(labels, lab["name"])
+
+	}
+	return labels, err
+}
+
 func (c *Client) AddLabel(org, repo string, number int, label string) error {
 	c.log("AddLabel", org, repo, number, label)
 	_, err := c.request(&request{

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -106,8 +106,12 @@ func (f *FakeClient) CreateStatus(owner, repo, ref string, s github.Status) erro
 	return nil
 }
 
-func (f *FakeClient) GetLabels(owner, repo string) ([]string, error) {
-	return f.ExistingLabels, nil
+func (f *FakeClient) GetLabels(owner, repo string) ([]github.Label, error) {
+	la := []github.Label{}
+	for _, l := range f.ExistingLabels {
+		la = append(la, github.Label{Name: l})
+	}
+	return la, nil
 }
 
 func (f *FakeClient) AddLabel(owner, repo string, number int, label string) error {

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -20,6 +20,7 @@ kubernetes/kubernetes:
 
 kubernetes/test-infra:
 - trigger
+- label
 
 kubernetes:
 - assign

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -50,6 +50,7 @@ filegroup(
         "//prow/plugins/cla:all-srcs",
         "//prow/plugins/close:all-srcs",
         "//prow/plugins/heart:all-srcs",
+        "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/releasenote:all-srcs",
         "//prow/plugins/trigger:all-srcs",

--- a/prow/plugins/label/BUILD
+++ b/prow/plugins/label/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["label_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor:k8s.io/kubernetes/pkg/util/sets",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["label.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/plugins/label/BUILD
+++ b/prow/plugins/label/BUILD
@@ -16,7 +16,6 @@ go_test(
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
-        "//vendor:k8s.io/kubernetes/pkg/util/sets",
     ],
 )
 
@@ -27,6 +26,7 @@ go_library(
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
+        "//vendor:k8s.io/kubernetes/pkg/util/sets",
     ],
 )
 

--- a/prow/plugins/label/BUILD
+++ b/prow/plugins/label/BUILD
@@ -16,6 +16,7 @@ go_test(
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
     ],
 )
 
@@ -26,7 +27,7 @@ go_library(
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
-        "//vendor:k8s.io/kubernetes/pkg/util/sets",
+        "//vendor:github.com/Sirupsen/logrus",
     ],
 )
 

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -21,7 +21,8 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"github.com/Sirupsen/logrus"
+
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -30,8 +31,8 @@ const pluginName = "label"
 
 var (
 	labelRegex       = regexp.MustCompile(`(?m)^/(area|priority|kind)\s*(.*)$`)
-	nonExistentLabel = "`%v` does not exist in this repository"
-	labelFailed      = "The following labels: %v could not be added to the issue or PR"
+	sigMatcher       = regexp.MustCompile(`(?m)@sig-([\w-]*)-(?:misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`)
+	nonExistentLabel = "These labels do not exist in this repository: `%v`"
 )
 
 func init() {
@@ -42,56 +43,77 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	IsMember(org, user string) (bool, error)
 	AddLabel(owner, repo string, number int, label string) error
-	GetLabels(owner, repo string) ([]string, error)
+	GetLabels(owner, repo string) ([]github.Label, error)
+	BotName() string
 }
 
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
-	return handle(pc.GitHubClient, ic)
+	return handle(pc.GitHubClient, pc.Logger, ic)
 }
 
-func handle(gc githubClient, ic github.IssueCommentEvent) error {
+func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
 	commenter := ic.Comment.User.Login
 	owner := ic.Repo.Owner.Name
 	repo := ic.Repo.Name
 	number := ic.Issue.Number
 
-	matches := labelRegex.FindAllStringSubmatch(ic.Comment.Body, -1)
-	if matches == nil || len(matches) == 0 {
+	// only parse newly created comments and if non bot author
+	if commenter == gc.BotName() || ic.Action != "created" {
 		return nil
 	}
-	member, err := gc.IsMember(repo, commenter)
-	if err != nil {
-		return fmt.Errorf("IsMember failed: %v", err)
-	}
-	if !member {
-		return gc.CreateComment(owner, repo, number, plugins.FormatResponse(ic.Comment, "Only kubernetes org members can add labels."))
+
+	labelMatches := labelRegex.FindAllStringSubmatch(ic.Comment.Body, -1)
+	sigMatches := sigMatcher.FindAllStringSubmatch(ic.Comment.Body, -1)
+	if len(labelMatches) == 0 && len(sigMatches) == 0 {
+		return nil
 	}
 
 	labels, err := gc.GetLabels(owner, repo)
 	if err != nil {
 		return err
 	}
-	existingLabels := sets.NewString(labels...)
-	var failures []string
-	for _, match := range matches {
+	existingLabels := map[string]bool{}
+	for _, l := range labels {
+		existingLabels[l.Name] = true
+	}
+	var nonexistent []string
+
+	for _, match := range labelMatches {
 		for _, newLabel := range strings.Split(match[0], " ")[1:] {
 			newLabel = match[1] + "/" + strings.TrimSpace(newLabel)
 			if ic.Issue.HasLabel(newLabel) {
 				continue
 			}
-			if !existingLabels.Has(newLabel) {
-				gc.CreateComment(owner, repo, number, fmt.Sprintf(nonExistentLabel, newLabel))
+			if !existingLabels[newLabel] {
+				nonexistent = append(nonexistent, newLabel)
 				continue
 			}
 			if err := gc.AddLabel(owner, repo, number, newLabel); err != nil {
-				failures = append(failures, newLabel)
+				log.WithError(err).Errorf("Github failed to add the following label: %s", newLabel)
 			}
 		}
 	}
 
-	if len(failures) > 0 {
-		gc.CreateComment(owner, repo, number, fmt.Sprintf(labelFailed, strings.Join(failures, ", "), number))
-		return err
+	for _, sigMatch := range sigMatches {
+		sigLabel := "sig" + "/" + strings.TrimSpace(sigMatch[1])
+		if ic.Issue.HasLabel(sigLabel) {
+			continue
+		}
+		if !existingLabels[sigLabel] {
+			nonexistent = append(nonexistent, sigLabel)
+			continue
+		}
+		if err := gc.AddLabel(owner, repo, number, sigLabel); err != nil {
+			log.WithError(err).Errorf("Github failed to add the following label: %s", sigLabel)
+		}
+
+	}
+
+	if len(nonexistent) > 0 {
+		msg := fmt.Sprintf(nonExistentLabel, strings.Join(nonexistent, ", "))
+		if err := gc.CreateComment(owner, repo, number, plugins.FormatResponse(ic.Comment, msg)); err != nil {
+			log.WithError(err).Errorf("Could not create comment \"%s\".", msg)
+		}
 	}
 
 	return nil

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package label
+
+import (
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const pluginName = "label"
+
+var (
+	allowedPrefixes = []string{"area", "priority"}
+	regexBuilder    = `(?m)^/%s[\t\s]+(?:\S*(?:[^\n]+))*`
+	labelFailed     = "The following labels: %v could not be added to the issue or PR"
+)
+
+func init() {
+	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
+}
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	IsMember(org, user string) (bool, error)
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+}
+
+func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
+	return handle(pc.GitHubClient, ic)
+}
+
+func handle(gc githubClient, ic github.IssueCommentEvent) error {
+	commenter := ic.Comment.User.Login
+	owner := ic.Repo.Owner.Name
+	repo := ic.Repo.Name
+	number := ic.Issue.Number
+
+	member, err := gc.IsMember(repo, commenter)
+	if err != nil {
+		return fmt.Errorf("IsMember failed: %v", err)
+	}
+	if !member {
+		return gc.CreateComment(owner, repo, number, plugins.FormatResponse(ic.Comment, "Only kubernetes org members can add labels."))
+	}
+
+	var failures []string
+	for _, pref := range allowedPrefixes {
+		labelRegex := regexp.MustCompile(fmt.Sprintf(regexBuilder, pref))
+		match := labelRegex.FindStringSubmatch(ic.Comment.Body)
+		if match == nil || len(match) == 0 {
+			continue
+		}
+		for _, newLabel := range strings.Split(match[0], " ")[1:] {
+			newLabel = strings.TrimSpace(newLabel)
+			if ic.Issue.HasLabel(newLabel) {
+				continue
+			}
+			if strings.HasPrefix(newLabel, pref) {
+				if err := gc.AddLabel(owner, repo, number, newLabel); err != nil {
+					failures = append(failures, newLabel)
+				}
+			} else {
+				failures = append(failures, newLabel)
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		gc.CreateComment(owner, repo, number, fmt.Sprintf(labelFailed, strings.Join(failures, ", "), number))
+	}
+
+	return nil
+}

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package label
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+const (
+	fakeRepoOrg  = "fakeOrg"
+	fakeRepoName = "fakeName"
+	orgMember    = "Alice"
+	nonOrgMember = "Bob"
+	prNumber     = 1
+)
+
+var areaLabels = []string{"area/api", "area/infra"}
+var priorityLabels = []string{"priority/important", "priority/critical"}
+
+func formatLabels(labels sets.String) sets.String {
+	r := sets.NewString()
+	for l := range labels {
+		r.Insert(fmt.Sprintf("%s/%s#%d:%s", fakeRepoOrg, fakeRepoName, prNumber, l))
+	}
+	return r
+}
+
+func getFakeRepo(commentBody, commenter string, initial_labels []string) (*fakegithub.FakeClient, github.IssueCommentEvent) {
+	fc := &fakegithub.FakeClient{
+		IssueComments: make(map[int][]github.IssueComment),
+		OrgMembers:    []string{orgMember},
+	}
+	startingLabels := []github.Label{}
+	for _, l := range initial_labels {
+		startingLabels = append(startingLabels, github.Label{Name: l})
+	}
+
+	ice := github.IssueCommentEvent{
+		Repo: github.Repo{
+			Owner: github.User{Name: fakeRepoOrg},
+			Name:  fakeRepoName,
+		},
+		Comment: github.IssueComment{
+			Body: commentBody,
+			User: github.User{Login: commenter},
+		},
+		Issue: github.Issue{
+			User:        github.User{Login: "a"},
+			Number:      prNumber,
+			PullRequest: &struct{}{},
+			Labels:      startingLabels,
+		},
+	}
+	return fc, ice
+}
+
+func TestLabel(t *testing.T) {
+	// "a" is the author, "a", "r1", and "r2" are reviewers.
+	var testcases = []struct {
+		name              string
+		body              string
+		commenter         string
+		expectedNewLabels sets.String
+		removedLabels     []string
+		initialLabels     []string
+		isPr              bool
+	}{
+		{
+			name:              "Irrelevant comment",
+			body:              "irrelelvant",
+			expectedNewLabels: sets.NewString(),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Empty Area",
+			body:              "/area",
+			expectedNewLabels: formatLabels(sets.NewString()),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Add Single Area Label",
+			body:              "/area area/infra",
+			expectedNewLabels: formatLabels(sets.NewString("area/infra")),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Add Single Priority Label",
+			body:              "/priority priority/critical",
+			expectedNewLabels: formatLabels(sets.NewString("priority/critical")),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Non Org Member Can't Add",
+			body:              "/area area/infra",
+			expectedNewLabels: formatLabels(sets.NewString()),
+			commenter:         nonOrgMember,
+		},
+		{
+			name:              "Command must start at the beginning of the line",
+			body:              "  /area lgtm",
+			expectedNewLabels: formatLabels(sets.NewString()),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Can't Add Labels With Wrong Prefixes",
+			body:              "/area lgtm",
+			expectedNewLabels: formatLabels(sets.NewString()),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Add Multiple Area Labels",
+			body:              "/area area/api area/infra",
+			expectedNewLabels: formatLabels(sets.NewString("area/api", "area/infra")),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Add Multiple Priority Labels",
+			body:              "/priority priority/critical priority/urgent",
+			expectedNewLabels: formatLabels(sets.NewString("priority/critical", "priority/urgent")),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Label Prefix Must Match Command (Area-Priority Mismatch)",
+			body:              "/area priority/urgent",
+			expectedNewLabels: formatLabels(sets.NewString()),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Label Prefix Must Match Command (Priority-Area Mismatch)",
+			body:              "/priority area/infra",
+			expectedNewLabels: formatLabels(sets.NewString()),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Add Multiple Labels (Some Valid)",
+			body:              "/area lgtm area/infra",
+			expectedNewLabels: formatLabels(sets.NewString("area/infra")),
+			commenter:         orgMember,
+		},
+		{
+			name:              "Add Multiple Types of Labels Different Lines",
+			body:              "/priority priority-urgent\n/area area/infra",
+			expectedNewLabels: formatLabels(sets.NewString("priority-urgent", "area/infra")),
+			commenter:         orgMember,
+		},
+	}
+	for _, tc := range testcases {
+		fc, ice := getFakeRepo(tc.body, tc.commenter, tc.initialLabels)
+		if err := handle(fc, ice); err != nil {
+			t.Errorf("For case %s, didn't expect error from label test: %v", tc.name, err)
+			continue
+		}
+		if !tc.expectedNewLabels.Equal(sets.NewString(fc.LabelsAdded...)) {
+			t.Errorf("For test %v,\n\tExpected %+v \n\tFound %+v", tc.name, tc.expectedNewLabels, sets.NewString(fc.LabelsAdded...))
+		}
+	}
+}


### PR DESCRIPTION
I'm open to changing the command name but does the functionality and design sound okay.

As currently implemented you could type

/label sig-testing sig-network area/kubelet 

And all of those labels would be added.

Fixes #1640 