### PR TITLE
Use double-quote for PULL_REFS

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -50,7 +50,7 @@
         './test-infra/jenkins/bootstrap.py' \
             --job='{job-name}' \
             --json \
-            --repo='{repo-name}=${{PULL_REFS}}' \
+            --repo="{repo-name}=${{PULL_REFS}}" \
             --repo='k8s.io/release' \
             --root="${{GOPATH}}/src" \
             --service-account="${{GOOGLE_APPLICATION_CREDENTIALS}}" \


### PR DESCRIPTION
```
ValueError: ('bad repo', 'k8s.io/kubernetes=${PULL_REFS}', ['k8s.io/kubernetes=${PULL_REFS}', 'k8s.io/release'])
Build step 'Execute shell' marked build as failure
```
/assign @krzyzacy @madhusudancs 

