### PR TITLE
Add scripts that publish repos

### DIFF
--- a/mungegithub/mungers/publish_scripts/publish_apimachinery.sh
+++ b/mungegithub/mungers/publish_scripts/publish_apimachinery.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script publishes the latest changes in the ${src_branch} of
+# k8s.io/kubernetes/staging/src/apimachinery to the ${dst_branch} of
+# k8s.io/apimachinery.
+#
+# The script assumes that the working directory is
+# $GOPATH/src/k8s.io/apimachinery.
+#
+# The script is expected to be run by
+# k8s.io/test-infra/mungegithub/mungers/publisher.go
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ ! $# -eq 3 ]; then
+    echo "usage: $0 token src_branch dst_branch"
+    exit 1
+fi
+
+TOKEN="${1}"
+# src branch of k8s.io/kubernetes
+SRC_BRANCH="${2:-master}"
+# dst branch of k8s.io/apimachinery
+DST_BRANCH="${3:-master}"
+readonly TOKEN SRC_BRANCH DST_BRANCH
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
+
+git checkout "${DST_BRANCH}"
+
+source "${SCRIPT_DIR}"/util.sh
+
+set_github_token "${TOKEN}"
+trap cleanup_github_token EXIT SIGINT
+
+sync_repo "staging/src/k8s.io/apimachinery" "${SRC_BRANCH}"
+# restore the vendor/ folder. k8s.io/* and github.com/golang/glog will be
+# removed from the vendor folder
+restore_vendor

--- a/mungegithub/mungers/publish_scripts/publish_client_go.sh
+++ b/mungegithub/mungers/publish_scripts/publish_client_go.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script publishes the latest changes in the ${src_branch} of
+# k8s.io/kubernetes/staging/src/client-go to the ${dst_branch} of
+# k8s.io/client-go.
+#
+# The script assumes that the working directory is $GOPATH/src/k8s.io/client-go.
+# It also assumes $GOPATH/k8s.io/apimachinery has been updated.
+#
+# The script is expected to be run by
+# k8s.io/test-infra/mungegithub/mungers/publisher.go
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ ! $# -eq 3 ]; then
+    echo "usage: $0 token src_branch dst_branch"
+    exit 1
+fi
+
+TOKEN="${1}"
+# src branch of k8s.io/kubernetes
+SRC_BRANCH="${2:-master}"
+# dst branch of k8s.io/client-go
+DST_BRANCH="${3:-master}"
+readonly TOKEN SRC_BRANCH DST_BRANCH
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
+
+git checkout "${DST_BRANCH}"
+
+source "${SCRIPT_DIR}"/util.sh
+
+set_github_token "${TOKEN}"
+trap cleanup_github_token EXIT SIGINT
+
+# this currently only updates commit hash of k8s.io/apimachinery
+update_godeps_json() {
+    local godeps_json="./Godeps/Godeps.json"
+    local old_revs
+    local new_rev=$(cd ../apimachinery; git rev-parse HEAD)
+
+    # TODO: simplify the following lines
+    while read path rev; do
+        if [[ "${path}" == "k8s.io/apimachinery"* ]]; then
+            old_revs+="${rev}"$'\n'
+        fi
+    done < <(jq '.Deps|.[]|.ImportPath + " " + .Rev' -r < "${godeps_json}")
+    old_revs=$(echo "${old_revs%%$'\n'}" | sort | uniq)
+    while read old_rev; do
+        if [[ -z "${old_rev}" ]]; then
+            continue
+        fi
+        sed -i "s|${old_rev}|${new_rev}|g" "${godeps_json}"
+    done <<< "${old_revs}"
+}
+
+basic_tests() {
+    go build ./...
+    go test ./...
+}
+
+# sync with kubernetes/staging, commit the changes
+sync_repo "staging/src/k8s.io/client-go" "${SRC_BRANCH}"
+# update the Godeps.json. The dummy revision of k8s.io/apimachinery entries will
+# be updated with the latest commit hash.
+update_godeps_json
+# restore the vendor/ folder. k8s.io/* and github.com/golang/glog will be
+# removed from the vendor folder
+restore_vendor
+# Smoke test client-go
+basic_tests

--- a/mungegithub/mungers/publish_scripts/util.sh
+++ b/mungegithub/mungers/publish_scripts/util.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file includes functions shared by the each repository's publish scripts.
+
+# sync_repo() cherry picks the latest changes in k8s.io/kubernetes/${filter} to the
+# local copy of the repository to be published.
+#
+# prerequisites
+# 1. we are in the root of the repository to be published
+# 2. we are on the branch to be published (let's call it "target-branch")
+# overall flow
+# 1. fetch the current level of k8s.io/kubernetes
+# 2. check out the $src_branch of k8s.io/kubernetes as branch kube-sync
+# 3. rewrite the history of branch kube-sync to *only* include code in $subdirectory
+# 4. locate all commits between the last time we sync'ed and now
+# 5. switch back to the "target-branch"
+# 6. for each commit, cherry-pick it (which will keep authorship) into "target-branch"
+# 7. update metadata files indicating which commits we've sync'ed to
+sync_repo() {
+    # subdirectory in k8s.io/kubernetes, e.g., staging/src/k8s.io/apimachinery
+    local subdirectory="${1}"
+    local src_branch="${2}"
+    readonly filter src_branch
+
+    local currBranch=$(git rev-parse --abbrev-ref HEAD)
+    local previousKubeSHA=$(cat kubernetes-sha)
+    local previousBranchSHA=$(cat filter-branch-sha)
+    
+    git remote add upstream-kube https://github.com/kubernetes/kubernetes.git || true
+    git fetch upstream-kube
+    git branch -D kube-sync || true
+    git checkout upstream-kube/"${src_branch}" -b kube-sync
+    git reset --hard upstream-kube/"${src_branch}"
+    local newKubeSHA=$(git log --oneline --format='%H' kube-sync -1)
+    
+    # this command rewrites git history to *only* include $subdirectory 
+    git filter-branch -f --subdirectory-filter "${subdirectory}" HEAD
+    
+    newBranchSHA=$(git log --oneline --format='%H' kube-sync -1)
+    # we need to start after _vendor is removed from master
+    local commits=$(git log --no-merges --format='%H' --reverse ${previousBranchSHA}..HEAD)
+    
+    git checkout ${currBranch}
+
+    echo "commits to be cherry-picked:"
+    echo "${commits}"
+    echo ""
+    
+    while read commitSHA; do
+        if [[ -z "${commitSHA}" ]]; then
+            continue
+        fi
+    	echo "working ${commitSHA}"
+    	git cherry-pick ${commitSHA}
+    done <<< "${commits}"
+    
+    # track the k8s.io/kubernetes commit SHA so we can always determine which level of kube this repo matches
+    # track the filtered branch commit SHA so that we can determine which commits need to be picked
+    echo ${newKubeSHA} > kubernetes-sha
+    echo ${newBranchSHA} > filter-branch-sha
+    if git diff --exit-code &>/dev/null; then
+        echo "SHAs havne't changed!"
+        return
+    fi
+    git -c user.name="Kubernetes Publisher" -c user.email="k8s-publish-robot@users.noreply.github.com" commit -m "sync(k8s.io/kubernetes): ${newKubeSHA}" -- kubernetes-sha filter-branch-sha
+}
+
+# To avoid repeated godep restore, repositories should share the GOPATH.
+# This function should be run after the Godeps.json are updated with the latest
+# revs of k8s.io/ dependencies.
+# The function assumes to be called at the root of the repository that's going to be published.
+restore_vendor() {
+    godep restore
+    # need to remove the Godeps folder, otherwise godep won't save source code to vendor/
+    mv ./Godeps ./Godeps.backup
+    godep save ./...
+    rm -rf ./Godeps
+    mv ./Godeps.backup ./Godeps
+    # glog uses global variables, it panics when multiple copies are compiled.
+    rm -rf ./vendor/github.com/golang/glog
+    # this ensures users who get the repository via `go get` won't end up with
+    # multiple copies of k8s.io/ repos. The only copy will be the one in the
+    # GOPATH.
+    # Godeps.json has a complete, up-to-date list of dependencies, so
+    # Godeps.json will be the ground truth for users using godep/glide/dep.
+    rm -rf ./vendor/k8s.io  
+    git add --all
+    # check if there are new contents 
+    if git diff --cached --exit-code &>/dev/null; then
+        echo "vendor hasn't changed!"
+        return
+    fi
+    git -c user.name="Kubernetes Publisher" -c user.email="k8s-publish-robot@users.noreply.github.com" commit -m "Update vendor/"
+}
+
+# set up github token in ~/.netrc
+set_github_token() {
+    mv ~/.netrc ~/.netrc.bak || true
+    echo "machine github.com login ${1}" > ~/.netrc
+}
+
+cleanup_github_token() {
+    rm -rf ~/.netrc
+    mv ~/.netrc.bak ~/.netrc || true
+}


### PR DESCRIPTION
This is addressing the first step proposed in https://github.com/kubernetes/test-infra/pull/1784#pullrequestreview-22134220, "we get the shell scripts set up and runable by a human."

The next step (in another pull) is letting the publish robot run these scripts. In this pull, I made client-go's publish script to share the code with apimachinery's script. This will simplify the publish robot's code a lot.

Regarding updating depdencies, the publish script will update the client-go's Godeps.json with the just published commit of k8s.io/apimachinery, and will make sure that client-go works with the just published apimachinery. vendor/k8s.io/* and vendor/../glog are removed, to let `go get` users get a single copy of these dependencies in their GOPATH.

See the generated changes at:
https://github.com/kubernetes/apimachinery/pull/8/commits
https://github.com/kubernetes/client-go/pull/133

Side note:
Depends on https://github.com/kubernetes/kubernetes/pull/42084. The publish_client_go.sh will fail if _vendor still exist in staging/client-go. We also need to sync client-go after #42084 is merged and manually add a starting [filter-branch-sha](https://github.com/caesarxuchao/client-go/blob/master/filter-branch-sha). 

