### PR TITLE
Download comments seperately

### DIFF
--- a/velodrome/fetcher/client.go
+++ b/velodrome/fetcher/client.go
@@ -120,8 +120,8 @@ type ClientInterface interface {
 	RepositoryName() string
 	FetchIssues(time.Time, chan *github.Issue)
 	FetchIssueEvents(*int, chan *github.IssueEvent)
-	FetchIssueComments(int, time.Time, chan *github.IssueComment)
-	FetchPullComments(int, time.Time, chan *github.PullRequestComment)
+	FetchIssueComments(time.Time, chan *github.IssueComment)
+	FetchPullComments(time.Time, chan *github.PullRequestComment)
 }
 
 func (client *Client) RepositoryName() string {
@@ -212,8 +212,8 @@ func (client *Client) FetchIssueEvents(latest *int, c chan *github.IssueEvent) {
 	close(c)
 }
 
-// FetchIssueComments fetches comments associated to given Issue (since latest)
-func (client *Client) FetchIssueComments(issueID int, latest time.Time, c chan *github.IssueComment) {
+// FetchIssueComments fetches issue comments (since latest)
+func (client *Client) FetchIssueComments(latest time.Time, c chan *github.IssueComment) {
 	opt := &github.IssueListCommentsOptions{Since: latest, Sort: "updated", Direction: "asc"}
 
 	githubClient, err := client.getGithubClient()
@@ -227,7 +227,7 @@ func (client *Client) FetchIssueComments(issueID int, latest time.Time, c chan *
 	for {
 		client.limitsCheckAndWait()
 
-		comments, resp, err := githubClient.Issues.ListComments(client.Org, client.Project, issueID, opt)
+		comments, resp, err := githubClient.Issues.ListComments(client.Org, client.Project, 0, opt)
 		if err != nil {
 			close(c)
 			glog.Error(err)
@@ -244,12 +244,12 @@ func (client *Client) FetchIssueComments(issueID int, latest time.Time, c chan *
 		opt.ListOptions.Page = resp.NextPage
 	}
 
-	glog.Infof("Fetched %d issue comments updated since %v for issue #%d.", count, latest, issueID)
+	glog.Infof("Fetched %d issue comments updated since %v.", count, latest)
 	close(c)
 }
 
-// FetchPullComments fetches comments associated to given PullRequest (since latest)
-func (client *Client) FetchPullComments(issueID int, latest time.Time, c chan *github.PullRequestComment) {
+// FetchPullComments fetches pull-request comments (since latest)
+func (client *Client) FetchPullComments(latest time.Time, c chan *github.PullRequestComment) {
 	opt := &github.PullRequestListCommentsOptions{Since: latest, Sort: "updated", Direction: "asc"}
 
 	githubClient, err := client.getGithubClient()
@@ -263,7 +263,7 @@ func (client *Client) FetchPullComments(issueID int, latest time.Time, c chan *g
 	for {
 		client.limitsCheckAndWait()
 
-		comments, resp, err := githubClient.PullRequests.ListComments(client.Org, client.Project, issueID, opt)
+		comments, resp, err := githubClient.PullRequests.ListComments(client.Org, client.Project, 0, opt)
 		if err != nil {
 			close(c)
 			glog.Error(err)
@@ -280,6 +280,6 @@ func (client *Client) FetchPullComments(issueID int, latest time.Time, c chan *g
 		opt.ListOptions.Page = resp.NextPage
 	}
 
-	glog.Infof("Fetched %d review comments updated since %v for issue #%d.", count, latest, issueID)
+	glog.Infof("Fetched %d review comments updated since %v.", count, latest)
 	close(c)
 }

--- a/velodrome/fetcher/client_test.go
+++ b/velodrome/fetcher/client_test.go
@@ -27,8 +27,8 @@ type FakeClient struct {
 	Repository    string
 	Issues        []*github.Issue
 	IssueEvents   []*github.IssueEvent
-	IssueComments map[int][]*github.IssueComment
-	PullComments  map[int][]*github.PullRequestComment
+	IssueComments []*github.IssueComment
+	PullComments  []*github.PullRequestComment
 }
 
 func (client FakeClient) RepositoryName() string {
@@ -49,15 +49,15 @@ func (client FakeClient) FetchIssueEvents(latest *int, c chan *github.IssueEvent
 	close(c)
 }
 
-func (client FakeClient) FetchIssueComments(issueID int, latest time.Time, c chan *github.IssueComment) {
-	for _, comment := range client.IssueComments[issueID] {
+func (client FakeClient) FetchIssueComments(latest time.Time, c chan *github.IssueComment) {
+	for _, comment := range client.IssueComments {
 		c <- comment
 	}
 	close(c)
 }
 
-func (client FakeClient) FetchPullComments(issueID int, latest time.Time, c chan *github.PullRequestComment) {
-	for _, comment := range client.PullComments[issueID] {
+func (client FakeClient) FetchPullComments(latest time.Time, c chan *github.PullRequestComment) {
+	for _, comment := range client.PullComments {
 		c <- comment
 	}
 	close(c)

--- a/velodrome/fetcher/deployment.yaml
+++ b/velodrome/fetcher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - --token-file=/etc/secret-volume/k8s-merge-robot
         - --stderrthreshold=0
         - --host=sqlproxy
-        image: gcr.io/google-containers/github-fetcher:v20170303-213119
+        image: gcr.io/google-containers/github-fetcher:v20170322-151808
         resources:
           requests:
             cpu: 0m

--- a/velodrome/fetcher/fetcher.go
+++ b/velodrome/fetcher/fetcher.go
@@ -58,6 +58,7 @@ func runProgram(config *fetcherConfig) error {
 	for {
 		tx := db.Begin()
 		UpdateIssues(tx, config)
+		UpdateComments(tx, config)
 		UpdateIssueEvents(tx, config)
 		tx.Commit()
 

--- a/velodrome/fetcher/issues.go
+++ b/velodrome/fetcher/issues.go
@@ -74,8 +74,5 @@ func UpdateIssues(db *gorm.DB, client ClientInterface) {
 				glog.Error("Failed to update database issue: ", err)
 			}
 		}
-
-		// Issue is updated, find if we have new comments
-		UpdateComments(*issue.Number, issueOrm.IsPR, db, client)
 	}
 }


### PR DESCRIPTION
There used to be a bug in github that prevented us from downloading
comments directly. The workaround was that we were downloading comments
for each individual issue rather than all comments at once.

This has been fixed on Github so we can now use that API again. It means
that we don't need to make 2 github calls per issue we update, which
makes it much faster and much better on token usage.