### PR TITLE
Added log exporter tool for uploading k8s cluster logs directly to GCS

### DIFF
--- a/logexporter/Makefile
+++ b/logexporter/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROJECT = google-containers
+IMG = gcr.io/$(PROJECT)/logexporter
+TAG = test
+
+.PHONY: build push
+
+all: build
+
+cmd/logexporter: cmd/main.go
+	CGO_ENABLED=0 go build -o cmd/logexporter k8s.io/test-infra/logexporter/cmd
+
+build: cmd/logexporter
+	docker build --pull -t $(IMG):$(TAG) cmd
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	rm cmd/logexporter
+	@echo Built $(IMG):$(TAG) and tagged with latest
+
+push: build
+	gcloud docker -- push $(IMG):$(TAG)
+	gcloud docker -- push $(IMG):latest
+	@echo Pushed $(IMG) with :latest and :$(TAG) tags

--- a/logexporter/README.md
+++ b/logexporter/README.md
@@ -1,0 +1,32 @@
+# LogExporter
+
+LogExporter is a tool that runs post-test on our kubernetes test clusters.
+It does the job of computing the set of logfiles to be exported (based on the
+node type (master/node), cloud provider, and the node's system services),and
+then actually exports them to the GCS path provided to it.
+
+## How to run the tool?
+
+Before running the tool on any node, create a secret with the gcloud service account credentials:
+1. Prepare service-account.json file (that should have write access to specified GCS path)
+2. `kubectl create secret generic logexporter-service-account --from-file=service-account.json=/path/to/service-account.json`
+
+To run the tool as a pod on a single node:
+3. Fill in the template with environment variable values in cluster/pod.yaml
+4. `kubectl create -f pod.yaml` (for master, run this as a static pod or set nodeName field in the podspec)
+
+To run the tool as a run-to-completion job on an entire k8s cluster (we ensure exactly 1 logexporter pod runs per node using hard inter-pod anti-affinity):
+3. Fill in the template with environment variable values in cluster/job.yaml
+4. `kubectl create -f job.yaml`
+
+## Why not other logging tools?
+
+Open source logging tools like Elasticsearch, Fluentd and Kibana are mostly centred
+around taking in a stream of logs, adding metadata to them, creating individual log
+entries that are then indexable/searchable/visualizable. We do not want all this
+complicated machinery around the logfiles. Firstly because we don't want to affect
+the performance of our tests depending on custom logging tools which can significantly
+change from one to another. Secondly, a simple multi-threaded file block upload to GCS
+(like this tool does) performs way faster than streaming log entries. Finally, having
+logs as files on GCS fits into our current test-infra framework, while using these
+tools would make log retrieval an API-oriented process, an unneeded complexity.

--- a/logexporter/cluster/job.yaml
+++ b/logexporter/cluster/job.yaml
@@ -1,0 +1,67 @@
+# Template job config for running the log exporter on a whole kubernetes cluster.
+# We ensure that exactly one logexporter pod runs per node using hard inter-pod anti-affinity.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: logexporter
+spec:
+  completions: {{.NumNodes}}
+  parallelism: {{.NumNodes}}
+  template:
+    metadata:
+      labels:
+        app: logexporter
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - logexporter
+            topologyKey: kubernetes.io/hostname
+      restartPolicy: OnFailure
+      containers:
+      - name: logexporter-test
+        image: gcr.io/google-containers/logexporter:latest
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        command:
+        - logexporter
+        - --node-name=$(NODE_NAME)
+        - --cloud-provider={{.CloudProvider}}
+        - --gcs-path={{.GCSPath}}
+        - --gcloud-auth-file-path={{.GcloudAuthFilePath}}
+        - --enable-hollow-node-logs={{.EnableHollowNodeLogs}}
+        - --sleep-duration={{.SleepDuration}}
+        - --alsologtostderr
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /var/log
+          name: varlog
+          readOnly: true
+        - mountPath: /workspace/etc
+          name: hostetc
+          readOnly: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      volumes:
+      - name: service
+        secret:
+          secretName: "logexporter-service-account"
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: hostetc
+        hostPath:
+          path: /etc

--- a/logexporter/cluster/pod.yaml
+++ b/logexporter/cluster/pod.yaml
@@ -1,0 +1,49 @@
+# Template pod config for running the log exporter pod on a kubernetes node/master.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: logexporter
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: logexporter-test
+    image: gcr.io/google-containers/logexporter:latest
+    env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    command:
+    - logexporter
+    - --node-name=$(NODE_NAME)
+    - --cloud-provider={{.CloudProvider}}
+    - --gcs-path={{.GCSPath}}
+    - --gcloud-auth-file-path={{.GcloudAuthFilePath}}
+    - --enable-hollow-node-logs={{.EnableHollowNodeLogs}}
+    - --sleep-duration={{.SleepDuration}}
+    - --alsologtostderr
+    volumeMounts:
+    - mountPath: /etc/service-account
+      name: service
+      readOnly: true
+    - mountPath: /var/log
+      name: varlog
+      readOnly: true
+    - mountPath: /workspace/etc
+      name: hostetc
+      readOnly: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 10Mi
+  volumes:
+  - name: service
+    secret:
+      secretName: "logexporter-service-account"
+  - name: varlog
+    hostPath:
+      path: /var/log
+  - name: hostetc
+    hostPath:
+      path: /etc

--- a/logexporter/cmd/Dockerfile
+++ b/logexporter/cmd/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file builds an image for the log exporter tool. For more info,
+# have a look at the tool's README.md file.
+
+FROM fedora
+MAINTAINER Shyam Jeedigunta <shyamjvs@google.com>
+
+# Setup gcloud SDK for using gsutil.
+RUN dnf -y -q install which
+RUN dnf -y -q install python27
+ADD ["https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz", \
+     "/workspace/"]
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
+    /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false && \
+    gcloud info | tee /workspace/gcloud-info.txt
+
+# Setup the log exporter script.
+ADD ["logexporter", "/workspace/"]
+WORKDIR "/workspace"
+
+ENTRYPOINT ["/workspace/logexporter"]

--- a/logexporter/cmd/main.go
+++ b/logexporter/cmd/main.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO(shyamjvs): Make this exporter work for master too, currently facing
+// gcloud auth error when run from within a pod on the master.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// Initialize the log exporter's configuration related flags.
+var (
+	nodeName             = flag.String("node-name", "", "Name of the node this log exporter is running on")
+	gcsPath              = flag.String("gcs-path", "", "Path to the GCS directory under which to upload logs, for eg: gs://my-logs-bucket/logs")
+	cloudProvider        = flag.String("cloud-provider", "", "Cloud provider for this node (gce/gke/aws/kubemark/..)")
+	gcloudAuthFilePath   = flag.String("gcloud-auth-file-path", "/etc/service-account/service-account.json", "Path to gcloud service account file, for authenticating gsutil to write to GCS bucket")
+	enableHollowNodeLogs = flag.Bool("enable-hollow-node-logs", false, "Enable uploading hollow node logs too. Relevant only for kubemark nodes")
+	sleepDuration        = flag.Duration("sleep-duration", 60*time.Second, "Duration to sleep before exiting with success. Useful for making pods schedule with hard anti-affinity when run as a job on a k8s cluster")
+)
+
+var (
+	localLogPath = "/var/log"
+
+	// Node-type specific logfiles.
+	// Currently we only handle nodes, and neglect master.
+	nodeLogs = []string{"kube-proxy", "node-problem-detector", "fluentd"}
+
+	// Cloud provider specific logfiles.
+	awsLogs      = []string{"cloud-init-output"}
+	gceLogs      = []string{"startupscript"}
+	kubemarkLogs = []string{}
+
+	// System services/kernel related logfiles.
+	kernelLog            = "kern"
+	initdLogs            = []string{"docker"}
+	supervisordLogs      = []string{"kubelet", "supervisor/supervisord", "supervisor/kubelet-stdout", "supervisor/kubelet-stderr", "supervisor/docker-stdout", "supervisor/docker-stderr"}
+	systemdServices      = []string{"kern", "kubelet", "docker"}
+	systemdSetupServices = []string{"kube-node-installation", "kube-node-configuration"}
+	nodeSystemdServices  = []string{"node-problem-detector"}
+)
+
+// Check if the config provided through the flags take valid values.
+func checkConfigValidity() error {
+	glog.Infof("Verifying if a valid config has been provided through the flags")
+	if *nodeName == "" {
+		return fmt.Errorf("Flag --node-name has its value unspecified")
+	}
+	if *gcsPath == "" {
+		return fmt.Errorf("Flag --gcs-path has its value unspecified")
+	}
+	if _, err := os.Stat(*gcloudAuthFilePath); err != nil {
+		return fmt.Errorf("Could not find the gcloud service account file: %v", err)
+	} else {
+		cmd := exec.Command("gcloud", "auth", "activate-service-account", "--key-file="+*gcloudAuthFilePath)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("Failed to activate gcloud service account: %v", err)
+		}
+	}
+	return nil
+}
+
+// Create logfile for systemd service in outputDir with the given journalctl outputMode.
+func createSystemdLogfile(service string, outputMode string, outputDir string) error {
+	// Generate the journalctl command.
+	journalCmdArgs := []string{fmt.Sprintf("--output=%v", outputMode), "-D", "/var/log/journal"}
+	if service == "kern" {
+		journalCmdArgs = append(journalCmdArgs, "-k")
+	} else {
+		journalCmdArgs = append(journalCmdArgs, "-u", fmt.Sprintf("%v.service", service))
+	}
+	cmd := exec.Command("journalctl", journalCmdArgs...)
+
+	// Run the command and record the output to a file.
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("Journalctl command for '%v' service failed: %v", service, err)
+	}
+	logfile := filepath.Join(outputDir, service+".log")
+	if err := ioutil.WriteFile(logfile, output, 0444); err != nil {
+		return fmt.Errorf("Writing to file of journalctl logs for '%v' service failed: %v", service, err)
+	}
+	return nil
+}
+
+// Create logfiles for systemd services in outputDir.
+func createSystemdLogfiles(outputDir string) {
+	services := append(systemdServices, nodeSystemdServices...)
+	for _, service := range services {
+		if err := createSystemdLogfile(service, "cat", outputDir); err != nil {
+			glog.Warningf("Failed to record journalctl logs: %v", err)
+		}
+	}
+	// Service logs specific to VM setup.
+	for _, service := range systemdSetupServices {
+		if err := createSystemdLogfile(service, "short-precise", outputDir); err != nil {
+			glog.Warningf("Failed to record journalctl logs: %v", err)
+		}
+	}
+}
+
+// Copy logfiles specific to this node based on the cloud-provider, system services, etc
+// to a temporary directory. Also create logfiles for systemd services if journalctl is present.
+// We do not expect this function to see an error.
+func prepareLogfiles(logDir string) {
+	glog.Infof("Preparing logfiles relevant to this node")
+	logfiles := nodeLogs[:]
+
+	switch *cloudProvider {
+	case "gce", "gke":
+		logfiles = append(logfiles, gceLogs...)
+	case "kubemark":
+		// TODO(shyamjvs): Pick logs based on kubemark's real provider.
+		logfiles = append(logfiles, gceLogs...)
+		if *enableHollowNodeLogs {
+			logfiles = append(logfiles, kubemarkLogs...)
+		}
+	case "aws":
+		logfiles = append(logfiles, awsLogs...)
+	default:
+		glog.Errorf("Unknown cloud provider '%v' provided, skipping any provider specific logs", *cloudProvider)
+	}
+
+	// Select system/service specific logs.
+	if _, err := os.Stat("/workspace/etc/systemd/journald.conf"); err == nil {
+		glog.Infof("Journalctl found on host. Collecting systemd logs")
+		createSystemdLogfiles(logDir)
+	} else {
+		glog.Infof("Journalctl not found on host (%v). Collecting supervisord logs instead", err)
+		logfiles = append(logfiles, kernelLog)
+		logfiles = append(logfiles, initdLogs...)
+		logfiles = append(logfiles, supervisordLogs...)
+	}
+
+	// Copy all the logfiles that exist, to logDir.
+	for _, logfile := range logfiles {
+		logfileFullPath := filepath.Join(localLogPath, logfile+".log*") // Append .log* to copy rotated logs too.
+		cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("cp %v %v", logfileFullPath, logDir))
+		if err := cmd.Run(); err != nil {
+			glog.Warningf("Failed to copy any logfiles with pattern '%v': %v", logfileFullPath, err)
+		}
+	}
+}
+
+func uploadLogfilesToGCS(logDir string) error {
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("ls %v/*", logDir))
+	if output, err := cmd.Output(); err != nil {
+		return fmt.Errorf("Could not list any logfiles: %v", err)
+	} else {
+		glog.Infof("List of logfiles available: %v", string(output))
+	}
+
+	gcsLogPath := *gcsPath + "/" + *nodeName
+	glog.Infof("Uploading logfiles to GCS at path '%v'", gcsLogPath)
+	var err error
+	for uploadAttempt := 0; uploadAttempt < 3; uploadAttempt++ {
+		// Upload the files with compression (-z) and parallelism (-m) for speeding
+		// up, and set their ACL to make them publicly readable.
+		cmd := exec.Command("gsutil", "-m", "-q", "cp", "-a", "public-read", "-c",
+			"-z", "log,txt,xml", logDir+"/*", gcsLogPath)
+		if err = cmd.Run(); err != nil {
+			glog.Errorf("Attempt %v to upload to GCS failed: %v", uploadAttempt, err)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("Multiple attempts of gsutil failed, the final one due to: %v", err)
+}
+
+func main() {
+	flag.Parse()
+	if err := checkConfigValidity(); err != nil {
+		glog.Fatalf("Bad config provided: %v", err)
+	}
+
+	localTmpLogPath, err := ioutil.TempDir("/tmp", "k8s-systemd-logs")
+	if err != nil {
+		glog.Fatalf("Could not create temporary dir locally for copying logs: %v", err)
+	}
+	defer os.RemoveAll(localTmpLogPath)
+
+	prepareLogfiles(localTmpLogPath)
+	if err := uploadLogfilesToGCS(localTmpLogPath); err != nil {
+		glog.Fatalf("Could not upload logs to GCS: %v", err)
+	}
+	glog.Infof("Logs successfully uploaded")
+
+	glog.Infof("Entering sleep for a duration of %v seconds", *sleepDuration)
+	time.Sleep(*sleepDuration)
+}


### PR DESCRIPTION
This tool would help save time in our tests (currently ~4 hours for 2000 node tests) by making nodes in the cluster upload logs to GCS directly rather than first copying them over to the Jenkins node (through scp) and then uploading to GCS from there. For more info, read the README.md file. This PR would be followed up with another one to make this the logging option for our tests.
Thanks @crassirostris for discussing how this approach is better than existing open source logging tools.

cc @kubernetes/sig-scalability-misc @kubernetes/sig-testing-misc @wojtek-t @gmarek @fejta