### PR TITLE
Reduce frequency of non-1.6 release verify/test-go jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -85,19 +85,19 @@
         timeout: 80
     - kubernetes-verify-release-1.5:
         branch: release-1.5
-        frequency: 'H/5 * * * *'
+        frequency: 'H H/3 * * *'
         job-name: ci-kubernetes-verify-release-1.5
         repo-name: k8s.io/kubernetes
         timeout: 80
     - kubernetes-verify-release-1.4:
         branch: release-1.4
-        frequency: 'H/5 * * * *'
+        frequency: 'H H/3 * * *'
         job-name: ci-kubernetes-verify-release-1.4
         repo-name: k8s.io/kubernetes
         timeout: 80
     - kubernetes-verify-release-1.3:
         branch: release-1.3
-        frequency: 'H/5 H/3 * * *'
+        frequency: 'H H * * *' # Once per day for old releases
         job-name: ci-kubernetes-verify-release-1.3
         repo-name: k8s.io/kubernetes
         timeout: 60
@@ -128,7 +128,7 @@
         timeout: 100
     - kubernetes-test-go-release-1.3:
         branch: release-1.3
-        frequency: 'H H/3 * * *'
+        frequency: 'H H * * *' # Once per day for old releases
         job-name: ci-kubernetes-test-go-release-1.3
         repo-name: k8s.io/kubernetes
         timeout: 100


### PR DESCRIPTION
Free up some Jenkins resources so we can schedule 1.6 jobs more quickly.