### PR TITLE
Make cmd/deck understand both ProwJobs and k8s Jobs.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -18,7 +18,7 @@ all: build test
 HOOK_VERSION       = 0.95
 LINE_VERSION       = 0.86
 SINKER_VERSION     = 0.6
-DECK_VERSION       = 0.18
+DECK_VERSION       = 0.19
 SPLICE_VERSION     = 0.16
 MARQUE_VERSION     = 0.1
 TOT_VERSION        = 0.0

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.18
+        image: gcr.io/k8s-prow/deck:0.19
         ports:
           - name: http
             containerPort: 80

--- a/prow/kube/BUILD
+++ b/prow/kube/BUILD
@@ -10,7 +10,10 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["client_test.go"],
+    srcs = [
+        "client_test.go",
+        "prowjob_test.go",
+    ],
     library = ":go_default_library",
     tags = ["automanaged"],
 )
@@ -19,6 +22,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "client.go",
+        "prowjob.go",
         "types.go",
     ],
     tags = ["automanaged"],

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ProwJobType string
+type ProwJobState string
+type ProwJobAgent string
+
+const (
+	PresubmitJob  ProwJobType = "presubmit"
+	PostsubmitJob             = "postsubmit"
+	PeriodicJob               = "periodic"
+	BatchJob                  = "batch"
+)
+
+const (
+	TriggeredState ProwJobState = "triggered"
+	PendingState                = "pending"
+	SuccessState                = "success"
+	FailureState                = "failure"
+	AbortedState                = "aborted"
+	ErrorState                  = "error"
+)
+
+const (
+	KubernetesAgent ProwJobAgent = "kubernetes"
+	JenkinsAgent                 = "jenkins"
+)
+
+type ProwJob struct {
+	Metadata ObjectMeta    `json:"metadata,omitempty"`
+	Spec     ProwJobSpec   `json:"spec,omitempty"`
+	Status   ProwJobStatus `json:"status,omitempty"`
+}
+
+type ProwJobSpec struct {
+	Type  ProwJobType  `json:"type,omitempty"`
+	Agent ProwJobAgent `json:"agent,omitempty"`
+	Job   string       `json:"job,omitempty"`
+	Refs  Refs         `json:"refs,omitempty"`
+
+	Context     string `json:"context,omitempty"`
+	Description string `json:"description,omitempty"`
+	URL         string `json:"url,omitempty"`
+}
+
+type ProwJobStatus struct {
+	StartTime      time.Time    `json:"startTime,omitempty"`
+	CompletionTime time.Time    `json:"completionTime,omitempty"`
+	State          ProwJobState `json:"state,omitempty"`
+	PodName        string       `json:"pod_name,omitempty"`
+	// TODO(spxtr): Remove this once migration is complete.
+	KubeJobName string `json:"kube_job_name,omitempty"`
+}
+
+func (j *ProwJob) Complete() bool {
+	return !j.Status.CompletionTime.IsZero()
+}
+
+type Pull struct {
+	Number int    `json:"number,omitempty"`
+	Author string `json:"author,omitempty"`
+	SHA    string `json:"sha,omitempty"`
+}
+
+type Refs struct {
+	Org  string `json:"org,omitempty"`
+	Repo string `json:"repo,omitempty"`
+
+	BaseRef string `json:"base_ref,omitempty"`
+	BaseSHA string `json:"base_sha,omitempty"`
+
+	Pulls []Pull `json:"pulls,omitempty"`
+}
+
+func (r Refs) String() string {
+	rs := []string{fmt.Sprintf("%s:%s", r.BaseRef, r.BaseSHA)}
+	for _, pull := range r.Pulls {
+		rs = append(rs, fmt.Sprintf("%d:%s", pull.Number, pull.SHA))
+	}
+	return strings.Join(rs, ",")
+}

--- a/prow/kube/prowjob_test.go
+++ b/prow/kube/prowjob_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"testing"
+)
+
+func TestRefs(t *testing.T) {
+	testcases := []struct {
+		ref      Refs
+		expected string
+	}{
+		{
+			ref: Refs{
+				BaseRef: "master",
+				BaseSHA: "123abc",
+			},
+			expected: "master:123abc",
+		},
+		{
+			ref: Refs{
+				BaseRef: "release-1.6",
+				BaseSHA: "123",
+				Pulls: []Pull{
+					{
+						Number: 5,
+						SHA:    "qwe",
+					},
+				},
+			},
+			expected: "release-1.6:123,5:qwe",
+		},
+		{
+			ref: Refs{
+				BaseRef: "foo",
+				BaseSHA: "123",
+				Pulls: []Pull{
+					{
+						Number: 1,
+						SHA:    "qwe",
+					},
+					{
+						Number: 2,
+						SHA:    "asd",
+					},
+				},
+			},
+			expected: "foo:123,1:qwe,2:asd",
+		},
+	}
+	for _, tc := range testcases {
+		actual := tc.ref.String()
+		if actual != tc.expected {
+			t.Errorf("Ref %+v, got %s, expected, %s", tc.ref, actual, tc.expected)
+		}
+	}
+}

--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -30,66 +30,6 @@ type ObjectMeta struct {
 	UID             string `json:"uid,omitempty"`
 }
 
-type ProwJobType string
-type ProwJobState string
-
-const (
-	PresubmitJob  ProwJobType = "presubmit"
-	PostsubmitJob             = "postsubmit"
-	PeriodicJob               = "periodic"
-	BatchJob                  = "batch"
-)
-
-const (
-	TriggeredState ProwJobState = "triggered"
-	PendingState                = "pending"
-	SuccessState                = "success"
-	FailureState                = "failure"
-	AbortedState                = "aborted"
-	ErrorState                  = "error"
-)
-
-type ProwJob struct {
-	Metadata ObjectMeta    `json:"metadata,omitempty"`
-	Spec     ProwJobSpec   `json:"spec,omitempty"`
-	Status   ProwJobStatus `json:"status,omitempty"`
-}
-
-type ProwJobSpec struct {
-	Type    ProwJobType `json:"type,omitempty"`
-	Job     string      `json:"job,omitempty"`
-	Refs    Refs        `json:"refs,omitempty"`
-	Context string      `json:"context,omitempty"`
-}
-
-type ProwJobStatus struct {
-	StartTime      time.Time    `json:"startTime,omitempty"`
-	CompletionTime time.Time    `json:"completionTime,omitempty"`
-	State          ProwJobState `json:"state,omitempty"`
-	// TODO(spxtr): Remove this once migration is complete.
-	KubeJobName string `json:"kube_job_name,omitempty"`
-}
-
-func (j *ProwJob) Complete() bool {
-	return !j.Status.CompletionTime.IsZero()
-}
-
-type Pull struct {
-	Number int    `json:"number,omitempty"`
-	Author string `json:"author,omitempty"`
-	SHA    string `json:"sha,omitempty"`
-}
-
-type Refs struct {
-	Org  string `json:"org,omitempty"`
-	Repo string `json:"repo,omitempty"`
-
-	BaseRef string `json:"base_ref,omitempty"`
-	BaseSHA string `json:"base_sha,omitempty"`
-
-	Pulls []Pull `json:"pulls,omitempty"`
-}
-
 type Secret struct {
 	Metadata ObjectMeta        `json:"metadata,omitempty"`
 	Data     map[string]string `json:"data,omitempty"`


### PR DESCRIPTION
There's some logic for removing duplicates if both a ProwJob and a k8s
Job exist for the same test. This also splits the ProwJob definition out
of kube/types.go, since it's a non-standard k8s type.

See #2054.