### PR TITLE
approval: Search all possible approvals for assignees

### DIFF
--- a/mungegithub/mungers/approvers/approvers_test.go
+++ b/mungegithub/mungers/approvers/approvers_test.go
@@ -19,7 +19,6 @@ package approvers
 import (
 	"testing"
 
-	"fmt"
 	"reflect"
 
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -347,6 +346,15 @@ func TestGetCCs(t *testing.T) {
 			// We suggest assigned people rather than "suggested" people
 			expectedCCs: []string{"Art", "Ben", "Carol"},
 		},
+		{
+			testName:          "Assignee is top OWNER, No one has approved",
+			filenames:         []string{"a/test.go"},
+			testSeed:          0,
+			currentlyApproved: sets.NewString(),
+			// Assignee is a root approver
+			assignees:   []string{"Alice"},
+			expectedCCs: []string{"Alice"},
+		},
 	}
 
 	for _, test := range tests {
@@ -357,7 +365,6 @@ func TestGetCCs(t *testing.T) {
 		testApprovers.AddAssignees(test.assignees...)
 		calculated := testApprovers.GetCCs()
 		if !reflect.DeepEqual(test.expectedCCs, calculated) {
-			fmt.Printf("Currently Approved %v\n", test.currentlyApproved)
 			t.Errorf("Failed for test %v.  Expected CCs: %v. Found %v", test.testName, test.expectedCCs, calculated)
 		}
 	}
@@ -458,7 +465,6 @@ func TestIsApproved(t *testing.T) {
 		}
 		calculated := testApprovers.IsApproved()
 		if test.isApproved != calculated {
-			fmt.Printf("Currently Approved %v\n", test.currentlyApproved)
 			t.Errorf("Failed for test %v.  Expected Approval Status: %v. Found %v", test.testName, test.isApproved, calculated)
 		}
 	}

--- a/mungegithub/mungers/approvers/owners_test.go
+++ b/mungegithub/mungers/approvers/owners_test.go
@@ -341,7 +341,7 @@ func TestGetSuggestedApprovers(t *testing.T) {
 
 	for _, test := range tests {
 		testOwners := Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: TEST_SEED}
-		suggested := testOwners.GetSuggestedApprovers(testOwners.GetShuffledApprovers())
+		suggested := testOwners.GetSuggestedApprovers(testOwners.GetReverseMap(testOwners.GetLeafApprovers()), testOwners.GetShuffledApprovers())
 		for _, ownersSet := range test.expectedOwners {
 			if ownersSet.Intersection(suggested).Len() == 0 {
 				t.Errorf("Failed for test %v.  Didn't find an approver from: %v. Actual Owners %v", test.testName, ownersSet, suggested)
@@ -498,7 +498,7 @@ func TestFindMostCoveringApprover(t *testing.T) {
 
 	for _, test := range tests {
 		testOwners := Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: TEST_SEED}
-		bestPerson := findMostCoveringApprover(testOwners.GetAllPotentialApprovers(), testOwners.GetReverseMap(), test.unapproved)
+		bestPerson := findMostCoveringApprover(testOwners.GetAllPotentialApprovers(), testOwners.GetReverseMap(testOwners.GetLeafApprovers()), test.unapproved)
 		if test.expectedMostCovering.Intersection(sets.NewString(bestPerson)).Len() != 1 {
 			t.Errorf("Failed for test %v.  Didn't correct approvers list.  Expected: %v. Found %v", test.testName, test.expectedMostCovering, bestPerson)
 		}
@@ -554,7 +554,7 @@ func TestGetReverseMap(t *testing.T) {
 
 	for _, test := range tests {
 		testOwners := Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: TEST_SEED}
-		calculatedRevMap := testOwners.GetReverseMap()
+		calculatedRevMap := testOwners.GetReverseMap(testOwners.GetLeafApprovers())
 		if !reflect.DeepEqual(calculatedRevMap, test.expectedRevMap) {
 			t.Errorf("Failed for test %v.  Didn't find correct reverse map.", test.testName)
 			t.Errorf("Person \t\t Expected \t\tFound ")


### PR DESCRIPTION
Currently, even if an assignee can approve everything (because for
example he's a root approver), we can't use him as a suggested person
because suggestion only looks for leafApprovers. When we consider who is
the best assignee to suggest, we should not only look for leaves, but
for all possible approvals.

One of the consequence of that is that if a root approver is assigned,
he'll almost always be suggested.