### PR TITLE
Add a canary PR job that uses scenarios/kubernetes_e2e.py

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -1,0 +1,68 @@
+# Temporary, will switch boostrap-pull.yaml to use this
+# after validating it works
+
+- job-template:
+    name: 'pull-{jsonsuffix}'
+    concurrent: true
+    properties:
+    - build-discarder:
+        days-to-keep: 7
+    - throttle:
+        max-total: '{max-total}'
+        max-per-node: 2
+        option: project
+    - raw:
+        xml: |
+            <com.cloudbees.plugins.JobPrerequisites plugin="slave-prerequisites@1.0">
+                <script>docker version; gcloud version</script>
+                <interpreter>shell script</interpreter>
+            </com.cloudbees.plugins.JobPrerequisites>
+    parameters:
+    - string:
+        name: PULL_REFS
+    - string:
+        name: PULL_NUMBER
+    - string:
+        name: PULL_BASE_REF
+    # The test job tracks a run through the queue using the buildId parameter.
+    - string:
+        name: buildId
+    wrappers:
+    - e2e-credentials-binding
+    - inject:
+        properties-content: |
+            GOROOT=/usr/local/go
+            GOPATH=$WORKSPACE/go
+            PATH=$PATH:$GOROOT/bin:$WORKSPACE/go/bin
+    - workspace-cleanup:
+        dirmatch: true
+        exclude:
+        - 'go/src/{repo-name}/.git/'
+        - 'test-infra/.git/'
+        external-deletion-command: 'sudo rm -rf %s'
+    - timeout:
+        timeout: 90
+        fail: true
+    builders:
+    - shell: |
+        # TODO(fejta): consider a stable tag instead of master
+        git clone https://github.com/kubernetes/test-infra -b master
+        './test-infra/jenkins/bootstrap.py' \
+            --job='{job-name}' \
+            --json \
+            --repo='{repo-name}=${{PULL_REFS}}' \
+            --repo='k8s.io/release' \
+            --root="${{GOPATH}}/src" \
+            --service-account="${{GOOGLE_APPLICATION_CREDENTIALS}}" \
+            --timeout='{timeout}' \
+            --upload='gs://kubernetes-jenkins/pr-logs'
+- project:
+    name: bootstrap-pull-jobs-json
+    jobs:
+    - 'pull-{jsonsuffix}'
+    jsonsuffix:  # pull-<repo>-<suffix> is the expected format
+    - kubernetes-e2e-gce-canary:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gce-canary
+        repo-name: 'k8s.io/kubernetes'
+        timeout: 75

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -307,6 +307,18 @@
   ]
 },
 
+"pull-kubernetes-e2e-gce-canary": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+     "--env-file=platforms/gce.env",
+     "--env-file=jobs/pull-kubernetes-e2e.env",
+     "--env-file=jobs/pull-kubernetes-e2e-gce-canary.env",
+     "--build",
+     "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e",
+     "--cluster="
+  ]
+},
+
 "pull-kubernetes-node-e2e": {
   "scenario": "kubernetes_kubelet",
   "args": [

--- a/jobs/pull-kubernetes-e2e-gce-canary.env
+++ b/jobs/pull-kubernetes-e2e-gce-canary.env
@@ -1,0 +1,12 @@
+# For now explicitly test etcd v2 mode in this suite.
+STORAGE_BACKEND=etcd2
+TEST_ETCD_IMAGE=2.2.1
+TEST_ETCD_VERSION=2.2.1
+
+# Force to use container-vm.
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+# Panic if anything mutates a shared informer cache
+ENABLE_CACHE_MUTATION_DETECTOR=true
+
+KUBEKINS_TIMEOUT=55m

--- a/jobs/pull-kubernetes-e2e-gce.sh
+++ b/jobs/pull-kubernetes-e2e-gce.sh
@@ -20,12 +20,6 @@ set -o xtrace
 
 readonly testinfra="$(dirname "${0}")/.."
 
-# TODO(fejta): remove this
-if [[ "${PULL_BASE_REF:-}" == "release-1.0" || "${PULL_BASE_REF:-}" == "release-1.1" ]]; then
-  echo "PR GCE job disabled for legacy branches."
-  exit
-fi
-
 export KUBE_GCS_RELEASE_BUCKET="${KUBE_GCS_RELEASE_BUCKET:-kubernetes-release-pull}"
 export KUBE_GCS_RELEASE_SUFFIX="/${JOB_NAME}"
 export KUBE_GCS_UPDATE_LATEST=n

--- a/jobs/pull-kubernetes-e2e.env
+++ b/jobs/pull-kubernetes-e2e.env
@@ -1,0 +1,15 @@
+# PR ENVs
+E2E_MIN_STARTUP_PODS=1
+# Flake detection. Individual tests get a second chance to pass.
+GINKGO_TOLERATE_FLAKES=y
+KUBE_GCS_UPDATE_LATEST=n
+JENKINS_USE_LOCAL_BINARIES=y
+
+FAIL_ON_GCP_RESOURCE_LEAK=false
+GINKGO_PARALLEL=y
+# This list should match the list in kubernetes-e2e-gce.
+GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+
+# NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
+NUM_NODES=4
+GINKGO_PARALLEL_NODES=30

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -86,6 +86,11 @@ presubmits:
     rerun_command: "@k8s-bot cvm gce e2e test this"
     trigger: "@k8s-bot (cvm )?(gce )?(e2e )?test this"
 
+  - name: pull-kubernetes-e2e-gce-canary
+    context: pull-kubernetes-e2e-gce-canary
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce-canary test this"
+    trigger: "@k8s-bot pull-kubernetes-e2e-gce-canary test this"
+
   - name: pull-kubernetes-e2e-gce-etcd3
     always_run: true
     context: Jenkins GCE etcd3 e2e

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -298,6 +298,8 @@ def main(args):
         runner_args.append('--stage=%s' % args.stage)
 
 
+    cluster = args.cluster or 'e2e-gce-%s-%s' % (
+        os.environ['NODE_NAME'], os.getenv('EXECUTOR_NUMBER', 0))
     mode.add_environment(
       # Boilerplate envs
       # Skip gcloud update checking
@@ -308,16 +310,16 @@ def main(args):
       'E2E_UP=%s' % args.up,
       'E2E_TEST=%s' % args.test,
       'E2E_DOWN=%s' % args.down,
-      'E2E_NAME=%s' % args.cluster,
+      'E2E_NAME=%s' % cluster,
       # AWS
-      'KUBE_AWS_INSTANCE_PREFIX=%s' % args.cluster,
+      'KUBE_AWS_INSTANCE_PREFIX=%s' % cluster,
       # GCE
-      'INSTANCE_PREFIX=%s' % args.cluster,
-      'KUBE_GCE_NETWORK=%s' % args.cluster,
-      'KUBE_GCE_INSTANCE_PREFIX=%s' % args.cluster,
+      'INSTANCE_PREFIX=%s' % cluster,
+      'KUBE_GCE_NETWORK=%s' % cluster,
+      'KUBE_GCE_INSTANCE_PREFIX=%s' % cluster,
       # GKE
-      'CLUSTER_NAME=%s' % args.cluster,
-      'KUBE_GKE_NETWORK=%s' % args.cluster,
+      'CLUSTER_NAME=%s' % cluster,
+      'KUBE_GKE_NETWORK=%s' % cluster,
     )
 
     # env blacklist.


### PR DESCRIPTION
Create a `pull-kubernetes-e2e-gce-canary` job in jenkins and configs.json, which sends `--build` and `--stage` flags to `kubetest`
Add an `@k8s-bot pull-kubernetes-e2e-gce-canary test this` job to prow
Make `scenarios/kubernetes_e2e.py` choose a cluster name if unset.
Create a `jobs/pull-kubernetes-e2e.env` with common PR vars.

ref https://github.com/kubernetes/test-infra/issues/2074
