### PR TITLE
Fix real-time logs and gubernator link.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,7 +24,7 @@ MARQUE_VERSION     = 0.1
 TOT_VERSION        = 0.0
 CRIER_VERSION      = 0.5
 HOROLOGIUM_VERSION = 0.3
-PLANK_VERSION      = 0.6
+PLANK_VERSION      = 0.7
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -29,7 +29,7 @@ spec:
         role: prow
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.6
+        image: gcr.io/k8s-prow/plank:0.7
         volumeMounts:
         - mountPath: /etc/jenkins
           name: jenkins

--- a/prow/plank/plank_test.go
+++ b/prow/plank/plank_test.go
@@ -596,9 +596,13 @@ func TestBatch(t *testing.T) {
 	}
 	jc.status = jenkins.Status{
 		Building: false,
+		Number:   42,
 	}
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on fifth sync: %v", err)
+	}
+	if fc.prowjobs[0].Status.PodName != "pr-some-job-42" {
+		t.Fatalf("Wrong PodName: %s", fc.prowjobs[0].Status.PodName)
 	}
 	if fc.prowjobs[0].Status.State != kube.FailureState {
 		t.Fatalf("Wrong state: %v", fc.prowjobs[0].Status.State)


### PR DESCRIPTION
1. Even Jenkins jobs have a `pod_name`, for real-time logs.
1. Fix k8s gubernator links.