### PR TITLE
Add line no for xtrace output to aid debugging in e2e-runner.sh

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -20,6 +20,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
 # Have cmd/e2e run by goe2e.sh generate JUnit report in ${WORKSPACE}/junit*.xml
 ARTIFACTS=${WORKSPACE}/_artifacts
 mkdir -p ${ARTIFACTS}


### PR DESCRIPTION
The bash output in logs is little confusing and could not exactly figure out which line being output.
So adding a line numbers and function name to xtrace output to aid debugging.

cc @madhusudancs @fejta 