### PR TITLE
Don't treat pull_request_review submitted as adding to Reviewers.

### DIFF
--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -296,8 +296,6 @@ def get_reviewers(events):
                 reviewers.add(body['requested_reviewer']['login'])
             elif action == 'review_request_removed':
                 reviewers -= {body['requested_reviewer']['login']}
-        elif event == 'pull_request_review' and action == 'submitted':
-            reviewers.add(body['sender']['login'])
     return reviewers
 
 

--- a/gubernator/github/classifier_test.py
+++ b/gubernator/github/classifier_test.py
@@ -256,7 +256,6 @@ class CalculateTest(unittest.TestCase):
         expect(mk(('pull_request', 'review_request_removed', user_a)), set())
         expect(mk(('pull_request', 'review_requested', user_a),
                   ('pull_request', 'review_request_removed', user_a)), set())
-        expect(mk(('pull_request_review', 'submitted', {'sender': {'login': 'b'}})), {'b'})
 
     def test_approvers(self):
         def expect(comment, result):


### PR DESCRIPTION
It turns out that commenting on a review gives two events,
"pull_request_review submitted" and "pull_request_review_comment
created". I assumed that "submitted" only happened if a new review was
started.