### PR TITLE
Refactor cmd.Output() calls to use output()

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -267,11 +267,7 @@ func DiffResources(before, clusterUp, clusterDown, after []byte, location string
 		return err
 	}
 
-	cmd := exec.Command("diff", "-sw", "-U0", "-F^\\[.*\\]$", bp, ap)
-	if verbose {
-		cmd.Stderr = os.Stderr
-	}
-	stdout, cerr := cmd.Output()
+	stdout, cerr := output(exec.Command("diff", "-sw", "-U0", "-F^\\[.*\\]$", bp, ap))
 	if err := ioutil.WriteFile(dp, stdout, mode); err != nil {
 		return err
 	}
@@ -303,22 +299,18 @@ func DiffResources(before, clusterUp, clusterDown, after []byte, location string
 
 func ListResources() ([]byte, error) {
 	log.Printf("Listing resources...")
-	cmd := exec.Command("./cluster/gce/list-resources.sh")
-	if verbose {
-		cmd.Stderr = os.Stderr
-	}
-	stdout, err := cmd.Output()
+	stdout, err := output(exec.Command("./cluster/gce/list-resources.sh"))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to list resources (%s):\n%s", err, string(stdout))
+		return stdout, fmt.Errorf("Failed to list resources (%s):\n%s", err, string(stdout))
 	}
-	return stdout, nil
+	return stdout, err
 }
 
 func clusterSize(deploy deployer) (int, error) {
 	if err := deploy.SetupKubecfg(); err != nil {
 		return -1, err
 	}
-	o, err := exec.Command("kubectl", "get", "nodes", "--no-headers").Output()
+	o, err := output(exec.Command("kubectl", "get", "nodes", "--no-headers"))
 	if err != nil {
 		log.Printf("kubectl get nodes failed: %s\n%s", WrapError(err).Error(), string(o))
 		return -1, err

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -151,7 +151,7 @@ func inputCommand(input, cmd string, args ...string) (*exec.Cmd, error) {
 	return c, nil
 }
 
-// return cmd.CombinedOutput(), potentially timing out in the process.
+// return cmd.Output(), potentially timing out in the process.
 func output(cmd *exec.Cmd) ([]byte, error) {
 	stepName := strings.Join(cmd.Args, " ")
 	if verbose {

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -329,7 +329,7 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     PARSER.add_argument(
-        '--tag', default='v20170227-4ae05be9', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170228-ebc41180', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(


### PR DESCRIPTION
`output()` pays attention to timeout and also logs the command run.

```
I0228 11:38:10.148] process 15801 exited with code 0 after 14.4m
I0228 11:38:10.148] PASS: ci-kubernetes-e2e-gce-canary
```