### PR TITLE
[Federation] Fix federation soak deploy job to bringup federation

### DIFF
--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.env
@@ -24,6 +24,6 @@ FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 # accurate.
 FEDERATION_HOST_CLUSTER_ZONE=us-central1-f
 
-FEDERATION_DNS_ZONE_NAME=test-f8n.k8s.io.
+FEDERATION_DNS_ZONE_NAME=soak.test-f8n.k8s.io.
 
 KUBEKINS_TIMEOUT=90m

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.env
@@ -14,6 +14,9 @@ KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 FEDERATION=true
 USE_KUBEFED=true
 
+FEDERATION_UP=true
+FEDERATION_DOWN=false
+
 # Where the clusters will be created.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
 FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f


### PR DESCRIPTION
federation soak deploy job is not bringing up federation control plane. On examination, i found that even when FEDERATION env variable is true, it is not getting reflected in e2e-runner.sh, which in turn would have set FEDERATION_UP to true. here is the reference to [code](https://github.com/kubernetes/test-infra/blob/master/jenkins/e2e-image/e2e-runner.sh#L46)

this pr does following:
- setting FEDERATION_UP explicitly to true in soak deploy job.
- fix dns zone used for soak deploy job (Copy/Paste mistake)
~~- print line no is (e2e-runner.sh) shell script to aid debugging.~~

cc @madhusudancs 