### PR TITLE
bootstrap: recognize release branches

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -809,7 +809,7 @@ def parse_repos(args):
         ret[repos[0]] = (args.branch, args.pull)
         return ret
     for repo in repos:
-        mat = re.match(r'([^=]+)(=(\w+(:[0-9a-fA-F]+)?(,|$))+)?$', repo)
+        mat = re.match(r'([^=]+)(=([^:,~^\s]+(:[0-9a-fA-F]+)?(,|$))+)?$', repo)
         if not mat:
             raise ValueError('bad repo', repo, repos)
         this_repo = mat.group(1)

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -418,6 +418,14 @@ class ParseReposTest(unittest.TestCase):
             bootstrap.parse_repos(
                 FakeArgs(repo=['foo=master,111,222'], branch='', pull='')))
 
+    def testPullReleaseBranch(self):
+        """foo=release-3.14,&a-fancy%_branch+:abcd,222 works"""
+        self.assertEquals(
+            {'foo': ('', 'release-3.14,&a-fancy%_branch+:abcd,222')},
+            bootstrap.parse_repos(
+                FakeArgs(repo=['foo=release-3.14,&a-fancy%_branch+:abcd,222'],
+                         branch='', pull='')))
+
     def testPullBranchCommit(self):
         """foo=master,111,222 works"""
         self.assertEquals(


### PR DESCRIPTION
`\w` only matches `a-zA-Z0-9_`, but git branches can have hyphens and periods too.