### PR TITLE
Fix unbound variable E2E_ZONES in federation soak job

### DIFF
--- a/jobs/ci-kubernetes-soak-gce-federation-test.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.env
@@ -20,6 +20,16 @@ USE_KUBEFED=true
 FEDERATION_UP=false
 FEDERATION_DOWN=false
 
+# Where the clusters will be created.
+E2E_ZONES=us-central1-a us-central1-b us-central1-f
+FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
+
+# TODO: Replace this with FEDERATION_HOST_CLUSTER, but do it in
+# lock steps. First make current the scripts understand the host
+# parameters. Then make the necessary changes to make them more
+# accurate.
+FEDERATION_HOST_CLUSTER_ZONE=us-central1-f
+
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
 GINKGO_PARALLEL=y
 


### PR DESCRIPTION
Federation soak test job is failing in isUp because of E2E_ZONES unbound variable. Fixing it.

cc @madhusudancs 