### PR TITLE
Quick fix for kubeadm e2es.

### DIFF
--- a/images/ci-kubernetes-e2e-kubeadm/Makefile
+++ b/images/ci-kubernetes-e2e-kubeadm/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.3
+VERSION = 0.4
 
 image:
 	docker build -t "gcr.io/k8s-testimages/e2e-kubeadm:$(VERSION)" .

--- a/images/ci-kubernetes-e2e-kubeadm/runner
+++ b/images/ci-kubernetes-e2e-kubeadm/runner
@@ -22,7 +22,10 @@ if [ ! -e test-infra ]; then
 fi
 
 if [ ! -e kubernetes-anywhere ]; then
-  git clone https://github.com/kubernetes/kubernetes-anywhere
+  # This is a short-term fix to get kubeadm e2es stable before the correct fix
+  # is in place. https://github.com/kubernetes/kubeadm/issues/219
+  # TODO(pipejakob): point this back to kubernetes/kubernetes-anywhere
+  git clone https://github.com/pipejakob/kubernetes-anywhere
 fi
 
 # This is required until https://github.com/kubernetes/kubernetes-anywhere/issues/332

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -549,8 +549,7 @@
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce.env",
     "--kubeadm",
-    "--mode=local",
-    "--test=false"
+    "--mode=local"
   ]
 },
 
@@ -561,8 +560,7 @@
     "--env-file=platforms/gce.env",
     "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env",
     "--kubeadm",
-    "--mode=local",
-    "--test=false"
+    "--mode=local"
   ]
 },
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -86,7 +86,7 @@ presubmits:
       trigger: "@k8s-bot (kubeadm e2e )?test this"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
           args:
           - "--pull=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -260,7 +260,7 @@ presubmits:
       trigger: "@k8s-bot (kubeadm e2e )?test this"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
           args:
           - "--pull=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -547,7 +547,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -644,7 +644,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce-1-6
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.3
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"


### PR DESCRIPTION
Until a sustainable fix is in place, I have a short-term workaround in my fork of kubernetes-anywhere. I'd like to switch to using that in order to get the kubeadm e2es stable, then figure out the correct fix
for kubernetes-anywhere and revert this commit.

https://github.com/kubernetes/kubeadm/issues/219

CC @mikedanese 