### PR TITLE
Increase timeout for kubernetes-build-1.6 to match kubernetes-build-cross

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -114,7 +114,7 @@
         giturl: 'https://github.com/kubernetes/kubernetes'
         job-name: ci-kubernetes-build-1.6
         repo-name: k8s.io/kubernetes
-        timeout: 50
+        timeout: 100
 
     - kubernetes-federation-build:
         branch: master


### PR DESCRIPTION
We're building more platforms and architectures compared to 1.5, so it's going to take more time.

cc @luxas @ethernetdan 