### PR TITLE
Add nodejs and mocha to the pull_kubernetes_bazel image.

### DIFF
--- a/images/pull_kubernetes_bazel/Dockerfile
+++ b/images/pull_kubernetes_bazel/Dockerfile
@@ -30,17 +30,23 @@ RUN apt-get update && apt-get install -y \
     python-pip && \
     apt-get clean
 
-ENV BAZEL_VERSION 0.4.2
+ENV BAZEL_VERSION 0.4.4
 RUN wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     rm "bazel_${BAZEL_VERSION}-linux-x86_64.deb"
 
-ENV GCLOUD_VERSION 138.0.0
+ENV GCLOUD_VERSION 145.0.0
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     tar xf google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     rm google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     ./google-cloud-sdk/install.sh
 ENV PATH "/google-cloud-sdk/bin:${PATH}"
+
+ENV NODE_VERSION 6.10.0
+RUN wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && \
+    tar xf node-v${NODE_VERSION}-linux-x64.tar.xz --strip-components=1 -C /usr && \
+    rm node-v${NODE_VERSION}-linux-x64.tar.xz && \
+    npm install -g mocha
 
 WORKDIR /workspace
 ADD runner /

--- a/images/pull_kubernetes_bazel/Makefile
+++ b/images/pull_kubernetes_bazel/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.9
+VERSION = 0.10
 
 image:
 	docker build -t "gcr.io/k8s-testimages/bazelbuild:$(VERSION)" .

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -347,7 +347,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.9
+      - image: gcr.io/k8s-testimages/bazelbuild:0.10
         args:
         - "--branch=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/logs"
@@ -400,7 +400,7 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.9
+    - image: gcr.io/k8s-testimages/bazelbuild:0.10
       args:
       - "--branch=master"
       - "--upload=gs://kubernetes-jenkins/logs"


### PR DESCRIPTION
Bump bazel (0.4.2->0.4.4) and gcloud (138-145) while we're at it.

Only changes the test-infra jobs for now. Increases image size from 997MB to 1.09GB.