### PR TITLE
Update go version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
     - master
 language: go
 go:
-    - 1.7.4
+    - 1.8.x
 go_import_path: k8s.io/test-infra
 services:
     - docker


### PR DESCRIPTION
Update to go1.7.5, with a non-blocking test for go1.8