### PR TITLE
Create more GCE 1.6 jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -105,6 +105,18 @@
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620
+    - kubernetes-soak-gce-1.6-deploy:
+        blocker: ci-kubernetes-soak-gce-1.6-test
+        job-name: ci-kubernetes-soak-gce-1.6-deploy
+        frequency: 'H 0 * * 2'
+        scan: DISABLED
+        timeout: 110
+    - kubernetes-soak-gce-1.6-test:
+        blocker: ci-kubernetes-soak-gce-1.6-deploy
+        job-name: ci-kubernetes-soak-gce-1.6-test
+        frequency: 'H/30 * * * *'
+        scan: ALL
+        timeout: 620
     - kubernetes-soak-gce-1.5-deploy:
         blocker: ci-kubernetes-soak-gce-1.5-test
         job-name: ci-kubernetes-soak-gce-1.5-deploy
@@ -138,6 +150,18 @@
     - kubernetes-soak-gce-1.3-test:
         blocker: ci-kubernetes-soak-gce-1.3-deploy
         job-name: ci-kubernetes-soak-gce-1.3-test
+        frequency: 'H/30 * * * *'
+        scan: ALL
+        timeout: 620
+    - kubernetes-soak-gci-gce-1.6-deploy:
+        blocker: ci-kubernetes-soak-gci-gce-1.6-test
+        job-name: ci-kubernetes-soak-gci-gce-1.6-deploy
+        frequency: 'H 0 * * 2'
+        scan: DISABLED
+        timeout: 110
+    - kubernetes-soak-gci-gce-1.6-test:
+        blocker: ci-kubernetes-soak-gci-gce-1.6-deploy
+        job-name: ci-kubernetes-soak-gci-gce-1.6-test
         frequency: 'H/30 * * * *'
         scan: ALL
         timeout: 620

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -614,6 +614,12 @@
         timeout: 70
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gce-etcd2-release-1.6:
+        job-name: ci-kubernetes-e2e-gce-etcd2-release-1.6
+        jenkins-timeout: 170
+        timeout: 70
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'ci-kubernetes-build-1.6'
     - kubernetes-e2e-gce-reboot-release-1.6:
         job-name: ci-kubernetes-e2e-gce-reboot-release-1.6
         jenkins-timeout: 300
@@ -640,6 +646,19 @@
         trigger-job: 'ci-kubernetes-build-1.6'
         use-blocker: true
         blocker: 'ci-kubernetes-e2e-gce-scalability-release-1.5'
+    - kubernetes-e2e-gce-alpha-features-release-1.6:
+        job-name: ci-kubernetes-e2e-gce-alpha-features-release-1.6
+        jenkins-timeout: 300
+        timeout: 200
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gce-federation-release-1.6:
+        job-name: ci-kubernetes-e2e-gce-federation-release-1.6
+        jenkins-timeout: 1020
+        timeout: 920
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'ci-kubernetes-build-1.6'
+
     # gci-gce-1.6
     - kubernetes-e2e-gci-gce-release-1.6:
         job-name: ci-kubernetes-e2e-gci-gce-release-1.6
@@ -673,6 +692,18 @@
         trigger-job: 'ci-kubernetes-build-1.6'
         use-blocker: true
         blocker: 'ci-kubernetes-e2e-gci-gce-scalability-release-1.5'
+    - kubernetes-e2e-gci-gce-ingress-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gce-ingress-release-1.6
+        jenkins-timeout: 210
+        timeout: 110
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'ci-kubernetes-build-1.6'
+    - kubernetes-e2e-gci-gce-alpha-features-release-1.6:
+        job-name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6
+        jenkins-timeout: 300
+        timeout: 200
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: 'ci-kubernetes-build-1.6'
 
     # gce-features
     - kubernetes-e2e-gce-ingress:

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+KUBE_FEATURE_GATES=AllAlpha=true
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]|ScheduledJob
+PROJECT=k8s-jkns-gce-alpha-1-6
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gce-etcd2-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd2-release-1.6.env
@@ -1,0 +1,12 @@
+### job-env
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-gce-etcd2-1-6
+KUBE_NODE_OS_DISTRIBUTION=debian
+# Explicitly test etcd v2 mode in this suite.
+STORAGE_BACKEND=etcd2
+TEST_ETCD_IMAGE=2.2.1
+TEST_ETCD_VERSION=2.2.1
+
+KUBEKINS_TIMEOUT=50m

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.6.env
@@ -1,0 +1,29 @@
+### job-env
+FEDERATION=true
+USE_KUBEFED=true
+
+PROJECT=k8s-jkns-e2e-gce-f8n-1-6
+KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-f8n-1-6
+KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-6
+KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-6
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+# Where the clusters will be created. Federation components are now deployed to the last one.
+E2E_ZONES=us-central1-a us-central1-b us-central1-f
+FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
+
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
+
+FEDERATION_DNS_ZONE_NAME=release1-6.test-f8n.k8s.io.
+FEDERATIONS_DOMAIN_MAP=federation=release1-6.test-f8n.k8s.io
+
+# TODO: Replace this with FEDERATION_HOST_CLUSTER, but do it in
+# # lock steps. First make current the scripts understand the host
+# # parameters. Then make the necessary changes to make them more
+# # accurate.
+FEDERATION_HOST_CLUSTER_ZONE=us-central1-f
+
+FEDERATION_PUSH_REPO_BASE=gcr.io/k8s-jkns-e2e-gce-f8n-1-6
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6.env
@@ -1,0 +1,8 @@
+### job-env
+KUBE_FEATURE_GATES=AllAlpha=true
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+PROJECT=k8s-jkns-gci-gce-alpha-1-6
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.6.env
@@ -1,0 +1,7 @@
+### job-env
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
+PROJECT=k8s-jkns-gci-gce-ingress-1-6
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/ci-kubernetes-soak-gce-1.6-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-1.6-deploy.env
@@ -1,0 +1,11 @@
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+### soak-env
+JENKINS_SOAK_MODE=y
+FAIL_ON_GCP_RESOURCE_LEAK=false
+
+### job-env
+PROJECT=k8s-jkns-gce-soak-1-6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/ci-kubernetes-soak-gce-1.6-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.6-test.env
@@ -1,0 +1,19 @@
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+### soak-env
+JENKINS_SOAK_MODE=y
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Clear out any orphaned namespaces in case previous run was interrupted.
+E2E_CLEAN_START=true
+# TODO: Remove when we figure out #22166 and other docker potential slowness.
+DOCKER_TEST_LOG_LEVEL=--log-level=warn
+# We should be testing the reliability of a long-running cluster. The
+# [Disruptive] tests kill/restart components or nodes in the cluster,
+# defeating the purpose of a soak cluster. (#15722)
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+
+### job-env
+PROJECT=k8s-jkns-gce-soak-1-6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-soak-gci-gce-1.6-deploy.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.6-deploy.env
@@ -1,0 +1,11 @@
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+### soak-env
+JENKINS_SOAK_MODE=y
+FAIL_ON_GCP_RESOURCE_LEAK=false
+
+### job-env
+PROJECT=k8s-jkns-gci-gce-soak-1-6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+KUBEKINS_TIMEOUT=90m

--- a/jobs/ci-kubernetes-soak-gci-gce-1.6-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.6-test.env
@@ -1,0 +1,19 @@
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+### soak-env
+JENKINS_SOAK_MODE=y
+FAIL_ON_GCP_RESOURCE_LEAK=false
+# Clear out any orphaned namespaces in case previous run was interrupted.
+E2E_CLEAN_START=true
+# TODO: Remove when we figure out #22166 and other docker potential slowness.
+DOCKER_TEST_LOG_LEVEL=--log-level=warn
+# We should be testing the reliability of a long-running cluster. The
+# [Disruptive] tests kill/restart components or nodes in the cluster,
+# defeating the purpose of a soak cluster. (#15722)
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+
+### job-env
+PROJECT=k8s-jkns-gci-gce-soak-1-6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2214,6 +2214,50 @@
   ]
 },
 
+"ci-kubernetes-soak-gce-1.6-deploy": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gce-1.6-deploy.env",
+    "--test=false",
+    "--down=false",
+    "--tag=v20170223-43ce8f86"
+  ]
+},
+
+"ci-kubernetes-soak-gce-1.6-test": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gce-1.6-test.env",
+    "--test=false",
+    "--down=false",
+    "--tag=v20170223-43ce8f86"
+  ]
+},
+
+"ci-kubernetes-soak-gci-gce-1.6-deploy": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.6-deploy.env",
+    "--test=false",
+    "--down=false",
+    "--tag=v20170223-43ce8f86"
+  ]
+},
+
+"ci-kubernetes-soak-gci-gce-1.6-test": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.6-test.env",
+    "--test=false",
+    "--down=false",
+    "--tag=v20170223-43ce8f86"
+  ]
+},
+
 "ci-kubernetes-soak-gce-1.5-deploy": {
   "scenario": "kubernetes_e2e",
   "args": [
@@ -3426,6 +3470,46 @@
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env",
     "--cluster=e2e-scalability-1-6"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-etcd2-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-etcd2-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-alpha-features-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-federation-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-federation-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gce-ingress-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1.6.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6.env"
   ]
 },
 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -330,10 +330,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability-release-1.5
 - name: kubernetes-e2e-gci-gce-scalability-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5
-- name: kubernetes-e2e-gce-scalability-release-1.6
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability-release-1.6
-- name: kubernetes-e2e-gci-gce-scalability-release-1.6
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6
 - name: kubernetes-e2e-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial
 - name: kubernetes-e2e-gce-serial-release-1.3
@@ -838,18 +834,32 @@ test_groups:
 - name: kubernetes-e2e-gce-taint-evict
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-taint-evict
 # release-1.6 e2e
+- name: ci-kubernetes-e2e-gce-alpha-features-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-features-release-1.6
+- name: ci-kubernetes-e2e-gce-etcd2-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd2-release-1.6
+- name: ci-kubernetes-e2e-gce-federation-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-federation-release-1.6
 - name: ci-kubernetes-e2e-gce-reboot-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-reboot-release-1.6
 - name: ci-kubernetes-e2e-gce-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-release-1.6
+- name: ci-kubernetes-e2e-gce-scalability-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scalability-release-1.6
 - name: ci-kubernetes-e2e-gce-serial-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-serial-release-1.6
 - name: ci-kubernetes-e2e-gce-slow-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-slow-release-1.6
+- name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6
+- name: ci-kubernetes-e2e-gci-gce-ingress-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress-release-1.6
 - name: ci-kubernetes-e2e-gci-gce-reboot-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-reboot-release-1.6
 - name: ci-kubernetes-e2e-gci-gce-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-release-1.6
+- name: ci-kubernetes-e2e-gci-gce-scalability-release-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6
 - name: ci-kubernetes-e2e-gci-gce-serial-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1.6
 - name: ci-kubernetes-e2e-gci-gce-slow-release-1.6
@@ -874,6 +884,14 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-serial-release-1.6
 - name: ci-kubernetes-e2e-gke-slow-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-slow-release-1.6
+- name: ci-kubernetes-soak-gce-1.6-deploy
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-1.6-deploy
+- name: ci-kubernetes-soak-gce-1.6-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-1.6-test
+- name: ci-kubernetes-soak-gci-gce-1.6-deploy
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gci-gce-1.6-deploy
+- name: ci-kubernetes-soak-gci-gce-1.6-test
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gci-gce-1.6-test
 # Manual, federated groups
 # bazel, run on prow
 - name: ci-kubernetes-bazel-build
@@ -1075,9 +1093,9 @@ dashboards:
   - name: gci-gce-scalability-1.5
     test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.5
   - name: gce-scalability-1.6
-    test_group_name: kubernetes-e2e-gce-scalability-release-1.6
+    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
   - name: gci-gce-scalability-1.6
-    test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-scalability-release-1.6
   - name: gce-serial
     test_group_name: kubernetes-e2e-gce-serial
   - name: gci-gce-serial
@@ -1727,26 +1745,36 @@ dashboards:
     test_group_name: kubernetes-verify-release-1.6
   - name: kubelet-1.6
     test_group_name: ci-kubernetes-node-kubelet-1.6
+  - name: gce-alpha-features-1.6
+    test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1.6
+  - name: gce-etcd2-1.6
+    test_group_name: ci-kubernetes-e2e-gce-etcd2-release-1.6
+  - name: gce-federation-1.6
+    test_group_name: ci-kubernetes-e2e-gce-federation-release-1.6
   - name: gce-reboot-1.6
     test_group_name: ci-kubernetes-e2e-gce-reboot-release-1.6
   - name: gce-1.6
     test_group_name: ci-kubernetes-e2e-gce-release-1.6
+  - name: gce-scalability-1.6
+    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
   - name: gce-serial-1.6
     test_group_name: ci-kubernetes-e2e-gce-serial-release-1.6
   - name: gce-slow-1.6
     test_group_name: ci-kubernetes-e2e-gce-slow-release-1.6
+  - name: gci-gce-alpha-features-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6
+  - name: gci-gce-ingress-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-release-1.6
   - name: gci-gce-reboot-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-reboot-release-1.6
   - name: gci-gce-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-release-1.6
+  - name: gci-gce-scalability-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-scalability-release-1.6
   - name: gci-gce-serial-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-serial-release-1.6
   - name: gci-gce-slow-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-slow-release-1.6
-  - name: gce-scalability-1.6
-    test_group_name: kubernetes-e2e-gce-scalability-release-1.6
-  - name: gci-gce-scalability-1.6
-    test_group_name: kubernetes-e2e-gci-gce-scalability-release-1.6
   - name: gci-gke-ingress-1.6
     test_group_name: ci-kubernetes-e2e-gci-gke-ingress-release-1.6
   - name: gci-gke-reboot-1.6
@@ -1767,6 +1795,14 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-serial-release-1.6
   - name: gke-slow-1.6
     test_group_name: ci-kubernetes-e2e-gke-slow-release-1.6
+  - name: ci-kubernetes-soak-gce-1.6-deploy
+    test_group_name: ci-kubernetes-soak-gce-1.6-deploy
+  - name: ci-kubernetes-soak-gce-1.6-test
+    test_group_name: ci-kubernetes-soak-gce-1.6-test
+  - name: ci-kubernetes-soak-gci-gce-1.6-deploy
+    test_group_name: ci-kubernetes-soak-gci-gce-1.6-deploy
+  - name: ci-kubernetes-soak-gci-gce-1.6-test
+    test_group_name: ci-kubernetes-soak-gci-gce-1.6-test
 
 - name: release-1.6-blocking
   dashboard_tab:
@@ -1783,7 +1819,7 @@ dashboards:
   - name: gci-gce-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-release-1.6
   - name: gce-scalability-1.6
-    test_group_name: kubernetes-e2e-gce-scalability-release-1.6
+    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
   - name: gce-reboot-1.6
     test_group_name: ci-kubernetes-e2e-gce-reboot-release-1.6
   - name: gce-slow-1.6

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1804,32 +1804,85 @@ dashboards:
   - name: ci-kubernetes-soak-gci-gce-1.6-test
     test_group_name: ci-kubernetes-soak-gci-gce-1.6-test
 
+# Matches the list on https://github.com/kubernetes/test-infra/issues/2029
 - name: release-1.6-blocking
   dashboard_tab:
+  # Build/Verify
   - name: build-1.6
     test_group_name: kubernetes-build-1.6
-  - name: test-go-1.6
-    test_group_name: kubernetes-test-go-release-1.6
   - name: verify-1.6
     test_group_name: kubernetes-verify-release-1.6
-  - name: kubelet-1.6
-    test_group_name: ci-kubernetes-node-kubelet-1.6
+  - name: test-go-1.6
+    test_group_name: kubernetes-test-go-release-1.6
+  - name: federation-build-1.6
+    test_group_name: kubernetes-federation-build-1.6
+  # E2E
   - name: gce-1.6
     test_group_name: ci-kubernetes-e2e-gce-release-1.6
   - name: gci-gce-1.6
     test_group_name: ci-kubernetes-e2e-gci-gce-release-1.6
-  - name: gce-scalability-1.6
-    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
-  - name: gce-reboot-1.6
-    test_group_name: ci-kubernetes-e2e-gce-reboot-release-1.6
-  - name: gce-slow-1.6
-    test_group_name: ci-kubernetes-e2e-gce-slow-release-1.6
   - name: gke-1.6
     test_group_name: ci-kubernetes-e2e-gke-release-1.6
-  - name: gke-serial-1.6
-    test_group_name: ci-kubernetes-e2e-gke-serial-release-1.6
+  - name: gci-gke-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-release-1.6
+  # TODO: AWS
+  # Slow
+  - name: gce-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gce-slow-release-1.6
+  - name: gci-gce-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-slow-release-1.6
   - name: gke-slow-1.6
     test_group_name: ci-kubernetes-e2e-gke-slow-release-1.6
+  - name: gci-gke-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow-release-1.6
+  # Serial
+  - name: gce-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gce-serial-release-1.6
+  - name: gci-gce-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial-release-1.6
+  - name: gke-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gke-serial-release-1.6
+  - name: gci-gke-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-serial-release-1.6
+  # Federation
+  - name: gce-federation-1.6
+    test_group_name: ci-kubernetes-e2e-gce-federation-release-1.6
+  # Alpha
+  - name: gce-alpha-features-1.6
+    test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1.6
+  - name: gci-gce-alpha-features-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6
+  # Scalability
+  - name: gce-scalability-1.6
+    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
+  - name: gci-gce-scalability-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-scalability-release-1.6
+  # Ingress
+  - name: gci-gce-ingress-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-release-1.6
+  - name: gci-gke-ingress-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-ingress-release-1.6
+  # Reboot
+  - name: gce-reboot-1.6
+    test_group_name: ci-kubernetes-e2e-gce-reboot-release-1.6
+  - name: gci-gce-reboot-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gce-reboot-release-1.6
+  - name: gke-reboot-1.6
+    test_group_name: ci-kubernetes-e2e-gke-reboot-release-1.6
+  - name: gci-gke-reboot-1.6
+    test_group_name: ci-kubernetes-e2e-gci-gke-reboot-release-1.6
+  # Soak
+  - name: ci-kubernetes-soak-gce-1.6-deploy
+    test_group_name: ci-kubernetes-soak-gce-1.6-deploy
+  - name: ci-kubernetes-soak-gce-1.6-test
+    test_group_name: ci-kubernetes-soak-gce-1.6-test
+  - name: ci-kubernetes-soak-gci-gce-1.6-deploy
+    test_group_name: ci-kubernetes-soak-gci-gce-1.6-deploy
+  - name: ci-kubernetes-soak-gci-gce-1.6-test
+    test_group_name: ci-kubernetes-soak-gci-gce-1.6-test
+  # Node
+  - name: kubelet-1.6
+    test_group_name: ci-kubernetes-node-kubelet-1.6
 
 - name: release-1.5-all
   dashboard_tab:


### PR DESCRIPTION
Should be the last set of GCE jobs required by #2029.
* ci-kubernetes-e2e-gce-alpha-features-release-1.6
* ci-kubernetes-e2e-gce-etcd2-release-1.6
* ci-kubernetes-e2e-gce-federation-release-1.6
* ci-kubernetes-e2e-gci-gce-alpha-features-release-1.6
* ci-kubernetes-e2e-gci-gce-ingress-release-1.6
* ci-kubernetes-soak-gce-1.6-deploy
* ci-kubernetes-soak-gce-1.6-test
* ci-kubernetes-soak-gci-gce-1.6-deploy
* ci-kubernetes-soak-gci-gce-1.6-test

@madhusudancs can you please review the config for the federation job? I basically merged the configuration from the master-branch job with the configuration from the release-1.5 job, but I don't know if I did that properly.

This also creates an etcd2 job, per @wojtek-t's request.

cc @ethernetdan @enisoc @marun