### PR TITLE
Add build, verify, test-go, and kubelet jobs for release-1.6.

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -108,6 +108,14 @@
         repo-name: k8s.io/kubernetes
         timeout: 50
 
+    - kubernetes-build-1.6:
+        branch: release-1.6
+        commit-frequency: 'H/5 * * * *'
+        giturl: 'https://github.com/kubernetes/kubernetes'
+        job-name: ci-kubernetes-build-1.6
+        repo-name: k8s.io/kubernetes
+        timeout: 50
+
     - kubernetes-federation-build:
         branch: master
         commit-frequency: 'H/5 * * * *'
@@ -128,6 +136,14 @@
         branch: release-1.5
         giturl: 'https://github.com/kubernetes/kubernetes'
         job-name: ci-kubernetes-federation-build-1.5
+        repo-name: k8s.io/kubernetes
+        commit-frequency: 'H/5 * * * *'
+        timeout: 50
+
+    - kubernetes-federation-build-1.6:
+        branch: release-1.6
+        giturl: 'https://github.com/kubernetes/kubernetes'
+        job-name: ci-kubernetes-federation-build-1.6
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
         timeout: 50

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -81,6 +81,13 @@
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 80
+    - kubernetes-verify-release-1.6:
+        branch: release-1.6
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-verify-release-1.6
+        json: 1
+        repo-name: k8s.io/kubernetes
+        timeout: 80
     - kubernetes-verify-release-1.5:
         branch: release-1.5
         frequency: 'H/5 * * * *'
@@ -97,7 +104,7 @@
         timeout: 80
     - kubernetes-verify-release-1.3:
         branch: release-1.3
-        frequency: 'H/5 * * * *'
+        frequency: 'H/5 H/3 * * *'
         job-name: ci-kubernetes-verify-release-1.3
         json: 1
         repo-name: k8s.io/kubernetes
@@ -107,6 +114,13 @@
         branch: master
         frequency: 'H/5 * * * *'
         job-name: ci-kubernetes-test-go
+        json: 1
+        repo-name: k8s.io/kubernetes
+        timeout: 100
+    - kubernetes-test-go-release-1.6:
+        branch: release-1.6
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-test-go-release-1.6
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 100
@@ -199,6 +213,13 @@
         branch: release-1.5
         frequency: 'H/5 * * * *'
         job-name: ci-kubernetes-node-kubelet-1.5
+        json: 1
+        repo-name: k8s.io/kubernetes
+        timeout: 90
+    - kubernetes-node-kubelet-1.6:
+        branch: release-1.6
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-node-kubelet-1.6
         json: 1
         repo-name: k8s.io/kubernetes
         timeout: 90

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -34,6 +34,10 @@
   "scenario": "kubernetes_build"
 },
 
+"ci-kubernetes-build-1.6": {
+  "scenario": "kubernetes_build"
+},
+
 "ci-kubernetes-build-debian-unstable": {
   "scenario": "kubernetes_build",
   "args": [
@@ -76,6 +80,15 @@
   ]
 },
 
+"ci-kubernetes-federation-build-1.6": {
+  "scenario": "kubernetes_build",
+  "args": [
+    "--fast",
+    "--federation=k8s-jkns-e2e-gce-f8n-1-6",
+    "--release=kubernetes-federation-release-1-6"
+  ]
+},
+
 "ci-kubernetes-federation-build-soak": {
   "scenario": "kubernetes_build",
   "args": [
@@ -114,6 +127,13 @@
   "scenario": "kubernetes_kubelet",
   "args": [
     "--branch=release-1.5"
+  ]
+},
+
+"ci-kubernetes-node-kubelet-1.6": {
+  "scenario": "kubernetes_kubelet",
+  "args": [
+    "--branch=release-1.6"
   ]
 },
 
@@ -199,6 +219,14 @@
   ]
 },
 
+"ci-kubernetes-test-go-release-1.6": {
+  "scenario": "kubernetes_verify",
+  "args": [
+    "--branch=release-1.6",
+    "--force"
+  ]
+},
+
 "ci-kubernetes-verify-master": {
   "scenario": "kubernetes_verify",
   "args": [
@@ -230,6 +258,15 @@
   "scenario": "kubernetes_verify",
   "args": [
     "--branch=release-1.5",
+    "--force",
+    "--script=./hack/jenkins/verify-dockerized.sh"
+  ]
+},
+
+"ci-kubernetes-verify-release-1.6": {
+  "scenario": "kubernetes_verify",
+  "args": [
+    "--branch=release-1.6",
     "--force",
     "--script=./hack/jenkins/verify-dockerized.sh"
   ]

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -72,6 +72,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.4
 - name: kubernetes-build-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.5
+- name: kubernetes-build-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.6
 - name: kubernetes-e2e-aws
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-aws
 - name: kubernetes-e2e-aws-release-1.5
@@ -196,6 +198,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-1.4
 - name: kubernetes-federation-build-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-1.5
+- name: kubernetes-federation-build-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-1.6
 - name: kubernetes-federation-build-soak
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-soak
 - name: kubernetes-e2e-gce-flaky
@@ -550,8 +554,13 @@ test_groups:
 - name: kubernetes-test-go-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-test-go-release-1.5
   days_of_results: 4
+- name: kubernetes-test-go-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-test-go-release-1.6
+  days_of_results: 4
 - name: kubernetes-verify-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-master
+- name: kubernetes-verify-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.6
 - name: kubernetes-verify-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.5
 - name: kubernetes-verify-release-1.4
@@ -796,6 +805,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.4
 - name: ci-kubernetes-node-kubelet-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.5
+- name: ci-kubernetes-node-kubelet-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.6
 - name: kops-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kops-build
 - name: kubernetes-e2e-gce-enormous-deploy
@@ -1387,6 +1398,8 @@ dashboards:
     test_group_name: kubernetes-test-go-release-1.5
   - name: verify-master
     test_group_name: kubernetes-verify-master
+  - name: verify-1.6
+    test_group_name: kubernetes-verify-release-1.6
   - name: verify-1.5
     test_group_name: kubernetes-verify-release-1.5
   - name: verify-1.4
@@ -1635,8 +1648,32 @@ dashboards:
     test_group_name: kubernetes-federation-build-1.4
   - name: build-1.5
     test_group_name: kubernetes-federation-build-1.5
+  - name: build-1.6
+    test_group_name: kubernetes-federation-build-1.6
   - name: build-soak
     test_group_name: kubernetes-federation-build-soak
+
+- name: release-1.6-all
+  dashboard_tab:
+  - name: build-1.6
+    test_group_name: kubernetes-build-1.6
+  - name: test-go-1.6
+    test_group_name: kubernetes-test-go-release-1.6
+  - name: verify-1.6
+    test_group_name: kubernetes-verify-release-1.6
+  - name: kubelet-1.6
+    test_group_name: ci-kubernetes-node-kubelet-1.6
+
+- name: release-1.6-blocking
+  dashboard_tab:
+  - name: build-1.6
+    test_group_name: kubernetes-build-1.6
+  - name: test-go-1.6
+    test_group_name: kubernetes-test-go-release-1.6
+  - name: verify-1.6
+    test_group_name: kubernetes-verify-release-1.6
+  - name: kubelet-1.6
+    test_group_name: ci-kubernetes-node-kubelet-1.6
 
 - name: release-1.5-all
   dashboard_tab:


### PR DESCRIPTION
Also reduce frequency of kubernetes-verify-release-1.3.

I've already created the `gs://kubernetes-federation-release-1-6` bucket and `k8s-jkns-e2e-gce-f8n-1-6` project.

x-ref #2029

cc @enisoc @ethernetdan 