### PR TITLE
Run kubeadm e2e job during pulls

### DIFF
--- a/jobs/pull-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/pull-kubernetes-e2e-kubeadm-gce.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+readonly testinfra="$(dirname "${0}")/.."
+
+### builder
+
+### job-env
+
+export PROJECT="k8s-jkns-e2e-kubeadm-gce-ci"
+export KUBERNETES_PROVIDER=kubernetes-anywhere
+
+# This job only runs against the kubernetes repo, and bootstrap.py leaves the
+# current working directory at the repository root. Grab the SCM_REVISION so we
+# can use the .debs built during the bazel-build job that should have already
+# succeeded.
+export SCM_VERSION=$(./hack/print-workspace-status.sh | grep ^STABLE_BUILD_SCM_REVISION | cut -d' ' -f2)
+
+export E2E_NAME="e2e-kubeadm-${BUILD_NUMBER:-0}"
+export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path /workspace/kubernetes-anywhere"
+export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}"
+# The gs:// path given here should match jobs/ci-kubernetes-bazel-build.sh
+export E2E_OPT+=" --kubernetes-anywhere-kubeadm-version gs://kubernetes-release-dev/bazel/${SCM_VERSION}/build/debs/"
+export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
+
+# Resource leak detection is disabled because prow runs multiple instances of
+# this job in the same project concurrently, and resource leak detection will
+# make the job flaky.
+export FAIL_ON_GCP_RESOURCE_LEAK="false"
+
+### post-env
+
+# Assume we're upping, testing, and downing a cluster
+export E2E_UP="${E2E_UP:-true}"
+# TODO(pipejakob): Reenable testing when we have a pod network that works with
+#     kubeadm 1.6 clusters. For now, simply bringing up a cluster is a good e2e
+#     test, since it will only succeed if the apiserver is healthy and all
+#     expected nodes are registered.
+export E2E_TEST="false"
+export E2E_DOWN="${E2E_DOWN:-true}"
+
+# Skip gcloud update checking
+export CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
+# Use default component update behavior
+export CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
+
+# Get golang into our PATH so we can run e2e.go
+export PATH="${PATH}:/usr/local/go/bin"
+
+# After post-env
+export GINKGO_PARALLEL="y"
+
+### Runner
+readonly runner="/workspace/e2e-runner.sh"
+export DOCKER_TIMEOUT="140m"
+export KUBEKINS_TIMEOUT="120m"
+"${runner}"

--- a/jobs/pull-kubernetes-e2e-kubeadm-gce.sh
+++ b/jobs/pull-kubernetes-e2e-kubeadm-gce.sh
@@ -24,7 +24,7 @@ readonly testinfra="$(dirname "${0}")/.."
 
 ### job-env
 
-export PROJECT="k8s-jkns-e2e-kubeadm-gce-ci"
+export PROJECT="k8s-jkns-pr-kubeadm"
 export KUBERNETES_PROVIDER=kubernetes-anywhere
 
 # This job only runs against the kubernetes repo, and bootstrap.py leaves the
@@ -36,7 +36,7 @@ export SCM_VERSION=$(./hack/print-workspace-status.sh | grep ^STABLE_BUILD_SCM_R
 export E2E_NAME="e2e-kubeadm-${BUILD_NUMBER:-0}"
 export E2E_OPT="--deployment kubernetes-anywhere --kubernetes-anywhere-path /workspace/kubernetes-anywhere"
 export E2E_OPT+=" --kubernetes-anywhere-phase2-provider kubeadm --kubernetes-anywhere-cluster ${E2E_NAME}"
-# The gs:// path given here should match jobs/ci-kubernetes-bazel-build.sh
+# The gs:// path given here should match jobs/pull-kubernetes-bazel.sh
 export E2E_OPT+=" --kubernetes-anywhere-kubeadm-version gs://kubernetes-release-dev/bazel/${SCM_VERSION}/build/debs/"
 export GINKGO_TEST_ARGS="--ginkgo.focus=\[Conformance\]"
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -77,6 +77,48 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+    run_after_success:
+    - name: pull-kubernetes-e2e-kubeadm-gce
+      context: Jenkins kubeadm e2e
+      always_run: false
+      skip_report: true
+      rerun_command: "@k8s-bot kubeadm e2e test this"
+      trigger: "@k8s-bot (kubeadm e2e )?test this"
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.2
+          args:
+          - "--pull=$(PULL_REFS)"
+          - "--upload=gs://kubernetes-jenkins/pr-logs"
+          - "--git-cache=/root/.cache/git"
+          - "--clean"
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name:  JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name:  JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: ssh
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-cross
     context: Jenkins Cross Build


### PR DESCRIPTION
I'm looking for early feedback on making sure I'm doing this safely, and any testing I can do ahead of time to make sure it works as expected.

 - I want this new job to be exercised on incoming PRs, but not actually block them
 - I've tested the job itself locally, but not the actual prow config for it (can I?)
 - I know that this is a lot of duplication between the jobs, but there's a separate TODO to migrate it to a scenario instead

I've broken this change up into two commits so it's easy to see the diff of the new pull job compared to the original CI job.

CC @spxtr 