### PR TITLE
aws/kops: add statefulset test

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -99,6 +99,12 @@
         timeout: 140
         frequency: '@hourly'
         trigger-job: ''
+    - kubernetes-e2e-kops-aws-statefulset:
+        job-name: ci-kubernetes-e2e-kops-aws-statefulset
+        jenkins-timeout: 170
+        timeout: 70
+        frequency: '@daily'
+        trigger-job: ''
     - kubernetes-e2e-kops-aws-updown: #zmerlynn
         job-name: ci-kubernetes-e2e-kops-aws-updown
         jenkins-timeout: 140

--- a/jobs/ci-kubernetes-e2e-kops-aws-statefulset.env
+++ b/jobs/ci-kubernetes-e2e-kops-aws-statefulset.env
@@ -1,0 +1,3 @@
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StatefulSet\]
+
+KUBEKINS_TIMEOUT=50m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -530,6 +530,16 @@
   ]
 },
 
+"ci-kubernetes-e2e-kops-aws-statefulset": {
+  "scenario": "kubernetes_kops_aws",
+  "args": [
+    "--cluster=e2e-kops-aws-statefulset.test-aws.k8s.io",
+    "--env-file=platforms/kops_aws.env",
+    "--env-file=jobs/ci-kubernetes-e2e-kops-aws.env",
+    "--env-file=jobs/ci-kubernetes-e2e-kops-aws-statefulset.env"
+  ]
+},
+
 "ci-kubernetes-e2e-kops-aws-updown": {
   "scenario": "kubernetes_kops_aws",
   "args": [

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -82,6 +82,7 @@ data:
     ci-kubernetes-e2e-kops-aws-serial,\
     ci-kubernetes-e2e-kops-aws-release-1.5,\
     ci-kubernetes-e2e-kops-aws-release-1.6,\
+    ci-kubernetes-e2e-kops-aws-statefulset,\
     ci-kubernetes-e2e-kops-aws-updown,\
     ci-kubernetes-kubemark-5-gce,\
     ci-kubernetes-node-kubelet-serial,\

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -142,6 +142,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-release-1.5
 - name: kubernetes-e2e-kops-aws-release-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-release-1.6
+- name: kubernetes-e2e-kops-aws-statefulset
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-statefulset
 - name: kubernetes-e2e-kops-aws-updown
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-updown
 - name: kubernetes-e2e-gce
@@ -987,6 +989,8 @@ dashboards:
     test_group_name: kubernetes-e2e-kops-aws-release-1.6
   - name: kops-aws-updown
     test_group_name: kubernetes-e2e-kops-aws-updown
+  - name: kops-aws-statefulset
+    test_group_name: kubernetes-e2e-kops-aws-statefulset
   - name: aws-1.5
     test_group_name: kubernetes-e2e-aws-release-1.5
 


### PR DESCRIPTION
We aren't running the more aggressive statefulset e2e tests on AWS.
These have historically proved great at finding volume problems.