### PR TITLE
Add /assign and /unassign commands to prow

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build fmt vet test
 
 
-HOOK_VERSION       = 0.85
+HOOK_VERSION       = 0.86
 LINE_VERSION       = 0.82
 SINKER_VERSION     = 0.5
 DECK_VERSION       = 0.17

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.85
+        image: gcr.io/k8s-prow/hook:0.86
         imagePullPolicy: Always
         args:
         - "--github-bot-name=k8s-ci-robot"

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/plugins/assign:go_default_library",
         "//prow/plugins/cla:go_default_library",
         "//prow/plugins/close:go_default_library",
         "//prow/plugins/heart:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/plugins"
 
+	_ "k8s.io/test-infra/prow/plugins/assign"
 	_ "k8s.io/test-infra/prow/plugins/cla"
 	_ "k8s.io/test-infra/prow/plugins/close"
 	_ "k8s.io/test-infra/prow/plugins/heart"

--- a/prow/cmd/horologium/main_test.go
+++ b/prow/cmd/horologium/main_test.go
@@ -98,7 +98,7 @@ func TestSync(t *testing.T) {
 		var jobs []kube.Job
 		now := time.Now()
 		if tc.jobName != "" {
-			jobs = []kube.Job{kube.Job{
+			jobs = []kube.Job{{
 				Metadata: kube.ObjectMeta{
 					Labels: map[string]string{"jenkins-job-name": tc.jobName},
 				},

--- a/prow/commands.md
+++ b/prow/commands.md
@@ -4,6 +4,8 @@
 
 Command | Plugin | Who can run it | Description
 --- | --- | --- | --- | ---
+`/assign [@userA @userB @etc]` | [assign](./plugins/assign) | org members | Assigns specified people (or yourself if no one is specified)
+`/unassign [@userA @userB @etc]` | [assign](./plugins/assign) | org members | Unassigns specified people (or yourself if no one is specified)
 `/lgtm` | [lgtm](./plugins/lgtm) | assignees | adds the `lgtm` label
 `/lgtm cancel` | [lgtm](./plugins/lgtm) | authors and assignees | removes the `lgtm` label
 `/close` | [close](./plugins/close) | authors and assignees | closes the issue

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -408,6 +408,28 @@ func (c *Client) RemoveLabel(org, repo string, number int, label string) error {
 	return err
 }
 
+func (c *Client) AssignIssue(org, repo string, number int, logins []string) error {
+	c.log("AssignIssue", org, repo, number, logins)
+	_, err := c.request(&request{
+		method:      http.MethodPost,
+		path:        fmt.Sprintf("%s/repos/%s/%s/issues/%d/assignees", c.base, org, repo, number),
+		requestBody: map[string][]string{"assignees": logins},
+		exitCodes:   []int{201},
+	}, nil)
+	return err
+}
+
+func (c *Client) UnassignIssue(org, repo string, number int, logins []string) error {
+	c.log("UnassignIssue", org, repo, number, logins)
+	_, err := c.request(&request{
+		method:      http.MethodDelete,
+		path:        fmt.Sprintf("%s/repos/%s/%s/issues/%d/assignees", c.base, org, repo, number),
+		requestBody: map[string][]string{"assignees": logins},
+		exitCodes:   []int{200},
+	}, nil)
+	return err
+}
+
 func (c *Client) CloseIssue(org, repo string, number int) error {
 	c.log("CloseIssue", org, repo, number)
 	_, err := c.request(&request{

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -22,6 +22,7 @@ kubernetes/test-infra:
 - trigger
 
 kubernetes:
+- assign
 - cla
 - close
 - heart

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -46,6 +46,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//prow/plugins/assign:all-srcs",
         "//prow/plugins/cla:all-srcs",
         "//prow/plugins/close:all-srcs",
         "//prow/plugins/heart:all-srcs",

--- a/prow/plugins/assign/BUILD
+++ b/prow/plugins/assign/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["assign_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["assign.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assign
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "assign"
+
+var assignRe = regexp.MustCompile(`(?mi)^/(un)?assign(( @[-\w]+?)*)\r?$`)
+
+func init() {
+	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
+}
+
+type githubClient interface {
+	AssignIssue(owner, repo string, number int, logins []string) error
+	UnassignIssue(owner, repo string, number int, logins []string) error
+}
+
+func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
+	return handle(pc.GitHubClient, pc.Logger, ic)
+}
+
+func parseLogins(text string) []string {
+	var parts []string
+	for _, p := range strings.Split(text, " ") {
+		t := strings.Trim(p, "@ ")
+		if t == "" {
+			continue
+		}
+		parts = append(parts, t)
+	}
+	return parts
+}
+
+func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
+	if ic.Action != "created" { // Only consider new comments.
+		return nil
+	}
+
+	re := assignRe.FindStringSubmatch(ic.Comment.Body)
+	if re == nil {
+		return nil
+	}
+
+	var logins []string
+	if re[2] == "" {
+		logins = append(logins, ic.Comment.User.Login)
+	} else {
+		logins = parseLogins(re[2])
+	}
+
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	number := ic.Issue.Number
+
+	if re[1] == "un" {
+		log.Printf("Removing assignees from %s/%s#%d: %v", org, repo, number, logins)
+		return gc.UnassignIssue(org, repo, number, logins)
+	} else {
+		log.Printf("Adding assignees to %s/%s#%d: %v", org, repo, number, logins)
+		return gc.AssignIssue(org, repo, number, logins)
+	}
+}

--- a/prow/plugins/assign/assign_test.go
+++ b/prow/plugins/assign/assign_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assign
+
+import (
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+type fakeClient struct {
+	assigned   []string
+	unassigned []string
+}
+
+func (c *fakeClient) UnassignIssue(owner, repo string, number int, assignees []string) error {
+	c.unassigned = assignees
+	return nil
+}
+
+func (c *fakeClient) AssignIssue(owner, repo string, number int, assignees []string) error {
+	c.assigned = assignees
+	return nil
+}
+
+func TestParseLogins(t *testing.T) {
+	var testcases = []struct {
+		name   string
+		text   string
+		logins []string
+	}{
+		{
+			name: "empty",
+			text: "",
+		},
+		{
+			name:   "one",
+			text:   " @jungle",
+			logins: []string{"jungle"},
+		},
+		{
+			name:   "two",
+			text:   " @erick @fejta",
+			logins: []string{"erick", "fejta"},
+		},
+	}
+	for _, tc := range testcases {
+		l := parseLogins(tc.text)
+		if len(l) != len(tc.logins) {
+			t.Errorf("For case %s, expected %s and got %s", tc.name, tc.logins, l)
+		}
+		for n, who := range l {
+			if tc.logins[n] != who {
+				t.Errorf("For case %s, expected %s and got %s", tc.name, tc.logins, l)
+			}
+		}
+	}
+}
+
+func TestAssignComment(t *testing.T) {
+	var testcases = []struct {
+		name      string
+		action    string
+		body      string
+		commenter string
+		added     []string
+		removed   []string
+	}{
+		{
+			name:      "unrelated comment",
+			action:    "created",
+			body:      "uh oh",
+			commenter: "o",
+		},
+		{
+			name:      "not created",
+			action:    "something",
+			body:      "uh oh",
+			commenter: "o",
+		},
+		{
+			name:      "assign me",
+			action:    "created",
+			body:      "/assign",
+			commenter: "rando",
+			added:     []string{"rando"},
+		},
+		{
+			name:      "unassign myself",
+			action:    "created",
+			body:      "/unassign",
+			commenter: "rando",
+			removed:   []string{"rando"},
+		},
+		{
+			name:      "interesting names",
+			action:    "created",
+			body:      "/assign @hello-world @allow_underscore",
+			commenter: "rando",
+			added:     []string{"hello-world", "allow_underscore"},
+		},
+		{
+			name:      "bad login",
+			action:    "created",
+			commenter: "rando",
+			body:      "/assign @Invalid$User",
+		},
+		{
+			name:      "require @",
+			action:    "created",
+			commenter: "rando",
+			body:      "/assign no at symbol",
+		},
+		{
+			name:      "assign friends",
+			action:    "created",
+			body:      "/assign @bert @ernie",
+			commenter: "rando",
+			added:     []string{"bert", "ernie"},
+		},
+		{
+			name:      "unassign buddies",
+			action:    "created",
+			body:      "/unassign @ashitaka @eboshi",
+			commenter: "san",
+			removed:   []string{"ashitaka", "eboshi"},
+		},
+	}
+	for _, tc := range testcases {
+		fc := &fakeClient{}
+		ice := github.IssueCommentEvent{
+			Action: tc.action,
+			Comment: github.IssueComment{
+				Body: tc.body,
+				User: github.User{Login: tc.commenter},
+			},
+			Issue: github.Issue{
+				User:      github.User{Login: "a"},
+				Number:    5,
+				Assignees: []github.User{{Login: "a"}, {Login: "r1"}, {Login: "r2"}},
+			},
+		}
+		if err := handle(fc, logrus.WithField("plugin", pluginName), ice); err != nil {
+			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
+			continue
+		}
+		if len(fc.assigned) != len(tc.added) {
+			t.Errorf("For case %s, assigned actual %s != expected %s", tc.name, fc.assigned, tc.added)
+		} else {
+			for n, who := range tc.added {
+				if who != fc.assigned[n] {
+					t.Errorf("For case %s, assigned actual %s != expected %s", tc.name, fc.assigned, tc.added)
+					break
+				}
+			}
+		}
+		if len(fc.unassigned) != len(tc.removed) {
+			t.Errorf("For case %s, unassigned %s != %s", tc.name, fc.unassigned, tc.removed)
+		} else {
+			for n, who := range tc.removed {
+				if who != fc.unassigned[n] {
+					t.Errorf("For case %s, unassigned %s != %s", tc.name, fc.unassigned, tc.removed)
+					break
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds the following commands:
```
/assign  # alias for @fejta
/assign @fejta @spxtr etc
/unassign  # alias for @fejta
/unassign @fejta @spxtr etc
```

PS: FYI, why do I see `cmd/deck/main_test.go:91: rr.Result undefined (type *httptest.ResponseRecorder has no field or method Result)` when I `make test`