### PR TITLE
Create GKE e2e jobs for release-1.6

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -1491,6 +1491,80 @@
         json: 1
         trigger-job: 'ci-kubernetes-build-1.5'
 
+    # gke-1.6
+    - kubernetes-e2e-gke-release-1.6:
+        job-name: ci-kubernetes-e2e-gke-release-1.6
+        jenkins-timeout: 170
+        timeout: 70
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gke-serial-release-1.6:
+        job-name: ci-kubernetes-e2e-gke-serial-release-1.6
+        jenkins-timeout: 420
+        timeout: 320
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gke-alpha-features-release-1.6:
+        job-name: ci-kubernetes-e2e-gke-alpha-features-release-1.6
+        jenkins-timeout: 300
+        timeout: 200
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gke-slow-release-1.6:
+        job-name: ci-kubernetes-e2e-gke-slow-release-1.6
+        jenkins-timeout: 270
+        timeout: 170
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gke-reboot-release-1.6:
+        job-name: ci-kubernetes-e2e-gke-reboot-release-1.6
+        jenkins-timeout: 300
+        timeout: 200
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+
+    # gci-gke-1.6
+    - kubernetes-e2e-gci-gke-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gke-release-1.6
+        jenkins-timeout: 170
+        timeout: 70
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gci-gke-serial-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gke-serial-release-1.6
+        jenkins-timeout: 420
+        timeout: 320
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gci-gke-slow-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gke-slow-release-1.6
+        jenkins-timeout: 270
+        timeout: 170
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gci-gke-reboot-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gke-reboot-release-1.6
+        jenkins-timeout: 300
+        timeout: 200
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gci-gke-ingress-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gke-ingress-release-1.6
+        jenkins-timeout: 420
+        timeout: 320
+        frequency: 'H/5 * * * *' # At least every 30m
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+
     # gke-version-pinned
     # trigger-job: 'ci-kubernetes-build-1.4'
     # TODO(spxtr) float with current release.

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gci-gke-ingress-1-6
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gci-gke-reboot-1-6
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.6.env
@@ -1,0 +1,9 @@
+### job-env
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gci-gke-1-6
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=50m

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] \--ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gci-gke-serial-1-6
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.6.env
@@ -1,0 +1,9 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gci-gke-slow-1-6
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=150m

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+PROJECT=k8s-jkns-gke-alpha-1-6
+GKE_CREATE_FLAGS=--enable-kubernetes-alpha
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.6.env
@@ -1,0 +1,7 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gke-reboot-1-6
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gke-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gke-1-6
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=50m

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.6.env
@@ -1,0 +1,7 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gke-serial-1-6
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-jkns-gke-slow-1-6
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=150m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3408,5 +3408,85 @@
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1.6.env"
   ]
+},
+
+"ci-kubernetes-e2e-gke-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-serial-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-alpha-features-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-slow-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-reboot-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gke-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gke-serial-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gke-slow-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gke-reboot-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gke-ingress-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6.env"
+  ]
 }
 }

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -850,6 +850,26 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1.6
 - name: ci-kubernetes-e2e-gci-gce-slow-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-slow-release-1.6
+- name: ci-kubernetes-e2e-gci-gke-ingress-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6
+- name: ci-kubernetes-e2e-gci-gke-reboot-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-reboot-release-1.6
+- name: ci-kubernetes-e2e-gci-gke-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-release-1.6
+- name: ci-kubernetes-e2e-gci-gke-serial-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-serial-release-1.6
+- name: ci-kubernetes-e2e-gci-gke-slow-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-slow-release-1.6
+- name: ci-kubernetes-e2e-gke-alpha-features-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-alpha-features-release-1.6
+- name: ci-kubernetes-e2e-gke-reboot-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-reboot-release-1.6
+- name: ci-kubernetes-e2e-gke-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-release-1.6
+- name: ci-kubernetes-e2e-gke-serial-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-serial-release-1.6
+- name: ci-kubernetes-e2e-gke-slow-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-slow-release-1.6
 # Manual, federated groups
 # bazel, run on prow
 - name: ci-kubernetes-bazel-build
@@ -1715,6 +1735,26 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-serial-release-1.6
   - name: gci-gce-slow-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-slow-release-1.6
+  - name: gci-gke-ingress-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-ingress-release-1.6
+  - name: gci-gke-reboot-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-reboot-release-1.6
+  - name: gci-gke-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-release-1.6
+  - name: gci-gke-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-serial-release-1.6
+  - name: gci-gke-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow-release-1.6
+  - name: gke-alpha-features-1.6
+    test_group_name: ci-kubernetes-e2e-gke-alpha-features-release-1.6
+  - name: gke-reboot-1.6
+    test_group_name: ci-kubernetes-e2e-gke-reboot-release-1.6
+  - name: gke-1.6
+    test_group_name: ci-kubernetes-e2e-gke-release-1.6
+  - name: gke-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gke-serial-release-1.6
+  - name: gke-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gke-slow-release-1.6
 
 - name: release-1.6-blocking
   dashboard_tab:
@@ -1730,6 +1770,16 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-release-1.6
   - name: gci-gce-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-release-1.6
+  - name: gce-reboot-1.6
+    test_group_name: ci-kubernetes-e2e-gce-reboot-release-1.6
+  - name: gce-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gce-slow-release-1.6
+  - name: gke-1.6
+    test_group_name: ci-kubernetes-e2e-gke-release-1.6
+  - name: gke-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gke-serial-release-1.6
+  - name: gke-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gke-slow-release-1.6
 
 - name: release-1.5-all
   dashboard_tab:


### PR DESCRIPTION
New jobs created:
* ci-kubernetes-e2e-gke-release-1.6
* ci-kubernetes-e2e-gke-serial-release-1.6
* ci-kubernetes-e2e-gke-alpha-features-release-1.6
* ci-kubernetes-e2e-gke-slow-release-1.6
* ci-kubernetes-e2e-gke-reboot-release-1.6
* ci-kubernetes-e2e-gci-gke-release-1.6
* ci-kubernetes-e2e-gci-gke-serial-release-1.6
* ci-kubernetes-e2e-gci-gke-slow-release-1.6
* ci-kubernetes-e2e-gci-gke-reboot-release-1.6
* ci-kubernetes-e2e-gci-gke-ingress-release-1.6

Surprisingly, this was less painful than #2068. I've started to figure out how to apply sed in the right places, I think.

Most of these are direct translations from the release-1.5 configurations, but the ingress job needed a larger timeout, and alpha-features tests more features.

x-ref #2029

cc @ethernetdan @enisoc @marun 