### PR TITLE
Add --stage-suffix flag to kubetest

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -88,6 +88,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.save, "save", "", "Save credentials to gs:// path on --up if set (or load from there if not --up)")
 	flag.BoolVar(&o.skew, "skew", false, "If true, run tests in another version at ../kubernetes/hack/e2e.go")
 	flag.Var(&o.stage, "stage", "Upload binaries to gs://bucket/devel/job-suffix if set")
+	flag.StringVar(&o.stage.versionSuffix, "stage-suffix", "", "Append suffix to staged version when set")
 	flag.BoolVar(&o.test, "test", false, "Run Ginkgo tests.")
 	flag.StringVar(&o.testArgs, "test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
 	flag.DurationVar(&timeout, "timeout", time.Duration(0), "Terminate testing after the timeout duration (s/m/h)")

--- a/kubetest/stage.go
+++ b/kubetest/stage.go
@@ -25,9 +25,10 @@ import (
 )
 
 type stageStrategy struct {
-	bucket string
-	ci     bool
-	suffix string
+	bucket        string
+	ci            bool
+	gcsSuffix     string
+	versionSuffix string
 }
 
 // Return something like gs://bucket/ci/suffix
@@ -36,7 +37,7 @@ func (s *stageStrategy) String() string {
 	if s.ci {
 		p = "ci"
 	}
-	return fmt.Sprintf("%v%v%v", s.bucket, p, s.suffix)
+	return fmt.Sprintf("%v%v%v", s.bucket, p, s.gcsSuffix)
 }
 
 // Parse bucket, ci, suffix from gs://BUCKET/ci/SUFFIX
@@ -48,7 +49,7 @@ func (s *stageStrategy) Set(value string) error {
 	}
 	s.bucket = mat[1]
 	s.ci = mat[2] == "ci"
-	s.suffix = mat[3]
+	s.gcsSuffix = mat[3]
 	return nil
 }
 
@@ -73,8 +74,11 @@ func (s *stageStrategy) Stage() error {
 	if s.ci {
 		args = append(args, "--ci")
 	}
-	if len(s.suffix) > 0 {
-		args = append(args, fmt.Sprintf("--gcs-suffix=%v", s.suffix))
+	if len(s.gcsSuffix) > 0 {
+		args = append(args, fmt.Sprintf("--gcs-suffix=%v", s.gcsSuffix))
+	}
+	if len(s.versionSuffix) > 0 {
+		args = append(args, fmt.Sprintf("--version-suffix=%s", s.versionSuffix))
 	}
 	if os.Getenv("FEDERATION") == "true" {
 		args = append(args, "--federation")


### PR DESCRIPTION
ref https://github.com/kubernetes/release/pull/286

`kubetest --stage=S --stage-suffix=X` gets piped into `release/push-build.sh --version-suffix=X` and allows `kubetest` to support staging for GKE pull jobs.

/assign @ixdy @rmmh @krzyzacy 