### PR TITLE
Support multi /assign in one comment, trailing whitespace

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build fmt vet test
 
 
-HOOK_VERSION       = 0.87
+HOOK_VERSION       = 0.88
 LINE_VERSION       = 0.82
 SINKER_VERSION     = 0.5
 DECK_VERSION       = 0.17

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build fmt vet test
 
 
-HOOK_VERSION       = 0.86
+HOOK_VERSION       = 0.87
 LINE_VERSION       = 0.82
 SINKER_VERSION     = 0.5
 DECK_VERSION       = 0.17

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.86
+        image: gcr.io/k8s-prow/hook:0.87
         imagePullPolicy: Always
         args:
         - "--github-bot-name=k8s-ci-robot"

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.87
+        image: gcr.io/k8s-prow/hook:0.88
         imagePullPolicy: Always
         args:
         - "--github-bot-name=k8s-ci-robot"

--- a/prow/cmd/hook/server.go
+++ b/prow/cmd/hook/server.go
@@ -76,31 +76,36 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) demuxEvent(eventType string, payload []byte) error {
 	switch eventType {
-	case "pull_request":
-		var pr github.PullRequestEvent
-		if err := json.Unmarshal(payload, &pr); err != nil {
+	case "issues":
+		var i github.IssueEvent
+		if err := json.Unmarshal(payload, &i); err != nil {
 			return err
 		}
-		go s.handlePullRequestEvent(pr)
+		go s.handleIssueEvent(i)
 	case "issue_comment":
 		var ic github.IssueCommentEvent
 		if err := json.Unmarshal(payload, &ic); err != nil {
 			return err
 		}
 		go s.handleIssueCommentEvent(ic)
-	case "status":
-		var se github.StatusEvent
-		if err := json.Unmarshal(payload, &se); err != nil {
+	case "pull_request":
+		var pr github.PullRequestEvent
+		if err := json.Unmarshal(payload, &pr); err != nil {
 			return err
 		}
-		go s.handleStatusEvent(se)
+		go s.handlePullRequestEvent(pr)
 	case "push":
 		var pe github.PushEvent
 		if err := json.Unmarshal(payload, &pe); err != nil {
 			return err
 		}
 		go s.handlePushEvent(pe)
+	case "status":
+		var se github.StatusEvent
+		if err := json.Unmarshal(payload, &se); err != nil {
+			return err
+		}
+		go s.handleStatusEvent(se)
 	}
-
 	return nil
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -71,6 +71,7 @@ type PullRequest struct {
 	User    User              `json:"user"`
 	Base    PullRequestBranch `json:"base"`
 	Head    PullRequestBranch `json:"head"`
+	Body    string            `json:"body"`
 }
 
 // PullRequestBranch contains information about a particular branch in a PR.
@@ -105,6 +106,12 @@ type Repo struct {
 	HTMLURL  string `json:"html_url"`
 }
 
+type IssueEvent struct {
+	Action string `json:"action"`
+	Issue  Issue  `json:"issue"`
+	Repo   Repo   `json:"repository"`
+}
+
 type IssueCommentEvent struct {
 	Action  string       `json:"action"`
 	Issue   Issue        `json:"issue"`
@@ -120,6 +127,7 @@ type Issue struct {
 	HTMLURL   string  `json:"html_url"`
 	Labels    []Label `json:"labels"`
 	Assignees []User  `json:"assignees"`
+	Body      string  `json:"body"`
 
 	// This will be non-nil if it is a pull request.
 	PullRequest *struct{} `json:"pull_request,omitempty"`

--- a/prow/plugins/assign/BUILD
+++ b/prow/plugins/assign/BUILD
@@ -13,10 +13,7 @@ go_test(
     srcs = ["assign_test.go"],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = [
-        "//prow/github:go_default_library",
-        "//vendor:github.com/Sirupsen/logrus",
-    ],
+    deps = ["//vendor:github.com/Sirupsen/logrus"],
 )
 
 go_library(

--- a/prow/plugins/assign/assign_test.go
+++ b/prow/plugins/assign/assign_test.go
@@ -109,6 +109,21 @@ func TestAssignComment(t *testing.T) {
 			removed:   []string{"rando"},
 		},
 		{
+			name:      "tab completion",
+			action:    "created",
+			body:      "/assign @fejta ",
+			commenter: "rando",
+			added:     []string{"fejta"},
+		},
+		{
+			name:      "multi commands",
+			action:    "created",
+			body:      "/assign @fejta\n/unassign @spxtr",
+			commenter: "rando",
+			added:     []string{"fejta"},
+			removed:   []string{"spxtr"},
+		},
+		{
 			name:      "interesting names",
 			action:    "created",
 			body:      "/assign @hello-world @allow_underscore",


### PR DESCRIPTION
Github adds trailing whitespace when it completes a login
Allow an /assign and /unassign comment in the same comment

/assign @spxtr @grodrigues3