### PR TITLE
Fix save/load kubetest behavior

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -26,7 +26,7 @@ mkdir -p ${ARTIFACTS}
 
 : ${KUBE_GCS_RELEASE_BUCKET:="kubernetes-release"}
 : ${KUBE_GCS_DEV_RELEASE_BUCKET:="kubernetes-release-dev"}
-JENKINS_SOAK_PREFIX="gs://kubernetes-jenkins/soak/${JOB_NAME}"
+: ${JENKINS_SOAK_PREFIX:="gs://kubernetes-jenkins/soak/${JOB_NAME}"}
 
 # Explicitly set config path so staging gcloud (if installed) uses same path
 export CLOUDSDK_CONFIG="${WORKSPACE}/.config/gcloud"
@@ -91,9 +91,7 @@ if [[ "${JENKINS_SOAK_MODE:-}" == "y" ]]; then
   # In soak mode we sync cluster state to gcs.
   # If we --up a cluster, we save the kubecfg and version info to gcs.
   # Otherwise we load kubecfg and version info from gcs.
-  #e2e_go_args+=(--save="gs://${JENKINS_SOAK_PREFIX}")
-  # TODO FIX ME DO NOT SUBMIT AAAAAAAAAAAAAAAAAAA
-  e2e_go_args+=(--save="gs://fejternetes/soak")
+  e2e_go_args+=(--save="${JENKINS_SOAK_PREFIX}")
 fi
 
 

--- a/kubetest/extract.go
+++ b/kubetest/extract.go
@@ -43,6 +43,7 @@ const (
 	stable              // release/stable, release/stable-1.5
 	version             // v1.5.0, v1.5.0-beta.2
 	gcs                 // gs://bucket/prefix/v1.6.0-alpha.0
+	load                // Load a --save cluster
 )
 
 type extractStrategy struct {
@@ -227,7 +228,7 @@ func getKube(url, version string) error {
 	}
 	log.Printf("U=%s R=%s get-kube.sh", url, version)
 	if err := finishRunning(exec.Command(k)); err != nil {
-		return err
+		return fmt.Errorf("U=%s R=%s get-kube.sh failed: %v", url, version, err)
 	}
 	i, err := os.Stat("./kubernetes/cluster/get-kube-binaries.sh")
 	if err != nil || i.IsDir() {
@@ -367,6 +368,74 @@ func (e extractStrategy) Extract() error {
 		return getKube(url, release)
 	case gcs:
 		return getKube(path.Dir(e.option), path.Base(e.option))
+	case load:
+		return loadState(e.option)
 	}
 	return fmt.Errorf("Unrecognized extraction: %v(%v)", e.mode, e.value)
+}
+
+func loadState(save string) error {
+	log.Printf("Restore state from %s", save)
+	cUrl, err := joinUrl(save, "kube-config")
+	if err != nil {
+		return fmt.Errorf("bad load url %s: %v", save, err)
+	}
+	uUrl, err := joinUrl(save, "release-url.txt")
+	if err != nil {
+		return fmt.Errorf("bad load url %s: %v", save, err)
+	}
+	rUrl, err := joinUrl(save, "release.txt")
+	if err != nil {
+		return fmt.Errorf("bad load url %s: %v", save, err)
+	}
+
+	if err := os.MkdirAll(home(".kube"), 0775); err != nil {
+		return err
+	}
+	if err := finishRunning(exec.Command("gsutil", "cp", cUrl, home(".kube", "config"))); err != nil {
+		return err
+	}
+	url, err := combinedOutput(exec.Command("gsutil", "cat", uUrl))
+	if err != nil {
+		return err
+	}
+	release, err := combinedOutput(exec.Command("gsutil", "cat", rUrl))
+	if err != nil {
+		return err
+	}
+	return getKube(string(url), string(release))
+}
+
+func saveState(save string) error {
+	url := os.Getenv("KUBERNETES_RELEASE_URL")
+	version := os.Getenv("KUBERNETES_RELEASE")
+	log.Printf("Save U=%s R=%s to %s", url, version, save)
+	cUrl, err := joinUrl(save, "kube-config")
+	if err != nil {
+		return fmt.Errorf("bad save url %s: %v", save, err)
+	}
+	uUrl, err := joinUrl(save, "release-url.txt")
+	if err != nil {
+		return fmt.Errorf("bad save url %s: %v", save, err)
+	}
+	rUrl, err := joinUrl(save, "release.txt")
+	if err != nil {
+		return fmt.Errorf("bad save url %s: %v", save, err)
+	}
+
+	if err := finishRunning(exec.Command("gsutil", "cp", home(".kube", "config"), cUrl)); err != nil {
+		return fmt.Errorf("failed to save .kube/config to %s: %v", cUrl, err)
+	}
+	if cmd, err := inputCommand(url, "gsutil", "cp", "-", uUrl); err != nil {
+		return fmt.Errorf("failed to write url %s to %s: %v", url, uUrl, err)
+	} else if err = finishRunning(cmd); err != nil {
+		return fmt.Errorf("failed to upload url %s to %s: %v", url, uUrl, err)
+	}
+
+	if cmd, err := inputCommand(version, "gsutil", "cp", "-", rUrl); err != nil {
+		return fmt.Errorf("failed to write release %s to %s: %v", version, rUrl, err)
+	} else if err = finishRunning(cmd); err != nil {
+		return fmt.Errorf("failed to upload release %s to %s: %v", version, rUrl, err)
+	}
+	return nil
 }

--- a/kubetest/extract.go
+++ b/kubetest/extract.go
@@ -223,7 +223,7 @@ func getKube(url, version string) error {
 		return err
 	}
 	// kube-up in cluster/gke/util.sh depends on this
-	if err := os.Setenv("CLUSTER_API_VERSION", version[1:len(version)]); err != nil {
+	if err := os.Setenv("CLUSTER_API_VERSION", version[1:]); err != nil {
 		return err
 	}
 	log.Printf("U=%s R=%s get-kube.sh", url, version)

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -188,3 +189,14 @@ func combinedOutput(cmd *exec.Cmd) ([]byte, error) {
 		}
 	}
 }
+
+// gs://foo and bar becomes gs://foo/bar
+func joinUrl(urlPath, path string) (string, error) {
+	u, err := url.Parse(urlPath)
+	if err != nil {
+		return "", err
+	}
+	u.Path = filepath.Join(u.Path, path)
+	return u.String(), nil
+}
+

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -199,4 +199,3 @@ func joinUrl(urlPath, path string) (string, error) {
 	u.Path = filepath.Join(u.Path, path)
 	return u.String(), nil
 }
-

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -326,7 +326,7 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     PARSER.add_argument(
-        '--tag', default='v20170225-670e418a', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170225-b97ce6de', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(


### PR DESCRIPTION
ref #2021 

Make `kubetest --save=S --up --down=false` save `.kube/config` `KUBERNETES_RELEASE` and `KUBERNETES_RELEASE_URL` to `S`
Make `kubetest --save=S --up=false` load `.kube/config` `KUBERNETES_RELEASE` and `KUBERNETES_RELEASE_URL` from `S`
Allow jobs to explicitly specify `S` by setting `JENKINS_SOAK_PREFIX`
`chmod -R o+r` all artifacts on exit