### PR TITLE
[mungegithub/approvers]enable alias expansion for approvers

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -101,7 +101,10 @@ func (h *ApprovalHandler) Munge(obj *github.MungeObject) {
 
 	approverSet := createApproverSet(comments, prAuthor)
 	approversHandler := approvers.Approvers{
-		approvers.NewOwners(filenames, h.features.Repos, int64(*obj.Issue.Number)),
+		approvers.NewOwners(
+			filenames,
+			approvers.NewRepoAlias(h.features.Repos, *h.features.Aliases),
+			int64(*obj.Issue.Number)),
 		approverSet}
 
 	notificationMatcher := c.MungerNotificationName(approvers.ApprovalNotificationName)

--- a/mungegithub/mungers/approvers/owners.go
+++ b/mungegithub/mungers/approvers/owners.go
@@ -46,8 +46,8 @@ type RepoAlias struct {
 	alias features.Aliases
 }
 
-func NewRepoAlias(repo RepoInterface, alias features.Aliases) RepoAlias {
-	return RepoAlias{
+func NewRepoAlias(repo RepoInterface, alias features.Aliases) *RepoAlias {
+	return &RepoAlias{
 		repo:  repo,
 		alias: alias,
 	}


### PR DESCRIPTION
Make sure that approvers expands the aliases from the aliases file in the root of the project