### PR TITLE
Add periodic kubeadm e2e run against release-1.6.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -564,6 +564,17 @@
   ]
 },
 
+"periodic-kubernetes-e2e-kubeadm-gce-1-6": {
+  "scenario": "kubernetes_e2e",
+  "args": [
+    "--cluster=",
+    "--env-file=platforms/gce.env",
+    "--env-file=jobs/periodic-kubernetes-e2e-kubeadm-gce-1-6.env",
+    "--kubeadm",
+    "--mode=local"
+  ]
+},
+
 "ci-kubernetes-e2e-non-cri-gce": {
   "scenario": "kubernetes_e2e",
   "args": [

--- a/jobs/periodic-kubernetes-bazel-build-1-6.sh
+++ b/jobs/periodic-kubernetes-bazel-build-1-6.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Cache location.
+export TEST_TMPDIR="/root/.cache/bazel"
+
+bazel clean --expunge
+
+make bazel-build && rc=$? || rc=$?
+
+if [[ "${rc}" == 0 ]]; then
+  make bazel-release && rc=$? || rc=$?
+fi
+
+if [[ "${rc}" == 0 ]]; then
+  version=$(cat bazel-genfiles/version || true)
+  if [[ -z "${version}" ]]; then
+    echo "Kubernetes version missing; not uploading ci artifacts."
+    rc=1
+  else
+    bazel run //:ci-artifacts -- "gs://kubernetes-release-dev/bazel/${version}" && rc=$? || rc=$?
+  fi
+fi
+
+# Coalesce test results into one file for upload.
+"$(dirname "${0}")/../images/pull_kubernetes_bazel/coalesce.py"
+
+exit "${rc}"

--- a/jobs/periodic-kubernetes-bazel-test-1-6.sh
+++ b/jobs/periodic-kubernetes-bazel-test-1-6.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Cache location.
+export TEST_TMPDIR="/root/.cache/bazel"
+
+bazel clean --expunge
+
+make bazel-test && rc=$? || rc=$?
+
+# Coalesce test results into one file for upload.
+"$(dirname "${0}")/../images/pull_kubernetes_bazel/coalesce.py"
+
+exit "${rc}"

--- a/jobs/periodic-kubernetes-e2e-kubeadm-gce-1-6.env
+++ b/jobs/periodic-kubernetes-e2e-kubeadm-gce-1-6.env
@@ -1,0 +1,14 @@
+### job-env
+
+PROJECT=k8s-jkns-e2e-kubeadm-per-1-6
+KUBERNETES_PROVIDER=kubernetes-anywhere
+
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
+
+# Resource leak detection is disabled because prow runs multiple instances of
+# this job in the same project concurrently, and resource leak detection will
+# make the job flaky.
+FAIL_ON_GCP_RESOURCE_LEAK=false
+
+# After post-env
+KUBEKINS_TIMEOUT=120m

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -816,3 +816,103 @@ periodics:
     - name: service
       secret:
         secretName: triage-service-account
+
+- name: periodic-kubernetes-bazel-build-1-6
+  interval: 2h
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bazelbuild:0.9
+      args:
+      - "--repo=kubernetes"
+      - "--branch=release-1.6"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      - "--git-cache=/root/.cache/git"
+      - "--clean"
+      # Bazel needs privileged mode in order to sandbox builds.
+      securityContext:
+        privileged: true
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: cache-ssd
+        mountPath: /root/.cache
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: cache-ssd
+      hostPath:
+        path: /mnt/disks/ssd0
+  run_after_success:
+  - name: periodic-kubernetes-bazel-test-1-6
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:0.9
+        args:
+        - "--repo=kubernetes"
+        - "--branch=release-1.6"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--git-cache=/root/.cache/git"
+        - "--clean"
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: periodic-kubernetes-e2e-kubeadm-gce-1-6
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
+          args:
+          - "--repo=kubernetes"
+          - "--branch=release-1.6"
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--json"
+          - "--timeout=140"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name:  JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name:  JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: ssh
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0


### PR DESCRIPTION
Since it depends on the .debs generated during the bazel step, I've copied the entire pipeline, and renamed the jobs from `ci` to `periodic`, and added the repo/branch flags.

This change is mostly copy/paste for `config.yaml` and `config.json`, along with:

    cp jobs/ci-kubernetes-bazel-build-1-6.sh jobs/periodic-kubernetes-bazel-build-1-6.sh
    cp jobs/ci-kubernetes-bazel-test-1-6.sh jobs/periodic-kubernetes-bazel-test-1-6.sh
    cp jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env jobs/periodic-kubernetes-e2e-kubeadm-gce-1-6.env

Then, I created a new project for the e2e and updated the .env file's `PROJECT` value.

There is a potential race condition since the three steps refer to the `release-1.6` branch HEAD, which can change between job steps, so I see this as a short-term solution until we keep track of the most recent bazel build for the branch and can just run the kubeadm e2e without the full pipeline.