### PR TITLE
Trigger release-1.3 jobs only once per day

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -415,50 +415,50 @@
         job-name: ci-kubernetes-e2e-gce-release-1.3
         jenkins-timeout: 170
         timeout: 70
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gce-reboot-release-1.3:
         job-name: ci-kubernetes-e2e-gce-reboot-release-1.3
         jenkins-timeout: 300
         timeout: 200
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gce-slow-release-1.3:
         job-name: ci-kubernetes-e2e-gce-slow-release-1.3
         jenkins-timeout: 270
         timeout: 170
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gce-serial-release-1.3:
         job-name: ci-kubernetes-e2e-gce-serial-release-1.3
         jenkins-timeout: 420
         timeout: 320
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     # gci-gce-1.3
     - kubernetes-e2e-gci-gce-release-1.3:
         job-name: ci-kubernetes-e2e-gci-gce-release-1.3
         jenkins-timeout: 170
         timeout: 70
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gci-gce-reboot-release-1.3:
         job-name: ci-kubernetes-e2e-gci-gce-reboot-release-1.3
         jenkins-timeout: 300
         timeout: 200
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gci-gce-slow-release-1.3:
         job-name: ci-kubernetes-e2e-gci-gce-slow-release-1.3
         jenkins-timeout: 270
         timeout: 170
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gci-gce-serial-release-1.3:
         job-name: ci-kubernetes-e2e-gci-gce-serial-release-1.3
         jenkins-timeout: 420
         timeout: 320
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
 
     # gce-1.4
@@ -826,7 +826,7 @@
         timeout: 70
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-gci-ci-release-1.3:
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         job-name: ci-kubernetes-e2e-gce-gci-ci-release-1.3
         jenkins-timeout: 170
         timeout: 70
@@ -888,7 +888,7 @@
         timeout: 320
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-gci-ci-serial-release-1.3:
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         job-name: ci-kubernetes-e2e-gce-gci-ci-serial-release-1.3
         jenkins-timeout: 420
         timeout: 320
@@ -950,7 +950,7 @@
         timeout: 170
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-gci-ci-slow-release-1.3:
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         job-name: ci-kubernetes-e2e-gce-gci-ci-slow-release-1.3
         jenkins-timeout: 270
         timeout: 170
@@ -1219,25 +1219,25 @@
         job-name: ci-kubernetes-e2e-gke-release-1.3
         jenkins-timeout: 170
         timeout: 70
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gke-serial-release-1.3:
         job-name: ci-kubernetes-e2e-gke-serial-release-1.3
         jenkins-timeout: 420
         timeout: 320
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gke-slow-release-1.3:
         job-name: ci-kubernetes-e2e-gke-slow-release-1.3
         jenkins-timeout: 270
         timeout: 170
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gke-reboot-release-1.3:
         job-name: ci-kubernetes-e2e-gke-reboot-release-1.3
         jenkins-timeout: 300
         timeout: 200
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
 
     # gci-gke-1.3
@@ -1245,25 +1245,25 @@
         job-name: ci-kubernetes-e2e-gci-gke-release-1.3
         jenkins-timeout: 170
         timeout: 70
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gci-gke-serial-release-1.3:
         job-name: ci-kubernetes-e2e-gci-gke-serial-release-1.3
         jenkins-timeout: 420
         timeout: 320
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gci-gke-slow-release-1.3:
         job-name: ci-kubernetes-e2e-gci-gke-slow-release-1.3
         jenkins-timeout: 270
         timeout: 170
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
     - kubernetes-e2e-gci-gke-reboot-release-1.3:
         job-name: ci-kubernetes-e2e-gci-gke-reboot-release-1.3
         jenkins-timeout: 300
         timeout: 200
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.3'
 
     # gke-1.4
@@ -1670,19 +1670,19 @@
         job-name: ci-kubernetes-e2e-gke-1.3-1.4-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-1.3-1.4-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-1.3-1.4-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     ### kubernetes-e2e-upgrades-gce #davidopp
@@ -1690,19 +1690,19 @@
         job-name: ci-kubernetes-e2e-gce-1.3-1.4-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-1.3-1.4-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gce-1.3-1.4-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gce-1.4-1.5-upgrade-master:
@@ -1754,57 +1754,57 @@
         job-name: ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master:
         job-name: ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master:
         job-name: ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master:
@@ -1871,26 +1871,26 @@
         job-name: ci-kubernetes-e2e-gke-1.3-1.4-cvm-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-1.3-1.4-gci-kubectl-skew:
         job-name: ci-kubernetes-e2e-gke-1.3-1.4-gci-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gke-1.4-1.3-cvm-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew:
         job-name: ci-kubernetes-e2e-gke-1.4-1.3-gci-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     # Skew 1.4 vs 1.5
@@ -2031,26 +2031,26 @@
         job-name: ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-cvm-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-latest-1.3-latest-1.4-gci-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-1.3-latest-1.4-gci-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gce-latest-1.4-latest-1.3-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-cvm-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-latest-1.4-latest-1.3-gci-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-1.4-latest-1.3-gci-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     # Skew 1.4 vs 1.5
@@ -2163,26 +2163,26 @@
         job-name: ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gce-latest-latest-1.3-cvm-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-latest-1.3-cvm-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gce-latest-latest-1.3-gci-kubectl-skew:
         job-name: ci-kubernetes-e2e-gce-latest-latest-1.3-gci-kubectl-skew
         jenkins-timeout: 240
         timeout: 140
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew:
@@ -2217,133 +2217,133 @@
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.4-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.4-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-1.4-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-1.5-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-1.5-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-1.5-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-1.5-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     ### 1.4 to 1.5 GKE upgrade tests
@@ -2599,76 +2599,76 @@
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
     - kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new:
         job-name: ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new
         jenkins-timeout: 720
         timeout: 620
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
+        frequency: 'H H * * *' # once a day for older jobs.
         trigger-job: ''
 
     - kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master:


### PR DESCRIPTION
Many of these jobs take so long to complete that we're still effectively running them constantly, even when only triggered 4 times per day.

This will hopefully reduce some of the Jenkins load so that jobs we care about more (e.g. release-1.6 jobs) have a chance to run more frequently.

(There are 79 e2e/upgrade jobs related to 1.3. 79!)