### PR TITLE
Add the kubelet-non-cri-1.6 job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -205,6 +205,12 @@
         job-name: ci-kubernetes-node-kubelet-1.6
         repo-name: k8s.io/kubernetes
         timeout: 90
+    - kubernetes-node-kubelet-non-cri-1.6:
+        branch: release-1.6
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-node-kubelet-non-cri-1.6
+        repo-name: k8s.io/kubernetes
+        timeout: 90
 
     - kubernetes-node-docker:  # dawnchen
         branch: master

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -137,6 +137,14 @@
   ]
 },
 
+"ci-kubernetes-node-kubelet-non-cri-1.6": {
+  "scenario": "kubernetes_kubelet",
+  "args": [
+    "--branch=release-1.6",
+    "--properties=test/e2e_node/jenkins/non-cri_validation/jenkins-validation.properties"
+  ]
+},
+
 "ci-kubernetes-node-kubelet-benchmark": {
   "scenario": "kubernetes_kubelet",
   "args": [

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -825,6 +825,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.5
 - name: ci-kubernetes-node-kubelet-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.6
+- name: ci-kubernetes-node-kubelet-non-cri-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-non-cri-1.6
 - name: kops-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kops-build
 - name: kubernetes-e2e-gce-enormous-deploy
@@ -1928,6 +1930,8 @@ dashboards:
     test_group_name: kubernetes-verify-release-1.6
   - name: kubelet-1.6
     test_group_name: ci-kubernetes-node-kubelet-1.6
+  - name: kubelet-non-cri-1.6
+    test_group_name: ci-kubernetes-node-kubelet-non-cri-1.6
   - name: gce-alpha-features-1.6
     test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1.6
   - name: gce-etcd2-1.6
@@ -2070,6 +2074,8 @@ dashboards:
   # Node
   - name: kubelet-1.6
     test_group_name: ci-kubernetes-node-kubelet-1.6
+  - name: kubelet-non-cri-1.6
+    test_group_name: ci-kubernetes-node-kubelet-non-cri-1.6
 
 - name: release-1.6-upgrade-skew
   dashboard_tab:


### PR DESCRIPTION
This maintains the minimum test coverage for the non-default
configuration for the 1.6 branch.

/cc @Random-Liu @dchen1107 
/cc @enisoc @ethernetdan 