### PR TITLE
Enable installing weave-net addon during kubeadm e2e jobs.

### DIFF
--- a/images/ci-kubernetes-e2e-kubeadm/Dockerfile
+++ b/images/ci-kubernetes-e2e-kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170313-9987c745
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170327-d33e8685
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \
@@ -24,9 +24,12 @@ RUN apt-get update && apt-get install -y \
     wget && \
     apt-get clean
 
-# Add kubernetes-anywhere dependencies: jsonnet, terraform
-ENV TERRAFORM_VERSION 0.7.2
+ENV TERRAFORM_VERSION=0.7.2 \
+    KUBERNETES_PROVIDER=kubernetes-anywhere \
+    KUBECTL_VERSION=1.6.0-beta.4 \
+    PATH=/usr/local/bin:${PATH}
 
+# Add kubernetes-anywhere dependencies: jsonnet, terraform, kubectl
 RUN cd /tmp && \
     git clone https://github.com/google/jsonnet.git && \
     ( cd jsonnet && \
@@ -41,6 +44,11 @@ RUN mkdir -p /tmp/terraform/ && \
       unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin \
     ) && \
     rm -rf /tmp/terraform
+
+# TODO(pipejakob): Instead of fetching a specific precompiled version, get
+# kubernetes-anywhere to use the kubectl built as part of this job.
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 WORKDIR /workspace
 ADD runner /

--- a/images/ci-kubernetes-e2e-kubeadm/Makefile
+++ b/images/ci-kubernetes-e2e-kubeadm/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.2
+VERSION = 0.3
 
 image:
 	docker build -t "gcr.io/k8s-testimages/e2e-kubeadm:$(VERSION)" .

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -48,7 +48,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["util_test.go"],
+    srcs = [
+        "anywhere_test.go",
+        "util_test.go",
+    ],
     library = ":go_default_library",
     tags = ["automanaged"],
 )

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -55,10 +55,11 @@ const kubernetesAnywhereConfigTemplate = `
 .phase2.kubeadm.version="{{.KubeadmVersion}}"
 
 .phase3.run_addons=y
-.phase3.kube_proxy=y
-.phase3.dashboard=y
-.phase3.heapster=y
-.phase3.kube_dns=y
+.phase3.weave_net={{if eq .Phase2Provider "kubeadm" -}} y {{- else -}} n {{- end}}
+.phase3.kube_proxy=n
+.phase3.dashboard=n
+.phase3.heapster=n
+.phase3.kube_dns=n
 `
 
 type kubernetesAnywhere struct {
@@ -137,7 +138,7 @@ func (k kubernetesAnywhere) writeConfig() error {
 }
 
 func (k kubernetesAnywhere) Up() error {
-	cmd := exec.Command("make", "-C", k.path, "WAIT_FOR_KUBECONFIG=y", "deploy-cluster")
+	cmd := exec.Command("make", "-C", k.path, "WAIT_FOR_KUBECONFIG=y", "deploy")
 	if err := finishRunning(cmd); err != nil {
 		return err
 	}
@@ -169,5 +170,5 @@ func (k kubernetesAnywhere) Down() error {
 		// This is expected if the cluster doesn't exist.
 		return nil
 	}
-	return finishRunning(exec.Command("make", "-C", k.path, "FORCE_DESTROY=y", "destroy-cluster"))
+	return finishRunning(exec.Command("make", "-C", k.path, "FORCE_DESTROY=y", "destroy"))
 }

--- a/kubetest/anywhere_test.go
+++ b/kubetest/anywhere_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewKubernetesAnywhere(t *testing.T) {
+	if err := os.Setenv("PROJECT", "test-project"); err != nil {
+		t.Fatalf("couldn't set PROJECT environment: %v", err)
+	}
+
+	cases := []struct {
+		phase2            string
+		expectConfigLines []string
+	}{
+		{
+			phase2: "kubeadm",
+			expectConfigLines: []string{
+				".phase2.provider=\"kubeadm\"",
+				".phase3.weave_net=y",
+			},
+		},
+		{
+			phase2: "ignition",
+			expectConfigLines: []string{
+				".phase2.provider=\"ignition\"",
+				".phase3.weave_net=n",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tmpdir, err := ioutil.TempDir("", "kubernetes-anywhere-test")
+		if err != nil {
+			t.Errorf("couldn't create tempdir: %v", err)
+			continue
+		}
+
+		defer os.Remove(tmpdir)
+
+		*kubernetesAnywherePath = tmpdir
+		*kubernetesAnywhereCluster = "test-cluster"
+		*kubernetesAnywherePhase2Provider = tc.phase2
+
+		_, err = NewKubernetesAnywhere()
+		if err != nil {
+			t.Errorf("NewKubernetesAnywhere(%s) failed: %v", tc.phase2, err)
+			continue
+		}
+
+		config, err := ioutil.ReadFile(tmpdir + "/.config")
+		if err != nil {
+			t.Errorf("NewKubernetesAnywhere(%s) failed to create readable config file: %v", tc.phase2, err)
+			continue
+		}
+
+		configLines := strings.Split(string(config), "\n")
+
+		if !containsLine(configLines, ".phase1.cloud_provider=\"gce\"") {
+			t.Errorf("NewKubernetesAnywhere(%s) config got %q, wanted line: .cloud_provider=\"gce\"", tc.phase2, config)
+		}
+
+		for _, line := range tc.expectConfigLines {
+			if !containsLine(configLines, line) {
+				t.Errorf("NewKubernetesAnywhere(%s) config got %q, wanted line: %v", tc.phase2, config, line)
+			}
+		}
+	}
+}
+
+func containsLine(haystack []string, needle string) bool {
+	for _, line := range haystack {
+		if line == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -86,7 +86,7 @@ presubmits:
       trigger: "@k8s-bot (kubeadm e2e )?test this"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.2
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
           args:
           - "--pull=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -265,7 +265,7 @@ presubmits:
       trigger: "@k8s-bot (kubeadm e2e )?test this"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.2
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
           args:
           - "--pull=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -528,7 +528,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.2
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"


### PR DESCRIPTION
This is needed because kubeadm clusters only support CNI, and need a provider to be installed before starting other pods. This change should allow us to re-enable e2e Conformance tests for kubeadm.

- Use `deploy`/`destroy` make targets, which run phase3 of kubernetes-anywhere to deploy addons (`deploy-cluster` stops before addons).
- Disable all addons (except weave-net) for backwards compatibility.
- Explicitly set `KUBERNETES_PROVIDER` on this image because it was inheriting the value `gce` from the base image, which was incorrect for these jobs.
- Add a newer version of kubectl to the image, since the weave-net addon requires a more recent version than provided by gcloud.

CC @mikedanese 