### PR TITLE
Push events with issues

### DIFF
--- a/velodrome/fetcher/client_test.go
+++ b/velodrome/fetcher/client_test.go
@@ -26,7 +26,7 @@ import (
 type FakeClient struct {
 	Repository    string
 	Issues        []*github.Issue
-	IssueEvents   []*github.IssueEvent
+	IssueEvents   map[int][]*github.IssueEvent
 	IssueComments map[int][]*github.IssueComment
 	PullComments  map[int][]*github.PullRequestComment
 }
@@ -42,8 +42,8 @@ func (client FakeClient) FetchIssues(latest time.Time, c chan *github.Issue) {
 	close(c)
 }
 
-func (client FakeClient) FetchIssueEvents(latest *int, c chan *github.IssueEvent) {
-	for _, event := range client.IssueEvents {
+func (client FakeClient) FetchIssueEvents(issueID int, latest *int, c chan *github.IssueEvent) {
+	for _, event := range client.IssueEvents[issueID] {
 		c <- event
 	}
 	close(c)

--- a/velodrome/fetcher/conversion.go
+++ b/velodrome/fetcher/conversion.go
@@ -78,12 +78,10 @@ func NewIssue(gIssue *github.Issue, repository string) (*sql.Issue, error) {
 }
 
 // NewIssueEvent creates a new (orm) Issue from a github Issue
-func NewIssueEvent(gIssueEvent *github.IssueEvent, repository string) (*sql.IssueEvent, error) {
+func NewIssueEvent(gIssueEvent *github.IssueEvent, issueID int, repository string) (*sql.IssueEvent, error) {
 	if gIssueEvent.ID == nil ||
 		gIssueEvent.Event == nil ||
-		gIssueEvent.CreatedAt == nil ||
-		gIssueEvent.Issue == nil ||
-		gIssueEvent.Issue.Number == nil {
+		gIssueEvent.CreatedAt == nil {
 		return nil, fmt.Errorf("IssueEvent is missing mandatory field: %+v", gIssueEvent)
 	}
 
@@ -105,7 +103,7 @@ func NewIssueEvent(gIssueEvent *github.IssueEvent, repository string) (*sql.Issu
 		Label:          label,
 		Event:          *gIssueEvent.Event,
 		EventCreatedAt: *gIssueEvent.CreatedAt,
-		IssueId:        strconv.Itoa(*gIssueEvent.Issue.Number),
+		IssueId:        strconv.Itoa(issueID),
 		Assignee:       assignee,
 		Actor:          actor,
 		Repository:     strings.ToLower(repository),

--- a/velodrome/fetcher/conversion_test.go
+++ b/velodrome/fetcher/conversion_test.go
@@ -170,7 +170,7 @@ func makeIssueEvent(
 }
 
 func makeGithubIssueEvent(
-	eventId, issueId int,
+	eventId int,
 	label, event, assignee, actor string,
 	createdAt time.Time) *github.IssueEvent {
 
@@ -193,7 +193,6 @@ func makeGithubIssueEvent(
 		Label:     gLabel,
 		Event:     &event,
 		CreatedAt: &createdAt,
-		Issue:     &github.Issue{Number: &issueId},
 		Assignee:  gAssignee,
 		Actor:     gActor,
 	}
@@ -202,31 +201,35 @@ func makeGithubIssueEvent(
 func TestNewIssueEvent(t *testing.T) {
 	tests := []struct {
 		gIssueEvent *github.IssueEvent
+		issueID     int
 		mIssueEvent *sql.IssueEvent
 	}{
 		// Only mandatory
 		{
-			gIssueEvent: makeGithubIssueEvent(1, 2, "", "Event", "", "",
+			gIssueEvent: makeGithubIssueEvent(1, "", "Event", "", "",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
+			issueID: 2,
 			mIssueEvent: makeIssueEvent(1, 2, "", "Event", "", "", "full/repo",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 		},
 		// All fields
 		{
-			gIssueEvent: makeGithubIssueEvent(1, 2, "Label", "Event", "Assignee", "Actor",
+			gIssueEvent: makeGithubIssueEvent(1, "Label", "Event", "Assignee", "Actor",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
+			issueID: 2,
 			mIssueEvent: makeIssueEvent(1, 2, "Label", "Event", "Assignee", "Actor", "full/repo",
 				time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 		},
 		// Missing mandatory fields returns nil
 		{
 			&github.IssueEvent{},
+			2,
 			nil,
 		},
 	}
 
 	for _, test := range tests {
-		actualIssueEvent, _ := NewIssueEvent(test.gIssueEvent, "FULL/REPO")
+		actualIssueEvent, _ := NewIssueEvent(test.gIssueEvent, test.issueID, "FULL/REPO")
 		if !reflect.DeepEqual(actualIssueEvent, test.mIssueEvent) {
 			t.Error("Actual: ", actualIssueEvent,
 				"doesn't match expected: ", test.mIssueEvent)

--- a/velodrome/fetcher/deployment.yaml
+++ b/velodrome/fetcher/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - --token-file=/etc/secret-volume/k8s-merge-robot
         - --stderrthreshold=0
         - --host=sqlproxy
-        image: gcr.io/google-containers/github-fetcher:v20170303-213119
+        image: gcr.io/google-containers/github-fetcher:v20170327-143731
         resources:
           requests:
             cpu: 0m

--- a/velodrome/fetcher/fetcher.go
+++ b/velodrome/fetcher/fetcher.go
@@ -58,7 +58,6 @@ func runProgram(config *fetcherConfig) error {
 	for {
 		tx := db.Begin()
 		UpdateIssues(tx, config)
-		UpdateIssueEvents(tx, config)
 		tx.Commit()
 
 		if config.once {

--- a/velodrome/fetcher/issue-events.go
+++ b/velodrome/fetcher/issue-events.go
@@ -25,11 +25,12 @@ import (
 	"k8s.io/test-infra/velodrome/sql"
 )
 
-func findLatestEvent(db *gorm.DB, repository string) (*int, error) {
+func findLatestEvent(issueID int, db *gorm.DB, repository string) (*int, error) {
 	var latestEvent sql.IssueEvent
 
 	query := db.
 		Select("id, event_created_at").
+		Where(&sql.IssueEvent{IssueId: strconv.Itoa(issueID)}).
 		Where("repository = ?", repository).
 		Order("event_created_at desc").
 		First(&latestEvent)
@@ -50,17 +51,17 @@ func findLatestEvent(db *gorm.DB, repository string) (*int, error) {
 
 // UpdateIssueEvents fetches all events until we find the most recent we
 // have in db, and saves everything in database
-func UpdateIssueEvents(db *gorm.DB, client ClientInterface) {
-	latest, err := findLatestEvent(db, client.RepositoryName())
+func UpdateIssueEvents(issueID int, db *gorm.DB, client ClientInterface) {
+	latest, err := findLatestEvent(issueID, db, client.RepositoryName())
 	if err != nil {
 		glog.Error("Failed to find last event: ", err)
 		return
 	}
 	c := make(chan *github.IssueEvent, 500)
 
-	go client.FetchIssueEvents(latest, c)
+	go client.FetchIssueEvents(issueID, latest, c)
 	for event := range c {
-		eventOrm, err := NewIssueEvent(event, client.RepositoryName())
+		eventOrm, err := NewIssueEvent(event, issueID, client.RepositoryName())
 		if err != nil {
 			glog.Error("Failed to create issue-event", err)
 		}

--- a/velodrome/fetcher/issue-events_test.go
+++ b/velodrome/fetcher/issue-events_test.go
@@ -34,38 +34,43 @@ func TestFindLatestUpdate(t *testing.T) {
 		events         []sql.IssueEvent
 		expectedLatest int
 		repository     string
+		issueID        int
 	}{
 		// If we don't have any issue, return 1900/1/1 0:0:0 UTC
 		{
 			[]sql.IssueEvent{},
 			0,
 			"ONE",
+			1,
 		},
 		{
 			[]sql.IssueEvent{
-				{ID: "2", EventCreatedAt: time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
-				{ID: "7", EventCreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
+				{ID: "2", IssueId: "7", EventCreatedAt: time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
+				{ID: "7", IssueId: "7", EventCreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
 			},
 			0,
 			"TWO",
-		},
-		{
-			[]sql.IssueEvent{
-				{ID: "2", EventCreatedAt: time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
-				{ID: "7", EventCreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
-				{ID: "1", EventCreatedAt: time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "TWO"},
-			},
 			7,
-			"ONE",
 		},
 		{
 			[]sql.IssueEvent{
-				{ID: "2", EventCreatedAt: time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
-				{ID: "7", EventCreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
-				{ID: "1", EventCreatedAt: time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "TWO"},
+				{ID: "2", IssueId: "7", EventCreatedAt: time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
+				{ID: "7", IssueId: "2", EventCreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
+				{ID: "1", IssueId: "7", EventCreatedAt: time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "TWO"},
+			},
+			2,
+			"ONE",
+			7,
+		},
+		{
+			[]sql.IssueEvent{
+				{ID: "2", IssueId: "7", EventCreatedAt: time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
+				{ID: "7", IssueId: "7", EventCreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "ONE"},
+				{ID: "1", IssueId: "7", EventCreatedAt: time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC), Repository: "TWO"},
 			},
 			1,
 			"TWO",
+			7,
 		},
 	}
 
@@ -81,7 +86,7 @@ func TestFindLatestUpdate(t *testing.T) {
 		}
 		tx.Commit()
 
-		actualLatest, err := findLatestEvent(db, test.repository)
+		actualLatest, err := findLatestEvent(test.issueID, db, test.repository)
 		if err != nil {
 			t.Error("findLatestEvent failed:", err)
 		}
@@ -101,9 +106,10 @@ func TestUpdateEvents(t *testing.T) {
 
 	tests := []struct {
 		before     []sql.IssueEvent
-		new        []*github.IssueEvent
+		new        map[int][]*github.IssueEvent
 		after      []sql.IssueEvent
 		repository string
+		issueID    int
 	}{
 		// No new issues
 		{
@@ -111,12 +117,13 @@ func TestUpdateEvents(t *testing.T) {
 				*makeIssueEvent(1, 2, "", "Event", "", "", "full/repo",
 					time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
-			new: []*github.IssueEvent{},
+			new: map[int][]*github.IssueEvent{},
 			after: []sql.IssueEvent{
 				*makeIssueEvent(1, 2, "", "Event", "", "", "full/repo",
 					time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
 			repository: "FULL/REPO",
+			issueID:    2,
 		},
 		// New issues
 		{
@@ -124,9 +131,11 @@ func TestUpdateEvents(t *testing.T) {
 				*makeIssueEvent(1, 2, "", "Event", "", "", "full/repo",
 					time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
-			new: []*github.IssueEvent{
-				makeGithubIssueEvent(2, 2, "Label", "Event", "Assignee", "Actor",
-					time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
+			new: map[int][]*github.IssueEvent{
+				2: {
+					makeGithubIssueEvent(2, "Label", "Event", "Assignee", "Actor",
+						time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
+				},
 			},
 			after: []sql.IssueEvent{
 				*makeIssueEvent(1, 2, "", "Event", "", "", "full/repo",
@@ -135,6 +144,7 @@ func TestUpdateEvents(t *testing.T) {
 					time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
 			repository: "FULL/REPO",
+			issueID:    2,
 		},
 		// New issues + already existing (doesn't update)
 		{
@@ -144,11 +154,13 @@ func TestUpdateEvents(t *testing.T) {
 				*makeIssueEvent(2, 2, "Label", "Event", "Assignee", "Actor", "full/repo",
 					time.Date(2001, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
-			new: []*github.IssueEvent{
-				makeGithubIssueEvent(1, 2, "", "EventNameChanged", "", "",
-					time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
-				makeGithubIssueEvent(3, 2, "Label", "Event", "Assignee", "",
-					time.Date(2002, time.January, 1, 19, 30, 0, 0, time.UTC)),
+			new: map[int][]*github.IssueEvent{
+				2: {
+					makeGithubIssueEvent(1, "", "EventNameChanged", "", "",
+						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
+					makeGithubIssueEvent(3, "Label", "Event", "Assignee", "",
+						time.Date(2002, time.January, 1, 19, 30, 0, 0, time.UTC)),
+				},
 			},
 			after: []sql.IssueEvent{
 				*makeIssueEvent(1, 2, "", "Event", "", "", "full/repo",
@@ -159,6 +171,7 @@ func TestUpdateEvents(t *testing.T) {
 					time.Date(2002, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
 			repository: "FULL/REPO",
+			issueID:    2,
 		},
 		// Fetch new repository
 		{
@@ -166,15 +179,18 @@ func TestUpdateEvents(t *testing.T) {
 				*makeIssueEvent(2, 2, "", "Event", "", "", "full/one",
 					time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
-			new: []*github.IssueEvent{
-				makeGithubIssueEvent(1, 2, "", "EventNameOther", "", "",
-					time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
+			new: map[int][]*github.IssueEvent{
+				2: {
+					makeGithubIssueEvent(1, "", "EventNameOther", "", "",
+						time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
+				},
 			},
 			after: []sql.IssueEvent{
 				*makeIssueEvent(1, 2, "", "EventNameOther", "", "", "full/other",
 					time.Date(2000, time.January, 1, 19, 30, 0, 0, time.UTC)),
 			},
 			repository: "FULL/OTHER",
+			issueID:    2,
 		},
 	}
 
@@ -188,7 +204,7 @@ func TestUpdateEvents(t *testing.T) {
 			db.Create(&event)
 		}
 
-		UpdateIssueEvents(db, FakeClient{IssueEvents: test.new, Repository: test.repository})
+		UpdateIssueEvents(test.issueID, db, FakeClient{IssueEvents: test.new, Repository: test.repository})
 		var issues []sql.IssueEvent
 		if err := db.Order("ID").Where("repository = ?", strings.ToLower(test.repository)).Find(&issues).Error; err != nil {
 			t.Fatal(err)

--- a/velodrome/fetcher/issues.go
+++ b/velodrome/fetcher/issues.go
@@ -77,5 +77,7 @@ func UpdateIssues(db *gorm.DB, client ClientInterface) {
 
 		// Issue is updated, find if we have new comments
 		UpdateComments(*issue.Number, issueOrm.IsPR, db, client)
+		// and find if we have new events
+		UpdateIssueEvents(*issue.Number, db, client)
 	}
 }


### PR DESCRIPTION
velodrome: fetcher: Fetch events for each issues
    
Github doesn't let us download all events for the repository anymore. As
a work-around, we can download events for each individual issue. This is
not as great because it means that for `n` issues, we need to make
`O(n)` calls to github API rather than `O(1)`, but all of this is done
completely in the background so it doesn't really matter after all.
