### PR TITLE
Revert set GIT_TRACE since that might not be compatible with go get

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -771,7 +771,6 @@ def setup_root(call, root, repos, ssh, git_cache, clean):
         os.makedirs(root)
     root_dir = os.path.realpath(root)
     logging.info('Root: %s', root_dir)
-    os.environ['GIT_TRACE'] = '1'
     with choose_ssh_key(ssh):
         for repo, (branch, pull) in repos.items():
             os.chdir(root_dir)


### PR DESCRIPTION
As it might broke cadvisor build job, for instance, https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-cadvisor-node-kubelet/4888 since last Saturday, which is when it comes in.

/assign @fejta @ixdy 

cc @dashpole 
