### PR TITLE
No longer need upload-to-gcs.sh

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -125,10 +125,6 @@ class LocalMode(object):
     def install_prerequisites(self):
         """Copies upload-to-gcs and kubetest if needed."""
         parent = os.path.dirname(self.runner)
-        if not os.path.isfile(os.path.join(parent, 'upload-to-gcs.sh')):
-            shutil.copy(
-                test_infra('../kubernetes/hack/jenkins/upload-to-gcs.sh'),
-                os.path.join(parent, 'upload-to-gcs.sh'))
         if not os.path.isfile(os.path.join(parent, 'kubetest')):
             check('go', 'install', 'k8s.io/test-infra/kubetest')
             shutil.copy(


### PR DESCRIPTION
```
W0227 18:58:12.952] IOError: [Errno 2] No such file or directory: '/workspace/./test-infra/jenkins/../scenarios/../../kubernetes/hack/jenkins/upload-to-gcs.sh'
```

Fail due to prow local run does not necessarily have k/k repo