### PR TITLE
Use app default credentials for gke tests

### DIFF
--- a/platforms/gke.env
+++ b/platforms/gke.env
@@ -2,6 +2,8 @@
 
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://test-container.sandbox.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/ci/staging
+# Temporary fix until defaultVersion gke jobs use gcloud's kubectl
+CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
 E2E_MIN_STARTUP_PODS=8
 FAIL_ON_GCP_RESOURCE_LEAK=true
 KUBERNETES_PROVIDER=gke


### PR DESCRIPTION
Temporary to unbreak tests. gcloud 1.5.0 changes the auth it configures
kubectl to use to be gcloud active account by default. defaultVersion
gke tests are currently broken because they are using an older version
of kubectl instead of the one shipped with gcloud.