### PR TITLE
Add ci service account in prow as well

### DIFF
--- a/experiment/e2e-image/Makefile
+++ b/experiment/e2e-image/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.3
+VERSION = 0.4
 
 image:
 	docker build -t "gcr.io/k8s-testimages/kubekins-e2e-prow:$(VERSION)" .

--- a/experiment/e2e-image/runner
+++ b/experiment/e2e-image/runner
@@ -21,7 +21,7 @@ git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
     --bare \
     --job=${JOB_NAME} \
-    --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
+    --service-account=${GOOGLE_APPLICATION_CREDENTIALS_CI} \
     --upload='gs://kubernetes-jenkins/logs' \
     --json=1 \
     "$@"

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -16,7 +16,7 @@ all: build fmt vet test
 
 
 HOOK_VERSION       = 0.85
-LINE_VERSION       = 0.80
+LINE_VERSION       = 0.81
 SINKER_VERSION     = 0.5
 DECK_VERSION       = 0.17
 SPLICE_VERSION     = 0.15
@@ -44,6 +44,9 @@ JENKINS_ADDRESS_FILE = ${HOME}/jenkins-address
 # Service account key for bootstrap jobs.
 SERVICE_ACCOUNT_FILE = ${HOME}/service-account.json
 
+# CI-service account key for prow-e2e jobs.
+CI_SERVICE_ACCOUNT_FILE = ${HOME}/ci-service-account.json
+
 # GCE ssh key for gce-e2e jobs
 SSH_KEY_PRIVATE = ${HOME}/ssh-private
 SSH_KEY_PUBLIC = ${HOME}/ssh-public
@@ -56,6 +59,7 @@ create-cluster:
 	kubectl create secret generic oauth-token --from-file=oauth=$(OAUTH_SECRET_FILE)
 	kubectl create secret generic jenkins-token --from-file=jenkins=$(JENKINS_SECRET_FILE)
 	kubectl create secret generic service-account --from-file=service-account.json=$(SERVICE_ACCOUNT_FILE)
+	kubectl create secret generic ci-service-account --from-file=service-account.json=$(CI_SERVICE_ACCOUNT_FILE)
 	kubectl create secret generic ssh-key-secret --from-file=ssh-private=$(SSH_KEY_PRIVATE) --from-file=ssh-public=$(SSH_KEY_PUBLIC)
 	kubectl create configmap jenkins-address --from-file=jenkins-address=$(JENKINS_ADDRESS_FILE)
 	kubectl create configmap config --from-file=config=config.yaml

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - "--github-bot-name=k8s-ci-robot"
         env:
         - name: LINE_IMAGE
-          value: "gcr.io/k8s-prow/line:0.80"
+          value: "gcr.io/k8s-prow/line:0.81"
         - name: DRY_RUN
           value: "false"
         ports:

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -33,7 +33,7 @@ spec:
         image: gcr.io/k8s-prow/horologium:0.0
         env:
         - name: LINE_IMAGE
-          value: "gcr.io/k8s-prow/line:0.80"
+          value: "gcr.io/k8s-prow/line:0.81"
         - name: DRY_RUN
           value: "false"
         volumeMounts:

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - -log-json
         env:
         - name: LINE_IMAGE
-          value: "gcr.io/k8s-prow/line:0.80"
+          value: "gcr.io/k8s-prow/line:0.81"
         - name: DRY_RUN
           value: "false"
       volumes:

--- a/prow/cmd/line/main.go
+++ b/prow/cmd/line/main.go
@@ -302,6 +302,10 @@ func (c *testClient) TestKubernetes() error {
 				Value: "/etc/service-account/service-account.json",
 			},
 			kube.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS_CI",
+				Value: "/etc/ci-service-account/service-account.json",
+			},
+			kube.EnvVar{
 				Name:  "JENKINS_GCE_SSH_PRIVATE_KEY_FILE",
 				Value: "/etc/ssh-key-secret/ssh-private",
 			},
@@ -314,6 +318,11 @@ func (c *testClient) TestKubernetes() error {
 			kube.VolumeMount{
 				Name:      "service",
 				MountPath: "/etc/service-account",
+				ReadOnly:  true,
+			},
+			kube.VolumeMount{
+				Name:      "ci-service",
+				MountPath: "/etc/ci-service-account",
 				ReadOnly:  true,
 			},
 			kube.VolumeMount{
@@ -340,6 +349,12 @@ func (c *testClient) TestKubernetes() error {
 			Name: "service",
 			Secret: &kube.SecretSource{
 				Name: "service-account",
+			},
+		},
+		kube.Volume{
+			Name: "ci-service",
+			Secret: &kube.SecretSource{
+				Name: "ci-service-account",
 			},
 		},
 		kube.Volume{

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -275,6 +275,6 @@ periodics:
   interval: 5m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:0.3
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:0.4
       args:
       - "--timeout=60"


### PR DESCRIPTION
bootstrap will overwrite GOOGLE_APPLICATION_CREDENTIALS again

https://github.com/kubernetes/test-infra/blob/master/jenkins/bootstrap.py#L608

```
kubectl describe secrets/ci-service-account
Name:		ci-service-account
Namespace:	default
Labels:		<none>
Annotations:	<none>

Type:	Opaque

Data
====
service-account.json:	2332 bytes
```