### PR TITLE
Update consistency stats to data from Apr 12

### DIFF
--- a/experiment/bigquery/README.md
+++ b/experiment/bigquery/README.md
@@ -20,13 +20,19 @@ example suppose we run a build of a job 5 times at the same commit:
 
 ## Scripts
 
+Run [`daily.sh`](daily.sh) to do all the following:
+
+* `failures.sh` - find jobs that have been failing the longest
+    - Uses `failures.sql`
+    - Usage: `flakes.sh | tee failures-latest.json`
+    - Latest results: [failures-latest.json](failures-latest.json)
 * `flakes.sh` - find the flakiest jobs this week (and the flakiest tests in each job).
     - Uses `flakes.sql` to extract and group data from BigQuery
-    - Usage: `flakes.sh | tee flakes-$(date %Y-%m-%d).json`
+    - Usage: `flakes.sh | tee flakes-latest.json`
     - Latest results: [flakes-latest.json](flakes-latest.json)
 * `job-flakes.sh` - compute consistency of all jobs
     - Uses `job-flakes.sql` to compute this data
-    - Usage: `job-flakes.sh | tee job-flakes-$(date %Y-%m-%d).json`
+    - Usage: `job-flakes.sh | tee job-flakes-latest.json`
     - Latest results: [job-flakes-latest.json](job-flakes-latest.json)
 * `weekly-consistency.sh` - compute overall weekly consistency for PRs
     - Uses `weekly-consistency.sql` to compute this data

--- a/experiment/bigquery/daily.sh
+++ b/experiment/bigquery/daily.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: ./flakes.sh | tee flakes-$(date +%Y-%m-%d).json
+# This script uses flakes.sql to find job flake data for the past week
+# The script then filters jobs down to those which flake more than 4x/day
+# And also notes any test in those jobs which flake more than 1x/day
+
+set -o pipefail
+set -o errexit
+set -o xtrace
+
+dir="$(dirname "${0}")"
+"${dir}/flakes.sh" | tee "${dir}/flakes-latest.json"
+"${dir}/job-flakes.sh" | tee "${dir}/job-flakes-latest.json"
+"${dir}/weekly-consistency.sh" | tee "${dir}/weekly-consistency.json"

--- a/experiment/bigquery/failures-latest.json
+++ b/experiment/bigquery/failures-latest.json
@@ -1,0 +1,128 @@
+{
+  "ci-kubernetes-e2e-gce-gci-qa-serial-m54": {
+    "failing_since": "2016-11-14"
+  },
+  "ci-kubernetes-e2e-gce-gci-qa-serial-m55": {
+    "failing_since": "2016-11-14"
+  },
+  "ci-kubernetes-e2e-gci-gce-federation": {
+    "failing_since": "2016-11-15"
+  },
+  "ci-kubernetes-e2e-gce-federation-release-1.5": {
+    "failing_since": "2016-11-16"
+  },
+  "ci-kubernetes-e2e-gci-gke-alpha-features-release-1.4": {
+    "failing_since": "2016-11-17"
+  },
+  "ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-1.4-1.5-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-master": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-1.4-1.5-upgrade-cluster-new": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-debian-latest-1.4-gci-latest-upgrade-cluster-new": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-gci-latest-1.4-debian-latest-upgrade-cluster-new": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-gci-latest-1.4-gci-latest-upgrade-cluster-new": {
+    "failing_since": "2016-12-03"
+  },
+  "ci-kubernetes-e2e-gce-federation-serial": {
+    "failing_since": "2017-02-07"
+  },
+  "ci-kubernetes-e2e-gce-latest-upgrade-cluster": {
+    "failing_since": "2017-02-15"
+  },
+  "ci-kubernetes-e2e-non-cri-gce-federation": {
+    "failing_since": "2017-02-17"
+  },
+  "ci-kubernetes-e2e-non-cri-gce-examples": {
+    "failing_since": "2017-02-17"
+  },
+  "ci-kubernetes-soak-gce-non-cri-test": {
+    "failing_since": "2017-02-17"
+  },
+  "ci-kubernetes-e2e-non-cri-gce-flaky": {
+    "failing_since": "2017-02-17"
+  },
+  "ci-kubernetes-e2e-non-cri-gke-flaky": {
+    "failing_since": "2017-02-17"
+  },
+  "ci-kubernetes-e2e-non-cri-gce-serial": {
+    "failing_since": "2017-02-17"
+  },
+  "ci-kubernetes-charts-gce": {
+    "failing_since": "2017-02-23"
+  }
+}

--- a/experiment/bigquery/failures.sql
+++ b/experiment/bigquery/failures.sql
@@ -1,0 +1,41 @@
+#standardSQL
+select /* Find jobs that have not passed in a long time */
+  jobs.job,
+  latest_pass, /* how recently did this job pass */
+  weekly_builds,  /* how many times a week does it run */
+  first_run, /* when is the first time it ran */
+  latest_run  /* when is the most recent run */
+from (
+  select /* filter to jobs that ran this week */
+    job,
+    count(1) weekly_builds
+  from `k8s-gubernator.build.all`
+  where
+    started > timestamp_sub(current_timestamp(), interval 7 day)
+  group by job
+  order by job
+) jobs
+left join (
+  select /* find the most recent time each job passed (may not be this week) */
+    job,
+    max(started) latest_pass
+  from `k8s-gubernator.build.all`
+  where
+    result = 'SUCCESS'
+  group by job
+) passes
+on jobs.job = passes.job
+left join (
+  select /* find the oldest, newest run of each job */
+    job,
+    date(min(started)) first_run,
+    date(max(started)) latest_run
+  from `k8s-gubernator.build.all`
+  group by job
+) runs
+on jobs.job = runs.job
+where
+  latest_pass is null /* that never passed */
+  and date_diff(current_date, first_run, month) > 1 /* running for more than a month */
+  and date_diff(current_date, latest_run, day) < 7 /* ran this week */
+order by latest_pass, first_run, weekly_builds desc, jobs.job

--- a/experiment/bigquery/flakes-latest.json
+++ b/experiment/bigquery/flakes-latest.json
@@ -1,93 +1,105 @@
 {
-  "pr:pull-kubernetes-e2e-gce-non-cri": {
-    "consistency": 0.929,
-    "flakes": 62,
+  "ci-kubernetes-e2e-gci-gce-proto": {
+    "consistency": 0.867,
+    "flakes": 42,
     "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 28
-    }
-  },
-  "ci-kubernetes-e2e-non-cri-gce-etcd3": {
-    "consistency": 0.863,
-    "flakes": 43,
-    "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 24,
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 7
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 8
     }
   },
   "ci-kubernetes-e2e-non-cri-gce": {
-    "consistency": 0.864,
+    "consistency": 0.867,
     "flakes": 42,
     "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 24,
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 10
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 12
     }
   },
-  "ci-kubernetes-e2e-gce-container-vm": {
-    "consistency": 0.863,
-    "flakes": 42,
+  "ci-kubernetes-e2e-non-cri-gce-etcd3": {
+    "consistency": 0.886,
+    "flakes": 36,
     "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 10,
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 8
-    }
-  },
-  "ci-kubernetes-e2e-non-cri-gce-proto": {
-    "consistency": 0.865,
-    "flakes": 41,
-    "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 22
-    }
-  },
-  "ci-kubernetes-e2e-gce-gci-ci-master": {
-    "consistency": 0.868,
-    "flakes": 41,
-    "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 16,
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 8
-    }
-  },
-  "ci-kubernetes-e2e-gce-etcd3": {
-    "consistency": 0.876,
-    "flakes": 40,
-    "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 14,
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 7
-    }
-  },
-  "ci-kubernetes-e2e-gce-proto": {
-    "consistency": 0.872,
-    "flakes": 40,
-    "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 15,
       "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 11
     }
   },
-  "ci-kubernetes-e2e-gci-gce-proto": {
-    "consistency": 0.875,
-    "flakes": 39,
+  "ci-kubernetes-e2e-gce-proto": {
+    "consistency": 0.887,
+    "flakes": 36,
     "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 16,
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 7
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 13
+    }
+  },
+  "ci-kubernetes-e2e-gce-etcd3": {
+    "consistency": 0.89,
+    "flakes": 35,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 10
+    }
+  },
+  "ci-kubernetes-e2e-gce-gci-ci-master": {
+    "consistency": 0.89,
+    "flakes": 34,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 9
+    }
+  },
+  "ci-kubernetes-e2e-non-cri-gce-proto": {
+    "consistency": 0.892,
+    "flakes": 33,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 10
     }
   },
   "ci-kubernetes-e2e-gci-gce-etcd3": {
-    "consistency": 0.874,
-    "flakes": 39,
+    "consistency": 0.893,
+    "flakes": 33,
     "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 9
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 8
     }
   },
-  "ci-kubernetes-e2e-gci-gce": {
-    "consistency": 0.892,
-    "flakes": 36,
+  "pr:pull-kubernetes-e2e-gce-non-cri": {
+    "consistency": 0.961,
+    "flakes": 33,
     "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 11
+      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 9,
+      "[k8s.io] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods [Conformance]": 7
+    }
+  },
+  "ci-kubernetes-e2e-gce-container-vm": {
+    "consistency": 0.896,
+    "flakes": 32,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 9
+    }
+  },
+  "ci-kubernetes-e2e-non-cri-gke": {
+    "consistency": 0.916,
+    "flakes": 32,
+    "flakiest": null
+  },
+  "ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd": {
+    "consistency": 0.86,
+    "flakes": 30,
+    "flakiest": {
+      "UpgradeTest": 30,
+      "[k8s.io] etcd Upgrade [Feature:EtcdUpgrade] [k8s.io] etcd upgrade should maintain a functioning cluster": 29
+    }
+  },
+  "ci-kubernetes-e2e-gke": {
+    "consistency": 0.92,
+    "flakes": 29,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 11
+    }
+  },
+  "ci-kubernetes-e2e-gci-gke": {
+    "consistency": 0.923,
+    "flakes": 29,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 15
     }
   },
   "ci-kubernetes-e2e-gce": {
-    "consistency": 0.894,
-    "flakes": 35,
-    "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 12
-    }
+    "consistency": 0.912,
+    "flakes": 29,
+    "flakiest": null
   }
 }

--- a/experiment/bigquery/flakes-latest.json
+++ b/experiment/bigquery/flakes-latest.json
@@ -1,105 +1,74 @@
 {
-  "ci-kubernetes-e2e-gci-gce-proto": {
-    "consistency": 0.867,
-    "flakes": 42,
+  "pr:pull-kubernetes-federation-e2e-gce": {
+    "consistency": 0.942,
+    "flakes": 50,
     "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 8
+      "[k8s.io] Federated Services [Feature:Federation] with clusters DNS should be able to discover a federated service": 42,
+      "Federation Up": 20,
+      "[k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses should create and update matching ingresses in underlying clusters": 18
+    }
+  },
+  "ci-kubernetes-e2e-non-cri-gke": {
+    "consistency": 0.892,
+    "flakes": 40,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 9
     }
   },
   "ci-kubernetes-e2e-non-cri-gce": {
-    "consistency": 0.867,
-    "flakes": 42,
+    "consistency": 0.88,
+    "flakes": 37,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 7
+    }
+  },
+  "ci-kubernetes-e2e-gci-gke": {
+    "consistency": 0.911,
+    "flakes": 33,
     "flakiest": {
       "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 12
     }
   },
-  "ci-kubernetes-e2e-non-cri-gce-etcd3": {
-    "consistency": 0.886,
-    "flakes": 36,
-    "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 11
-    }
-  },
-  "ci-kubernetes-e2e-gce-proto": {
-    "consistency": 0.887,
-    "flakes": 36,
-    "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 13
-    }
-  },
-  "ci-kubernetes-e2e-gce-etcd3": {
-    "consistency": 0.89,
-    "flakes": 35,
-    "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 10
-    }
-  },
-  "ci-kubernetes-e2e-gce-gci-ci-master": {
-    "consistency": 0.89,
-    "flakes": 34,
-    "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 9
-    }
-  },
-  "ci-kubernetes-e2e-non-cri-gce-proto": {
-    "consistency": 0.892,
-    "flakes": 33,
-    "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 10
-    }
-  },
-  "ci-kubernetes-e2e-gci-gce-etcd3": {
-    "consistency": 0.893,
-    "flakes": 33,
-    "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 8
-    }
-  },
-  "pr:pull-kubernetes-e2e-gce-non-cri": {
-    "consistency": 0.961,
-    "flakes": 33,
-    "flakiest": {
-      "[k8s.io] Volumes [Volume] [k8s.io] PD should be mountable": 9,
-      "[k8s.io] Kubectl client [k8s.io] Kubectl describe should check if kubectl describe prints relevant information for rc and pods [Conformance]": 7
-    }
-  },
-  "ci-kubernetes-e2e-gce-container-vm": {
-    "consistency": 0.896,
-    "flakes": 32,
-    "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 9
-    }
-  },
-  "ci-kubernetes-e2e-non-cri-gke": {
-    "consistency": 0.916,
-    "flakes": 32,
-    "flakiest": null
-  },
   "ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd": {
-    "consistency": 0.86,
-    "flakes": 30,
+    "consistency": 0.845,
+    "flakes": 32,
     "flakiest": {
-      "UpgradeTest": 30,
-      "[k8s.io] etcd Upgrade [Feature:EtcdUpgrade] [k8s.io] etcd upgrade should maintain a functioning cluster": 29
+      "UpgradeTest": 32,
+      "[k8s.io] etcd Upgrade [Feature:EtcdUpgrade] [k8s.io] etcd upgrade should maintain a functioning cluster": 31
     }
   },
   "ci-kubernetes-e2e-gke": {
-    "consistency": 0.92,
-    "flakes": 29,
+    "consistency": 0.909,
+    "flakes": 32,
+    "flakiest": {
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 9,
+      "[k8s.io] Projected should update annotations on modification [Conformance] [Volume]": 7
+    }
+  },
+  "ci-kubernetes-e2e-gci-gce-proto": {
+    "consistency": 0.898,
+    "flakes": 32,
+    "flakiest": null
+  },
+  "ci-kubernetes-e2e-gce-multizone": {
+    "consistency": 0.876,
+    "flakes": 31,
+    "flakiest": {
+      "[k8s.io] Firewall rule should have correct firewall rules for e2e cluster": 34
+    }
+  },
+  "ci-kubernetes-e2e-non-cri-gce-etcd3": {
+    "consistency": 0.9,
+    "flakes": 31,
     "flakiest": {
       "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 11
     }
   },
-  "ci-kubernetes-e2e-gci-gke": {
-    "consistency": 0.923,
-    "flakes": 29,
+  "ci-kubernetes-e2e-gce-etcd3": {
+    "consistency": 0.905,
+    "flakes": 30,
     "flakiest": {
-      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 15
+      "[k8s.io] Services should preserve source pod IP for traffic thru service cluster IP": 8
     }
-  },
-  "ci-kubernetes-e2e-gce": {
-    "consistency": 0.912,
-    "flakes": 29,
-    "flakiest": null
   }
 }

--- a/experiment/bigquery/job-flakes-latest.json
+++ b/experiment/bigquery/job-flakes-latest.json
@@ -1,62 +1,57 @@
 {
-  "pr:pull-kubernetes-e2e-gce-non-cri": {
-    "flakes": 33,
-    "runs": 843,
-    "consistency": 0.961
-  },
   "pr:pull-kubernetes-federation-e2e-gce": {
-    "flakes": 24,
-    "runs": 532,
-    "consistency": 0.955
+    "flakes": 50,
+    "runs": 859,
+    "consistency": 0.942
   },
   "pr:pull-kubernetes-e2e-gce": {
-    "flakes": 23,
-    "runs": 893,
-    "consistency": 0.974
+    "flakes": 27,
+    "runs": 908,
+    "consistency": 0.97
+  },
+  "pr:pull-kubernetes-bazel": {
+    "flakes": 22,
+    "runs": 889,
+    "consistency": 0.975
   },
   "pr:pull-kubernetes-e2e-gce-etcd3": {
-    "flakes": 20,
-    "runs": 891,
-    "consistency": 0.978
+    "flakes": 19,
+    "runs": 899,
+    "consistency": 0.979
   },
   "pr:pull-kubernetes-e2e-gce-gci": {
-    "flakes": 17,
-    "runs": 882,
-    "consistency": 0.981
+    "flakes": 19,
+    "runs": 892,
+    "consistency": 0.979
   },
-  "pr:pull-kubernetes-verify": {
+  "pr:pull-kubernetes-e2e-gce-non-cri": {
+    "flakes": 15,
+    "runs": 839,
+    "consistency": 0.982
+  },
+  "pr:pull-kubernetes-unit": {
     "flakes": 13,
-    "runs": 889,
+    "runs": 893,
     "consistency": 0.985
   },
   "pr:pull-kubernetes-node-e2e": {
-    "flakes": 11,
-    "runs": 872,
-    "consistency": 0.987
-  },
-  "pr:pull-kubernetes-kubemark-e2e-gce": {
     "flakes": 9,
-    "runs": 875,
+    "runs": 886,
     "consistency": 0.99
   },
-  "pr:pull-kubernetes-unit": {
+  "pr:pull-kubernetes-verify": {
     "flakes": 9,
-    "runs": 877,
+    "runs": 896,
     "consistency": 0.99
-  },
-  "pr:pull-kubernetes-bazel": {
-    "flakes": 8,
-    "runs": 852,
-    "consistency": 0.991
   },
   "pr:pull-kubernetes-e2e-kops-aws": {
     "flakes": 7,
-    "runs": 877,
+    "runs": 885,
     "consistency": 0.992
   },
-  "pr:pull-kubernetes-node-e2e-non-cri": {
-    "flakes": 6,
-    "runs": 865,
-    "consistency": 0.993
+  "pr:pull-kubernetes-kubemark-e2e-gce": {
+    "flakes": 7,
+    "runs": 888,
+    "consistency": 0.992
   }
 }

--- a/experiment/bigquery/job-flakes-latest.json
+++ b/experiment/bigquery/job-flakes-latest.json
@@ -1,57 +1,62 @@
 {
   "pr:pull-kubernetes-e2e-gce-non-cri": {
-    "flakes": 62,
-    "runs": 873,
-    "consistency": 0.929
-  },
-  "pr:pull-kubernetes-e2e-gce-gci": {
-    "flakes": 26,
-    "runs": 895,
-    "consistency": 0.971
-  },
-  "pr:pull-kubernetes-e2e-gce-etcd3": {
-    "flakes": 22,
-    "runs": 896,
-    "consistency": 0.975
-  },
-  "pr:pull-kubernetes-e2e-gce": {
-    "flakes": 21,
-    "runs": 896,
-    "consistency": 0.977
-  },
-  "pr:pull-kubernetes-verify": {
-    "flakes": 15,
-    "runs": 898,
-    "consistency": 0.983
-  },
-  "pr:pull-kubernetes-unit": {
-    "flakes": 10,
-    "runs": 882,
-    "consistency": 0.989
-  },
-  "pr:pull-kubernetes-node-e2e": {
-    "flakes": 8,
-    "runs": 879,
-    "consistency": 0.991
-  },
-  "pr:pull-kubernetes-bazel": {
-    "flakes": 6,
-    "runs": 848,
-    "consistency": 0.993
-  },
-  "pr:pull-kubernetes-e2e-kops-aws": {
-    "flakes": 6,
-    "runs": 885,
-    "consistency": 0.993
+    "flakes": 33,
+    "runs": 843,
+    "consistency": 0.961
   },
   "pr:pull-kubernetes-federation-e2e-gce": {
-    "flakes": 5,
-    "runs": 103,
-    "consistency": 0.951
+    "flakes": 24,
+    "runs": 532,
+    "consistency": 0.955
+  },
+  "pr:pull-kubernetes-e2e-gce": {
+    "flakes": 23,
+    "runs": 893,
+    "consistency": 0.974
+  },
+  "pr:pull-kubernetes-e2e-gce-etcd3": {
+    "flakes": 20,
+    "runs": 891,
+    "consistency": 0.978
+  },
+  "pr:pull-kubernetes-e2e-gce-gci": {
+    "flakes": 17,
+    "runs": 882,
+    "consistency": 0.981
+  },
+  "pr:pull-kubernetes-verify": {
+    "flakes": 13,
+    "runs": 889,
+    "consistency": 0.985
+  },
+  "pr:pull-kubernetes-node-e2e": {
+    "flakes": 11,
+    "runs": 872,
+    "consistency": 0.987
   },
   "pr:pull-kubernetes-kubemark-e2e-gce": {
-    "flakes": 5,
-    "runs": 880,
-    "consistency": 0.994
+    "flakes": 9,
+    "runs": 875,
+    "consistency": 0.99
+  },
+  "pr:pull-kubernetes-unit": {
+    "flakes": 9,
+    "runs": 877,
+    "consistency": 0.99
+  },
+  "pr:pull-kubernetes-bazel": {
+    "flakes": 8,
+    "runs": 852,
+    "consistency": 0.991
+  },
+  "pr:pull-kubernetes-e2e-kops-aws": {
+    "flakes": 7,
+    "runs": 877,
+    "consistency": 0.992
+  },
+  "pr:pull-kubernetes-node-e2e-non-cri": {
+    "flakes": 6,
+    "runs": 865,
+    "consistency": 0.993
   }
 }

--- a/experiment/bigquery/weekly-consistency.json
+++ b/experiment/bigquery/weekly-consistency.json
@@ -1,32 +1,32 @@
 [
   {
-    "commits": "702",
-    "consistency": "0.718",
+    "commits": "698",
+    "consistency": "0.807",
     "wk": "2017-03-04"
   },
   {
-    "commits": "697",
-    "consistency": "0.779",
+    "commits": "693",
+    "consistency": "0.844",
     "wk": "2017-03-11"
   },
   {
-    "commits": "639",
-    "consistency": "0.847",
+    "commits": "638",
+    "consistency": "0.906",
     "wk": "2017-03-18"
   },
   {
-    "commits": "640",
-    "consistency": "0.852",
+    "commits": "638",
+    "consistency": "0.909",
     "wk": "2017-03-25"
   },
   {
-    "commits": "746",
-    "consistency": "0.818",
+    "commits": "742",
+    "consistency": "0.922",
     "wk": "2017-04-01"
   },
   {
-    "commits": "388",
-    "consistency": "0.853",
+    "commits": "687",
+    "consistency": "0.884",
     "wk": "2017-04-08"
   }
 ]

--- a/experiment/bigquery/weekly-consistency.json
+++ b/experiment/bigquery/weekly-consistency.json
@@ -5,23 +5,28 @@
     "wk": "2017-03-04"
   },
   {
-    "commits": "698",
+    "commits": "697",
     "consistency": "0.779",
     "wk": "2017-03-11"
   },
   {
-    "commits": "640",
+    "commits": "639",
     "consistency": "0.847",
     "wk": "2017-03-18"
   },
   {
-    "commits": "642",
+    "commits": "640",
     "consistency": "0.852",
     "wk": "2017-03-25"
   },
   {
-    "commits": "745",
-    "consistency": "0.815",
+    "commits": "746",
+    "consistency": "0.818",
     "wk": "2017-04-01"
+  },
+  {
+    "commits": "388",
+    "consistency": "0.853",
+    "wk": "2017-04-08"
   }
 ]

--- a/experiment/bigquery/weekly-consistency.sql
+++ b/experiment/bigquery/weekly-consistency.sql
@@ -32,6 +32,7 @@ from ( /* For each week, count whether a (num, commit) flaked */
         started > date_add(current_timestamp(), -90, "DAY")
         and version != "unknown"
         and (metadata.key = 'repos' or left(job, 3) == "ci-")
+        and job != 'pr:pull-kubernetes-federation-e2e-gce'
       having kind=='pull'
     )
     group by wk, job, num, commit

--- a/experiment/bigquery/weekly-consistency.sql
+++ b/experiment/bigquery/weekly-consistency.sql
@@ -32,7 +32,15 @@ from ( /* For each week, count whether a (num, commit) flaked */
         started > date_add(current_timestamp(), -90, "DAY")
         and version != "unknown"
         and (metadata.key = 'repos' or left(job, 3) == "ci-")
-        and job != 'pr:pull-kubernetes-federation-e2e-gce'
+        and job in ( /* only consider merge-blocking jobs */
+          'pr:pull-kubernetes-bazel',
+          'pr:pull-kubernetes-unit',
+          'pr:pull-kubernetes-verify',
+          'pr:pull-kubernetes-e2e-gce',
+          'pr:pull-kubernetes-e2e-kops-aws',
+          'pr:pull-kubernetes-kubemark-e2e-gce',
+          'pr:pull-kubernetes-node-e2e',
+        )
       having kind=='pull'
     )
     group by wk, job, num, commit


### PR DESCRIPTION
Create a `daily.sh` script to more quickly create these files.

Ignore federation flakes when calculating PR consistency (remove once we make federation presubmit required)

Also create a `failures.sh` to generate the data for https://github.com/kubernetes/test-infra/issues/2453 (once we no longer have jobs that have never passed the intent is to find the jobs that have been failing the longest... which right now is forever).

PS: Ryan I'm using `/* comment */` because vim recognizes this comment style and does not recognize `# comment`