### PR TITLE
Fix ifconfig.co url for EXTERNAL_IP

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -58,7 +58,7 @@ if [[ -z "${EXTERNAL_IP}" ]]; then
   echo
   echo "WARNING: Getting external IP from instance metadata failed, assuming not running on GCE."
   echo
-  EXTERNAL_IP=$(curl 'http://v4.ifconfig.co')
+  EXTERNAL_IP=$(curl 'http://ifconfig.co')
 fi
 export E2E_OPT="${E2E_OPT} --kops-admin-access ${EXTERNAL_IP}/32"
 


### PR DESCRIPTION
https://github.com/mpolden/ipd/issues/28: the author of ifconfig.co dropped IPv6 support and so removed the "v4" subdomain distinction. Currently the runner doesn't work for me since it's gone