### PR TITLE
Bump e2e scenario to kubekins-test:v20170228-c2fc37ee

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -334,7 +334,7 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     PARSER.add_argument(
-        '--tag', default='v20170228-ebc41180', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170228-c2fc37ee', help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-canary/128/finished.json and https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-canary/jobResultsCache.json look good with this image.