### PR TITLE
Make 1.6 soak tests actually run tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2282,7 +2282,8 @@
   "args": [
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-soak-gce-1.6-test.env",
-    "--test=false",
+    "--soak-test",
+    "--up=false",
     "--down=false",
     "--tag=v20170223-43ce8f86"
   ]
@@ -2304,7 +2305,8 @@
   "args": [
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.6-test.env",
-    "--test=false",
+    "--soak-test",
+    "--up=false",
     "--down=false",
     "--tag=v20170223-43ce8f86"
   ]


### PR DESCRIPTION
`--soak-test` should probably imply `--up=false` and `--down=false`.

I also don't understand what `--soak-test` means and why the deploy jobs don't get it.

x-ref #2029
cc @ethernetdan @enisoc @marun