### PR TITLE
Fix commands.md markdown formatting

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -3,7 +3,7 @@
 `k8s-ci-robot` and `k8s-merge-robot` understand several commands. They should all be uttered on their own line, and they are case-sensitive.
 
 Command | Implemented By | Who can run it | Description
---- | --- | --- | --- | ---
+--- | --- | --- | ---
 `/assign [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | kubernetes org members | Assigns specified people (or yourself if no one is specified)
 `/unassign [@userA @userB @etc]` | prow [assign](./prow/plugins/assign) | kubernetes org members | Unassigns specified people (or yourself if no one is specified)
 `/lgtm` | prow [lgtm](./prow/plugins/lgtm) | assignees | adds the `lgtm` label


### PR DESCRIPTION
I think github changed something in how markdown is rendered, as even previous versions of ./prow/commands.md seem to be malformatted (https://github.com/kubernetes/test-infra/blob/5e75f17f195176b142c647df20bb3b8cac06860b/prow/commands.md)

This should fix the formatting.

https://github.com/kubernetes/test-infra/pull/2126

cc: @spxtr @apelisse