### PR TITLE
New postsubmit kubeadm e2e job for release-1.6 branch.

### DIFF
--- a/jobs/ci-kubernetes-e2e-kubeadm-gce-1.6.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce-1.6.env
@@ -1,0 +1,14 @@
+### job-env
+
+PROJECT=k8s-jkns-e2e-kubeadm-ci-1-6
+KUBERNETES_PROVIDER=kubernetes-anywhere
+
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
+
+# Resource leak detection is disabled because prow runs multiple instances of
+# this job in the same project concurrently, and resource leak detection will
+# make the job flaky.
+FAIL_ON_GCP_RESOURCE_LEAK=false
+
+# After post-env
+KUBEKINS_TIMEOUT=120m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -527,6 +527,18 @@
   ]
 },
 
+"ci-kubernetes-e2e-kubeadm-gce-1.6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--cluster=",
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce-1.6.env",
+    "--kubeadm",
+    "--mode=local",
+    "--test=false"
+  ]
+},
+
 "ci-kubernetes-e2e-non-cri-gce": {
   "scenario": "kubernetes_e2e",
   "args": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -563,6 +563,103 @@ postsubmits:
           - name: cache-ssd
             hostPath:
               path: /mnt/disks/ssd0
+  - name: ci-kubernetes-bazel-build-1.6
+    branches:
+    - release-1.6
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:0.9
+        args:
+        - "--branch=$(PULL_REFS)"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--git-cache=/root/.cache/git"
+        - "--clean"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: ci-kubernetes-bazel-test-1.6
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/bazelbuild:0.9
+          args:
+          - "--branch=$(PULL_REFS)"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          - "--git-cache=/root/.cache/git"
+          - "--clean"
+          securityContext:
+            privileged: true
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+      run_after_success:
+      - name: ci-kubernetes-e2e-kubeadm-gce-1.6
+        spec:
+          containers:
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
+            args:
+            - "--branch=$(PULL_REFS)"
+            - "--clean"
+            - "--git-cache=/root/.cache/git"
+            - "--json"
+            - "--timeout=140"
+            - "--upload=gs://kubernetes-jenkins/logs"
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/service-account/service-account.json
+            - name:  JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-private
+            - name:  JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-public
+            volumeMounts:
+            - name: service
+              mountPath: /etc/service-account
+              readOnly: true
+            - name: ssh
+              mountPath: /etc/ssh-key-secret
+              readOnly: true
+            - name: cache-ssd
+              mountPath: /root/.cache
+          volumes:
+          - name: service
+            secret:
+              secretName: service-account
+          - name: ssh
+            secret:
+              secretName: ssh-key-secret
+              defaultMode: 0400
+          - name: cache-ssd
+            hostPath:
+              path: /mnt/disks/ssd0
 
   kubernetes/test-infra:
   - name: ci-test-infra-bazel

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1028,8 +1028,12 @@ test_groups:
 # bazel, run on prow
 - name: ci-kubernetes-bazel-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-build
+- name: ci-kubernetes-bazel-build-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-build-1.6
 - name: ci-kubernetes-bazel-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test
+- name: ci-kubernetes-bazel-test-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test-1.6
 - name: ci-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-bazel
 # rktnetes
@@ -1072,6 +1076,8 @@ test_groups:
 # kubeadm tests
 - name: kubernetes-e2e-kubeadm-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce
+- name: kubernetes-e2e-kubeadm-gce-1.6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1.6
 # upgrade CI tests
 - name: kubernetes-e2e-gce-latest-upgrade-cluster
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-latest-upgrade-cluster
@@ -1293,6 +1299,8 @@ dashboards:
     test_group_name: kubernetes-e2e-gce-taint-evict
   - name: gce-kubeadm
     test_group_name: kubernetes-e2e-kubeadm-gce
+  - name: gce-kubeadm-1.6
+    test_group_name: kubernetes-e2e-kubeadm-gce-1.6
 
 # "google-gci-dev" is a tab for tests that are used for GCI(aka COS) image
 # development and qualification. It should not be confused with the "google-gci"
@@ -1642,8 +1650,12 @@ dashboards:
     test_group_name: kubernetes-build-1.5
   - name: bazel-build
     test_group_name: ci-kubernetes-bazel-build
+  - name: bazel-build-1.6
+    test_group_name: ci-kubernetes-bazel-build-1.6
   - name: bazel-test
     test_group_name: ci-kubernetes-bazel-test
+  - name: bazel-test-1.6
+    test_group_name: ci-kubernetes-bazel-test-1.6
   - name: test-go
     test_group_name: kubernetes-test-go
   - name: test-go-1.3


### PR DESCRIPTION
Since the kubeadm e2e job depends on the successful runs of bazel/bazel-test, duplicate those jobs for the release-1.6 branch as well.