### PR TITLE
Fix federation soak jobs

### DIFF
--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.env
@@ -1,4 +1,4 @@
-KUBE_NODE_OS_DISTRIBUTION=debian
+KUBE_NODE_OS_DISTRIBUTION=gci
 
 ### soak-env
 JENKINS_SOAK_MODE=y
@@ -7,7 +7,7 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 ### job-env
 PROJECT=k8s-jkns-gce-federation-soak
 
-KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-federation
+KUBE_REGISTRY=gcr.io/k8s-jkns-gce-federation-soak
 KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 

--- a/jobs/ci-kubernetes-soak-gce-federation-test.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.env
@@ -1,4 +1,4 @@
-KUBE_NODE_OS_DISTRIBUTION=debian
+KUBE_NODE_OS_DISTRIBUTION=gci
 
 ### soak-env
 JENKINS_SOAK_MODE=y
@@ -10,7 +10,7 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 ### job-env
 PROJECT=k8s-jkns-gce-federation-soak
 
-KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-federation
+KUBE_REGISTRY=gcr.io/k8s-jkns-gce-federation-soak
 KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 


### PR DESCRIPTION
Seems like a copy-paste mistake. federation-soak-build job was pushing image to some other project and federation-soak-deploy was pulling from some other project. 
Hope this will fix `federation up` for soak jobs

cc @madhusudancs 