### PR TITLE
Add GCE scalability jobs for release-1.6

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1564,6 +1564,11 @@ class JobTest(unittest.TestCase):
 
     def testAllProjectAreUnique(self):
         allowed_list = {
+            # The 1.5 and 1.6 scalability jobs intentionally share projects.
+            'ci-kubernetes-e2e-gce-scalability-release-1.5.env': 'ci-kubernetes-e2e-gce-scalability-release-*',
+            'ci-kubernetes-e2e-gce-scalability-release-1.6.env': 'ci-kubernetes-e2e-gce-scalability-release-*',
+            'ci-kubernetes-e2e-gci-gce-scalability-release-1.5.env': 'ci-kubernetes-e2e-gci-gce-scalability-release-*',
+            'ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env': 'ci-kubernetes-e2e-gci-gce-scalability-release-*',
             # TODO(fejta): remove these (found while migrating jobs)
             'ci-kubernetes-kubemark-100-gce.env': 'ci-kubernetes-kubemark-*',
             'ci-kubernetes-kubemark-5-gce.env': 'ci-kubernetes-kubemark-*',

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -14,7 +14,14 @@
     disabled: false
     name: 'ci-{suffix}'
     node: 'e2e'
+    use-blocker: false
+    blocker: ''
     properties:
+    - build-blocker:
+        use-build-blocker: '{use-blocker}'
+        blocking-jobs:
+        - '{blocker}'
+        queue-scanning: ALL
     - build-discarder:
         days-to-keep: 7
     triggers:
@@ -622,6 +629,8 @@
         frequency: '@daily'
         json: 1
         trigger-job: 'ci-kubernetes-build-1.5'
+        use-blocker: true
+        blocker: 'ci-kubernetes-e2e-gce-scalability-release-1.6'
     - kubernetes-e2e-gce-federation-release-1.5:
         job-name: ci-kubernetes-e2e-gce-federation-release-1.5
         jenkins-timeout: 850
@@ -680,6 +689,8 @@
         frequency: '@daily'
         json: 1
         trigger-job: 'ci-kubernetes-build-1.5'
+        use-blocker: true
+        blocker: 'ci-kubernetes-e2e-gci-gce-scalability-release-1.6'
 
     # gce-1.6
     - kubernetes-e2e-gce-release-1.6:
@@ -710,6 +721,15 @@
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gce-scalability-release-1.6:
+        job-name: ci-kubernetes-e2e-gce-scalability-release-1.6
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: '@daily'
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+        use-blocker: true
+        blocker: 'ci-kubernetes-e2e-gce-scalability-release-1.5'
     # gci-gce-1.6
     - kubernetes-e2e-gci-gce-release-1.6:
         job-name: ci-kubernetes-e2e-gci-gce-release-1.6
@@ -739,6 +759,15 @@
         frequency: 'H/5 * * * *' # At least every 30m
         json: 1
         trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gci-gce-scalability-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gce-scalability-release-1.6
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: '@daily'
+        json: 1
+        trigger-job: 'ci-kubernetes-build-1.6'
+        use-blocker: true
+        blocker: 'ci-kubernetes-e2e-gci-gce-scalability-release-1.5'
 
     # gce-features
     - kubernetes-e2e-gce-ingress:

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.6.env
@@ -1,0 +1,27 @@
+KUBE_GCE_ZONE=us-east1-b
+
+### job-env
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
+# Use the 1.1 project for now, since it has quota.
+# TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+PROJECT=k8s-e2e-gce-scalability-1-1
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Override GCE defaults.
+MASTER_SIZE=n1-standard-4
+NODE_SIZE=n1-standard-1
+NODE_DISK_SIZE=50GB
+NUM_NODES=100
+ALLOWED_NOTREADY_NODES=1
+REGISTER_MASTER=true
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=2
+# TODO: Remove when we figure out the reason for occasional failures #19048
+KUBELET_TEST_LOG_LEVEL=--v=4
+# Increase resync period to simulate production
+TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+# Increase delete collection parallelism
+TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env
@@ -1,0 +1,33 @@
+### Provider Env Override
+KUBE_GCE_ZONE=us-east1-b
+
+### job-env
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
+
+# Use the 1.4 project for now, since it has quota.
+# TODO: create a project k8s-e2e-gce-scalability-release and move this test there
+PROJECT=k8s-e2e-gci-gce-scale-1-4
+FAIL_ON_GCP_RESOURCE_LEAK=false
+
+# Override GCE defaults.
+MASTER_SIZE=n1-standard-4
+NODE_SIZE=n1-standard-1
+NODE_DISK_SIZE=50GB
+NUM_NODES=100
+ALLOWED_NOTREADY_NODES=1
+REGISTER_MASTER=true
+# Reduce logs verbosity
+TEST_CLUSTER_LOG_LEVEL=--v=2
+
+# TODO: Remove when we figure out the reason for occasional failures #19048
+KUBELET_TEST_LOG_LEVEL=--v=4
+
+# Increase resync period to simulate production
+TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
+
+# Increase delete collection parallelism
+TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3411,6 +3411,24 @@
   ]
 },
 
+"ci-kubernetes-e2e-gce-scalability-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-scalability-release-1.6.env",
+    "--cluster=e2e-scalability-1-6"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gce-scalability-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env",
+    "--cluster=e2e-scalability-1-6"
+  ]
+},
+
 "ci-kubernetes-e2e-gke-release-1.6": {
   "scenario": "kubernetes_e2e",
   "args": [

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -330,6 +330,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability-release-1.5
 - name: kubernetes-e2e-gci-gce-scalability-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5
+- name: kubernetes-e2e-gce-scalability-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability-release-1.6
+- name: kubernetes-e2e-gci-gce-scalability-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6
 - name: kubernetes-e2e-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial
 - name: kubernetes-e2e-gce-serial-release-1.3
@@ -1070,6 +1074,10 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-scalability-release-1.5
   - name: gci-gce-scalability-1.5
     test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.5
+  - name: gce-scalability-1.6
+    test_group_name: kubernetes-e2e-gce-scalability-release-1.6
+  - name: gci-gce-scalability-1.6
+    test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.6
   - name: gce-serial
     test_group_name: kubernetes-e2e-gce-serial
   - name: gci-gce-serial
@@ -1735,6 +1743,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-serial-release-1.6
   - name: gci-gce-slow-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-slow-release-1.6
+  - name: gce-scalability-1.6
+    test_group_name: kubernetes-e2e-gce-scalability-release-1.6
+  - name: gci-gce-scalability-1.6
+    test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.6
   - name: gci-gke-ingress-1.6
     test_group_name: ci-kubernetes-e2e-gci-gke-ingress-release-1.6
   - name: gci-gke-reboot-1.6
@@ -1770,6 +1782,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-release-1.6
   - name: gci-gce-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-release-1.6
+  - name: gce-scalability-1.6
+    test_group_name: kubernetes-e2e-gce-scalability-release-1.6
   - name: gce-reboot-1.6
     test_group_name: ci-kubernetes-e2e-gce-reboot-release-1.6
   - name: gce-slow-1.6


### PR DESCRIPTION
Manually checked timeouts and flags vs. master, everything looks OK.

x-ref #2029 

cc @ethernetdan @enisoc @marun @wojtek-t @kubernetes/sig-scalability-pr-reviews 