### PR TITLE
Use CI .deb builds in kubeadm e2e job.

### DIFF
--- a/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
@@ -26,9 +26,18 @@ readonly testinfra="$(dirname "${0}")/.."
 
 export PROJECT="k8s-jkns-e2e-kubeadm-gce-ci"
 export KUBERNETES_PROVIDER=kubernetes-anywhere
+
+# This job only runs against the kubernetes repo, and bootstrap.py leaves the
+# current working directory at the repository root. Grab the SCM_REVISION so we
+# can use the .debs built during the bazel-build job that should have already
+# succeeded.
+export SCM_VERSION=$(./hack/print-workspace-status.sh | grep ^STABLE_BUILD_SCM_REVISION | cut -d' ' -f2)
+
 export E2E_NAME="e2e-kubeadm-gce"
 export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path /workspace/kubernetes-anywhere"
 export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}"
+# The gs:// path given here should match jobs/ci-kubernetes-bazel-build.sh
+export E2E_OPT+=" --kubernetes-anywhere-kubeadm-version gs://kubernetes-release-dev/bazel/${SCM_VERSION}/build/debs/"
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
 
 ### post-env


### PR DESCRIPTION
Since this job is chained after `ci-kubernetes-bazel-build` (which publishes .debs), use those .debs while testing.