### PR TITLE
Add KOPS_ARGS for passing arbitrary args to 'kops create cluster'

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -81,7 +81,7 @@ function log_dump_custom_get_instances() {
 pip install awscli # Only needed for log_dump_custom_get_instances
 export -f log_dump_custom_get_instances # Export to cluster/log-dump.sh
 
-$(dirname "${BASH_SOURCE}")/e2e-runner.sh
+$(dirname "${BASH_SOURCE}")/e2e-runner.sh "${@}"
 
 if [[ -n "${KOPS_PUBLISH_GREEN_PATH:-}" ]]; then
   export CLOUDSDK_CONFIG="/workspace/.config/gcloud"

--- a/scenarios/kubernetes_kops_aws.py
+++ b/scenarios/kubernetes_kops_aws.py
@@ -65,7 +65,7 @@ def kubekins(tag):
 
 def main(args):
     """Set up env, start kops-runner, handle termination. """
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-branches
 
     job_name = (os.environ.get('JOB_NAME') or
                 os.environ.get('USER') or
@@ -198,6 +198,9 @@ def main(args):
 
     cmd.append(kubekins(args.tag))
 
+    if args.kops_args:
+        cmd.append('--kops-args=%s' % args.kops_args)
+
     setup_signal_handlers(container)
 
     check(*cmd)
@@ -261,6 +264,11 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--image', default='',
         help='Image (AMI) for nodes to use. Defaults to kops default.')
+    PARSER.add_argument(
+        '--kops-args', default='',
+        help='Additional space-separated args to pass unvalidated to \'kops '
+        'create cluster\', e.g. \'--kops-args="--dns private --node-size '
+        't2.micro"\'')
     ARGS = PARSER.parse_args()
 
     if not ARGS.cluster:


### PR DESCRIPTION
This small change could let me pass any arbitrary args without having to continue making too many PRs/changes to kops.go (or worse somehow maintain my own fork of it.) 

I agree for sure that a 'kops cli pass-thru' as mentioned here https://github.com/kubernetes/test-infra/pull/2019 would be ideal but since I'm apparnetly the only one using these scripts outside of official CI and I'm not sure how to implement it properly, this should be enough for now :)