### PR TITLE
Let kubetest talk with boskos instead

### DIFF
--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -19,6 +19,7 @@ go_library(
     srcs = [
         "anywhere.go",
         "bash.go",
+        "boskos.go",
         "build.go",
         "e2e.go",
         "extract.go",

--- a/kubetest/boskos.go
+++ b/kubetest/boskos.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func renew(proj string) error {
+	resp, err := http.Get(fmt.Sprintf("http://boskos/request?name=%v&duration=5m", proj))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Status %s, StatusCode %v", resp.Status, resp.StatusCode)
+	}
+	return nil
+}
+
+func returnProj(proj string) error {
+	resp, err := http.Get(fmt.Sprintf("http://boskos/request?name=%v", proj))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Status %s, StatusCode %v", resp.Status, resp.StatusCode)
+	}
+	return nil
+}
+
+func requestProj() (string, error) {
+	resp, err := http.Get(fmt.Sprintf("http://boskos/request?type=free&duration=5m"))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 204 {
+		log.Print("No available projects, retrying in 30sec.")
+		time.Sleep(30 * time.Second)
+		return "", nil
+	} else if resp.StatusCode == 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+
+		type GCPProject struct {
+			// This need to be consistent with boskos
+			Name     string        `json:"name"`
+			Owner    string        `json:"owner"`
+			Duration time.Duration `json:"duration"`
+			Start    time.Time     `json:"start"`
+		}
+		var p = new(GCPProject)
+		err = json.Unmarshal(body, &p)
+		if err != nil {
+			return "", err
+		}
+		return p.Name, nil
+	} else {
+		return "", fmt.Errorf("Status %s, StatusCode %v", resp.Status, resp.StatusCode)
+	}
+}
+
+func boskos(lease time.Duration) (string, error) {
+
+	var proj string
+	for i := 0; i < 3; i++ {
+		proj, err := requestProj()
+		if err != nil {
+			return "", err
+		}
+		if proj != "" {
+			break
+		}
+		return "", fmt.Errorf("No available projects")
+	}
+
+	go func(proj string, lease time.Duration) {
+		sigs := make(chan os.Signal, 1)
+		leaseChan := time.NewTimer(lease).C
+		tickChan := time.NewTicker(time.Minute * 4).C // Give 1 min overhead
+
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+		for {
+			select {
+			case <-tickChan:
+				log.Print("Renew lease for another 5min")
+				renew(proj)
+			case <-leaseChan:
+				log.Print("Lease timed up")
+				returnProj(proj)
+				return
+			case <-sigs:
+				log.Printf("Terminated : sig %v", sigs)
+				returnProj(proj)
+				return
+			}
+		}
+	}(proj, lease)
+
+	return proj, nil
+}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -34,12 +34,12 @@ import (
 
 var (
 	artifacts             = initPath("./_artifacts")
+	deprecatedVersionSkew = flag.Bool("check_version_skew", true, "Verify client and server versions match")
 	interrupt             = time.NewTimer(time.Duration(0)) // interrupt testing at this time.
 	kubetestPath          = initPath(os.Args[0])
 	terminate             = time.NewTimer(time.Duration(0)) // terminate testing at this time.
-	verbose               = false
 	timeout               = time.Duration(0)
-	deprecatedVersionSkew = flag.Bool("check_version_skew", true, "Verify client and server versions match")
+	verbose               = false
 )
 
 // Joins os.Getwd() and path
@@ -396,9 +396,19 @@ func installGcloud(tarball string, location string) error {
 
 func prepareGcp(kubernetesProvider string) error {
 	// Ensure project is set
+	var err error
 	p := os.Getenv("PROJECT")
 	if p == "" {
-		return fmt.Errorf("KUBERNETES_PROVIDER=%s requires setting PROJECT", kubernetesProvider)
+		log.Printf("K8s provider: %v, PROJECT not set, will make a lease from boskos.", kubernetesProvider)
+		p, err = boskos(timeout)
+		if err != nil {
+			return fmt.Errorf("[boskos] Fail to request project - %v", err)
+		}
+	}
+
+	// set current project
+	if err := finishRunning(exec.Command("gcloud", "config", "set", "project", p)); err != nil {
+		return err
 	}
 
 	// gcloud creds may have changed


### PR DESCRIPTION
Let kubetest get a spare GCP project from boskos service, if one is not specified.

An alternative of https://github.com/kubernetes/test-infra/pull/2242
/assign @fejta 
take your pick :-)