### PR TITLE
Downgrade redundant gce testing to non-blocking

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -43,6 +43,7 @@ data:
     ci-kubernetes-e2e-gce-scalability,\
     ci-kubernetes-e2e-gce-serial,\
     ci-kubernetes-e2e-gce-taint-evict,\
+    ci-kubernetes-e2e-gci-gce,\
     ci-kubernetes-e2e-gci-gce-autoscaling,\
     ci-kubernetes-e2e-gci-gce-autoscaling-migs,\
     ci-kubernetes-e2e-gci-gce-es-logging,\
@@ -54,7 +55,9 @@ data:
     ci-kubernetes-e2e-gci-gce-reboot,\
     ci-kubernetes-e2e-gci-gce-scalability,\
     ci-kubernetes-e2e-gci-gce-serial,\
+    ci-kubernetes-e2e-gci-gce-slow,\
     ci-kubernetes-e2e-gci-gce-statefulset,\
+    ci-kubernetes-e2e-gci-gke,\
     ci-kubernetes-e2e-gci-gke-alpha-features,\
     ci-kubernetes-e2e-gci-gke-autoscaling,\
     ci-kubernetes-e2e-gci-gke-ingress,\
@@ -65,22 +68,21 @@ data:
     ci-kubernetes-e2e-gci-gke-prod-smoke,\
     ci-kubernetes-e2e-gci-gke-reboot,\
     ci-kubernetes-e2e-gci-gke-serial,\
+    ci-kubernetes-e2e-gci-gke-slow,\
     ci-kubernetes-e2e-gci-gke-staging,\
     ci-kubernetes-e2e-gci-gke-staging-parallel,\
     ci-kubernetes-e2e-gci-gke-subnet,\
     ci-kubernetes-e2e-gci-gke-test,\
     ci-kubernetes-e2e-gci-gke-updown,\
-    ci-kubernetes-e2e-gci-gke,\
-    ci-kubernetes-e2e-gci-gke-slow,\
     ci-kubernetes-e2e-gke-large-cluster,\
     ci-kubernetes-e2e-gke-serial,\
     ci-kubernetes-e2e-gke-staging,\
     ci-kubernetes-e2e-gke-staging-parallel,\
     ci-kubernetes-e2e-gke-test,\
-    ci-kubernetes-e2e-kops-aws-slow,\
-    ci-kubernetes-e2e-kops-aws-serial,\
     ci-kubernetes-e2e-kops-aws-release-1.5,\
     ci-kubernetes-e2e-kops-aws-release-1.6,\
+    ci-kubernetes-e2e-kops-aws-serial,\
+    ci-kubernetes-e2e-kops-aws-slow,\
     ci-kubernetes-e2e-kops-aws-updown,\
     ci-kubernetes-kubemark-5-gce,\
     ci-kubernetes-node-kubelet-serial,\
@@ -96,9 +98,6 @@ data:
   submit-queue.jenkins-jobs: "\
     ci-kubernetes-build,\
     ci-kubernetes-e2e-gce-etcd3,\
-    ci-kubernetes-e2e-gci-gce,\
-    ci-kubernetes-e2e-gci-gce-slow,\
-    ci-kubernetes-e2e-gci-gce-ingress,\
     ci-kubernetes-e2e-kops-aws,\
     ci-kubernetes-kubemark-500-gce,\
     ci-kubernetes-node-kubelet,\

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2137,10 +2137,6 @@ dashboards:
     test_group_name: ci-kubernetes-build
   - name: gce-etcd3
     test_group_name: ci-kubernetes-e2e-gce-etcd3
-  - name: gci-gce
-    test_group_name: ci-kubernetes-e2e-gci-gce
-  - name: gci-gce-slow
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow
   - name: kops-aws
     test_group_name: ci-kubernetes-e2e-kops-aws
   - name: kubemark-500-gce
@@ -2149,9 +2145,7 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet
   - name: test-go
     test_group_name: ci-kubernetes-test-go
-  - name: ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-  - name: verify 
+  - name: verify
     test_group_name: ci-kubernetes-verify-master
 
 - name: google-non-cri


### PR DESCRIPTION
Keeping the most stable gce parallel job.

We now have the ability to run lots of tests on presubmit. Intent is for all tests that we want to block merges to run during presubmit. Otherwise intent is to discover, investigate and resolve problems in tests without blocking the merges for everyone.

Details: https://docs.google.com/document/d/10AN_hgEM77CLtfZ-3v7zRV4ep5phqw2jc0jY4n8WRus/edit

/assign @spxtr 