### PR TITLE
Use absolute path to skew upgrade script in 1.6-1.5 downgrade job

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
@@ -10,6 +10,6 @@ JENKINS_USE_SKEW_KUBECTL=false
 JENKINS_USE_SKEW_TESTS=false
 
 # Rather than downgrading and then running e2e tests, just downgrade.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --gce-upgrade-script=../kubernetes_skew/cluster/gce/upgrade.sh
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --gce-upgrade-script=/workspace/kubernetes_skew/cluster/gce/upgrade.sh
 
 KUBEKINS_TIMEOUT=300m


### PR DESCRIPTION
It seems like relative paths don't work correctly, or at least I don't know what the cwd is when e2e tests run.