### PR TITLE
approvers: Do not suggest people who can't approve more

### DIFF
--- a/mungegithub/mungers/approvers/approvers_test.go
+++ b/mungegithub/mungers/approvers/approvers_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 
 	"fmt"
-	"k8s.io/kubernetes/pkg/util/sets"
 	"reflect"
+
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func TestUnapprovedFiles(t *testing.T) {
@@ -292,6 +293,15 @@ func TestGetCCs(t *testing.T) {
 			currentlyApproved: sets.NewString(),
 			// Need an approver from each of the three owners files
 			expectedCCs: []string{"Anne", "Bill", "Carol"},
+		},
+		{
+			testName:  "A, B, C; Partially approved by non-suggested approvers",
+			filenames: []string{"a/test.go", "b/test.go", "c/test"},
+			testSeed:  0,
+			// Approvers are valid approvers, but not the one we would suggest
+			currentlyApproved: sets.NewString("Art", "Ben"),
+			// We don't suggest approvers for a and b, only for unapproved c.
+			expectedCCs: []string{"Carol"},
 		},
 	}
 


### PR DESCRIPTION
Maybe someone has already approved some files, and we keep suggesting
people that can't add more approval (because the files they could
approve have already been approved).