### PR TITLE
Add kubectl to e2e image.

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -55,6 +55,7 @@ RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
         --usage-reporting=false && \
     gcloud components install beta && \
     gcloud components install alpha && \
+    gcloud components update kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
 ADD ["e2e-runner.sh", \


### PR DESCRIPTION
This is a dependency of `kubetest`, and I believe it got removed from the base image somewhere along the way.