### PR TITLE
Fix periodic bazel jobs.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -823,7 +823,6 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:0.9
       args:
-      - "--repo=k8s.io/kubernetes=release-1.6"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--git-cache=/root/.cache/git"
       - "--clean"
@@ -831,6 +830,8 @@ periodics:
       securityContext:
         privileged: true
       env:
+      - name: REPO_NAME
+        value: kubernetes=release-1.6
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       volumeMounts:
@@ -852,13 +853,14 @@ periodics:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:0.9
         args:
-        - "--repo=k8s.io/kubernetes=release-1.6"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
         - "--clean"
         securityContext:
           privileged: true
         env:
+        - name: REPO_NAME
+          value: kubernetes=release-1.6
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         volumeMounts:


### PR DESCRIPTION
The [bazel runner](https://github.com/kubernetes/test-infra/blob/9e97786d67fba827f1bff23f7a77d5f93a23b1bc/images/pull_kubernetes_bazel/runner#L22) already specifies a `--repo` argument based off of `$REPO_NAME`, so adding a second `--repo` option was checking out the kubernetes repo, but making the test-infra repo primary, so it failed the job because there was no `bazel-build` target in test-infra.

I'm looking for feedback to see whether this approach is better than forking the bazelbuild image to create a runner more suitable for periodic jobs.

CC @spxtr @mikedanese 