### PR TITLE
Support file:// urls in kubetest

### DIFF
--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -65,7 +65,11 @@ func insertPath(path string) error {
 // Essentially curl url | writer
 func httpRead(url string, writer io.Writer) error {
 	log.Printf("curl %s", url)
-	r, err := http.Get(url)
+	// TODO: we should probably create only one Transport and reuse it for all calls
+	t := &http.Transport{}
+	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+	c := &http.Client{Transport: t}
+	r, err := c.Get(url)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Go's `http` module doesn't support the `file` scheme by default. Since we use this in PR testing to "download" artifacts for release branches before release-1.5, we need to explicitly enable it.