### PR TITLE
Bump PR e2e runs to use kubekins-e2e:v20170324-331e93f3

### DIFF
--- a/jenkins/dockerized-e2e-runner.sh
+++ b/jenkins/dockerized-e2e-runner.sh
@@ -33,7 +33,7 @@ mkdir -p "${HOST_ARTIFACTS_DIR}"
 # DO NOT CHANGE THIS VALUE. THIS FILE IS DEPRECATED.
 # Job changes requiring a new image require first updating the job to use the
 # kubernetes_e2e.py scenario, which requires setting --json for the job.
-KUBEKINS_E2E_IMAGE_TAG='v20170215-331e93f3'
+KUBEKINS_E2E_IMAGE_TAG='v20170324-331e93f3'
 KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE="${WORKSPACE}/hack/jenkins/.kubekins_e2e_image_tag"
 if [[ -r "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}" ]]; then
   KUBEKINS_E2E_IMAGE_TAG=$(cat "${KUBEKINS_E2E_IMAGE_TAG_OVERRIDE_FILE}")


### PR DESCRIPTION
This pulls in updates upstream dependencies (such as get-kube.sh) while keeping test-infra code the same.

Discussed why this is needed in https://github.com/kubernetes/kubernetes/pull/43647#issuecomment-289189098.

Testing this image in https://github.com/kubernetes/kubernetes/pull/43660.

/assign @fejta 