### PR TITLE
Enable Federation tests as merge blocking

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -25,7 +25,8 @@ data:
     \"Jenkins Kubemark GCE e2e\",\
     \"Jenkins GCE etcd3 e2e\",\
     \"Jenkins Bazel Build\",\
-    \"Jenkins kops AWS e2e\""
+    \"Jenkins kops AWS e2e\",\
+    \"Jenkins GCI Federation GCE e2e\""
 
   submit-queue.protected-branches: "master"
   submit-queue.protected-branches-extra-contexts: "cla/linuxfoundation"
@@ -38,7 +39,6 @@ data:
     ci-kubernetes-cross-build,\
     ci-kubernetes-e2e-garbage-gci,\
     ci-kubernetes-e2e-gce-examples,\
-    ci-kubernetes-e2e-gce-federation,\
     ci-kubernetes-e2e-gce-multizone,\
     ci-kubernetes-e2e-gce-scalability,\
     ci-kubernetes-e2e-gce-serial,\
@@ -97,6 +97,7 @@ data:
   submit-queue.jenkins-jobs: "\
     ci-kubernetes-build,\
     ci-kubernetes-e2e-gce-etcd3,\
+    ci-kubernetes-e2e-gce-federation,\
     ci-kubernetes-e2e-gci-gce,\
     ci-kubernetes-e2e-gci-gce-slow,\
     ci-kubernetes-e2e-gci-gce-ingress,\

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2198,8 +2198,10 @@ dashboards:
     test_group_name: kubernetes-test-go
   - name: ingress
     test_group_name: kubernetes-e2e-gci-gce-ingress
-  - name: verify 
+  - name: verify
     test_group_name: kubernetes-verify-master
+  - name: federation
+    test_group_name: kubernetes-e2e-gce-federation
 
 - name: google-non-cri
   dashboard_tab:


### PR DESCRIPTION
Enable merge blocking on Federation after big 1.6 push for stable e2e tests