### PR TITLE
Create GCE-CVM and GKE-GCI 1.6->1.5 downgrade jobs

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -63,7 +63,11 @@ e2e_go_args=( \
 # For upgrades, PUBLISHED_SKEW should be a new release than PUBLISHED.
 if [[ -n "${JENKINS_PUBLISHED_SKEW_VERSION:-}" ]]; then
   e2e_go_args+=(--extract="${JENKINS_PUBLISHED_SKEW_VERSION}")
-  if [[ "${JENKINS_USE_SKEW_TESTS:-}" != "true" ]]; then
+  # Assume JENKINS_USE_SKEW_KUBECTL == true for backward compatibility
+  : ${JENKINS_USE_SKEW_KUBECTL:=true}
+  if [[ "${JENKINS_USE_SKEW_TESTS:-}" == "true" ]]; then
+    e2e_go_args+=(--skew)  # Get kubectl as well as test code from kubernetes_skew
+  elif [[ "${JENKINS_USE_SKEW_KUBECTL}" == "true" ]]; then
     # Append kubectl-path of skewed kubectl to test args, since we always
     # want that to use the skewed kubectl version:
     #  - for upgrade jobs, we want kubectl to be at the same version as
@@ -71,8 +75,6 @@ if [[ -n "${JENKINS_PUBLISHED_SKEW_VERSION:-}" ]]; then
     #  - for client skew tests, we want to use the skewed kubectl
     #    (that's what we're testing).
     GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/kubernetes_skew/cluster/kubectl.sh"
-  else
-    e2e_go_args+=(--skew)  # Get kubectl as well as test code from kubernetes_skew
   fi
 fi
 

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -1742,6 +1742,12 @@
         timeout: 920
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
+    - kubernetes-e2e-gce-1.6-1.5-downgrade-cluster:
+        job-name: ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster
+        jenkins-timeout: 420
+        timeout: 320
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
 
     ### kubernetes-e2e-upgrades-gce-cross-image-and-gci #mtaufen
     - kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master:
@@ -2532,6 +2538,12 @@
         job-name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
         jenkins-timeout: 1020
         timeout: 920
+        frequency: 'H/5 * * * *' # At least every 30m
+        trigger-job: ''
+    - kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster:
+        job-name: ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster
+        jenkins-timeout: 420
+        timeout: 320
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: ''
 

--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
@@ -1,0 +1,15 @@
+# Create cluster at 1.6, downgrade to 1.5 using 1.6 e2e test binary and kubectl
+# but 1.5 cluster downgrade script
+E2E_OPT=--check_version_skew=false
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=k8s-gce-dg-1-6-1-5-dwngr-clu
+
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_KUBECTL=false
+JENKINS_USE_SKEW_TESTS=false
+
+# Rather than downgrading and then running e2e tests, just downgrade.
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --gce-upgrade-script=../kubernetes_skew/cluster/gce/upgrade.sh
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster.env
@@ -1,0 +1,17 @@
+# Create cluster at 1.6, downgrade to 1.5 using 1.6 e2e test binary and kubectl
+E2E_OPT=--check_version_skew=false
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=k8s-gke-dg-g1-6-g1-5-dwngr-clu
+
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
+JENKINS_USE_SKEW_KUBECTL=false
+JENKINS_USE_SKEW_TESTS=false
+
+# Rather than downgrading and then running e2e tests, just downgrade.
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4088,5 +4088,21 @@
     "--env-file=platforms/gke.env",
     "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env"
   ]
+},
+
+"ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env"
+  ]
+},
+
+"ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--env-file=platforms/gke.env",
+    "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster.env"
+  ]
 }
 }

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -999,6 +999,11 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
 - name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master
+# 1.6 downgrade
+- name: ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster
+- name: ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster
 # Manual, federated groups
 # bazel, run on prow
 - name: ci-kubernetes-bazel-build
@@ -2114,6 +2119,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new
   - name: gke-gci-1.5-gci-1.6-upgrade-master
     test_group_name: ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master
+  - name: gce-1.6-1.5-downgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster
+  - name: gke-gci-1.6-gci-1.5-downgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster
 
 - name: release-1.5-all
   dashboard_tab:


### PR DESCRIPTION
I basically just copied the configurations for the corresponding upgrade-cluster jobs and inverted the arguments. I hope that's all I need to do.

GCP projects have not yet been created.