### PR TITLE
Rebuild/bump kubeadm CI image.

### DIFF
--- a/images/ci-kubernetes-e2e-kubeadm/Dockerfile
+++ b/images/ci-kubernetes-e2e-kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170217-47d95907
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170313-9987c745
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/images/ci-kubernetes-e2e-kubeadm/Makefile
+++ b/images/ci-kubernetes-e2e-kubeadm/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.1
+VERSION = 0.2
 
 image:
 	docker build -t "gcr.io/k8s-testimages/e2e-kubeadm:$(VERSION)" .

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -307,7 +307,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.1
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.2
             args:
             - "--branch=$(PULL_REFS)"
             - "--upload=gs://kubernetes-jenkins/logs"


### PR DESCRIPTION
I wanted to rebuild this image to take advantage of some recent merges (https://github.com/kubernetes/test-infra/pull/2094, https://github.com/kubernetes/test-infra/pull/2179, https://github.com/kubernetes/test-infra/pull/2182, https://github.com/kubernetes/test-infra/pull/2183).

Based on my local testing, this should bring the kubeadm e2e job back to green.