### PR TITLE
Allow ProwJobs to abort presubmits.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,7 +24,7 @@ MARQUE_VERSION     = 0.1
 TOT_VERSION        = 0.0
 CRIER_VERSION      = 0.5
 HOROLOGIUM_VERSION = 0.2
-PLANK_VERSION      = 0.3
+PLANK_VERSION      = 0.4
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -29,7 +29,7 @@ spec:
         role: prow
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.3
+        image: gcr.io/k8s-prow/plank:0.4
         env:
         - name: LINE_IMAGE
           value: "gcr.io/k8s-prow/line:0.86"

--- a/prow/line/line_test.go
+++ b/prow/line/line_test.go
@@ -89,7 +89,7 @@ func TestStartJob(t *testing.T) {
 // Just make sure we set the parallelism to 0.
 func TestDeleteJob(t *testing.T) {
 	c := &kc{}
-	if err := deleteJob(c, "job-name", github.PullRequest{}); err != nil {
+	if err := DeletePRJob(c, "job-name", github.PullRequest{}); err != nil {
 		t.Fatalf("Didn't expect error deleting job: %v", err)
 	}
 	// The default kube.Job has nil parallelism and 0 succeeded pods. Ensure


### PR DESCRIPTION
This isn't super pretty, but it will get a lot better once I don't have to call out to `line.DeleteJob`. #2054