### PR TITLE
Fix cronspec for daily kubernetes-e2e-gce-canary job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -84,7 +84,7 @@
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-canary:  # Canary job for image infra-changes
         job-name: ci-kubernetes-e2e-gce-canary
-        frequency: '* H * * *'  # At least once a day, can manually trigger too
+        frequency: '@daily'  # At least once a day, can manually trigger too
         json: 1
         jenkins-timeout: 250
         timeout: 50


### PR DESCRIPTION
We should use @daily, which is the equivalent of `H H * * *`

(and daily == `H H * * *`: https://github.com/jenkinsci/jenkins/blob/08def67a18eee51de9f3f99bc2a792fee1c160e0/core/src/main/grammar/crontab.g#L64-L67 )