### PR TITLE
Shorten cluster name for GCE multizone

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1168,7 +1168,7 @@
 "ci-kubernetes-e2e-gce-multizone": {
   "scenario": "kubernetes_e2e",
   "args": [
-    "--cluster=bootstrap-e2e-gce-multizone",
+    "--cluster=bootstrap-e2e-gce-mz",
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-e2e-gce-multizone.env"
   ]


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/38658

Currently it is trying to create a firewall rule named
bootstrap-e2e-gce-multizone-minion-bootstrap-e2e-gce-multizone-http-alt,
but GCE has a 63 character limit.

With this change, the name should now be
bootstrap-e2e-gce-mz-minion-bootstrap-e2e-gce-mz-http-alt,
which is 57 characters.