### PR TITLE
Let janitor also clean up leaking health-checks

### DIFF
--- a/jenkins/janitor.py
+++ b/jenkins/janitor.py
@@ -31,6 +31,7 @@ DEMOLISH_ORDER = [
     Resource('instances', 'zone', None),
     Resource('addresses', 'region', None),
     Resource('disks', 'zone', None),
+    Resource('health-checks', None, None),
     Resource('firewall-rules', None, None),
     Resource('routes', None, None),
     Resource('forwarding-rules', 'region', None),


### PR DESCRIPTION
/assign @MrHohn 

ref https://github.com/kubernetes/kubernetes/issues/38020

If http-health-check and https-health-check are deprecated then I'll leave them along.