### PR TITLE
Add kubeadm GCE e2e tests to google-gce tab.

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1246,6 +1246,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-ha-master
   - name: gce-taint-evict
     test_group_name: kubernetes-e2e-gce-taint-evict
+  - name: gce-kubeadm
+    test_group_name: kubernetes-e2e-kubeadm-gce
 
 # "google-gci-dev" is a tab for tests that are used for GCI(aka COS) image
 # development and qualification. It should not be confused with the "google-gci"


### PR DESCRIPTION
So far, these have been hidden away in "misc" due to instability, but I want them to be more easily findable and prominent so failures go noticed.