### PR TITLE
Add Ubuntu GKE e2e test results bucket

### DIFF
--- a/buckets.yaml
+++ b/buckets.yaml
@@ -21,3 +21,7 @@ gs://canonical-kubernetes-tests/logs/:
   contact: "chuckbutler"
   prefix: "juju:"
   sequential: false
+gs://canonical-kubernetes-tests/logs-gke/:
+  contact: "vorlonofportland"
+  prefix: "ubuntu:"
+  sequential: false

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1004,6 +1004,8 @@ dashboards:
   dashboard_tab:
   - name: cdk-gce
     test_group_name: canonical-kubernetes-e2e-gce
+  - name: ubuntu-gke
+    test_group_name: ubuntu-gke
 
 - name: kopeio
   dashboard_tab:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -948,6 +948,9 @@ test_groups:
 # Canonical Distribution of Kubernetes (contact: @chuckbutler on github)
 - name: canonical-kubernetes-e2e-gce
   gcs_prefix: canonical-kubernetes-tests/logs/kubernetes-gce-e2e-node
+# Ubuntu GKE (contact: @vorlonofportland on github)
+- name: ubuntu-gke
+  gcs_prefix: canonical-kubernetes-tests/logs-gke/kubernetes-gce-e2e-node
 # kopeio (contact: @justinsb on github)
 - name: kopeio-kubernetes-e2e-aws
   gcs_prefix: kopeio-kubernetes-e2e/logs/kubernetes-e2e-aws


### PR DESCRIPTION
Allow publishing of results for Ubuntu GKE e2e tests (separate from
the juju-managed Canonical Distribution of Kubernetes).