### PR TITLE
Create release-1.6 upgrade jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -1700,6 +1700,25 @@
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
 
+    - kubernetes-e2e-gce-1.5-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gce-1.5-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
     ### kubernetes-e2e-upgrades-gce-cross-image-and-gci #mtaufen
     - kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master:
         job-name: ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
@@ -2249,6 +2268,8 @@
         frequency: 'H H/6 * * *' # 4 times a day for older jobs.
         trigger-job: ''
 
+    ### 1.4 to 1.5 GKE upgrade tests
+    # cvm -> cvm
     - kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master
         jenkins-timeout: 720
@@ -2268,6 +2289,7 @@
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
 
+    # cvm -> gci
     - kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master
         jenkins-timeout: 720
@@ -2287,6 +2309,7 @@
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
 
+    # gci -> cvm
     - kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master
         jenkins-timeout: 720
@@ -2306,6 +2329,7 @@
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
 
+    # gci -> gci
     - kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master
         jenkins-timeout: 720
@@ -2320,6 +2344,168 @@
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    ### 1.4 to 1.6 GKE upgrade tests
+    # cvm -> cvm
+    - kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # cvm -> gci
+    - kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # gci -> cvm
+    - kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # gci -> gci
+    - kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    ### 1.5 to 1.6 GKE upgrade tests
+    # cvm -> cvm
+    - kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # cvm -> gci
+    - kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # gci -> cvm
+    - kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+
+    # gci -> gci
+    - kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master:
+        job-name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster
+        jenkins-timeout: 720
+        timeout: 620
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new:
+        job-name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
         frequency: 'H/5 * * * *' # At least every 30m

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
@@ -1,0 +1,12 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-gce-upg-1-5-1-6-up-clu-n
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
@@ -1,0 +1,11 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-gce-upg-1-5-1-6-up-clu
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
@@ -1,0 +1,11 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-gce-upg-1-5-1-6-up-mas
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-4-c1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-4-c1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-4-c1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-4-g1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-4-g1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-4-g1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-5-c1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-5-c1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-5-c1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-5-g1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-5-g1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=k8s-gke-upg-c1-5-g1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-4-c1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-4-c1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-4-c1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-4-g1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-4-g1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.4
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-4-g1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-5-c1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-5-c1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-5-c1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
@@ -1,0 +1,15 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-5-g1-6-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-5-g1-6-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
@@ -1,0 +1,14 @@
+### job-env
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_VERSION=ci/latest-1.5
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-upg-g1-5-g1-6-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=600m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3771,5 +3771,221 @@
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew.env"
   ]
+},
+
+"ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env"
+  ]
 }
 }

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -934,6 +934,61 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
 - name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
+# 1.6 upgrade
+- name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master
+- name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master
 # Manual, federated groups
 # bazel, run on prow
 - name: ci-kubernetes-bazel-build
@@ -1942,38 +1997,92 @@ dashboards:
 
 - name: release-1.6-upgrade-skew
   dashboard_tab:
-  - name: ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew
+  - name: gce-1.5-1.6-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew
+  - name: gce-1.5-1.6-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew
-  - name: ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew
+  - name: gce-1.6-1.5-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew
+  - name: gce-1.6-1.5-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew
-  - name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
+  - name: gce-1.6-master-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
+  - name: gce-1.6-master-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
-  - name: ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
+  - name: gce-master-1.6-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
+  - name: gce-master-1.6-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew
+  - name: gke-1.5-1.6-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew
+  - name: gke-1.5-1.6-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew
+  - name: gke-1.6-1.5-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew
+  - name: gke-1.6-1.5-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
+  - name: gke-1.6-master-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
+  - name: gke-1.6-master-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
+  - name: gke-master-1.6-cvm-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
-  - name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
+  - name: gke-master-1.6-gci-kubectl-skew
     test_group_name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
+  - name: gce-1.5-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster
+  - name: gce-1.5-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new
+  - name: gce-1.5-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master
+  - name: gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
+  - name: gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new
+  - name: gke-container_vm-1.4-container_vm-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master
+  - name: gke-container_vm-1.4-gci-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster
+  - name: gke-container_vm-1.4-gci-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new
+  - name: gke-container_vm-1.4-gci-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master
+  - name: gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
+  - name: gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
+  - name: gke-container_vm-1.5-container_vm-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master
+  - name: gke-container_vm-1.5-gci-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster
+  - name: gke-container_vm-1.5-gci-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new
+  - name: gke-container_vm-1.5-gci-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master
+  - name: gke-gci-1.4-container_vm-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster
+  - name: gke-gci-1.4-container_vm-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new
+  - name: gke-gci-1.4-container_vm-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master
+  - name: gke-gci-1.4-gci-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster
+  - name: gke-gci-1.4-gci-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new
+  - name: gke-gci-1.4-gci-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master
+  - name: gke-gci-1.5-container_vm-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster
+  - name: gke-gci-1.5-container_vm-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new
+  - name: gke-gci-1.5-container_vm-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master
+  - name: gke-gci-1.5-gci-1.6-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster
+  - name: gke-gci-1.5-gci-1.6-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
+  - name: gke-gci-1.5-gci-1.6-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master
 
 - name: release-1.5-all
   dashboard_tab:


### PR DESCRIPTION
Creates the following jobs, pulled from #2034:
* ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster
* ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master
* ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master
* ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master
* ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master
* ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master
* ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master
* ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master
* ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master
* ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster
* ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
* ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master

It'd be good to double-check my env files, since I may have typo'd something there.

I haven't created any GCP projects yet.

cc @ethernetdan @enisoc @marun @skriss @pwittrock 