### PR TITLE
kops: Move kops-aws-updown job to its own isolated account

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -359,7 +359,10 @@
 "ci-kubernetes-e2e-kops-aws-updown": {
   "scenario": "kubernetes_kops_aws",
   "args": [
-    "--cluster=e2e-kops-aws-updown.test-aws.k8s.io",
+    "--aws-role-arn=arn:aws:iam::660757973107:role/job-kops-aws-updown",
+    "--cluster=e2e.kops-aws-updown.test-aws.k8s.io",
+    "--state=s3://kops-aws-updown-store",
+    "--zones=us-west-1b",
     "--env-file=platforms/kops_aws.env",
     "--env-file=jobs/ci-kubernetes-e2e-kops-aws-updown.env"
   ]


### PR DESCRIPTION
This is a re-drive of #1843 after kops was shifted to a scenario/env.

Still TODO: The wheel of availability zones in `scenarios/kubernetes_kops_aws.py` needs to be moved somewhere else - each account doesn't have access to the same AZs. However, if we just keep the primary account for presubmits and separate the postsubmit tests, we really don't need this functionality. Locked kops-updown to a `us-west-1` AZ that happens to be available to the account.