### PR TITLE
Enable legacy abac for upgrade e2e tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env
@@ -7,3 +7,6 @@ PROJECT=k8s-gce-cvm-1-5-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env
@@ -7,3 +7,6 @@ PROJECT=k8s-gce-gci-1-5-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
@@ -10,3 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-gce-upg-1-5-1-6-up-clu-n
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-gce-upg-1-5-1-6-up-clu
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-gce-upg-1-5-1-6-up-mas
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster-new.env
@@ -10,3 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-glat-up-clu-n
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-glat-up-clu
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.3-gci-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-glat-up-mas
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new.env
@@ -10,3 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-4-glat-up-clu-n
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-4-glat-up-clu
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-4-glat-up-mas
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster-new.env
@@ -10,3 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-3-clat-up-clu-n
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-3-clat-up-clu
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-debian-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-3-clat-up-mas
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster-new.env
@@ -10,3 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-3-glat-up-clu-n
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-3-glat-up-clu
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.3-gci-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-3-glat-up-mas
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new.env
@@ -10,3 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-4-clat-up-clu-n
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-4-clat-up-clu
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-4-clat-up-mas
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new.env
@@ -10,3 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-4-glat-up-clu-n
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-4-glat-up-clu
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-4-glat-up-mas
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew.env
@@ -7,3 +7,6 @@ PROJECT=gce-cvm-upg-1-3-lat-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew.env
@@ -7,3 +7,6 @@ PROJECT=gce-gci-upg-1-3-lat-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew.env
@@ -7,3 +7,6 @@ PROJECT=gce-cvm-upg-1-4-lat-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-gci-kubectl-skew.env
@@ -7,3 +7,6 @@ PROJECT=gce-gci-upg-1-4-lat-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-lat-cluster
 
 KUBEKINS_TIMEOUT=90m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-lat-master
 
 KUBEKINS_TIMEOUT=90m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew.env
@@ -8,3 +8,6 @@ KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew.env
@@ -8,3 +8,6 @@ KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env
@@ -8,3 +8,6 @@ KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env
@@ -8,3 +8,6 @@ KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=120m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-c1-3-clat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-3-clat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-container_vm-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-3-clat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-c1-3-glat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-3-glat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.3-gci-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-3-glat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-c1-4-c1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-4-c1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-4-c1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-c1-4-clat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-4-clat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-4-clat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-c1-4-g1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-4-g1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-4-g1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-c1-4-glat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-4-glat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-c1-4-glat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-c1-5-c1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-5-c1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-5-c1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-c1-5-g1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-5-g1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-c1-5-g1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-g1-3-clat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-3-clat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-container_vm-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-3-clat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-g1-3-glat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-3-glat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.3-gci-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-3-glat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-g1-4-c1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-4-c1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-4-c1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-g1-4-clat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-4-clat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-4-clat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-g1-4-g1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-4-g1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-4-g1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.env
@@ -11,3 +11,6 @@ PROJECT=gke-up-g1-4-glat-up-clu-n
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-4-glat-up-clu
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master.env
@@ -10,3 +10,6 @@ PROJECT=gke-up-g1-4-glat-up-mas
 ZONE=us-central1-c
 
 KUBEKINS_TIMEOUT=600m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-g1-5-c1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-5-c1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-5-c1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
@@ -13,3 +13,6 @@ PROJECT=k8s-gke-upg-g1-5-g1-6-up-clu-n
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-5-g1-6-up-clu
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
@@ -12,3 +12,6 @@ PROJECT=k8s-gke-upg-g1-5-g1-6-up-mas
 ZONE=us-central1-a
 
 KUBEKINS_TIMEOUT=900m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gke-upg-lat-cluster
 
 KUBEKINS_TIMEOUT=90m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
@@ -9,3 +9,6 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gke-upg-lat-master
 
 KUBEKINS_TIMEOUT=90m
+
+# Enable when testing upgrades from a version < 1.6 to a version >= 1.6
+ENABLE_LEGACY_ABAC=true


### PR DESCRIPTION
as discussed in https://github.com/kubernetes/kubernetes/pull/43544#discussion_r107754004:
* we want to drive this behavior directly testing upgrades to 1.6+ from a version < 1.6
* we need to drive it explicitly for upgrade tests that aren't setting `E2E_UPGRADE_TEST=true`

I added this to all jobs where both of these were true:
* `JENKINS_PUBLISHED_SKEW_VERSION` was 1.6 or latest
* `JENKINS_PUBLISHED_VERSION` was a version prior to 1.6

This change enables ABAC in the following upgrade jobs which weren't setting `E2E_UPGRADE_TEST=true`:

```
$ git diff-tree --no-commit-id --name-only -r ca839fc665ee5a739c565f543c356b43bd266731 | xargs grep -L E2E_UPGRADE_TEST
jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env
jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env
jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-cvm-kubectl-skew.env
jobs/ci-kubernetes-e2e-gce-latest-1.3-latest-gci-kubectl-skew.env
jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-cvm-kubectl-skew.env
jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-gci-kubectl-skew.env
jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
jobs/ci-kubernetes-e2e-gke-1.4-latest-cvm-kubectl-skew.env
jobs/ci-kubernetes-e2e-gke-1.4-latest-gci-kubectl-skew.env
jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env
jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env
jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
```

Ref https://github.com/kubernetes/kubernetes/issues/43610