### PR TITLE
Refactor combinedOutput() as output() in kubetest

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -148,11 +148,11 @@ func (k kubernetesAnywhere) IsUp() error {
 }
 
 func (k kubernetesAnywhere) SetupKubecfg() error {
-	output, err := exec.Command("make", "--silent", "-C", k.path, "kubeconfig-path").Output()
+	o, err := output(exec.Command("make", "--silent", "-C", k.path, "kubeconfig-path"))
 	if err != nil {
 		return fmt.Errorf("Could not get kubeconfig-path: %v", err)
 	}
-	kubecfg := strings.TrimSuffix(string(output), "\n")
+	kubecfg := strings.TrimSuffix(string(o), "\n")
 
 	if err = os.Setenv("KUBECONFIG", kubecfg); err != nil {
 		return err

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -228,7 +228,7 @@ func run(deploy deployer, o options) error {
 }
 
 func listNodes(dump string) error {
-	b, err := combinedOutput(exec.Command("./cluster/kubectl.sh", "--match-server-version=false", "get", "nodes", "-oyaml"))
+	b, err := output(exec.Command("./cluster/kubectl.sh", "--match-server-version=false", "get", "nodes", "-oyaml"))
 	if verbose {
 		log.Printf("kubectl get nodes:\n%s", string(b))
 	}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -314,7 +314,7 @@ func findVersion() string {
 	if _, err := os.Stat("hack/lib/version.sh"); err == nil {
 		// TODO(fejta): do this in go. At least we removed the upload-to-gcs.sh dep.
 		gross := `. hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"`
-		if b, err := combinedOutput(exec.Command("bash", "-c", gross)); err == nil {
+		if b, err := output(exec.Command("bash", "-c", gross)); err == nil {
 			return string(b)
 		} else {
 			log.Printf("Failed to get_version_vars: %v", err)
@@ -406,7 +406,7 @@ func prepareGcp(kubernetesProvider string) error {
 	}
 
 	log.Printf("Checking presence of public key in %s", p)
-	if o, err := combinedOutput(exec.Command("gcloud", "compute", "--project="+p, "project-info", "describe")); err != nil {
+	if o, err := output(exec.Command("gcloud", "compute", "--project="+p, "project-info", "describe")); err != nil {
 		return err
 	} else if b, err := ioutil.ReadFile(pk); err != nil {
 		return err

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -152,8 +152,11 @@ func inputCommand(input, cmd string, args ...string) (*exec.Cmd, error) {
 }
 
 // return cmd.CombinedOutput(), potentially timing out in the process.
-func combinedOutput(cmd *exec.Cmd) ([]byte, error) {
+func output(cmd *exec.Cmd) ([]byte, error) {
 	stepName := strings.Join(cmd.Args, " ")
+	if verbose {
+		cmd.Stderr = os.Stderr
+	}
 	log.Printf("Running: %v", stepName)
 	defer func(start time.Time) {
 		log.Printf("Step '%s' finished in %s", stepName, time.Since(start))
@@ -166,7 +169,7 @@ func combinedOutput(cmd *exec.Cmd) ([]byte, error) {
 	}
 	finished := make(chan result)
 	go func() {
-		b, err := cmd.CombinedOutput()
+		b, err := cmd.Output()
 		finished <- result{b, err}
 	}()
 	for {

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -329,7 +329,7 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     PARSER.add_argument(
-        '--tag', default='v20170225-b97ce6de', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170227-4ae05be9', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(


### PR DESCRIPTION
ref #2011 

Switch `combinedOutput()` to `output()` so that we only include info from `stdout`.

For example `gcloud container get-server-config` prints diagnostic info to `stderr`, which we want to exclude from the version we are trying to calculate. Do the same for other methods.

Also we do not have a `ci/latest-1.5.2.txt` only a `ci/latest-1.5.txt` so use a regex to extract this value from the full version stanza, matching [previous behavior](https://github.com/kubernetes/test-infra/blob/025cce1d1aea0bf03ccc541f3f1a4d24356fd41a/jenkins/e2e-image/e2e-runner.sh#L119)

Finally trim the whitespace off the `gcloud describe-from-family` output.

Canary results:
```
I0226 07:31:00.437] JENKINS_USE_SERVER_VERSION=y

./kubetest -v --dump=/workspace/_artifacts --extract=gke --check-leaked-resources --timeout=40m --publish=gs://kubernetes-release-dev/ci/latest-canarygreen.txt

W0226 07:31:03.795] 2017/02/26 07:31:03 util.go:159: Running: gcloud container get-server-config --project=k8s-jkns-e2e-gce --zone=us-central1-f --format=value(defaultClusterVersion)
W0226 07:31:04.164] Fetching server config for us-central1-f
W0226 07:31:04.382] 2017/02/26 07:31:04 util.go:161: Step 'gcloud container get-server-config --project=k8s-jkns-e2e-gce --zone=us-central1-f --format=value(defaultClusterVersion)' finished in 586.301135ms
W0226 07:31:04.382] 2017/02/26 07:31:04 util.go:159: Running: gsutil cat gs://kubernetes-release-dev/ci/latest-1.5.txt
W0226 07:31:06.228] 2017/02/26 07:31:06 util.go:161: Step 'gsutil cat gs://kubernetes-release-dev/ci/latest-1.5.txt' finished in 1.846485902s
W0226 07:31:06.229] 2017/02/26 07:31:06 extract.go:228: U=https://storage.googleapis.com/kubernetes-release-dev/ci R=v1.5.4-beta.0.21+21616871cf8dc7 get-kube.sh

I0226 07:32:34.351] process 3716 exited with code 0 after 1.6m
I0226 07:32:34.351] PASS: ci-kubernetes-e2e-gce-canary
```