### PR TITLE
Set KUBE_GCE_NETWORK for the GKE tests.

### DIFF
--- a/jobs/pull-kubernetes-e2e-gke-gci.sh
+++ b/jobs/pull-kubernetes-e2e-gke-gci.sh
@@ -54,9 +54,6 @@ export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flak
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="k8s-jkns-pr-gci-gke"
 
-# Since we're only running one test, just use two nodes.
-export NUM_NODES="2"
-
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"
 export E2E_TEST="true"
@@ -69,6 +66,7 @@ export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 # GKE variables
 export CLUSTER_NAME=${E2E_NAME}
 export KUBE_GKE_NETWORK=${E2E_NAME}
+export KUBE_GCE_NETWORK=${E2E_NAME}
 export ZONE="us-central1-f"
 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False

--- a/jobs/pull-kubernetes-e2e-gke.sh
+++ b/jobs/pull-kubernetes-e2e-gke.sh
@@ -54,9 +54,6 @@ export GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flak
 export FAIL_ON_GCP_RESOURCE_LEAK="false"
 export PROJECT="k8s-jkns-pr-gke"
 
-# Since we're only running one test, just use two nodes.
-export NUM_NODES="2"
-
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="true"
 export E2E_TEST="true"
@@ -73,6 +70,7 @@ export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 # GKE variables
 export CLUSTER_NAME=${E2E_NAME}
 export KUBE_GKE_NETWORK=${E2E_NAME}
+export KUBE_GCE_NETWORK=${E2E_NAME}
 export ZONE="us-central1-f"
 export CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER="https://test-container.sandbox.googleapis.com/"
 export CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False


### PR DESCRIPTION
It gets set to `jenkins-e2e` in the Dockerfile, and then used instead of `KUBE_GKE_NETWORK` in `hack/ginkgo_e2e.sh`. See https://github.com/kubernetes/kubernetes/issues/38556#issuecomment-283698162 for details.