### PR TITLE
Extend publishing repo to handle more branches

### DIFF
--- a/mungegithub/mungers/publish_scripts/publish_apimachinery.sh
+++ b/mungegithub/mungers/publish_scripts/publish_apimachinery.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 3 ]; then
-    echo "usage: $0 src_branch dst_branch kubernetes_remote"
+if [ ! $# -eq 4 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "apimachinery" "${1}" "${2}" "" "${3}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "apimachinery" "${1}" "${2}" "${3}" "${4}" "true"

--- a/mungegithub/mungers/publish_scripts/publish_apiserver.sh
+++ b/mungegithub/mungers/publish_scripts/publish_apiserver.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 3 ]; then
-    echo "usage: $0 src_branch dst_branch kubernetes_remote"
+if [ ! $# -eq 4 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "apiserver" "${1}" "${2}" "apimachinery,client-go" "${3}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "apiserver" "${1}" "${2}" "${3}" "${4}" "true"

--- a/mungegithub/mungers/publish_scripts/publish_client_go.sh
+++ b/mungegithub/mungers/publish_scripts/publish_client_go.sh
@@ -34,13 +34,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 3 ]; then
-    echo "usage: $0 src_branch dst_branch kubernetes_remote"
+if [ ! $# -eq 4 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "client-go" "${1}" "${2}" "apimachinery" "${3}" "true"
+"${SCRIPT_DIR}"/publish_template.sh "client-go" "${1}" "${2}" "${3}" "${4}" "true"
 
 basic_tests() {
     go build ./...

--- a/mungegithub/mungers/publish_scripts/publish_kube_aggregator.sh
+++ b/mungegithub/mungers/publish_scripts/publish_kube_aggregator.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 3 ]; then
-    echo "usage: $0 src_branch dst_branch kubernetes_remote"
+if [ ! $# -eq 4 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "kube-aggregator" "${1}" "${2}" "apiserver,apimachinery,client-go" "${3}" "false"
+"${SCRIPT_DIR}"/publish_template.sh "kube-aggregator" "${1}" "${2}" "${3}" "${4}" "false"

--- a/mungegithub/mungers/publish_scripts/publish_sample_apiserver.sh
+++ b/mungegithub/mungers/publish_scripts/publish_sample_apiserver.sh
@@ -34,10 +34,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! $# -eq 3 ]; then
-    echo "usage: $0 src_branch dst_branch kubernetes_remote"
+if [ ! $# -eq 4 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
     exit 1
 fi
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
-"${SCRIPT_DIR}"/publish_template.sh "sample-apiserver" "${1}" "${2}" "apiserver,apimachinery,client-go" "${3}" "false"
+"${SCRIPT_DIR}"/publish_template.sh "sample-apiserver" "${1}" "${2}" "${3}" "${4}" "false"

--- a/mungegithub/mungers/publish_scripts/publish_template.sh
+++ b/mungegithub/mungers/publish_scripts/publish_template.sh
@@ -59,9 +59,14 @@ readonly SRC_BRANCH DST_BRANCH DEPS KUBERNETES_REMOTE IS_LIBRARY
 SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_DIR}"/util.sh
 
-git checkout "${DST_BRANCH}"
 git fetch origin
-git reset --hard origin/"${DST_BRANCH}"
+if [ "$(git rev-parse --abbrev-ref HEAD)" = "${DST_BRANCH}" ]; then
+    git reset --hard origin/"${DST_BRANCH}"
+else
+    git branch -D "${DST_BRANCH}" || true
+    git branch -f "${DST_BRANCH}" origin/"${DST_BRANCH}"
+    git checkout "${DST_BRANCH}"
+fi
 
 # sync_repo cherry-picks the commits that change
 # k8s.io/kubernetes/staging/src/k8s.io/${REPO} to the ${DST_BRANCH}


### PR DESCRIPTION
Expanding the publishing repo to handle release-3.0 of client-go, release-1.6 branches of apimachinery, apiserver, kube-aggregator, and sample-apiserver. These branches track tracking release-1.6 of kubernetes. 

Expanding the robot to publish branches that depend on non-master branch of other repos (e.g., client-go/release-3.0 depends on apimachinery/release-1.6).

Sample changes:
https://github.com/kubernetes/sample-apiserver/pull/4
https://github.com/kubernetes/kube-aggregator/pull/6
https://github.com/kubernetes/apiserver/pull/6
https://github.com/kubernetes/client-go/pull/160
no change to the release 1.6 branch of apimachinery

I verified the Godeps changes are correct. I randomly inpected several other cherry-picked commits and they did exist in the release-1.6 branch of Kubernetes.

@deads2k @sttts could you do a sanity check over these sample PRs? I'll then deploy the robot, and manually add kubernetes-v1.6.0 tags to these repos.

