### PR TITLE
Run docker pull via gcloud in AWS janitor

### DIFF
--- a/jobs/maintenance-ci-aws-janitor.sh
+++ b/jobs/maintenance-ci-aws-janitor.sh
@@ -20,7 +20,7 @@ set -o xtrace
 
 JANITOR=${AWS_JANITOR_IMAGE:-gcr.io/k8s-test-infra-aws/aws-janitor}
 
-docker pull "${JANITOR}"
+gcloud docker -- pull "${JANITOR}"
 docker run -v "${JENKINS_AWS_CREDENTIALS_FILE}:/root/.aws/credentials:ro" "${JANITOR}" \
   --path s3://janitor-jenkins/objs.json\
   --ttl 2h30m # Aggressive, but all of our jobs are <2h right now.


### PR DESCRIPTION
The `gcr.io/k8s-test-infra-aws/aws-janitor` image is not publicly accessible, so we need to use our service account to download it:

```
I0329 15:39:48.893] Pulling repository gcr.io/k8s-test-infra-aws/aws-janitor
W0329 15:39:49.439] Error: Status 403 trying to pull repository k8s-test-infra-aws/aws-janitor: "Unable to access the repository: k8s-test-infra-aws/aws-janitor; please verify that it exists and you have permission to access it (no valid credential was supplied)."
```