### PR TITLE
kops: dump journalctl -u kops-configuration

### DIFF
--- a/jobs/pull-kops-e2e-kubernetes-aws.sh
+++ b/jobs/pull-kops-e2e-kubernetes-aws.sh
@@ -69,7 +69,7 @@ export LOG_DUMP_USE_KUBECTL=yes
 export LOG_DUMP_SSH_KEY=/workspace/.ssh/kube_aws_rsa
 export LOG_DUMP_SSH_USER=admin
 export LOG_DUMP_SAVE_LOGS="cloud-init-output"
-export LOG_DUMP_SAVE_SERVICES="protokube"
+export LOG_DUMP_SAVE_SERVICES="protokube kops-configuration"
 
 # Flake detection. Individual tests get a second chance to pass.
 export GINKGO_TOLERATE_FLAKES="y"

--- a/jobs/pull-kubernetes-e2e-kops-aws.sh
+++ b/jobs/pull-kubernetes-e2e-kops-aws.sh
@@ -84,7 +84,7 @@ export LOG_DUMP_USE_KUBECTL=yes
 export LOG_DUMP_SSH_KEY=/workspace/.ssh/kube_aws_rsa
 export LOG_DUMP_SSH_USER=admin
 export LOG_DUMP_SAVE_LOGS="cloud-init-output"
-export LOG_DUMP_SAVE_SERVICES="protokube"
+export LOG_DUMP_SAVE_SERVICES="protokube kops-configuration"
 
 # Flake detection. Individual tests get a second chance to pass.
 export GINKGO_TOLERATE_FLAKES="y"

--- a/platforms/kops_aws.env
+++ b/platforms/kops_aws.env
@@ -8,7 +8,7 @@ KUBE_SSH_USER=admin
 LOG_DUMP_SSH_KEY=/workspace/.ssh/kube_aws_rsa
 LOG_DUMP_SSH_USER=admin
 LOG_DUMP_SAVE_LOGS=cloud-init-output
-LOG_DUMP_SAVE_SERVICES=protokube
+LOG_DUMP_SAVE_SERVICES="protokube kops-configuration"
 
 # kops testing only ever uses Cloud SDK for status and uploads
 CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true


### PR DESCRIPTION
To support CoreOS, which doesn't have a "normal" cloud-init, kops now
runs most of the bootstrap in a systemd unit called kops-configuration

To continue to capture this output - which used to be in
cloud-init-output.log - we need to capture the output from
kops-configuration.