### PR TITLE
Make the GKE presubmits match the blocking postsubmit, and make it non-blocking.

### DIFF
--- a/jobs/pull-kubernetes-e2e-gke-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gke-gci.sh
@@ -50,8 +50,7 @@ export GINKGO_TOLERATE_FLAKES="y"
 export E2E_NAME="e2e-gke-${NODE_NAME}-${EXECUTOR_NUMBER:-0}"
 export GINKGO_PARALLEL="y"
 
-# Just run a smoke test.
-export GINKGO_TEST_ARGS="--ginkgo.focus=Guestbook"
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="k8s-jkns-pr-gci-gke"
 

--- a/jobs/pull-kubernetes-e2e-gke.sh
+++ b/jobs/pull-kubernetes-e2e-gke.sh
@@ -50,8 +50,7 @@ export GINKGO_TOLERATE_FLAKES="y"
 export E2E_NAME="e2e-gke-${NODE_NAME}-${EXECUTOR_NUMBER:-0}"
 export GINKGO_PARALLEL="y"
 
-# Just run a smoke test.
-export GINKGO_TEST_ARGS="--ginkgo.focus=Guestbook"
+export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="k8s-jkns-pr-gke"
 

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -72,6 +72,8 @@ data:
     ci-kubernetes-e2e-cri-gce-slow,\
     ci-kubernetes-e2e-cri-gke,\
     ci-kubernetes-e2e-cri-gke-slow,\
+    ci-kubernetes-e2e-gci-gke,\
+    ci-kubernetes-e2e-gci-gke-slow,\
     ci-kubernetes-e2e-gke-large-cluster,\
     ci-kubernetes-e2e-gke-serial,\
     ci-kubernetes-e2e-gke-staging,\
@@ -95,8 +97,6 @@ data:
     ci-kubernetes-e2e-gci-gce,\
     ci-kubernetes-e2e-gci-gce-slow,\
     ci-kubernetes-e2e-gci-gce-ingress,\
-    ci-kubernetes-e2e-gci-gke,\
-    ci-kubernetes-e2e-gci-gke-slow,\
     ci-kubernetes-e2e-kops-aws,\
     ci-kubernetes-kubemark-500-gce,\
     ci-kubernetes-node-kubelet,\

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2070,10 +2070,6 @@ dashboards:
     test_group_name: kubernetes-e2e-gci-gce
   - name: gci-gce-slow
     test_group_name: kubernetes-e2e-gci-gce-slow
-  - name: gci-gke
-    test_group_name: kubernetes-e2e-gci-gke
-  - name: gci-gke-slow
-    test_group_name: kubernetes-e2e-gci-gke-slow
   - name: kops-aws
     test_group_name: kubernetes-e2e-kops-aws
   - name: kubemark-500-gce


### PR DESCRIPTION
This moves the pain to presubmit time, but doesn't fix the underlying problem. It also doesn't fix the fact that the slow tests aren't run at presubmit time, and probably never will be.