### PR TITLE
Run latest e2e-image for federation soak deploy & test

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1933,8 +1933,9 @@ class JobTest(unittest.TestCase):
                 if config[job]['scenario'] == 'kubernetes_e2e':
                     self.assertTrue(hasMatchingEnv, job)
                     if '-soak-' in job:
-                        self.assertIn(
-                            '--tag=v20170223-43ce8f86', config[job]['args'])
+                        if '-federation-' not in job:
+                            self.assertIn(
+                                '--tag=v20170223-43ce8f86', config[job]['args'])
                     if job.startswith('pull-kubernetes-'):
                         self.assertIn('--cluster=', config[job]['args'])
                         if 'gke' in job:

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2335,8 +2335,7 @@
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-soak-gce-federation-deploy.env",
     "--test=false",
-    "--down=false",
-    "--tag=v20170223-43ce8f86"
+    "--down=false"
   ]
 },
 
@@ -2347,8 +2346,7 @@
     "--env-file=jobs/ci-kubernetes-soak-gce-federation-test.env",
     "--soak-test",
     "--up=false",
-    "--down=false",
-    "--tag=v20170223-43ce8f86"
+    "--down=false"
   ]
 },
 


### PR DESCRIPTION
Federation Soak test job is tied with a specific image of e2e-image (probably because the invocation federation soak job is copied from other soak jobs). This is causing the new improvements to federation test-infra not reflecting in `federation soak job`. So removing the specific tag to be used for federation soak job and to run the latest image.

cc @madhusudancs 