### PR TITLE
Allow concurrent runs of kubeadm e2e job.

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1814,7 +1814,7 @@ class JobTest(unittest.TestCase):
                 continue  # No clean way to determine version
             with open(job_path) as fp:
                 script = fp.read()
-            self.assertNotIn('source ', script, job)
+            self.assertFalse(re.search(r'\Wsource ', script), job)
             self.assertNotIn('\n. ', script, job)
 
     def testAllBashJobsHaveErrExit(self):

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce.sh
@@ -33,12 +33,17 @@ export KUBERNETES_PROVIDER=kubernetes-anywhere
 # succeeded.
 export SCM_VERSION=$(./hack/print-workspace-status.sh | grep ^STABLE_BUILD_SCM_REVISION | cut -d' ' -f2)
 
-export E2E_NAME="e2e-kubeadm-gce"
+export E2E_NAME="e2e-kubeadm-${BUILD_NUMBER:-0}"
 export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path /workspace/kubernetes-anywhere"
 export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}"
 # The gs:// path given here should match jobs/ci-kubernetes-bazel-build.sh
 export E2E_OPT+=" --kubernetes-anywhere-kubeadm-version gs://kubernetes-release-dev/bazel/${SCM_VERSION}/build/debs/"
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
+
+# Resource leak detection is disabled because prow runs multiple instances of
+# this job in the same project concurrently, and resource leak detection will
+# make the job flaky.
+export FAIL_ON_GCP_RESOURCE_LEAK="false"
 
 ### post-env
 


### PR DESCRIPTION
Since resources are named using this cluster name, include the `BUILD_NUMBER` so it should differ between multiple concurrent prow runs in the same project.

Here's an example of one such failure, complaining about resources already existing: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce/503?log#log