### PR TITLE
Explicitly specify etcd media type for upgrades

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf::
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.4

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
@@ -2,6 +2,7 @@
 
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
 JENKINS_PUBLISHED_VERSION=ci/latest-1.5


### PR DESCRIPTION
Sets media type for upgrades to explicitly use `application/vnd.kubernetes.protobuf`

Required after the addition of kubernetes/kubernetes#43681