### PR TITLE
Ignore DumpClusterLogs errors during --up failures, increase gce-serial timeout

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -129,8 +129,8 @@
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-serial:
         job-name: ci-kubernetes-e2e-gce-serial
-        jenkins-timeout: 420
-        timeout: 320
+        jenkins-timeout: 620
+        timeout: 520
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-reboot:

--- a/jobs/ci-kubernetes-e2e-gce-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial.env
@@ -3,4 +3,4 @@ GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\
 PROJECT=kubernetes-jkns-e2e-gce-serial
 KUBE_NODE_OS_DISTRIBUTION=debian
 
-KUBEKINS_TIMEOUT=300m
+KUBEKINS_TIMEOUT=500m

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -97,8 +97,13 @@ func run(deploy deployer, o options) error {
 		// Start the cluster using this version.
 		if err := xmlWrap("Up", deploy.Up); err != nil {
 			if o.dump != "" {
-				xmlWrap("DumpClusterLogs", func() error {
-					return DumpClusterLogs(o.dump)
+				xmlWrap("DumpClusterLogs (--up failed)", func() error {
+					// This frequently means the cluster does not exist.
+					// Thus DumpClusterLogs() typically fails.
+					// Therefore always return null for this scenarios.
+					// TODO(fejta): report a green E in testgrid if it errors.
+					DumpClusterLogs(o.dump)
+					return nil
 				})
 			}
 			return fmt.Errorf("starting e2e cluster: %s", err)


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/issues/43155 https://github.com/kubernetes/kubernetes/issues/43153

When `--up` fails this usually means we did not start the cluster. Therefore `DumpClusterLogs()` will also fail, although sometimes it captures partial resources so we still want it to run.

Testgrid [shows](https://k8s-testgrid.appspot.com/google-gce#gce-serial&graph-metrics=test-duration-minutes) that passing runs for gce-serial require just under 300 minutes. At 300 minutes we terminate the suite.

Increasing the timeout to give it some room to breathe

/assign @ethernetdan 

