### PR TITLE
Add canary federation pull job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -66,3 +66,8 @@
         job-name: pull-kubernetes-e2e-gce-canary
         repo-name: 'k8s.io/kubernetes'
         timeout: 75
+    - kubernetes-federation-e2e-gce-canary:
+        max-total: 12
+        job-name: pull-kubernetes-federation-e2e-gce-canary
+        repo-name: 'k8s.io/kubernetes'
+        timeout: 110

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -314,10 +314,23 @@
      "--env-file=jobs/pull-kubernetes-e2e.env",
      "--env-file=jobs/pull-kubernetes-e2e-gce-canary.env",
      "--build",
-     "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e",
+     "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary",
      "--cluster="
   ]
 },
+
+"pull-kubernetes-federation-e2e-gce-canary": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+     "--env-file=platforms/gce.env",
+     "--env-file=jobs/pull-kubernetes-e2e.env",
+     "--env-file=jobs/pull-kubernetes-federation-e2e-gce-canary.env",
+     "--build",
+     "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce-canary",
+     "--cluster="
+  ]
+},
+
 
 "pull-kubernetes-node-e2e": {
   "scenario": "kubernetes_kubelet",

--- a/jobs/pull-kubernetes-e2e.env
+++ b/jobs/pull-kubernetes-e2e.env
@@ -8,7 +8,7 @@ JENKINS_USE_LOCAL_BINARIES=y
 FAIL_ON_GCP_RESOURCE_LEAK=false
 GINKGO_PARALLEL=y
 # This list should match the list in kubernetes-e2e-gce.
-GINKGO_TEST_ARGS='--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 NUM_NODES=4

--- a/jobs/pull-kubernetes-federation-e2e-gce-canary.env
+++ b/jobs/pull-kubernetes-federation-e2e-gce-canary.env
@@ -1,0 +1,22 @@
+# Panic if anything mutates a shared informer cache
+ENABLE_CACHE_MUTATION_DETECTOR=true
+
+FEDERATION=true
+USE_KUBEFED=true
+PROJECT=k8s-jkns-pr-bldr-e2e-gce-fdrtn
+KUBE_REGISTRY=gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn
+KUBERNETES_PROVIDER=gce
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
+KUBEKINS_TIMEOUT=90m
+
+# Recycle control plane.
+# We only recycle federation control plane in each run, we don't
+# want to recycle the clusters, it's too slow.
+# This is accomplished by not setting FEDERATION_CLUSTERS env
+# var or setting it to empty string. We set it to empty string
+# to explicitly call it out.
+FEDERATION_CLUSTERS=
+
+# Federation control plane options.
+DNS_ZONE_NAME=pr-bldr.test-f8n.k8s.io.
+FEDERATIONS_DOMAIN_MAP=federation=pr-bldr.test-f8n.k8s.io

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -124,6 +124,11 @@ presubmits:
     rerun_command: "@k8s-bot federation gce e2e test this"
     trigger: "@k8s-bot federation (gce )?(e2e )?test this"
 
+  - name: pull-kubernetes-federation-e2e-gce-canary
+    context: pull-kubernetes-federation-e2e-gce-canary
+    rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce-canary test this"
+    trigger: "@k8s-bot pull-kubernetes-federation-e2e-gce-canary test this"
+
   - name: pull-kubernetes-federation-e2e-gce-gci
     context: Jenkins GCI Federation GCE e2e
     rerun_command: "@k8s-bot federation gci gce e2e test this"


### PR DESCRIPTION
/assign @madhusudancs @krzyzacy 

ref https://github.com/kubernetes/test-infra/issues/2074

Add a temporary `pull-kubernetes-federation-e2e-gce-canary` job to test whether the new image does federation builds/deployments correctly.

Fix extra `'`s in the `pull-kubernetes-e2e-gce-canary` job causing it to run disruptive jobs, causing the suite to fail.

Add unit tests for the expected pull flags.