### PR TITLE
Only up/down kubeadm clusters for testing.

### DIFF
--- a/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
@@ -35,7 +35,11 @@ export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
 
 # Assume we're upping, testing, and downing a cluster
 export E2E_UP="${E2E_UP:-true}"
-export E2E_TEST="${E2E_TEST:-true}"
+# TODO(pipejakob): Reenable testing when we have a pod network that works with
+#     kubeadm 1.6 clusters. For now, simply bringing up a cluster is a good e2e
+#     test, since it will only succeed if the apiserver is healthy and all
+#     expected nodes are registered.
+export E2E_TEST="false"
 export E2E_DOWN="${E2E_DOWN:-true}"
 
 # Skip gcloud update checking


### PR DESCRIPTION
See TODO from source.

For more context, this job has been red for a while because it was never blocking and there have been a lot of breaking upstream kubeadm changes leading to the beta. Now that things are settling down, I'm trying to get the job back into a green state and hopefully make a PR-blocking version to keep it green. I still want to get `--test` working as well, but a reliable job that will prevent regressions is incrementally better than what we have now.