### PR TITLE
Rework yaml2proto to accept multiple YAML files

### DIFF
--- a/jobs/maintenance-ci-testgrid-config-upload.sh
+++ b/jobs/maintenance-ci-testgrid-config-upload.sh
@@ -27,7 +27,7 @@ export TEST_INFRA=$GOPATH/src/k8s.io/test-infra
 
 # Export config
 export CONFIGDIR=$TEST_INFRA/testgrid/config
-go run $CONFIGDIR/main.go $CONFIGDIR/config.yaml $CONFIGDIR/config
+go run $CONFIGDIR/main.go --yaml=$CONFIGDIR/config.yaml --output=$CONFIGDIR/config
 gsutil cp $CONFIGDIR/config gs://k8s-testgrid/config
 rm $CONFIGDIR/config
 

--- a/testgrid/config/BUILD
+++ b/testgrid/config/BUILD
@@ -25,9 +25,8 @@ go_test(
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
-        "//testgrid/config/pb:go_default_library",
         "//testgrid/config/yaml2proto:go_default_library",
-        "//vendor:github.com/golang/protobuf/proto",
+        "//vendor:gopkg.in/yaml.v2",
     ],
 )
 

--- a/testgrid/config/config_test.go
+++ b/testgrid/config/config_test.go
@@ -21,8 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
-	"k8s.io/test-infra/testgrid/config/pb"
+	"gopkg.in/yaml.v2"
 	"k8s.io/test-infra/testgrid/config/yaml2proto"
 )
 
@@ -36,15 +35,14 @@ func TestConfig(t *testing.T) {
 		t.Errorf("IO Error : Cannot Open File config.yaml")
 	}
 
-	protobufData, err := yaml2proto.Yaml2Proto(yamlData)
-
-	if err != nil {
+	c := yaml2proto.Config{}
+	if err := c.Update(yamlData); err != nil {
 		t.Errorf("Yaml2Proto - Conversion Error %v", err)
 	}
 
-	config := &config.Configuration{}
-	if err := proto.Unmarshal(protobufData, config); err != nil {
-		t.Errorf("Failed to parse config: %v", err)
+	config, err := c.Raw()
+	if err != nil {
+		t.Errorf("Error validating config: %v", err)
 	}
 
 	// Validate config.yaml -
@@ -162,7 +160,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	sqData := &SQConfig{}
-	err = yaml2proto.Unmarshal([]byte(configData), &sqData)
+	err = yaml.Unmarshal([]byte(configData), &sqData)
 	if err != nil {
 		t.Errorf("Unmarshal Error for SQ Data : %v", err)
 	}

--- a/testgrid/config/main.go
+++ b/testgrid/config/main.go
@@ -55,7 +55,7 @@ func main() {
 	for _, file := range yamlFiles {
 		b, err := ioutil.ReadFile(file)
 		if err != nil {
-			errExit("IO Error : Cannot Read File %v\n", file)
+			errExit("IO Error : Cannot Read File %s : %v\n", file, err)
 		}
 		if err = c.Update(b); err != nil {
 			errExit("Error parsing file %s : %v\n", file, err)
@@ -71,8 +71,7 @@ func main() {
 		if err != nil {
 			errExit("err encoding proto: %v", err)
 		}
-		err = ioutil.WriteFile(*outputPath, b, 0644)
-		if err != nil {
+		if err = ioutil.WriteFile(*outputPath, b, 0644); err != nil {
 			errExit("IO Error : Cannot Write File %v\n", outputPath)
 		}
 	}

--- a/testgrid/config/main.go
+++ b/testgrid/config/main.go
@@ -17,40 +17,63 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"k8s.io/test-infra/testgrid/config/yaml2proto"
 )
 
-//
-// usage: config <input/path/to/yaml> <output/path/to/proto>
-//
+var (
+	yamlPaths  = flag.String("yaml", "", "comma-separated list of input YAML files")
+	printText  = flag.Bool("print-text", false, "print generated proto in text format to stdout")
+	outputPath = flag.String("output", "", "output path to save generated protobuf data")
+)
+
+func errExit(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, a...)
+	os.Exit(1)
+}
 
 func main() {
-	args := os.Args[1:]
+	flag.Parse()
 
-	if len(args) != 2 {
-		fmt.Printf("Wrong Arguments - usage: yaml2proto <input/path/to/yaml> <output/path/to/proto>\n")
-		os.Exit(-1)
+	yamlFiles := strings.Split(*yamlPaths, ",")
+	if len(yamlFiles) == 0 || yamlFiles[0] == "" {
+		errExit("Must specify one or more YAML files with --yaml\n")
+	}
+	if !*printText && *outputPath == "" {
+		errExit("Must set --print-text or --output\n")
+	}
+	if *printText && *outputPath != "" {
+		errExit("Cannot set both --print-text and --output\n")
 	}
 
-	yamlData, err := ioutil.ReadFile(args[0])
-	if err != nil {
-		fmt.Printf("IO Error : Cannot Read File %v\n", args[0])
-		os.Exit(-1)
+	var c yaml2proto.Config
+	for _, file := range yamlFiles {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
+			errExit("IO Error : Cannot Read File %v\n", file)
+		}
+		if err = c.Update(b); err != nil {
+			errExit("Error parsing file %s : %v\n", file, err)
+		}
 	}
 
-	protobufData, err := yaml2proto.Yaml2Proto(yamlData)
-	if err != nil {
-		fmt.Printf("Yaml2Proto Error : %v\n", err)
-		os.Exit(-1)
-	}
-
-	err = ioutil.WriteFile(args[1], protobufData, 0777)
-	if err != nil {
-		fmt.Printf("IO Error : Cannot Write File %v\n", args[1])
-		os.Exit(-1)
+	if *printText {
+		if err := c.MarshalText(os.Stdout); err != nil {
+			errExit("err printing proto: %v", err)
+		}
+	} else {
+		b, err := c.MarshalBytes()
+		if err != nil {
+			errExit("err encoding proto: %v", err)
+		}
+		err = ioutil.WriteFile(*outputPath, b, 0644)
+		if err != nil {
+			errExit("IO Error : Cannot Write File %v\n", outputPath)
+		}
 	}
 }

--- a/testgrid/config/yaml2proto/BUILD
+++ b/testgrid/config/yaml2proto/BUILD
@@ -13,10 +13,6 @@ go_test(
     srcs = ["yaml2proto_test.go"],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = [
-        "//testgrid/config/pb:go_default_library",
-        "//vendor:github.com/golang/protobuf/proto",
-    ],
 )
 
 go_library(

--- a/testgrid/config/yaml2proto/yaml2proto.go
+++ b/testgrid/config/yaml2proto/yaml2proto.go
@@ -18,15 +18,20 @@ package yaml2proto
 
 import (
 	"errors"
-	"fmt"
-	"gopkg.in/yaml.v2"
+	"io"
 
 	"github.com/golang/protobuf/proto"
+	"gopkg.in/yaml.v2"
 	"k8s.io/test-infra/testgrid/config/pb"
 )
 
+type Config struct {
+	config        *config.Configuration
+	defaultConfig *config.DefaultConfiguration
+}
+
 // Set up unfilled field in a TestGroup using the default TestGroup
-func ValidateTestGroup(currentTestGroup *config.TestGroup, defaultTestGroup *config.TestGroup) {
+func ReconcileTestGroup(currentTestGroup *config.TestGroup, defaultTestGroup *config.TestGroup) {
 	if currentTestGroup.DaysOfResults == 0 {
 		currentTestGroup.DaysOfResults = defaultTestGroup.DaysOfResults
 	}
@@ -50,7 +55,7 @@ func ValidateTestGroup(currentTestGroup *config.TestGroup, defaultTestGroup *con
 }
 
 // Set up unfilled field in a DashboardTab using the default DashboardTab
-func ValidateDashboardtab(currentTab *config.DashboardTab, defaultTab *config.DashboardTab) {
+func ReconcileDashboardtab(currentTab *config.DashboardTab, defaultTab *config.DashboardTab) {
 	if currentTab.BugComponent == 0 {
 		currentTab.BugComponent = defaultTab.BugComponent
 	}
@@ -84,54 +89,110 @@ func ValidateDashboardtab(currentTab *config.DashboardTab, defaultTab *config.Da
 	}
 }
 
-func Unmarshal(yamlData []byte, out interface{}) error {
-	// A Wrapper for yaml.Unmarshal
-	return yaml.Unmarshal(yamlData, out)
-}
-
-func Yaml2Proto(yamlData []byte) ([]byte, error) {
-
-	// Unmarshal yaml to config
-	curConfig := &config.Configuration{}
-	defaultConfig := &config.DefaultConfiguration{}
-	err := Unmarshal(yamlData, &curConfig)
+// updateDefaults reads any default configuration from yamlData and updates the
+// defaultConfig in c.
+//
+// Returns an error if the defaultConfig remains unset.
+func (c *Config) updateDefaults(yamlData []byte) error {
+	newDefaults := &config.DefaultConfiguration{}
+	err := yaml.Unmarshal(yamlData, newDefaults)
 	if err != nil {
-		fmt.Printf("Unmarshal Error for config : %v\n", err)
-		return nil, err
+		return err
 	}
 
-	err = Unmarshal(yamlData, &defaultConfig)
-	if err != nil {
-		fmt.Printf("Unmarshal Error for defaultconfig : %v\n", err)
-		return nil, err
-	}
-
-	// Reject empty yaml ( No testgroups or dashboards )
-	if len(curConfig.TestGroups) == 0 {
-		return nil, errors.New("Invalid Yaml : No Valid Testgroups")
-	}
-
-	if len(curConfig.Dashboards) == 0 {
-		return nil, errors.New("Invalid Yaml : No Valid Dashboards")
-	}
-
-	if defaultConfig.DefaultTestGroup == nil || defaultConfig.DefaultDashboardTab == nil {
-		return nil, errors.New("Please Include The Default Testgroup & Dashboardtab")
-	}
-
-	// validating testgroups
-	for _, testgroup := range curConfig.TestGroups {
-		ValidateTestGroup(testgroup, defaultConfig.DefaultTestGroup)
-	}
-
-	// validating dashboards
-	for _, dashboard := range curConfig.Dashboards {
-		// validate dashboard tabs
-		for _, dashboardtab := range dashboard.DashboardTab {
-			ValidateDashboardtab(dashboardtab, defaultConfig.DefaultDashboardTab)
+	if c.defaultConfig == nil {
+		c.defaultConfig = newDefaults
+	} else {
+		if newDefaults.DefaultTestGroup != nil {
+			c.defaultConfig.DefaultTestGroup = newDefaults.DefaultTestGroup
+		}
+		if newDefaults.DefaultDashboardTab != nil {
+			c.defaultConfig.DefaultDashboardTab = newDefaults.DefaultDashboardTab
 		}
 	}
 
-	// Marshal config to protobuf
-	return proto.Marshal(curConfig)
+	if c.defaultConfig.DefaultTestGroup == nil {
+		return errors.New("missing DefaultTestGroup")
+	}
+	if c.defaultConfig.DefaultDashboardTab == nil {
+		return errors.New("missing DefaultDashboardTab")
+	}
+
+	return nil
+}
+
+// Update reads the config in yamlData and updates the config in c.
+// If yamlData does not contain any defaults, the defaults from a
+// previous call to Update are used instead.
+func (c *Config) Update(yamlData []byte) error {
+	if err := c.updateDefaults(yamlData); err != nil {
+		return err
+	}
+
+	curConfig := &config.Configuration{}
+	err := yaml.Unmarshal(yamlData, curConfig)
+	if err != nil {
+		return err
+	}
+
+	if c.config == nil {
+		c.config = &config.Configuration{}
+	}
+
+	for _, testgroup := range curConfig.TestGroups {
+		ReconcileTestGroup(testgroup, c.defaultConfig.DefaultTestGroup)
+		c.config.TestGroups = append(c.config.TestGroups, testgroup)
+	}
+
+	for _, dashboard := range curConfig.Dashboards {
+		// validate dashboard tabs
+		for _, dashboardtab := range dashboard.DashboardTab {
+			ReconcileDashboardtab(dashboardtab, c.defaultConfig.DefaultDashboardTab)
+		}
+		c.config.Dashboards = append(c.config.Dashboards, dashboard)
+	}
+
+	return nil
+}
+
+// validate checks that a configuration is well-formed, having test groups and dashboards set.
+func (c *Config) validate() error {
+	if c.config == nil {
+		return errors.New("Configuration unset")
+	}
+	if len(c.config.TestGroups) == 0 {
+		return errors.New("Invalid YAML : No Valid Testgroups")
+	}
+	if len(c.config.Dashboards) == 0 {
+		return errors.New("Invalid YAML : No Valid Dashboards")
+	}
+
+	return nil
+}
+
+// MarshalText writes a text version of the parsed configuration to the supplied io.Writer.
+// Returns an error if config is invalid or writing failed.
+func (c *Config) MarshalText(w io.Writer) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
+	return proto.MarshalText(w, c.config)
+}
+
+// MarshalBytes returns the wire-encoded protobuf data for the parsed configuration.
+// Returns an error if config is invalid or encoding failed.
+func (c *Config) MarshalBytes() ([]byte, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return proto.Marshal(c.config)
+}
+
+// Raw returns the raw protocol buffer for the parsed configuration after validation.
+// Returns an error if validation fails.
+func (c *Config) Raw() (*config.Configuration, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return c.config, nil
 }

--- a/testgrid/config/yaml2proto/yaml2proto_test.go
+++ b/testgrid/config/yaml2proto/yaml2proto_test.go
@@ -19,9 +19,6 @@ package yaml2proto
 import (
 	"errors"
 	"testing"
-
-	"github.com/golang/protobuf/proto"
-	"k8s.io/test-infra/testgrid/config/pb"
 )
 
 func TestYaml2Proto_IsExternal_And_UseKuberClient_False(t *testing.T) {
@@ -35,17 +32,18 @@ test_groups:
 dashboards:
 - name: dashboard_1`
 
-	protobufData, err := Yaml2Proto([]byte(yaml))
+	c := Config{}
+	err := c.Update([]byte(yaml))
 
 	if err != nil {
 		t.Errorf("Convert Error: %v\n", err)
 	}
 
-	config := &config.Configuration{}
-	if err := proto.Unmarshal(protobufData, config); err != nil {
-		t.Errorf("Failed to parse config: %v\n", err)
+	config, err := c.Raw()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		t.FailNow()
 	}
-
 	for _, testgroup := range config.TestGroups {
 		if !testgroup.IsExternal {
 			t.Errorf("IsExternal should always be true!")
@@ -57,48 +55,82 @@ dashboards:
 	}
 }
 
-func TestYaml2Proto_Invalid_Yaml(t *testing.T) {
+func TestUpdateDefaults_Validity(t *testing.T) {
 	tests := []struct {
 		yaml          string
 		expectedError error
 	}{
 		{
 			yaml:          ``,
-			expectedError: errors.New("Invalid Yaml : No Valid Testgroups"),
+			expectedError: errors.New("missing DefaultTestGroup"),
 		},
 		{
-			yaml: `dashboards:
-- name: dashboard_1`,
-			expectedError: errors.New("Invalid Yaml : No Valid Testgroups"),
-		},
-		{
-			yaml: `test_groups:
-- name: testgroup_1`,
-			expectedError: errors.New("Invalid Yaml : No Valid Dashboards"),
-		},
-		{
-			yaml: `default_dashboard_tab:
-test_groups:
-- name: testgroup_1
-dashboards:
-- name: dashboard_1`,
-			expectedError: errors.New("Please Include The Default Testgroup & Dashboardtab"),
+			yaml: `default_test_group:
+  name: default`,
+			expectedError: errors.New("missing DefaultDashboardTab"),
 		},
 		{
 			yaml: `default_test_group:
   name: default
 default_dashboard_tab:
-  name: default
-test_groups:
-- name: testgroup_1
-dashboards:
-- name: dashboard_1`,
+  name: default`,
 			expectedError: nil,
 		},
 	}
 
 	for index, test := range tests {
-		_, err := Yaml2Proto([]byte(test.yaml))
+		c := Config{}
+		err := c.Update([]byte(test.yaml))
+		if (err == nil && test.expectedError == nil) ||
+			(err != nil && test.expectedError != nil && err.Error() == test.expectedError.Error()) {
+			continue
+		} else {
+			t.Errorf("Test %v fails. ExpectedError: %v, actual error: %v", index, test.expectedError, err)
+		}
+	}
+}
+func TestUpdate_Validate(t *testing.T) {
+	defaultYaml := `default_test_group:
+  name: default
+default_dashboard_tab:
+  name: default`
+
+	tests := []struct {
+		yaml          string
+		expectedError error
+	}{
+		{
+			yaml:          ``,
+			expectedError: errors.New("Invalid YAML : No Valid Testgroups"),
+		},
+		{
+			yaml: `dashboards:
+- name: dashboard_1`,
+			expectedError: errors.New("Invalid YAML : No Valid Testgroups"),
+		},
+		{
+			yaml: `test_groups:
+- name: testgroup_1`,
+			expectedError: errors.New("Invalid YAML : No Valid Dashboards"),
+		},
+		{
+			yaml: `dashboards:
+- name: dashboard_1
+test_groups:
+- name: testgroup_1`,
+			expectedError: nil,
+		},
+	}
+
+	for index, test := range tests {
+		c := Config{}
+		if err := c.Update([]byte(defaultYaml)); err != nil {
+			t.Errorf("Unexpected error in Update(defaultYaml): %v", err)
+		}
+		if err := c.Update([]byte(test.yaml)); err != nil {
+			t.Errorf("Unexpected error in Update(test[%d].yaml): %v", index, err)
+		}
+		err := c.validate()
 		if (err == nil && test.expectedError == nil) ||
 			(err != nil && test.expectedError != nil && err.Error() == test.expectedError.Error()) {
 			continue

--- a/testgrid/jenkins_verify/BUILD
+++ b/testgrid/jenkins_verify/BUILD
@@ -20,9 +20,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
-        "//testgrid/config/pb:go_default_library",
         "//testgrid/config/yaml2proto:go_default_library",
-        "//vendor:github.com/golang/protobuf/proto",
     ],
 )
 

--- a/testgrid/jenkins_verify/jenkins_validate.go
+++ b/testgrid/jenkins_verify/jenkins_validate.go
@@ -23,9 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	prow_config "k8s.io/test-infra/prow/config"
-	config "k8s.io/test-infra/testgrid/config/pb"
 	"k8s.io/test-infra/testgrid/config/yaml2proto"
 )
 
@@ -54,15 +52,20 @@ func main() {
 	}
 
 	data, err := ioutil.ReadFile(configPath)
-	protobufData, err := yaml2proto.Yaml2Proto(data)
 	if err != nil {
+		fmt.Printf("Failed reading %v\n", configPath)
+		os.Exit(1)
+	}
+
+	c := yaml2proto.Config{}
+	if err := c.Update(data); err != nil {
 		fmt.Printf("Failed to convert yaml to protobuf: %v\n", err)
 		os.Exit(1)
 	}
 
-	config := &config.Configuration{}
-	if err := proto.Unmarshal(protobufData, config); err != nil {
-		fmt.Printf("Failed to parse config: %v\n", err)
+	config, err := c.Raw()
+	if err != nil {
+		fmt.Printf("Error validating config: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Also add `-print-text` option to help with manual verification.

This ended up being less trivial than I'd hoped because I needed to add logic to handle updating the proto multiple times. Hopefully it all makes sense?

I'm guessing `testgrid/jenkins_verify/jenkins_validate.go` will need to be made aware of multiple YAML files as well, but this PR is already getting large enough as-is.