### PR TITLE
Make plank run k8s pods for periodic jobs.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -23,8 +23,8 @@ SPLICE_VERSION     = 0.16
 MARQUE_VERSION     = 0.1
 TOT_VERSION        = 0.0
 CRIER_VERSION      = 0.5
-HOROLOGIUM_VERSION = 0.2
-PLANK_VERSION      = 0.3
+HOROLOGIUM_VERSION = 0.3
+PLANK_VERSION      = 0.4
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.2
+        image: gcr.io/k8s-prow/horologium:0.3
         env:
         - name: LINE_IMAGE
           value: "gcr.io/k8s-prow/line:0.86"

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -29,7 +29,7 @@ spec:
         role: prow
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.3
+        image: gcr.io/k8s-prow/plank:0.4
         env:
         - name: LINE_IMAGE
           value: "gcr.io/k8s-prow/line:0.86"

--- a/prow/cmd/horologium/BUILD
+++ b/prow/cmd/horologium/BUILD
@@ -22,8 +22,8 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/plank:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
-        "//vendor:github.com/satori/go.uuid",
     ],
 )
 

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -25,12 +26,17 @@ import (
 	"k8s.io/test-infra/prow/plank"
 )
 
+var (
+	totURL   = flag.String("tot-url", "http://tot", "Tot URL")
+	crierURL = flag.String("crier-url", "http://crier", "Crier URL")
+)
+
 func main() {
 	kc, err := kube.NewClientInCluster("default")
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}
-	c := plank.NewController(kc)
+	c := plank.NewController(kc, *crierURL, *totURL)
 	for range time.Tick(30 * time.Second) {
 		if err := c.Sync(); err != nil {
 			logrus.WithError(err).Error("Error syncing.")

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -67,6 +67,8 @@ type Periodic struct {
 	Spec     *kube.PodSpec `json:"spec,omitempty"`
 	Interval string        `json:"interval"`
 
+	RunAfterSuccess []Periodic `json:"run_after_success"`
+
 	interval time.Duration
 }
 

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -59,9 +59,15 @@ type ProwJobSpec struct {
 	Job   string       `json:"job,omitempty"`
 	Refs  Refs         `json:"refs,omitempty"`
 
-	Context     string `json:"context,omitempty"`
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url,omitempty"`
+	Report       bool   `json:"report,omitempty"`
+	Context      string `json:"context,omitempty"`
+	Description  string `json:"description,omitempty"`
+	RerunCommand string `json:"rerun_command,omitempty"`
+	URL          string `json:"url,omitempty"`
+
+	PodSpec PodSpec `json:"pod_spec,omitempty"`
+
+	RunAfterSuccess []ProwJobSpec `json:"run_after_success,omitempty"`
 }
 
 type ProwJobStatus struct {

--- a/prow/plank/BUILD
+++ b/prow/plank/BUILD
@@ -13,16 +13,24 @@ go_test(
     srcs = ["plank_test.go"],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//prow/kube:go_default_library"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/kube:go_default_library",
+    ],
 )
 
 go_library(
     name = "go_default_library",
-    srcs = ["plank.go"],
+    srcs = [
+        "controller.go",
+        "plank.go",
+    ],
     tags = ["automanaged"],
     deps = [
+        "//prow/config:go_default_library",
+        "//prow/crier:go_default_library",
         "//prow/kube:go_default_library",
-        "//prow/line:go_default_library",
+        "//vendor:github.com/satori/go.uuid",
     ],
 )
 

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plank
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	"k8s.io/test-infra/prow/crier"
+	"k8s.io/test-infra/prow/kube"
+)
+
+type kubeClient interface {
+	CreateProwJob(kube.ProwJob) (kube.ProwJob, error)
+	ListProwJobs(map[string]string) ([]kube.ProwJob, error)
+	ReplaceProwJob(string, kube.ProwJob) (kube.ProwJob, error)
+
+	CreatePod(kube.Pod) (kube.Pod, error)
+	ListPods(map[string]string) ([]kube.Pod, error)
+	DeletePod(string) error
+}
+
+type Controller struct {
+	kc       kubeClient
+	crierURL string
+	totURL   string
+}
+
+func NewController(kc *kube.Client, crierURL, totURL string) *Controller {
+	return &Controller{
+		kc:       kc,
+		crierURL: crierURL,
+		totURL:   totURL,
+	}
+}
+
+func (c *Controller) Sync() error {
+	pjs, err := c.kc.ListProwJobs(nil)
+	if err != nil {
+		return fmt.Errorf("error listing prow jobs: %v", err)
+	}
+	pods, err := c.kc.ListPods(nil)
+	if err != nil {
+		return fmt.Errorf("error listing pods: %v", err)
+	}
+	pm := map[string]kube.Pod{}
+	for _, pod := range pods {
+		pm[pod.Metadata.Name] = pod
+	}
+	var errs []error
+	for _, pj := range pjs {
+		if err := c.syncJob(pj, pm); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	} else {
+		return fmt.Errorf("errors syncing: %v", errs)
+	}
+}
+
+func (c *Controller) syncJob(pj kube.ProwJob, pm map[string]kube.Pod) error {
+	if pj.Complete() {
+		// ProwJob is complete. Do nothing.
+		return nil
+	} else if pj.Status.PodName == "" {
+		// We haven't started the pod yet. Do so.
+		pj.Status.State = kube.PendingState
+		if pn, err := c.startPod(pj); err == nil {
+			pj.Status.PodName = pn
+		} else {
+			return fmt.Errorf("error starting pod: %v", err)
+		}
+		if err := c.report(pj); err != nil {
+			return fmt.Errorf("error reporting to crier: %v", err)
+		}
+	} else if pod, ok := pm[pj.Status.PodName]; !ok {
+		// Pod is missing. This shouldn't happen normally, but if someone goes
+		// in and manually deletes the pod then we'll hit it. Start a new pod.
+		pj.Status.PodName = ""
+		pj.Status.State = kube.PendingState
+	} else if pod.Status.Phase == kube.PodUnknown {
+		// Pod is in Unknown state. This can happen if there is a problem with
+		// the node. Delete the old pod, we'll start a new one next loop.
+		if err := c.kc.DeletePod(pj.Status.PodName); err != nil {
+			return fmt.Errorf("error deleting pod %s: %v", pj.Status.PodName, err)
+		}
+		pj.Status.PodName = ""
+		pj.Status.State = kube.PendingState
+	} else if pod.Status.Phase == kube.PodSucceeded {
+		// Pod succeeded. Update ProwJob, talk to crier, and start next jobs.
+		pj.Status.CompletionTime = time.Now()
+		pj.Status.State = kube.SuccessState
+		if err := c.report(pj); err != nil {
+			return fmt.Errorf("error reporting to crier: %v", err)
+		}
+		for _, nj := range pj.Spec.RunAfterSuccess {
+			if _, err := c.kc.CreateProwJob(NewProwJob(nj)); err != nil {
+				return fmt.Errorf("error starting next prowjob: %v", err)
+			}
+		}
+	} else if pod.Status.Phase == kube.PodFailed {
+		// Pod failed. Update ProwJob, talk to crier.
+		pj.Status.CompletionTime = time.Now()
+		pj.Status.State = kube.FailureState
+		if err := c.report(pj); err != nil {
+			return fmt.Errorf("error reporting to crier: %v", err)
+		}
+	} else {
+		// Pod is running. Do nothing.
+		return nil
+	}
+	_, err := c.kc.ReplaceProwJob(pj.Metadata.Name, pj)
+	return err
+}
+
+func (c *Controller) report(pj kube.ProwJob) error {
+	if !pj.Spec.Report {
+		return nil
+	}
+	if len(pj.Spec.Refs.Pulls) != 1 {
+		return fmt.Errorf("prowjob %s has %d pulls, not 1", pj.Metadata.Name, len(pj.Spec.Refs.Pulls))
+	}
+	return crier.ReportToCrier(c.crierURL, crier.Report{
+		RepoOwner:    pj.Spec.Refs.Org,
+		RepoName:     pj.Spec.Refs.Repo,
+		Author:       pj.Spec.Refs.Pulls[0].Author,
+		Number:       pj.Spec.Refs.Pulls[0].Number,
+		Commit:       pj.Spec.Refs.Pulls[0].SHA,
+		Context:      pj.Spec.Context,
+		State:        string(pj.Status.State),
+		Description:  pj.Spec.Description,
+		RerunCommand: pj.Spec.RerunCommand,
+		URL:          pj.Spec.URL,
+	})
+}
+
+func (c *Controller) startPod(pj kube.ProwJob) (string, error) {
+	buildID, err := c.getBuildID(c.totURL, pj.Spec.Job)
+	if err != nil {
+		return "", fmt.Errorf("error getting build ID: %v", err)
+	}
+	spec := pj.Spec.PodSpec
+	spec.RestartPolicy = "Never"
+	spec.NodeSelector = map[string]string{
+		"role": "build",
+	}
+	// keep this synchronized with get_running_build_log in Gubernator!
+	podName := fmt.Sprintf("%s-%s", pj.Spec.Job, buildID)
+	if len(podName) > 60 {
+		podName = podName[len(podName)-60:]
+	}
+
+	for i := range spec.Containers {
+		spec.Containers[i].Name = fmt.Sprintf("%s-%d", podName, i)
+		spec.Containers[i].Env = append(spec.Containers[i].Env,
+			kube.EnvVar{
+				Name:  "JOB_NAME",
+				Value: pj.Spec.Job,
+			},
+			kube.EnvVar{
+				Name:  "BUILD_NUMBER",
+				Value: buildID,
+			},
+		)
+		if pj.Spec.Type == kube.PeriodicJob {
+			continue
+		}
+		spec.Containers[i].Env = append(spec.Containers[i].Env,
+			kube.EnvVar{
+				Name:  "REPO_OWNER",
+				Value: pj.Spec.Refs.Org,
+			},
+			kube.EnvVar{
+				Name:  "REPO_NAME",
+				Value: pj.Spec.Refs.Repo,
+			},
+			kube.EnvVar{
+				Name:  "PULL_BASE_REF",
+				Value: pj.Spec.Refs.BaseRef,
+			},
+			kube.EnvVar{
+				Name:  "PULL_BASE_SHA",
+				Value: pj.Spec.Refs.BaseSHA,
+			},
+			kube.EnvVar{
+				Name:  "PULL_REFS",
+				Value: pj.Spec.Refs.String(),
+			},
+		)
+		if pj.Spec.Type == kube.PostsubmitJob || pj.Spec.Type == kube.BatchJob {
+			continue
+		}
+		spec.Containers[i].Env = append(spec.Containers[i].Env,
+			kube.EnvVar{
+				Name:  "PULL_NUMBER",
+				Value: strconv.Itoa(pj.Spec.Refs.Pulls[0].Number),
+			},
+			kube.EnvVar{
+				Name:  "PULL_PULL_SHA",
+				Value: pj.Spec.Refs.Pulls[0].SHA,
+			},
+		)
+		// Set the HostPort to 9999 for all build pods so that they are forced
+		// onto different nodes. Once pod affinity is GA, use that instead.
+		spec.Containers[i].Ports = append(spec.Containers[i].Ports,
+			kube.Port{
+				ContainerPort: 9999,
+				HostPort:      9999,
+			},
+		)
+	}
+	p := kube.Pod{
+		Metadata: kube.ObjectMeta{
+			Name: podName,
+		},
+		Spec: spec,
+	}
+	actual, err := c.kc.CreatePod(p)
+	if err != nil {
+		return "", fmt.Errorf("error creating pod: %v", err)
+	}
+	return actual.Metadata.Name, nil
+}
+
+func (c *Controller) getBuildID(server, name string) (string, error) {
+	var err error
+	url := server + "/vend/" + name
+	for retries := 0; retries < 60; retries++ {
+		if retries > 0 {
+			time.Sleep(2 * time.Second)
+		}
+		var resp *http.Response
+		resp, err = http.Get(url)
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			continue
+		}
+		if buf, err := ioutil.ReadAll(resp.Body); err == nil {
+			return string(buf), nil
+		} else {
+			return "", err
+		}
+	}
+	return "", err
+}


### PR DESCRIPTION
This copies much of the logic from cmd/line into plank. This should be safe to deploy as-is without any disruption. If something does go wrong, it will only break periodic jobs.

Currently it doesn't have logic for Jenkins jobs. That will happen before switching over presubmits.

/assign @krzyzacy 
This is a large part of the fifth step of #2054.