### PR TITLE
kops: Enable KOPS_RUN_OBSOLETE_VERSION

### DIFF
--- a/jobs/ci-kubernetes-e2e-kops-aws.env
+++ b/jobs/ci-kubernetes-e2e-kops-aws.env
@@ -12,6 +12,9 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Fe
 KOPS_LATEST=latest-ci-updown-green.txt
 KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-green.txt
 
+# Ignore version-we-pass vs version-kops-expects
+KOPS_RUN_OBSOLETE_VERSION=true
+
 # After post-env
 KOPS_DEPLOY_LATEST_KUBE=y
 GINKGO_PARALLEL=y


### PR DESCRIPTION
Fixes https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-release-1.5/1/?log#log

Note: This could be in the `release-1.5` env file instead, but I think it makes more sense to disable this check in general.