### PR TITLE
Make kubeadm 1.6 e2e job extract ci/latest-1.6.

### DIFF
--- a/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env
@@ -2,6 +2,7 @@
 
 PROJECT=k8s-jkns-e2e-kubeadm-ci-1-6
 KUBERNETES_PROVIDER=kubernetes-anywhere
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
 


### PR DESCRIPTION
This job was pulling the correct branch of the kubernetes repo, but then fetching/extracting the latest CI binaries for testing (which meant running e2e tests that only existed on master).

Setting this var signals `e2e-runner.sh` to pass the value to `kubetest --extract=...`, which fetches the latest 1.6 artifacts for testing.

Fixes kubernetes/kubeadm#227