### PR TITLE
Tidy up our Bazel rules.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,6 +26,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//experiment:all-srcs",
         "//gcsweb/cmd/gcsweb:all-srcs",
         "//gcsweb/pkg/version:all-srcs",
         "//images/pull_kubernetes_bazel:all-srcs",

--- a/BUILD.jinja2
+++ b/BUILD.jinja2
@@ -1,8 +1,0 @@
-py_library(
-    name = "jinja2",
-    srcs = glob(["*.py"]),
-    deps = [
-        "@markupsafe//:markupsafe",
-    ],
-    visibility = ["//visibility:public"],
-)

--- a/BUILD.markupsafe
+++ b/BUILD.markupsafe
@@ -1,5 +1,0 @@
-py_library(
-    name = "markupsafe",
-    srcs = glob(["*.py"]),
-    visibility = ["//visibility:public"],
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,16 +55,31 @@ py_library(
 
 new_http_archive(
     name = "markupsafe",
-    build_file = "BUILD.markupsafe",
     sha256 = "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",
     strip_prefix = "MarkupSafe-1.0/markupsafe",
     urls = ["https://pypi.python.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz"],
+    build_file_content = """
+py_library(
+    name = "markupsafe",
+    srcs = glob(["*.py"]),
+    visibility = ["//visibility:public"],
+)
+""",
 )
 
 new_http_archive(
     name = "jinja2",
-    build_file = "BUILD.jinja2",
     sha256 = "702a24d992f856fa8d5a7a36db6128198d0c21e1da34448ca236c42e92384825",
     strip_prefix = "Jinja2-2.9.5/jinja2",
     urls = ["https://pypi.python.org/packages/71/59/d7423bd5e7ddaf3a1ce299ab4490e9044e8dfd195420fc83a24de9e60726/Jinja2-2.9.5.tar.gz"],
+    build_file_content = """
+py_library(
+    name = "jinja2",
+    srcs = glob(["*.py"]),
+    deps = [
+        "@markupsafe//:markupsafe",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,34 @@ npm_repository(
 )
 
 new_http_archive(
+    name = "requests",
+    urls = ["https://pypi.python.org/packages/16/09/37b69de7c924d318e51ece1c4ceb679bf93be9d05973bb30c35babd596e2/requests-2.13.0.tar.gz"],
+    sha256 = "5722cd09762faa01276230270ff16af7acf7c5c45d623868d9ba116f15791ce8",
+    strip_prefix = "requests-2.13.0/requests",
+    build_file_content = """
+py_library(
+    name = "requests",
+    srcs = glob(["**/*.py"]),
+    visibility = ["//visibility:public"],
+)
+""",
+)
+
+new_http_archive(
+    name = "yaml",
+    urls = ["https://pypi.python.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"],
+    sha256 = "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
+    strip_prefix = "PyYAML-3.12/lib/yaml",
+    build_file_content = """
+py_library(
+    name = "yaml",
+    srcs = glob(["*.py"]),
+    visibility = ["//visibility:public"],
+)
+""",
+)
+
+new_http_archive(
     name = "markupsafe",
     build_file = "BUILD.markupsafe",
     sha256 = "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665",

--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -1,0 +1,19 @@
+py_binary(
+    name = "flakedetector",
+    srcs = ["flakedetector.py"],
+    deps = ["@requests//:requests"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/jenkins/BUILD
+++ b/jenkins/BUILD
@@ -4,6 +4,7 @@ py_test(
         "bootstrap.py",
         "bootstrap_test.py",
     ],
+    deps = ["@yaml//:yaml"],
     data = [
         "dockerized-e2e-runner.sh",
         "//jenkins/job-configs:configs",

--- a/jenkins/BUILD
+++ b/jenkins/BUILD
@@ -4,7 +4,6 @@ py_test(
         "bootstrap.py",
         "bootstrap_test.py",
     ],
-    deps = ["@yaml//:yaml"],
     data = [
         "dockerized-e2e-runner.sh",
         "//jenkins/job-configs:configs",
@@ -12,6 +11,7 @@ py_test(
         "//jenkins/job-configs/kubernetes-jenkins-pull:configs",
         "//jobs",
     ],
+    deps = ["@yaml//:yaml"],
 )
 
 filegroup(

--- a/jenkins/test_history/BUILD
+++ b/jenkins/test_history/BUILD
@@ -6,6 +6,7 @@ py_test(
     ],
     deps = [
         "@jinja2//:jinja2",
+        "@yaml//:yaml",
     ],
 )
 
@@ -19,6 +20,10 @@ py_test(
     # https://github.com/bazelbuild/bazel/issues/1973
     # https://github.com/bazelbuild/bazel/issues/2056
     local = True,
+    deps = [
+        "@requests//:requests",
+        "@yaml//:yaml",
+    ],
 )
 
 filegroup(

--- a/kettle/BUILD
+++ b/kettle/BUILD
@@ -5,14 +5,14 @@ py_test(
         "make_db_test.py",
         "model.py",
     ],
-    deps = [
-        "@requests//:requests",
-        "@yaml//:yaml",
-    ],
     # Remove when these are fixed.
     # https://github.com/bazelbuild/bazel/issues/1973
     # https://github.com/bazelbuild/bazel/issues/2056
     local = True,
+    deps = [
+        "@requests//:requests",
+        "@yaml//:yaml",
+    ],
 )
 
 py_binary(

--- a/kettle/BUILD
+++ b/kettle/BUILD
@@ -5,6 +5,10 @@ py_test(
         "make_db_test.py",
         "model.py",
     ],
+    deps = [
+        "@requests//:requests",
+        "@yaml//:yaml",
+    ],
     # Remove when these are fixed.
     # https://github.com/bazelbuild/bazel/issues/1973
     # https://github.com/bazelbuild/bazel/issues/2056

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -81,7 +81,7 @@ def parse_junit(xml):
 
 # pypy compatibility hack
 BUCKETS = json.loads(subprocess.check_output(
-    ['python', '-c', 'import json,yaml; print json.dumps(yaml.load(open("../buckets.yaml")))'],
+    ['python2', '-c', 'import json,yaml; print json.dumps(yaml.load(open("../buckets.yaml")))'],
     cwd=os.path.dirname(os.path.abspath(__file__))))
 
 


### PR DESCRIPTION
Add requests and yaml repositories. After this change, the test_history
page and bootstrap_test should have no external dependencies. We could
almost get rid of the requirements file for test_history, but it's
actually depended on in a few other places, such as kettle.

Make //kettle:make_json_test pass on my laptop by changing a "python" to
a "python2". This call is problematic, since the subprocess is executed
outside of Bazel's carefully crafted sandbox, and won't see the yaml
package from the rules.