### PR TITLE
Skip considering rare tests in the flakedetector.

### DIFF
--- a/experiment/flakedetector.py
+++ b/experiment/flakedetector.py
@@ -65,6 +65,8 @@ for job, commits in jobs.items():
 print('Certain flakes from the last day:')
 total_success_chance = 1.0
 for job, flakes in sorted(job_flakes.items(), key=operator.itemgetter(1), reverse=True):
+    if job_commits[job] < 10:
+        continue
     fail_chance = flakes / job_commits[job]
     total_success_chance *= (1.0 - fail_chance)
     print('{}/{}\t({:.0f}%)\t{}'.format(flakes, job_commits[job], 100*fail_chance, job))


### PR DESCRIPTION
Before this PR:
```
Certain flakes from the last day:
3/55	(5%)	pull-kubernetes-e2e-gce-etcd3
2/56	(4%)	pull-kubernetes-e2e-kops-aws
2/57	(4%)	pull-kubernetes-unit
2/59	(3%)	pull-kubernetes-node-e2e
1/54	(2%)	pull-kubernetes-e2e-gce
1/63	(2%)	pull-kubernetes-bazel
1/5	(20%)	pull-kubernetes-e2e-gke-gci
0/53	(0%)	pull-kubernetes-e2e-gce-non-cri
0/3	(0%)	pull-kubernetes-e2e-gke
0/59	(0%)	pull-kubernetes-kubemark-e2e-gce
0/55	(0%)	pull-kubernetes-e2e-gce-gci
0/60	(0%)	pull-kubernetes-node-e2e-non-cri
0/58	(0%)	pull-kubernetes-verify
0/5	(0%)	pull-kubernetes-cross
0/1	(0%)	pull-kubernetes-federation-e2e-gce
Chance that a PR hits a flake: 34%
```
We don't care about the few jobs that are only running a handful of times. I could have parsed `prow/config.yaml`, but that's too much work for such a simple heuristic script.

After this PR:
```
Certain flakes from the last day:
3/55	(5%)	pull-kubernetes-e2e-gce-etcd3
2/61	(3%)	pull-kubernetes-node-e2e
2/57	(4%)	pull-kubernetes-unit
2/56	(4%)	pull-kubernetes-e2e-kops-aws
1/60	(2%)	pull-kubernetes-node-e2e-non-cri
1/63	(2%)	pull-kubernetes-bazel
1/54	(2%)	pull-kubernetes-e2e-gce
0/59	(0%)	pull-kubernetes-kubemark-e2e-gce
0/53	(0%)	pull-kubernetes-e2e-gce-non-cri
0/58	(0%)	pull-kubernetes-verify
0/55	(0%)	pull-kubernetes-e2e-gce-gci
Chance that a PR hits a flake: 19%
```