### PR TITLE
kops: Use both KOPS_DEPLOY_LATEST_URL and JENKINS_PUBLISHED_VERSION

### DIFF
--- a/jobs/ci-kubernetes-e2e-kops-aws-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-kops-aws-release-1.5.env
@@ -1,4 +1,5 @@
 KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.5.txt
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 
 KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-1.5-ci-green.txt
 

--- a/jobs/ci-kubernetes-e2e-kops-aws-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-kops-aws-release-1.6.env
@@ -1,4 +1,5 @@
 KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.6.txt
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-1.6-ci-green.txt
 


### PR DESCRIPTION
Fixes a small issue in #2106 (see https://github.com/kubernetes/test-infra/pull/2106#issuecomment-284507959)