### PR TITLE
Add support for --build and --stage to e2e scenario

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -66,4 +66,4 @@ ADD ["e2e-runner.sh", \
 RUN ["chmod", "+x", "/workspace/get-kube.sh"]
 WORKDIR "/workspace"
 
-ENTRYPOINT "/workspace/e2e-runner.sh"
+ENTRYPOINT ["/workspace/e2e-runner.sh"]

--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -116,9 +116,6 @@ elif [[ "${FEDERATION_UP:-}" == "true" && -z "${FEDERATION_CLUSTERS:-}" ]]; then
   e2e_go_args+=(--save="${JENKINS_FEDERATION_PREFIX}")
 fi
 
-fi
-
-
 if [[ "${FAIL_ON_GCP_RESOURCE_LEAK:-true}" == "true" ]]; then
   case "${KUBERNETES_PROVIDER}" in
     gce|gke)
@@ -159,7 +156,7 @@ if [[ "${USE_KUBEMARK:-}" == "true" ]]; then
 fi
 
 if [[ "${CHARTS_TEST:-}" == "true" ]]; then
-  e2e_go_args+=("--charts=true")
+  e2e_go_args+=(--charts=true)
 fi
 
 if [[ -n "${KUBEKINS_TIMEOUT:-}" ]]; then
@@ -175,5 +172,4 @@ if [[ "${E2E_PUBLISH_GREEN_VERSION:-}" == "true" ]]; then
   e2e_go_args+=(--publish="gs://${KUBE_GCS_DEV_RELEASE_BUCKET}/ci/latest-green.txt")
 fi
 
-./kubetest ${E2E_OPT:-} "${e2e_go_args[@]}"
-
+./kubetest ${E2E_OPT:-} "${e2e_go_args[@]}" "${@}"

--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -73,5 +73,5 @@ func (b *buildStrategy) Build() error {
 	// TODO(fejta): FIX ME
 	// The build-release script needs stdin to ask the user whether
 	// it's OK to download the docker image.
-	return finishRunning(exec.Command("make", target))
+	return finishRunning(exec.Command("make", "-C", k8s("kubernetes"), target))
 }

--- a/kubetest/extract.go
+++ b/kubetest/extract.go
@@ -313,7 +313,7 @@ func setReleaseFromGci(image string) error {
 func (e extractStrategy) Extract() error {
 	switch e.mode {
 	case local:
-		url := "./_output/gcs-stage"
+		url := k8s("kubernetes", "/_output/gcs-stage")
 		files, err := ioutil.ReadDir(url)
 		if err != nil {
 			return err
@@ -329,7 +329,7 @@ func (e extractStrategy) Extract() error {
 		if len(release) == 0 {
 			return fmt.Errorf("No releases found in %v", url)
 		}
-		return getKube(url, release)
+		return getKube(fmt.Sprintf("file://%s", url), release)
 	case gci, gciCi:
 		if i, err := setupGciVars(e.option); err != nil {
 			return err

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -30,6 +30,15 @@ import (
 	"time"
 )
 
+// Returns $GOPATH/src/k8s.io/...
+func k8s(parts ...string) string {
+	p := []string{os.Getenv("GOPATH"), "src", "k8s.io"}
+	for _, a := range parts {
+		p = append(p, a)
+	}
+	return filepath.Join(p...)
+}
+
 // append(errs, err) if err != nil
 func appendError(errs []error, err error) []error {
 	if err != nil {

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -355,7 +355,7 @@ def create_parser():
     parser.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     parser.add_argument(
-        '--tag', default='v20170228-c2fc37ee', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170303-c2f53a54', help='Use a specific kubekins-e2e tag if set')
     parser.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     parser.add_argument(


### PR DESCRIPTION
ref #2074

* Allow kubekins image to accept args, which get passed to `kubetest`
* Make `--build` and `--stage` robust to `chdir`
* Do not pass the `gs://` prefix to `push-build.sh`
* Pass a `file://` prefix to `get-kube.sh` when `--extract=local`
* Add `--build` and `--stage` flags to `scenarios/kubernetes_e2e.py`, which send these flags to the image and mount appropriate volumes.


