### PR TITLE
Remove automatic --repo flag from bazel runner.

### DIFF
--- a/images/pull_kubernetes_bazel/Makefile
+++ b/images/pull_kubernetes_bazel/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.11
+VERSION = 0.12
 
 image:
 	docker build -t "gcr.io/k8s-testimages/bazelbuild:$(VERSION)" .

--- a/images/pull_kubernetes_bazel/runner
+++ b/images/pull_kubernetes_bazel/runner
@@ -19,7 +19,6 @@ set -o pipefail
 
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
-    --repo="k8s.io/${REPO_NAME:-test-infra}" \
     --job=${JOB_NAME} \
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     "$@"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -52,8 +52,9 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
+        - "--repo=k8s.io/$(REPO_NAME)"
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--git-cache=/root/.cache/git"
@@ -226,8 +227,9 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
+        - "--repo=k8s.io/$(REPO_NAME)"
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--git-cache=/root/.cache/git"
@@ -400,8 +402,9 @@ presubmits:
     trigger: "@k8s-bot (bazel )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
+        - "--repo=k8s.io/$(REPO_NAME)"
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--git-cache=/root/.cache/git"
@@ -490,8 +493,9 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
+        - "--repo=k8s.io/$(REPO_NAME)"
         - "--branch=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
@@ -519,8 +523,9 @@ postsubmits:
     - name: ci-kubernetes-bazel-test
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:0.11
+        - image: gcr.io/k8s-testimages/bazelbuild:0.12
           args:
+          - "--repo=k8s.io/$(REPO_NAME)"
           - "--branch=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/logs"
           - "--git-cache=/root/.cache/git"
@@ -587,8 +592,9 @@ postsubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.9
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
+        - "--repo=k8s.io/$(REPO_NAME)"
         - "--branch=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
@@ -616,8 +622,9 @@ postsubmits:
     - name: ci-kubernetes-bazel-test-1-6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:0.9
+        - image: gcr.io/k8s-testimages/bazelbuild:0.12
           args:
+          - "--repo=k8s.io/$(REPO_NAME)"
           - "--branch=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/logs"
           - "--git-cache=/root/.cache/git"
@@ -686,8 +693,9 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
+        - "--repo=k8s.io/$(REPO_NAME)"
         - "--branch=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
@@ -739,8 +747,9 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.11
+    - image: gcr.io/k8s-testimages/bazelbuild:0.12
       args:
+      - "--repo=k8s.io/test-infra"
       - "--branch=master"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--git-cache=/root/.cache/git"
@@ -821,8 +830,9 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.9
+    - image: gcr.io/k8s-testimages/bazelbuild:0.12
       args:
+      - "--repo=k8s.io/kubernetes=release-1.6"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--git-cache=/root/.cache/git"
       - "--clean"
@@ -830,8 +840,6 @@ periodics:
       securityContext:
         privileged: true
       env:
-      - name: REPO_NAME
-        value: kubernetes=release-1.6
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       volumeMounts:
@@ -851,16 +859,15 @@ periodics:
   - name: periodic-kubernetes-bazel-test-1-6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.9
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
+        - "--repo=k8s.io/kubernetes=release-1.6"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
         - "--clean"
         securityContext:
           privileged: true
         env:
-        - name: REPO_NAME
-          value: kubernetes=release-1.6
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         volumeMounts:


### PR DESCRIPTION
If a periodic job uses the bazelbuild image and passes an argument of `--repo=...`, it ends up getting appended to the list of repos instead of overwriting it. Since not all jobs want this behavior, move the
`--repo` flag to `config.yaml` per job instead.

This also reverts the attempted (failed) workaround from https://github.com/kubernetes/test-infra/pull/2393.

(See also previous effort: https://github.com/kubernetes/test-infra/pull/2415)