### PR TITLE
Clarified CLA message

### DIFF
--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -36,7 +36,7 @@ const (
 
 :memo: **Please follow instructions at <https://github.com/kubernetes/kubernetes/wiki/CLA-FAQ> to sign the CLA.**
 
-Once you've signed, please reply here (e.g. "I signed it!") and we'll verify.  Thanks.
+It may take a couple minutes for the CLA signature to be fully registered; after that, please reply here with a new comment and we'll verify.  Thanks.
 
 ---
 


### PR DESCRIPTION
It can take some time for the CLA signature to propagate through the
full system, so a user that posts a comment too quickly after signing
the CLA will not see the bot update their PR status. The message should
reflect this fact.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta -- open to wording changes, this is a little clunky