### PR TITLE
Make janitor clean up target-https-proxy as well

### DIFF
--- a/jenkins/janitor.py
+++ b/jenkins/janitor.py
@@ -35,6 +35,7 @@ DEMOLISH_ORDER = [
     Resource('routes', None, None),
     Resource('forwarding-rules', 'region', None),
     Resource('target-http-proxies', None, None),
+    Resource('target-https-proxies', None, None),
     Resource('url-maps', None, None),
     Resource('backend-services', 'region', None),
     Resource('target-pools', 'region', None),


### PR DESCRIPTION
Log:
```
ERROR: (gcloud.compute.url-maps.delete) Some requests did not succeed:
W0308 08:06:31.479]  - The url_map resource 'k8s-um-e2e-tests-ingress-upgrade-b971x-static-ip--6a7d2ae775930' is already being used by 'k8s-tps-e2e-tests-ingress-upgrade-b971x-static-ip--6a7d2ae77590'
W0308 08:06:31.479]  - The url_map resource 'k8s-um-e2e-tests-ingress-upgrade-pxpkb-static-ip--a8bc56a839ec0' is already being used by 'k8s-tps-e2e-tests-ingress-upgrade-pxpkb-static-ip--a8bc56a839e0'
```

cc @krousey might affect some projects there