### PR TITLE
Make kubetestPath robust to cd

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-canary.env
+++ b/jobs/ci-kubernetes-e2e-gce-canary.env
@@ -1,5 +1,17 @@
 # Everything else is the same as the other job it is testing
 KUBEKINS_TIMEOUT=40m
 GINKGO_TEST_ARGS=--ginkgo.focus=Variable.Expansion
+
+# Test --publish code path
 E2E_PUBLISH_PATH=gs://kubernetes-release-dev/ci/latest-canarygreen.txt
+
+# Test update gcloud code path
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/ci/staging
+
+# Test --upgrade_args and --extract=E --extract=E
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.5
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_NODE_OS_DISTRIBUTION=debian

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -476,7 +476,7 @@ func UpgradeTest(args string, checkSkew bool) error {
 	}
 	os.Setenv("E2E_REPORT_PREFIX", "upgrade")
 	return finishRunning(exec.Command(
-		os.Args[0],
+		kubetestPath,
 		"--test",
 		"--test_args="+args,
 		fmt.Sprintf("--v=%t", verbose),
@@ -490,7 +490,7 @@ func SkewTest(args string, checkSkew bool) error {
 	}
 	defer os.Chdir(old)
 	return finishRunning(exec.Command(
-		os.Args[0],
+		kubetestPath,
 		"--test",
 		"--test_args="+args,
 		fmt.Sprintf("--v=%t", verbose),

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -34,11 +34,20 @@ import (
 
 var (
 	interrupt             = time.NewTimer(time.Duration(0)) // interrupt testing at this time.
+	kubetestPath          = initKubetestPath()
 	terminate             = time.NewTimer(time.Duration(0)) // terminate testing at this time.
 	verbose               = false
 	timeout               = time.Duration(0)
 	deprecatedVersionSkew = flag.Bool("check_version_skew", true, "Verify client and server versions match")
 )
+
+func initKubetestPath() string {
+	d, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("failed getKubetestPath(): %v", err)
+	}
+	return filepath.Join(d, os.Args[0])
+}
 
 type options struct {
 	build       buildStrategy

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -322,7 +322,7 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     PARSER.add_argument(
-        '--tag', default='v20170224-14f08d6b', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170224-3f0b104f', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(


### PR DESCRIPTION
We cannot just use `os.Args[0]` because `--extract=E` changes `os.Getwd()` join these two together before we change directories.

Am testing this locally on an upgrade job, also expanding the canary job to cover this scenario