### PR TITLE
Only run affected tests in test-infra.

### DIFF
--- a/images/pull_kubernetes_bazel/coalesce.py
+++ b/images/pull_kubernetes_bazel/coalesce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2016 The Kubernetes Authors.
 #


### PR DESCRIPTION
If this ends up working well for us then we can do a similar thing for k8s unit tests. Doing the same for k8s e2e tests has a few issues:

1. The e2e image doesn't have bazel.
1. e2e.test is a huge binary, one rule. We would only be able to skip ALL tests, which won't help for most PRs.