### PR TITLE
Default kubernetes-anywhere to use the "latest" Kubernetes version.

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -49,7 +49,7 @@ const kubernetesAnywhereConfigTemplate = `
 
 .phase2.installer_container="docker.io/colemickens/k8s-ignition:latest"
 .phase2.docker_registry="gcr.io/google-containers"
-.phase2.kubernetes_version="v1.4.1"
+.phase2.kubernetes_version="latest"
 .phase2.provider="{{.Phase2Provider}}"
 .phase2.kubeadm.version="stable"
 


### PR DESCRIPTION
Previously, this `phase2.kubernetes_version` field was only referenced if the phase2 provider was `ignition`, and completely ignored if the phase2 provider was `kubeadm`. Now, upstream changes in kubernetes-anywhere make the kubeadm provider use this value to determine what Kubernetes images to use.

Using the string `latest` matches the previous behavior, since this is the kubeadm default if no Kubernetes version is specified.