### PR TITLE
Make plank handle Jenkins jobs, convert splice.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -18,13 +18,13 @@ all: build test
 HOOK_VERSION       = 0.96
 LINE_VERSION       = 0.86
 SINKER_VERSION     = 0.6
-DECK_VERSION       = 0.20
-SPLICE_VERSION     = 0.16
+DECK_VERSION       = 0.21
+SPLICE_VERSION     = 0.17
 MARQUE_VERSION     = 0.1
 TOT_VERSION        = 0.0
 CRIER_VERSION      = 0.5
 HOROLOGIUM_VERSION = 0.3
-PLANK_VERSION      = 0.4
+PLANK_VERSION      = 0.5
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.20
+        image: gcr.io/k8s-prow/deck:0.21
         ports:
           - name: http
             containerPort: 80

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -29,9 +29,26 @@ spec:
         role: prow
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.4
+        image: gcr.io/k8s-prow/plank:0.5
         env:
         - name: LINE_IMAGE
           value: "gcr.io/k8s-prow/line:0.86"
         - name: DRY_RUN
           value: "false"
+        args:
+        - --jenkins-url=$(JENKINS_URL)
+        env:
+        - name: JENKINS_URL
+          valueFrom:
+            configMapKeyRef:
+              key: jenkins-address
+              name: jenkins-address
+        volumeMounts:
+        - mountPath: /etc/jenkins
+          name: jenkins
+          readOnly: true
+      volumes:
+      - name: jenkins
+        secret:
+          defaultMode: 420
+          secretName: jenkins-token

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         role: prow
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.16
+        image: gcr.io/k8s-prow/splice:0.17
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cmd/deck/jobs.go
+++ b/prow/cmd/deck/jobs.go
@@ -186,12 +186,12 @@ func (ja *JobAgent) update() error {
 			Job:         j.Spec.Job,
 			Context:     j.Spec.Context,
 			Description: j.Spec.Description,
-			URL:         j.Spec.URL,
 			Agent:       string(j.Spec.Agent),
 
 			Started: j.Status.StartTime.Format(time.Stamp),
 			State:   string(j.Status.State),
 			PodName: j.Status.PodName,
+			URL:     j.Status.URL,
 
 			st: j.Status.StartTime,
 			ft: j.Status.CompletionTime,

--- a/prow/cmd/line/main.go
+++ b/prow/cmd/line/main.go
@@ -364,7 +364,7 @@ func (c *testClient) TestPRJenkins() error {
 		c.tryCreateStatus("", github.StatusError, "Error starting build.", testInfra)
 		return err
 	}
-	eq, err := c.JenkinsClient.Enqueued(b)
+	eq, err := c.JenkinsClient.Enqueued(b.QueueURL.String())
 	if err != nil {
 		c.tryCreateStatus("", github.StatusError, "Error queueing build.", testInfra)
 		return err
@@ -372,14 +372,14 @@ func (c *testClient) TestPRJenkins() error {
 	c.tryCreateStatus("", github.StatusPending, "Build queued.", "")
 	for eq { // Wait for it to move out of the queue
 		time.Sleep(10 * time.Second)
-		eq, err = c.JenkinsClient.Enqueued(b)
+		eq, err = c.JenkinsClient.Enqueued(b.QueueURL.String())
 		if err != nil {
 			c.tryCreateStatus("", github.StatusError, "Error in queue.", testInfra)
 			return err
 		}
 	}
 
-	result, err := c.JenkinsClient.Status(b)
+	result, err := c.JenkinsClient.Status(b.JobName, b.ID)
 	if err != nil {
 		c.tryCreateStatus("", github.StatusError, "Error waiting for build.", testInfra)
 		return err
@@ -406,7 +406,7 @@ func (c *testClient) TestPRJenkins() error {
 				break
 			}
 		}
-		result, err = c.JenkinsClient.Status(b)
+		result, err = c.JenkinsClient.Status(b.JobName, b.ID)
 	}
 	return nil
 }

--- a/prow/cmd/plank/BUILD
+++ b/prow/cmd/plank/BUILD
@@ -19,6 +19,7 @@ go_library(
     srcs = ["main.go"],
     tags = ["automanaged"],
     deps = [
+        "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/plank:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",

--- a/prow/cmd/splice/BUILD
+++ b/prow/cmd/splice/BUILD
@@ -29,7 +29,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",
-        "//prow/line:go_default_library",
+        "//prow/plank:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
     ],
 )

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -63,7 +63,6 @@ type ProwJobSpec struct {
 	Context      string `json:"context,omitempty"`
 	Description  string `json:"description,omitempty"`
 	RerunCommand string `json:"rerun_command,omitempty"`
-	URL          string `json:"url,omitempty"`
 
 	PodSpec PodSpec `json:"pod_spec,omitempty"`
 
@@ -74,9 +73,13 @@ type ProwJobStatus struct {
 	StartTime      time.Time    `json:"startTime,omitempty"`
 	CompletionTime time.Time    `json:"completionTime,omitempty"`
 	State          ProwJobState `json:"state,omitempty"`
+	URL            string       `json:"url,omitempty"`
 	PodName        string       `json:"pod_name,omitempty"`
 	// TODO(spxtr): Remove this once migration is complete.
-	KubeJobName string `json:"kube_job_name,omitempty"`
+	KubeJobName     string `json:"kube_job_name,omitempty"`
+	JenkinsQueueURL string `json:"jenkins_queue_url,omitempty"`
+	JenkinsEnqueued bool   `json:"jenkins_enqueued,omitempty"`
+	JenkinsBuildID  string `json:"jenkins_build_id,omitempty"`
 }
 
 func (j *ProwJob) Complete() bool {

--- a/prow/plank/BUILD
+++ b/prow/plank/BUILD
@@ -15,6 +15,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",
     ],
 )
@@ -29,6 +30,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/crier:go_default_library",
+        "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor:github.com/satori/go.uuid",
     ],

--- a/prow/plank/plank_test.go
+++ b/prow/plank/plank_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package plank
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/jenkins"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -70,6 +73,40 @@ func (f *fkc) DeletePod(name string) error {
 	return fmt.Errorf("did not find pod %s", name)
 }
 
+type fjc struct {
+	built    bool
+	enqueued bool
+	status   jenkins.Status
+	err      error
+}
+
+func (f *fjc) Build(br jenkins.BuildRequest) (*jenkins.Build, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.built = true
+	url, _ := url.Parse("localhost")
+	return &jenkins.Build{
+		JobName:  br.JobName,
+		ID:       "4",
+		QueueURL: url,
+	}, nil
+}
+
+func (f *fjc) Enqueued(string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.enqueued, nil
+}
+
+func (f *fjc) Status(job, id string) (*jenkins.Status, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &f.status, nil
+}
+
 func handleTot(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "42")
 }
@@ -77,7 +114,233 @@ func handleTot(w http.ResponseWriter, r *http.Request) {
 func handleCrier(w http.ResponseWriter, r *http.Request) {
 }
 
-func TestSyncJob(t *testing.T) {
+func TestSyncJenkinsJob(t *testing.T) {
+	var testcases = []struct {
+		name string
+		pj   kube.ProwJob
+
+		enqueued bool
+		status   jenkins.Status
+		err      error
+
+		expectedState    kube.ProwJobState
+		expectedBuild    bool
+		expectedComplete bool
+		expectedReport   bool
+		expectedEnqueued bool
+		expectedError    bool
+	}{
+		{
+			name: "complete pj",
+			pj: kube.ProwJob{
+				Status: kube.ProwJobStatus{
+					CompletionTime: time.Now(),
+				},
+			},
+			expectedComplete: true,
+		},
+		{
+			name: "start new job",
+			pj: kube.ProwJob{
+				Status: kube.ProwJobStatus{
+					State: kube.TriggeredState,
+				},
+			},
+			expectedBuild:    true,
+			expectedState:    kube.PendingState,
+			expectedEnqueued: true,
+		},
+		{
+			name: "start new job, report",
+			pj: kube.ProwJob{
+				Spec: kube.ProwJobSpec{
+					Type:   kube.PresubmitJob,
+					Report: true,
+					Refs: kube.Refs{
+						Pulls: []kube.Pull{kube.Pull{}},
+					},
+				},
+				Status: kube.ProwJobStatus{
+					State: kube.TriggeredState,
+				},
+			},
+			expectedBuild:    true,
+			expectedReport:   true,
+			expectedState:    kube.PendingState,
+			expectedEnqueued: true,
+		},
+		{
+			name: "start new job, error, report",
+			pj: kube.ProwJob{
+				Spec: kube.ProwJobSpec{
+					Type:   kube.PresubmitJob,
+					Report: true,
+					Refs: kube.Refs{
+						Pulls: []kube.Pull{kube.Pull{}},
+					},
+				},
+				Status: kube.ProwJobStatus{
+					State: kube.TriggeredState,
+				},
+			},
+			err:              errors.New("oh no!"),
+			expectedReport:   true,
+			expectedState:    kube.ErrorState,
+			expectedComplete: true,
+			expectedError:    true,
+		},
+		{
+			name: "enqueued",
+			pj: kube.ProwJob{
+				Status: kube.ProwJobStatus{
+					State:           kube.PendingState,
+					JenkinsEnqueued: true,
+				},
+			},
+			enqueued:         true,
+			expectedState:    kube.PendingState,
+			expectedEnqueued: true,
+		},
+		{
+			name: "finished queue",
+			pj: kube.ProwJob{
+				Status: kube.ProwJobStatus{
+					State:           kube.PendingState,
+					JenkinsEnqueued: true,
+				},
+			},
+			enqueued:         false,
+			expectedState:    kube.PendingState,
+			expectedEnqueued: false,
+		},
+		{
+			name: "enqueued, error",
+			pj: kube.ProwJob{
+				Spec: kube.ProwJobSpec{
+					Type:   kube.PresubmitJob,
+					Report: true,
+					Refs: kube.Refs{
+						Pulls: []kube.Pull{kube.Pull{}},
+					},
+				},
+
+				Status: kube.ProwJobStatus{
+					State:           kube.PendingState,
+					JenkinsEnqueued: true,
+				},
+			},
+			err:              errors.New("oh no!"),
+			expectedState:    kube.ErrorState,
+			expectedError:    true,
+			expectedComplete: true,
+			expectedReport:   true,
+		},
+		{
+			name: "building",
+			pj: kube.ProwJob{
+				Status: kube.ProwJobStatus{
+					State: kube.PendingState,
+				},
+			},
+			status: jenkins.Status{
+				Building: true,
+			},
+			expectedState: kube.PendingState,
+		},
+		{
+			name: "building, error",
+			pj: kube.ProwJob{
+				Spec: kube.ProwJobSpec{
+					Type:   kube.PresubmitJob,
+					Report: true,
+					Refs: kube.Refs{
+						Pulls: []kube.Pull{kube.Pull{}},
+					},
+				},
+				Status: kube.ProwJobStatus{
+					State: kube.PendingState,
+				},
+			},
+			err:              errors.New("oh no!"),
+			expectedState:    kube.ErrorState,
+			expectedError:    true,
+			expectedComplete: true,
+			expectedReport:   true,
+		},
+		{
+			name: "finished, success",
+			pj: kube.ProwJob{
+				Status: kube.ProwJobStatus{
+					State: kube.PendingState,
+				},
+			},
+			status: jenkins.Status{
+				Building: false,
+				Success:  true,
+			},
+			expectedState:    kube.SuccessState,
+			expectedComplete: true,
+		},
+		{
+			name: "finished, failed",
+			pj: kube.ProwJob{
+				Status: kube.ProwJobStatus{
+					State: kube.PendingState,
+				},
+			},
+			status: jenkins.Status{
+				Building: false,
+				Success:  false,
+			},
+			expectedState:    kube.FailureState,
+			expectedComplete: true,
+		},
+	}
+	for _, tc := range testcases {
+		var reported bool
+		var handleCrier = func(w http.ResponseWriter, r *http.Request) {
+			reported = true
+		}
+		crierServ := httptest.NewServer(http.HandlerFunc(handleCrier))
+		defer crierServ.Close()
+		fjc := &fjc{
+			enqueued: tc.enqueued,
+			status:   tc.status,
+			err:      tc.err,
+		}
+		fkc := &fkc{
+			prowjobs: []kube.ProwJob{tc.pj},
+		}
+
+		c := Controller{
+			kc:       fkc,
+			jc:       fjc,
+			crierURL: crierServ.URL,
+		}
+		if err := c.syncJenkinsJob(tc.pj); err != nil != tc.expectedError {
+			t.Errorf("for case %s got wrong error: %v", tc.name, err)
+			continue
+		}
+		actual := fkc.prowjobs[0]
+		if actual.Status.State != tc.expectedState {
+			t.Errorf("for case %s got state %v", tc.name, actual.Status.State)
+		}
+		if actual.Complete() != tc.expectedComplete {
+			t.Errorf("for case %s got wrong completion", tc.name)
+		}
+		if reported != tc.expectedReport {
+			t.Errorf("for case %s got wrong report", tc.name)
+		}
+		if fjc.built != tc.expectedBuild {
+			t.Errorf("for case %s got wrong built", tc.name)
+		}
+		if actual.Status.JenkinsEnqueued != tc.expectedEnqueued {
+			t.Errorf("for case %s got wrong enqueued", tc.name)
+		}
+	}
+}
+
+func TestSyncKubernetesJob(t *testing.T) {
 	var testcases = []struct {
 		name string
 
@@ -245,7 +508,7 @@ func TestSyncJob(t *testing.T) {
 			totURL:   totServ.URL,
 			crierURL: crierServ.URL,
 		}
-		if err := c.syncJob(tc.pj, pm); err != nil {
+		if err := c.syncKubernetesJob(tc.pj, pm); err != nil {
 			t.Errorf("for case %s got an error: %v", tc.name, err)
 			continue
 		}
@@ -265,6 +528,80 @@ func TestSyncJob(t *testing.T) {
 		if len(fc.prowjobs) != tc.expectedCreatedPJs+1 {
 			t.Errorf("for case %s got %d created prowjobs", tc.name, len(fc.prowjobs)-1)
 		}
+	}
+}
+
+// TestBatch walks through the happy path of a batch job on Jenkins.
+func TestBatch(t *testing.T) {
+	pre := config.Presubmit{
+		Name:    "pr-some-job",
+		Context: "pr-some-job",
+	}
+	crierServ := httptest.NewServer(http.HandlerFunc(handleCrier))
+	defer crierServ.Close()
+	fc := &fkc{
+		prowjobs: []kube.ProwJob{NewProwJob(BatchSpec(pre, kube.Refs{
+			Org:     "o",
+			Repo:    "r",
+			BaseRef: "master",
+			BaseSHA: "123",
+			Pulls: []kube.Pull{
+				kube.Pull{
+					Number: 1,
+					SHA:    "abc",
+				},
+				kube.Pull{
+					Number: 2,
+					SHA:    "qwe",
+				},
+			},
+		}))},
+	}
+	jc := &fjc{}
+	c := Controller{
+		kc:       fc,
+		jc:       jc,
+		crierURL: crierServ.URL,
+	}
+
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Error on first sync: %v", err)
+	}
+	if fc.prowjobs[0].Status.State != kube.PendingState {
+		t.Fatalf("Wrong state: %v", fc.prowjobs[0].Status.State)
+	}
+	if !fc.prowjobs[0].Status.JenkinsEnqueued {
+		t.Fatal("Wrong enqueued.")
+	}
+	jc.enqueued = true
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Error on second sync: %v", err)
+	}
+	if !fc.prowjobs[0].Status.JenkinsEnqueued {
+		t.Fatal("Wrong enqueued steady state.")
+	}
+	jc.enqueued = false
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Error on third sync: %v", err)
+	}
+	if fc.prowjobs[0].Status.JenkinsEnqueued {
+		t.Fatal("Wrong enqueued after leaving queue.")
+	}
+	jc.status = jenkins.Status{Building: true}
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Error on fourth sync: %v", err)
+	}
+	if fc.prowjobs[0].Status.State != kube.PendingState {
+		t.Fatalf("Wrong state: %v", fc.prowjobs[0].Status.State)
+	}
+	jc.status = jenkins.Status{
+		Building: false,
+	}
+	if err := c.Sync(); err != nil {
+		t.Fatalf("Error on fifth sync: %v", err)
+	}
+	if fc.prowjobs[0].Status.State != kube.FailureState {
+		t.Fatalf("Wrong state: %v", fc.prowjobs[0].Status.State)
 	}
 }
 


### PR DESCRIPTION
1. Plank now handles Jenkins jobs. It still polls per-job. I didn't
bother optimizing this, because we're transitioning off of Jenkins
anyway.
2. Splice now starts jobs using TPRs.
3. Deck will show URLs for periodics properly.

#2054. Once this is in-place and happy, converting the rest of the jobs will be a small change. This is the last PR in this batch of PRs that will have many + lines. It's all downhill from here!