### PR TITLE
github: Truncate issue body to 65500 chars

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -700,6 +700,10 @@ func (config *Config) NewIssue(title, body string, labels []string, owner string
 	if owner != "" {
 		assignee = &owner
 	}
+	if len(body) > maxCommentLen {
+		body = body[:maxCommentLen]
+	}
+
 	issue, _, err := config.client.Issues.Create(config.Org, config.Project, &github.IssueRequest{
 		Title:    &title,
 		Body:     &body,


### PR DESCRIPTION
This is similar to e0814bf34 (submit queue: truncate comments at 64k)
but for the body of an issue. We need to truncate or we can raise some
abuse detection mechanism from github.