### PR TITLE
Add release-1.6 kubectl skew tests, three dimensions:

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -1817,6 +1817,7 @@
 
 
     ### kubernetes-e2e-kubectl-skew-gke #maisem
+    # Skew 1.3 vs 1.4
     - kubernetes-e2e-gke-1.3-1.4-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gke-1.3-1.4-cvm-kubectl-skew
         jenkins-timeout: 240
@@ -1843,6 +1844,7 @@
         frequency: 'H H/6 * * *' # 4 times a day for older jobs.
         trigger-job: ''
 
+    # Skew 1.4 vs 1.5
     - kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew
         jenkins-timeout: 240
@@ -1869,6 +1871,61 @@
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
 
+    # Skew 1.5 vs 1.6
+    - kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    - kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # Skew 1.6 vs master
+    - kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-1.6-master-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    - kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-master-1.6-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # TODO(someone): do we still need to skew 1.4 vs master?
     - kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew
         jenkins-timeout: 240
@@ -1896,6 +1953,7 @@
         trigger-job: ''
 
     ### kubernetes-e2e-kubectl-skew-gce  #davidopp
+    # Skew 1.3 vs 1.4
     - kubernetes-e2e-gce-latest-1.3-latest-1.4-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-cvm-kubectl-skew
         jenkins-timeout: 240
@@ -1922,6 +1980,7 @@
         frequency: 'H H/6 * * *' # 4 times a day for older jobs.
         trigger-job: ''
 
+    # Skew 1.4 vs 1.5
     - kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew
         jenkins-timeout: 240
@@ -1948,6 +2007,61 @@
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
 
+    # Skew 1.5 vs 1.6
+    - kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    - kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # Skew 1.6 vs master
+    - kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gce-1.6-master-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    - kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gce-master-1.6-gci-kubectl-skew:
+        job-name: ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
+        jenkins-timeout: 240
+        timeout: 140
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # TODO(someone): do we still need to skew 1.3 or 1.4 vs master?
     - kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew
         jenkins-timeout: 240

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env
@@ -1,0 +1,9 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+PROJECT=k8s-gce-cvm-1-5-1-6-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env
@@ -1,0 +1,9 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+PROJECT=k8s-gce-gci-1-5-1-6-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew.env
@@ -1,0 +1,12 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gce-cvm-1-6-1-5-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew.env
@@ -1,0 +1,12 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gce-gci-1-6-1-5-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew.env
@@ -1,0 +1,9 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gce-cvm-1-6-mstr-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew.env
@@ -1,0 +1,9 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gce-gci-1-6-mstr-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew.env
@@ -1,0 +1,12 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest
+PROJECT=k8s-gce-cvm-mstr-1-6-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew.env
@@ -1,0 +1,12 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest
+PROJECT=k8s-gce-gci-mstr-1-6-ctl-skew
+KUBE_NODE_OS_DISTRIBUTION=gci
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env
@@ -1,0 +1,10 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+PROJECT=k8s-gke-cvm-1-5-1-6-ctl-skew
+KUBE_GKE_IMAGE_TYPE=container_vm
+ZONE=us-central1-c
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env
@@ -1,0 +1,10 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+PROJECT=k8s-gke-gci-1-5-1-6-ctl-skew
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-c
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew.env
@@ -1,0 +1,13 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gke-cvm-1-6-1-5-ctl-skew
+KUBE_GKE_IMAGE_TYPE=container_vm
+ZONE=us-central1-c
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew.env
@@ -1,0 +1,13 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gke-gci-1-6-1-5-ctl-skew
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-c
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew.env
@@ -1,0 +1,10 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gke-cvm-1-6-mstr-ctl-skew
+KUBE_GKE_IMAGE_TYPE=container_vm
+ZONE=us-central1-c
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew.env
@@ -1,0 +1,10 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+PROJECT=k8s-gke-gci-1-6-mstr-ctl-skew
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-c
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew.env
@@ -1,0 +1,13 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest
+PROJECT=k8s-gke-cvm-mstr-1-6-ctl-skew
+KUBE_GKE_IMAGE_TYPE=container_vm
+ZONE=us-central1-c
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew.env
@@ -1,0 +1,13 @@
+E2E_OPT=--check_version_skew=false
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest
+PROJECT=k8s-gke-gci-mstr-1-6-ctl-skew
+KUBE_GKE_IMAGE_TYPE=gci
+ZONE=us-central1-c
+
+### version-env
+JENKINS_USE_SKEW_TESTS=true
+
+KUBEKINS_TIMEOUT=120m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3643,5 +3643,133 @@
     "--env-file=platforms/gke.env",
     "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6.env"
   ]
+},
+
+"ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew.env"
+  ]
 }
 }

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -892,6 +892,7 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-serial-release-1.6
 - name: ci-kubernetes-e2e-gke-slow-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-slow-release-1.6
+# 1.6 soak
 - name: ci-kubernetes-soak-gce-1.6-deploy
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-1.6-deploy
 - name: ci-kubernetes-soak-gce-1.6-test
@@ -900,6 +901,39 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gci-gce-1.6-deploy
 - name: ci-kubernetes-soak-gci-gce-1.6-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gci-gce-1.6-test
+# 1.6 skew
+- name: ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew
+- name: ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew
+- name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
+- name: ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
+- name: ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew
+- name: ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew
+- name: ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
+- name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
+- name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
 # Manual, federated groups
 # bazel, run on prow
 - name: ci-kubernetes-bazel-build
@@ -1899,6 +1933,41 @@ dashboards:
   # Node
   - name: kubelet-1.6
     test_group_name: ci-kubernetes-node-kubelet-1.6
+
+- name: release-1.6-upgrade-skew
+  dashboard_tab:
+  - name: ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew
+  - name: ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew
+  - name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
+  - name: ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
+  - name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
 
 - name: release-1.5-all
   dashboard_tab:


### PR DESCRIPTION
* GKE and GCE
* CVM and GCI
* 1.5 vs. 1.6, 1.6 vs. 1.5, 1.6 vs master, master vs. 1.6

I hope I did this correctly. It's really hard to reason about what `JENKINS_PUBLISHED_SKEW_VERSION` vs `JENKINS_PUBLISHED_VERSION` means.

x-ref #2034

cc @ethernetdan @enisoc @marun @skriss