### PR TITLE
Update 1.6-1.5 GCE downgrades to deploy a cluster that can downgrade

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
@@ -9,7 +9,16 @@ JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
 JENKINS_USE_SKEW_KUBECTL=false
 JENKINS_USE_SKEW_TESTS=false
 
+# Make sure we set up etcd with json storage. Rolling back from proto
+# (default for 1.6) is not possible. This is specific to the 1.6 to
+# 1.5 downgrade.
+STORAGE_BACKEND=etcd3
+ETCD_VERSION=3.0.17
+ETCD_IMAGE=3.0.17
+STORAGE_MEDIA_TYPE=application/json
+
 # Rather than downgrading and then running e2e tests, just downgrade.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --gce-upgrade-script=/workspace/kubernetes_skew/cluster/gce/upgrade.sh
+# etcd flags are specific to the 1.6 to 1.5 downgrade
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --gce-upgrade-script=/workspace/kubernetes_skew/cluster/gce/upgrade.sh --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1
 
 KUBEKINS_TIMEOUT=300m


### PR DESCRIPTION
This is another part of fixing etcd downgrade for https://github.com/kubernetes/kubernetes/issues/43470. This goes along with https://github.com/kubernetes/kubernetes/pull/43481 but they can be submitted independently.