### PR TITLE
Start code freeze for 1.6 release.

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -112,7 +112,7 @@ data:
     kubernetes-pull-build-test-gci-e2e-gke,\
     kubernetes-pull-build-test-gci-kubemark-e2e-gce"
   submit-queue.weak-stable-jobs: "\"\""
-  submit-queue.do-not-merge-milestones: "\"\""
+  submit-queue.do-not-merge-milestones: "next-candidate,v1.7,"
   submit-queue.admin-port: "9999"
   submit-queue.chart-url: http://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
   submit-queue.history-url: http://storage.googleapis.com/kubernetes-test-history/static/index.html


### PR DESCRIPTION
@foxish 

Based on https://github.com/kubernetes/contrib/pull/1990.

This should be merged and applied before Tuesday (2017-02-28) morning. After that, only PRs with the v1.6 milestone will be allowed through the queue.