### PR TITLE
kubetest: initialize http.Transport only once and add unit test

### DIFF
--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -31,6 +31,13 @@ import (
 	"time"
 )
 
+var httpTransport *http.Transport
+
+func init() {
+	httpTransport = new(http.Transport)
+	httpTransport.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+}
+
 // Returns $GOPATH/src/k8s.io/...
 func k8s(parts ...string) string {
 	p := []string{os.Getenv("GOPATH"), "src", "k8s.io"}
@@ -65,10 +72,7 @@ func insertPath(path string) error {
 // Essentially curl url | writer
 func httpRead(url string, writer io.Writer) error {
 	log.Printf("curl %s", url)
-	// TODO: we should probably create only one Transport and reuse it for all calls
-	t := &http.Transport{}
-	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
-	c := &http.Client{Transport: t}
+	c := &http.Client{Transport: httpTransport}
 	r, err := c.Get(url)
 	if err != nil {
 		return err

--- a/kubetest/util_test.go
+++ b/kubetest/util_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
 	"strconv"
 	"testing"
@@ -253,5 +257,30 @@ func TestOutput(t *testing.T) {
 		if tc.causeTermination && !terminated {
 			t.Errorf("Step %s did not terminate, err: %v", tc.name, err)
 		}
+	}
+}
+
+func TestHttpFileScheme(t *testing.T) {
+	expected := "some testdata"
+	tmpfile, err := ioutil.TempFile("", "test_http_file_scheme")
+	if err != nil {
+		t.Errorf("Error creating temporary file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.WriteString(expected); err != nil {
+		t.Errorf("Error writing to temporary file: %v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Errorf("Error closing temporary file: %v", err)
+	}
+
+	fileUrl := fmt.Sprintf("file://%s", tmpfile.Name())
+	buf := new(bytes.Buffer)
+	if err := httpRead(fileUrl, buf); err != nil {
+		t.Errorf("Error reading temporary file through httpRead: %v", err)
+	}
+
+	if buf.String() != expected {
+		t.Errorf("httpRead(%s): expected %v, got %v", fileUrl, expected, buf)
 	}
 }


### PR DESCRIPTION
Follow-up to #2394 from yesterday.