### PR TITLE
Experimental queries to identify most flaky jobs and tests in those jobs

### DIFF
--- a/experiment/bigquery/README.md
+++ b/experiment/bigquery/README.md
@@ -1,0 +1,22 @@
+# Bigquery scripts
+
+This folder contains scripts to summarize data in our Bigquery test result
+database.
+
+## Assumptions
+
+We assume your machine has jq and bq. The bq program is part of gcloud.
+
+So please `apt-get install jq google-cloud-sdk` (see [gcloud install
+instructions](https://cloud.google.com/sdk/downloads#apt-get)).
+
+## Scripts
+
+* `flakes.sh` - find the flakiest jobs this week (and the flakiest tests in each
+  job).
+    - Uses `flakes.sql` to extract and group data from BigQuery
+    - Usage `flakes.sh | tee flakes-$(date %Y-%m-%d).json`
+    - Latest results: [flakes-latest](https://github.com/kubernetes/test-infra/blob/master/experiment/bigquery/flakes-latest.json)
+
+
+Future PRs will migrate other queries from [this spreadsheet](https://docs.google.com/spreadsheets/d/16nQPj_40xBgPLprj1DkKVTQ-BgQzO4A707q_JPsdxzY/edit).

--- a/experiment/bigquery/flakes-latest.json
+++ b/experiment/bigquery/flakes-latest.json
@@ -1,0 +1,90 @@
+{
+  "pr:pull-kubernetes-e2e-gce-non-cri": {
+    "consistency": "0.926",
+    "flakes": "63",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "29"
+    }
+  },
+  "ci-kubernetes-e2e-non-cri-gce-proto": {
+    "consistency": "0.861",
+    "flakes": "42",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "26"
+    }
+  },
+  "ci-kubernetes-e2e-non-cri-gce-etcd3": {
+    "consistency": "0.865",
+    "flakes": "42",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "29"
+    }
+  },
+  "ci-kubernetes-e2e-non-cri-gce": {
+    "consistency": "0.866",
+    "flakes": "41",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "27",
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": "9"
+    }
+  },
+  "ci-kubernetes-e2e-gce-gci-ci-master": {
+    "consistency": "0.868",
+    "flakes": "41",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "19"
+    }
+  },
+  "ci-kubernetes-e2e-gci-gce-proto": {
+    "consistency": "0.872",
+    "flakes": "40",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "16"
+    }
+  },
+  "ci-kubernetes-e2e-gce-container-vm": {
+    "consistency": "0.868",
+    "flakes": "40",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "12",
+      "[k8s.io] Downward API volume should update labels on modification [Conformance] [Volume]": "7"
+    }
+  },
+  "ci-kubernetes-e2e-gci-gce-etcd3": {
+    "consistency": "0.871",
+    "flakes": "40",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "11",
+      "[k8s.io] Projected should update labels on modification [Conformance] [Volume]": "7"
+    }
+  },
+  "ci-kubernetes-e2e-gce-proto": {
+    "consistency": "0.871",
+    "flakes": "40",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "18",
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": "10"
+    }
+  },
+  "ci-kubernetes-e2e-gce-etcd3": {
+    "consistency": "0.879",
+    "flakes": "39",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "17"
+    }
+  },
+  "ci-kubernetes-e2e-gci-gce": {
+    "consistency": "0.882",
+    "flakes": "39",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "14"
+    }
+  },
+  "ci-kubernetes-e2e-gce": {
+    "consistency": "0.888",
+    "flakes": "37",
+    "flakiest": {
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "15"
+    }
+  }
+}

--- a/experiment/bigquery/flakes-week.sql
+++ b/experiment/bigquery/flakes-week.sql
@@ -1,0 +1,89 @@
+#standardSQL
+select
+  job,
+  build_consistency,
+  commit_consistency,
+  flakes,
+  runs,
+  commits,
+  array(
+    select as struct
+      i.n name,
+      count(i.failures) flakes
+    from tt.tests i
+    group by name
+    having name not in ('Test', 'DiffResources')
+    order by flakes desc
+    limit 3
+  ) flakiest
+from (
+select
+  job,
+  round(sum(if(flaked=1,passed,runs))/sum(runs),3) build_consistency,
+  round(1-sum(flaked)/sum(runs),3) commit_consistency,
+  sum(flaked) flakes,
+  sum(runs) runs,
+  count(distinct commit) commits,
+  array_concat_agg(tests) tests
+from (
+select
+  job,
+  stamp,
+  num,
+  commit,
+  if(passed = runs or passed = 0, 0, 1) flaked,
+  passed,
+  safe_cast(runs as int64) runs,
+  array(
+    select as struct
+      i.name n,
+      countif(i.failed) failures
+    from tt.tests i
+    group by n
+    having failures > 0 and failures < tt.runs
+    order by failures desc
+  ) tests
+from (
+select
+  job,
+  max(stamp) stamp,
+  num,
+  if(kind = 'pull', commit, version) commit,
+  sum(if(result='SUCCESS',1,0)) passed,
+  count(result) runs,
+  array_concat_agg(test) tests
+from (
+SELECT
+  job,
+  regexp_extract(path, r'pull/(\d+)') as num,
+  if(substr(job, 0, 3) = 'pr:', 'pull', 'ci') kind,
+  version,
+  regexp_extract(
+    (
+      select i.value
+      from t.metadata i
+      where i.key = 'repos'
+    ),
+    r'[^,]+,\d+:([a-f0-9]+)"') commit,
+  date(started) stamp,
+  date_trunc(date(started), week) wk,
+  result,
+  test
+FROM `k8s-gubernator.build.all` as t
+where
+  datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)
+  and version != 'unknown'
+  and (
+    exists(
+      select as struct
+        i
+      from t.metadata i
+      where i.key = 'repos')
+    or substr(job, 0, 3) = 'ci-'))
+group by job, num, commit
+) as tt
+) as tt
+group by job
+order by flakes desc, build_consistency, commit_consistency, job
+) as tt
+order by flakes desc, build_consistency, commit_consistency, job

--- a/experiment/bigquery/flakes.sh
+++ b/experiment/bigquery/flakes.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: ./flakes.sh | tee flakes-$(date +%Y-%m-%d).json
+# This script uses flakes.sql to find job flake data for the past week
+# The script then filters jobs down to those which flake more than 4x/day
+# And also notes any test in those jobs which flake more than 1x/day
+
+out="/tmp/flakes-$(date +%Y-%m-%d).json"
+if [[ ! -f "${out}" ]]; then
+  which bq >/dev/null || (echo 'Cannot find bq on path. Install gcloud' 1>&2 && exit 1)
+  echo "Flakes results will be available at: ${out}" 1>&2
+  cat "$(dirname "${0}")/flakes.sql" | bq query --format=prettyjson > "${out}"
+fi
+which jq >/dev/null || (echo 'Cannot find jq on path. Install jq' 1>&2 && exit 1)
+echo 'Jobs flaking more than 4x/day:' 1>&2
+cat "${out}" | jq '
+  [(.[] | select(.flakes|tonumber > 28) | {(.job): {
+      consistency: .commit_consistency,
+      flakes: .flakes,
+      flakiest: ([(.flakiest[] | select(.flakes|tonumber >= 7) | {
+        (.name): .flakes}) ])| add
+  }})] | add'
+echo "Full flake data saved to: ${out}" 1>&2

--- a/experiment/bigquery/flakes.sql
+++ b/experiment/bigquery/flakes.sql
@@ -1,0 +1,89 @@
+#standardSQL
+select
+  job,
+  build_consistency,
+  commit_consistency,
+  flakes,
+  runs,
+  commits,
+  array(
+    select as struct
+      i.n name,
+      count(i.failures) flakes
+    from tt.tests i
+    group by name
+    having name not in ('Test', 'DiffResources')
+    order by flakes desc
+    limit 3
+  ) flakiest
+from (
+select
+  job,
+  round(sum(if(flaked=1,passed,runs))/sum(runs),3) build_consistency,
+  round(1-sum(flaked)/sum(runs),3) commit_consistency,
+  sum(flaked) flakes,
+  sum(runs) runs,
+  count(distinct commit) commits,
+  array_concat_agg(tests) tests
+from (
+select
+  job,
+  stamp,
+  num,
+  commit,
+  if(passed = runs or passed = 0, 0, 1) flaked,
+  passed,
+  safe_cast(runs as int64) runs,
+  array(
+    select as struct
+      i.name n,
+      countif(i.failed) failures
+    from tt.tests i
+    group by n
+    having failures > 0 and failures < tt.runs
+    order by failures desc
+  ) tests
+from (
+select
+  job,
+  max(stamp) stamp,
+  num,
+  if(kind = 'pull', commit, version) commit,
+  sum(if(result='SUCCESS',1,0)) passed,
+  count(result) runs,
+  array_concat_agg(test) tests
+from (
+SELECT
+  job,
+  regexp_extract(path, r'pull/(\d+)') as num,
+  if(substr(job, 0, 3) = 'pr:', 'pull', 'ci') kind,
+  version,
+  regexp_extract(
+    (
+      select i.value
+      from t.metadata i
+      where i.key = 'repos'
+    ),
+    r'[^,]+,\d+:([a-f0-9]+)"') commit,
+  date(started) stamp,
+  date_trunc(date(started), week) wk,
+  result,
+  test
+FROM `k8s-gubernator.build.week` as t
+where
+  datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)
+  and version != 'unknown'
+  and (
+    exists(
+      select as struct
+        i
+      from t.metadata i
+      where i.key = 'repos')
+    or substr(job, 0, 3) = 'ci-'))
+group by job, num, commit
+) as tt
+) as tt
+group by job
+order by flakes desc, build_consistency, commit_consistency, job
+) as tt
+order by flakes desc, build_consistency, commit_consistency, job


### PR DESCRIPTION
/assign @spxtr @cjwagner @brendandburns 

Includes output from today, which shows the following 12 jobs flake more than 4x per week:
```
  "ci-kubernetes-e2e-gce",
  "ci-kubernetes-e2e-gce-container-vm",
  "ci-kubernetes-e2e-gce-etcd3",
  "ci-kubernetes-e2e-gce-gci-ci-master",
  "ci-kubernetes-e2e-gce-proto",
  "ci-kubernetes-e2e-gci-gce",
  "ci-kubernetes-e2e-gci-gce-etcd3",
  "ci-kubernetes-e2e-gci-gce-proto",
  "ci-kubernetes-e2e-non-cri-gce",
  "ci-kubernetes-e2e-non-cri-gce-etcd3",
  "ci-kubernetes-e2e-non-cri-gce-proto",
  "pr:pull-kubernetes-e2e-gce-non-cri"
```
And that the following tests in those jobs flake more than once per day:
```
{
  "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": "18",
  "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": "8",
  "[k8s.io] Projected should update labels on modification [Conformance] [Volume]": "8"
}
```
