### PR TITLE
approvers: Consider assignees when CCing

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -108,6 +108,13 @@ func (h *ApprovalHandler) Munge(obj *github.MungeObject) {
 		}
 		approversHandler.AddAuthorSelfApprover(*obj.Issue.User.Login, url)
 	}
+
+	for _, user := range obj.Issue.Assignees {
+		if user != nil && user.Login != nil {
+			approversHandler.AddAssignees(*user.Login)
+		}
+	}
+
 	notificationMatcher := c.MungerNotificationName(approvers.ApprovalNotificationName)
 
 	latestNotification := c.FilterComments(comments, notificationMatcher).GetLast()

--- a/mungegithub/mungers/approvers/BUILD
+++ b/mungegithub/mungers/approvers/BUILD
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//mungegithub/features:go_default_library",
         "//mungegithub/mungers/matchers/comment:go_default_library",
+        "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/kubernetes/pkg/util/sets",
     ],
 )

--- a/mungegithub/mungers/approvers/owners_test.go
+++ b/mungegithub/mungers/approvers/owners_test.go
@@ -341,7 +341,7 @@ func TestGetSuggestedApprovers(t *testing.T) {
 
 	for _, test := range tests {
 		testOwners := Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: TEST_SEED}
-		suggested := testOwners.GetSuggestedApprovers()
+		suggested := testOwners.GetSuggestedApprovers(testOwners.GetShuffledApprovers())
 		for _, ownersSet := range test.expectedOwners {
 			if ownersSet.Intersection(suggested).Len() == 0 {
 				t.Errorf("Failed for test %v.  Didn't find an approver from: %v. Actual Owners %v", test.testName, ownersSet, suggested)


### PR DESCRIPTION
Right now we don't really make a corelation between the people assigned
to a PR and the people we select for approval. This is a problem because
some time we could reduce the list of suggested people by looking at the
list of assignees.

Consider the list of assignees when we suggest people, and don't suggest
people that can't approve more than current assignees.

Fixes #1769