### PR TITLE
Fix job config indentation.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -313,33 +313,33 @@ postsubmits:
             - "--upload=gs://kubernetes-jenkins/logs"
             - "--git-cache=/root/.cache/git"
             - "--clean"
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          - name:  JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-private
-          - name:  JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-public
-          volumeMounts:
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/service-account/service-account.json
+            - name:  JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-private
+            - name:  JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-public
+            volumeMounts:
+            - name: service
+              mountPath: /etc/service-account
+              readOnly: true
+            - name: ssh
+              mountPath: /etc/ssh-key-secret
+              readOnly: true
+            - name: cache-ssd
+              mountPath: /root/.cache
+          volumes:
           - name: service
-            mountPath: /etc/service-account
-            readOnly: true
+            secret:
+              secretName: service-account
           - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
+            secret:
+              secretName: ssh-key-secret
+              defaultMode: 0400
           - name: cache-ssd
-            mountPath: /root/.cache
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
-        - name: ssh
-          secret:
-            secretName: ssh-key-secret
-            defaultMode: 0400
-        - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
+            hostPath:
+              path: /mnt/disks/ssd0
 
   kubernetes/test-infra:
   - name: ci-test-infra-bazel


### PR DESCRIPTION
This was regressed in 52910a335, and was causing the environment variables to not be set on the pod.

The diff is a little difficult to read in the web view, but this block just needed to be indented two more spaces. Running `git diff -b HEAD^` (a diff ignoring whitespace changes) has empty output.