### PR TITLE
follow up of #2077

### DIFF
--- a/mungegithub/mungers/publish_scripts/publish_client_go.sh
+++ b/mungegithub/mungers/publish_scripts/publish_client_go.sh
@@ -52,7 +52,7 @@ trap cleanup_github_token EXIT SIGINT
 # this currently only updates commit hash of k8s.io/apimachinery
 update_godeps_json() {
     local godeps_json="./Godeps/Godeps.json"
-    local old_revs
+    local old_revs=""
     local new_rev=$(cd ../apimachinery; git rev-parse HEAD)
 
     # TODO: simplify the following lines


### PR DESCRIPTION
Follow up of #2077

1. included the original commit hash in the cherry-picked commits' commit message.
2. eliminate the need of filter-branch-sha meta file.
3. change the meaning of the kubernetes-sha meta file. It used to records the last commit of k8s.io/kubernetes when the sync script is called, now it records the last commit of k8s.io/kubernetes that ***affects staging/src/k8s.io/apimachinery*** when the sync script is called.

@sttts ptal, thanks!

ref: 
The changes generated by the scripts are in https://github.com/kubernetes/apimachinery/pull/9/files and https://github.com/kubernetes/client-go/pull/140