### PR TITLE
Show reviewers and approval requests in PR Dashboard.

### DIFF
--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -299,6 +299,11 @@ def get_reviewers(events):
 
 
 def get_approvers(comments):
+    '''
+    Return approvers requested in comments.
+
+    This MUST be kept in sync with mungegithub's getGubernatorMetadata().
+    '''
     approvers = []
     for comment in comments:
         if comment['author'] == 'k8s-merge-robot':

--- a/gubernator/github/classifier_test.py
+++ b/gubernator/github/classifier_test.py
@@ -232,6 +232,28 @@ class CalculateTest(unittest.TestCase):
         expect(fail('/a/b/34/'), [fail('/a/b/34]')], ['/a/b/34'])
         expect(fail('/a/b/34/)'), [fail('/a/b/35]')], ['/a/b/34', '/a/b/35'])
 
+    def test_reviewers(self):
+        def expect(events, result):
+            self.assertEqual(result, classifier.get_reviewers(events))
+
+        def mk(*specs):
+            out = []
+            for event, action, body in specs:
+                body = dict(body)  # copy
+                body['action'] = action
+                out.append((event, body, 0))
+            return out
+
+        expect([], set())
+
+        reviewer_a = {'requested_reviewer': {'login': 'a'}}
+        reviewer_b = {'requested_reviewer': {'login': 'b'}}
+        expect(mk(('pull_request', 'review_requested', reviewer_a)), {'a'})
+        expect(mk(('pull_request', 'review_request_removed', reviewer_a)), set())
+        expect(mk(('pull_request', 'review_requested', reviewer_a),
+                  ('pull_request', 'review_request_removed', reviewer_a)), set())
+        expect(mk(('pull_request_review', 'submitted', {'sender': {'login': 'b'}})), {'b'})
+
 
 class CommentsTest(unittest.TestCase):
     def test_basic(self):

--- a/gubernator/github/classifier_test.py
+++ b/gubernator/github/classifier_test.py
@@ -133,16 +133,18 @@ class CalculateTest(unittest.TestCase):
                 ('pull_request', {
                     'action': 'labeled',
                     'label': {'name': 'release-note-none', 'color': 'orange'},
-                }, 3)
+                }, 3),
+                make_comment_event(2, 'k8s-merge-robot', '<!-- META={"approvers":["o"]} -->', ts=4),
             ], {'e2e': ['failure', None, 'stuff is broken']}
         ),
         (True, True, ['a', 'b'],
          {
             'author': 'a',
+            'approvers': ['o'],
             'assignees': ['b'],
             'additions': 1,
             'deletions': 1,
-            'attn': {'a': 'fix tests', 'b': 'needs review#0#0'},
+            'attn': {'a': 'fix tests', 'b': 'needs review#0#0', 'o': 'needs approval'},
             'title': 'some fix',
             'labels': {'release-note-none': 'orange'},
             'head': 'abcdef',
@@ -193,6 +195,9 @@ class CalculateTest(unittest.TestCase):
 
         expect(make_payload('alpha', ['alpha']), [('comment', 'other', 1)],
             {'alpha': 'address comments#1#1'})
+
+        expect(make_payload('alpha', approvers=['owner']), [],
+            {'owner': 'needs approval'})
 
     def test_author_state(self):
         def expect(events, result):
@@ -246,13 +251,26 @@ class CalculateTest(unittest.TestCase):
 
         expect([], set())
 
-        reviewer_a = {'requested_reviewer': {'login': 'a'}}
-        reviewer_b = {'requested_reviewer': {'login': 'b'}}
-        expect(mk(('pull_request', 'review_requested', reviewer_a)), {'a'})
-        expect(mk(('pull_request', 'review_request_removed', reviewer_a)), set())
-        expect(mk(('pull_request', 'review_requested', reviewer_a),
-                  ('pull_request', 'review_request_removed', reviewer_a)), set())
+        user_a = {'requested_reviewer': {'login': 'a'}}
+        expect(mk(('pull_request', 'review_requested', user_a)), {'a'})
+        expect(mk(('pull_request', 'review_request_removed', user_a)), set())
+        expect(mk(('pull_request', 'review_requested', user_a),
+                  ('pull_request', 'review_request_removed', user_a)), set())
         expect(mk(('pull_request_review', 'submitted', {'sender': {'login': 'b'}})), {'b'})
+
+    def test_approvers(self):
+        def expect(comment, result):
+            self.assertEqual(result, classifier.get_approvers([{
+                'author': 'k8s-merge-robot', 'comment': comment}]))
+
+        expect('nothing', [])
+        expect('before\n<!-- META={approvers:[someone]} -->', ['someone'])
+        expect('<!-- META={approvers:[someone,else]} -->', ['someone', 'else'])
+        expect('<!-- META={approvers:[someone,else]} -->', ['someone', 'else'])
+
+        # The META format is *supposed* to be JSON, but a recent change broke it.
+        # Support both formats so it can be fixed in the future.
+        expect('<!-- META={"approvers":["username"]} -->\n', ['username'])
 
 
 class CommentsTest(unittest.TestCase):

--- a/gubernator/templates/pr_dashboard.html
+++ b/gubernator/templates/pr_dashboard.html
@@ -18,6 +18,9 @@ View
 
 % for title, pred, search in cats
 	% set sub_prs = prs | select(pred)
+	% if title == 'Approvable' and not sub_prs
+		% continue
+	% endif
 	<h3 class="pr-section">
 	% if search
 	<a href="https://github.com/pulls?q={{search|quote_plus}}">{{title}}</a>

--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -156,6 +156,9 @@ class PRDashboard(view_base.BaseHandler):
                     return filters.do_get_latest(p.payload, user) <= acks.get(p.key.id(), 0)
                 cats = [
                     ('Needs Attention', lambda p: user in p.payload['attn'] and not acked(p), ''),
+                    ('Approvable', lambda p: user in p.payload.get('approvers', []),
+                     'is:open is:pr ("additional approvers: {0}" ' +
+                     'OR "additional approver: {0}")'.format(user)),
                     ('Incoming', lambda p: user in p.payload['assignees'],
                      'is:open is:pr user:kubernetes assignee:%s' % user),
                     ('Outgoing', lambda p: user == p.payload['author'],

--- a/mungegithub/mungers/approvers/approvers_test.go
+++ b/mungegithub/mungers/approvers/approvers_test.go
@@ -572,7 +572,7 @@ Needs approval from an approver in each of these OWNERS Files:
 You can indicate your approval by writing ` + "`/approve`" + ` in a comment
 You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
-<!-- META={approvers:[Alice]} -->`
+<!-- META={"approvers":["Alice"]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {
@@ -606,7 +606,7 @@ Needs approval from an approver in each of these OWNERS Files:
 You can indicate your approval by writing ` + "`/approve`" + ` in a comment
 You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
-<!-- META={approvers:[]} -->`
+<!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {


### PR DESCRIPTION
This should bring the PR dashboard up to speed with recent changes in our workflow.