### PR TITLE
Add needs ok to test label

### DIFF
--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -47,6 +47,11 @@ func handleIC(c client, ic github.IssueCommentEvent) error {
 		return nil
 	}
 
+	if okToTest.MatchString(ic.Comment.Body) && ic.Issue.HasLabel(needsOkToTest) {
+		if err := c.GitHubClient.RemoveLabel(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, needsOkToTest); err != nil {
+			c.Logger.WithError(err).Errorf("Failed at removing %s label", needsOkToTest)
+		}
+	}
 	// Which jobs does the comment want us to run?
 	requestedJobs := c.Config.MatchingPresubmits(ic.Repo.FullName, ic.Comment.Body, okToTest)
 	if len(requestedJobs) == 0 {

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -39,6 +39,7 @@ func init() {
 }
 
 type githubClient interface {
+	AddLabel(org, repo string, number int, label string) error
 	BotName() string
 	IsMember(org, user string) (bool, error)
 	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
@@ -47,6 +48,7 @@ type githubClient interface {
 	ListIssueComments(owner, repo string, issue int) ([]github.IssueComment, error)
 	CreateStatus(owner, repo, ref string, status github.Status) error
 	GetPullRequestChanges(github.PullRequest) ([]github.PullRequestChange, error)
+	RemoveLabel(org, repo string, number int, label string) error
 }
 
 type client struct {


### PR DESCRIPTION
Per this thread:
https://groups.google.com/d/msgid/kubernetes-wg-contribex/CAKCBhs6GJvrSua255oiyAC%3D%2BM8TBDJ2TBfGkTxaBwe-QUcYn%3Dw%40mail.gmail.com?utm_medium=email&utm_source=footer

We should add a label indicating the state `needs ok to test` so we can verify how many PRs are blocking under this condition. 

We probably also need to remove the label when someone actually makes the comment.

Possibly Needs Redesign:
This will only work on new PRs that have the comment from the bot ok-to-test.  We may have to use the mungebot to handle existing PRs that are blocking on this..