### PR TITLE
Give CLI args higher priority over environment.

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -337,6 +337,23 @@ def main(args):
             # The gs:// path given here should match jobs/ci-kubernetes-bazel-build.sh
         mode.add_environment('E2E_OPT=%s' % opt)
 
+    # env blacklist.
+    # TODO(krzyzacy) change this to a whitelist
+    docker_env_ignore = [
+      'GOOGLE_APPLICATION_CREDENTIALS',
+      'GOPATH',
+      'GOROOT',
+      'HOME',
+      'PATH',
+      'PWD',
+      'WORKSPACE'
+    ]
+
+    # TODO(fejta): delete this
+    mode.add_environment(*(
+        '%s=%s' % (k, v) for (k, v) in os.environ.items()
+        if k not in docker_env_ignore))
+
     mode.add_environment(
       # Boilerplate envs
       # Skip gcloud update checking
@@ -358,23 +375,6 @@ def main(args):
       'CLUSTER_NAME=%s' % cluster,
       'KUBE_GKE_NETWORK=%s' % cluster,
     )
-
-    # env blacklist.
-    # TODO(krzyzacy) change this to a whitelist
-    docker_env_ignore = [
-      'GOOGLE_APPLICATION_CREDENTIALS',
-      'GOPATH',
-      'GOROOT',
-      'HOME',
-      'PATH',
-      'PWD',
-      'WORKSPACE'
-    ]
-
-    # TODO(fejta): delete this
-    mode.add_environment(*(
-        '%s=%s' % (k, v) for (k, v) in os.environ.items()
-        if k not in docker_env_ignore))
 
     # Overwrite JOB_NAME for soak-*-test jobs
     if args.soak_test and os.environ.get('JOB_NAME'):


### PR DESCRIPTION
As written, inherited environment variables like `E2E_UP` were overriding their CLI counterparts like `--up` in the `kubernetes_e2e` scenario. This change reorders the execution so that these command-line flags override environment variables, which seems more correct.

This explains why the kubeadm e2e job is [still running tests](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce/587), even though `--test=false` is [given on the command-line](https://github.com/kubernetes/test-infra/blob/535e32a840ee72bde11a8bd43a25728feb71291c/jobs/config.json#L517).