### PR TITLE
e2e-runner.sh: don't require specific working directory

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -45,7 +45,7 @@ ENV FAIL_ON_GCP_RESOURCE_LEAK=true \
 
 ADD ["https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz", \
      "/workspace/"]
-ENV PATH=/google-cloud-sdk/bin:${PATH} \
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
 RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
     /google-cloud-sdk/install.sh \

--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -172,4 +172,4 @@ if [[ "${E2E_PUBLISH_GREEN_VERSION:-}" == "true" ]]; then
   e2e_go_args+=(--publish="gs://${KUBE_GCS_DEV_RELEASE_BUCKET}/ci/latest-green.txt")
 fi
 
-./kubetest ${E2E_OPT:-} "${e2e_go_args[@]}" "${@}"
+kubetest ${E2E_OPT:-} "${e2e_go_args[@]}" "${@}"


### PR DESCRIPTION
Instead of requiring that `e2e-runner.sh` be invoked in the working directory of `kubetest`, use the `$PATH` to find it.

This fixes jobs that use the `e2e-runner.sh` directly, instead of `dockerized-e2e-runner.sh` (because they're running via custom images). The `dockerized-e2e-runner.sh` resets the current working directory to `/workspace` (where `kubetest` is), but calling `e2e-runner.sh` from a job script will have its current working directory set at the root of the cloned repository, since `bootstrap.py` chdirs into it. This used to work before https://github.com/kubernetes/test-infra/commit/0b8538ddf58d396cde7e90c365e71b1442dfa426.