### PR TITLE
Use k8s-testimages for queue-health

### DIFF
--- a/queue-health/base/Makefile
+++ b/queue-health/base/Makefile
@@ -1,3 +1,3 @@
 include ../common.mk  # defines TAG build push all
 
-IMG = gcr.io/google-containers/queue-health-base
+IMG = gcr.io/k8s-testimages/queue-health-base

--- a/queue-health/graph/Dockerfile
+++ b/queue-health/graph/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/queue-health-base:v20161020
+FROM gcr.io/k8s-testimages/queue-health-base:v20161020
 MAINTAINER Erick Fejta <fejta@google.com>
 
 # Install matplotlib

--- a/queue-health/graph/Makefile
+++ b/queue-health/graph/Makefile
@@ -1,3 +1,3 @@
 include ../common.mk  # defines TAG build push all
 
-IMG = gcr.io/google-containers/queue-health-graph
+IMG = gcr.io/k8s-testimages/queue-health-graph

--- a/queue-health/poll/Makefile
+++ b/queue-health/poll/Makefile
@@ -1,3 +1,3 @@
 include ../common.mk  # defines TAG build push all
 
-IMG = gcr.io/google-containers/queue-health-poll
+IMG = gcr.io/k8s-testimages/queue-health-poll

--- a/queue-health/queue-health-graph-dev.yaml
+++ b/queue-health/queue-health-graph-dev.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Test graph, prod history, no poller
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph
+        image: gcr.io/k8s-testimages/queue-health-graph
         command:
         - python
         - /graph.py

--- a/queue-health/queue-health-prod.yaml
+++ b/queue-health/queue-health-prod.yaml
@@ -11,7 +11,7 @@ spec:
     spec:  # Override with production targets
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph:v20161209
+        image: gcr.io/k8s-testimages/queue-health-graph:v20161209
         command:
         - python
         - /graph.py
@@ -23,7 +23,7 @@ spec:
           mountPath: /creds
           readOnly: true
       - name: poller
-      image: gcr.io/k8s-testimages/queue-health-poll:v20170407
+        image: gcr.io/k8s-testimages/queue-health-poll:v20170407
         command:
         - python
         - /poller.py

--- a/queue-health/queue-health.yaml
+++ b/queue-health/queue-health.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: grapher
-        image: gcr.io/google-containers/queue-health-graph
+        image: gcr.io/k8s-testimages/queue-health-graph
         command:
         - python
         - /graph.py
@@ -23,7 +23,7 @@ spec:
           mountPath: /creds
           readOnly: true
       - name: poller
-        image: gcr.io/google-containers/queue-health-poll
+        image: gcr.io/k8s-testimages/queue-health-poll
         command:
         - python
         - /poller.py


### PR DESCRIPTION
/assign @brendandburns 
Updates deployments to use `gcr.io/k8s-testimages` instead of `gcr.io/google-containers`