### PR TITLE
Remove etcd2 from blocking presubmit list, cleanup non-blocking jobs

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -18,7 +18,6 @@ data:
 
   # test-options feature options.
   test-options.required-retest-contexts: "\
-    \"Jenkins GCE e2e\",\
     \"Jenkins unit/integration\",\
     \"Jenkins verification\",\
     \"Jenkins GCE Node e2e\",\

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -139,10 +139,9 @@ presubmits:
     trigger: "@k8s-bot (verify )?test this"
 
   - name: pull-kubernetes-e2e-gce
-    always_run: true
-    context: Jenkins GCE e2e
-    rerun_command: "@k8s-bot cvm gce e2e test this"
-    trigger: "@k8s-bot (cvm )?(gce )?(e2e )?test this"
+    context: pull-kubernetes-e2e-gce
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce test this"
+    trigger: "@k8s-bot (pull-kubernetes-e2e-gce |cvm gce e2e )test this"
 
   - name: pull-kubernetes-e2e-gce-canary
     context: pull-kubernetes-e2e-gce-canary
@@ -166,10 +165,9 @@ presubmits:
     trigger: "@k8s-bot pull-kubernetes-e2e-gke-gci test this"
 
   - name: pull-kubernetes-e2e-gce-gci
-    always_run: true
-    context: Jenkins GCI GCE e2e
-    rerun_command: "@k8s-bot gci gce e2e test this"
-    trigger: "@k8s-bot (gci )?(gce )?(e2e )?test this"
+    context: pull-kubernetes-e2e-gce-gci
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce-gci test this"
+    trigger: "@k8s-bot (pull-kubernetes-e2e-gce-gci |gci gce e2e )test this"
 
   - name: pull-kubernetes-e2e-kops-aws
     always_run: true
@@ -186,7 +184,7 @@ presubmits:
     skip_report: true  # Remove this once we are confident about this job
     context: pull-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce test this"
-    trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce |federation gce e2e )?test this"
+    trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce )?test this"
 
   - name: pull-kubernetes-kubemark-e2e-gce
     trigger: "@k8s-bot (kubemark )?(e2e )?test this"
@@ -208,19 +206,17 @@ presubmits:
   - name: pull-kubernetes-e2e-gce-non-cri
     branches:
     - master
-    always_run: true
-    context: Jenkins non-CRI GCE e2e
-    rerun_command: "@k8s-bot non-cri e2e test this"
-    trigger: "@k8s-bot (non-cri e2e )?test this"
+    context: pull-kubernetes-e2e-gce-non-cri
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce-non-cri test this"
+    trigger: "@k8s-bot (pull-kubernetes-e2e-gce-non-cri |non-cri node e2e )test this"
 
   - name: pull-kubernetes-node-e2e-non-cri
     skip_branches:
     - release-1.3
     - release-1.4
-    always_run: true
-    context: Jenkins non-CRI GCE Node e2e
-    rerun_command: "@k8s-bot non-cri node e2e test this"
-    trigger: "@k8s-bot (non-cri node e2e )?test this"
+    context: pull-kubernetes-node-e2e-non-cri
+    rerun_command: "@k8s-bot pull-kubernetes-node-e2e-non-cri test this"
+    trigger: "@k8s-bot (pull-kubernetes-node-e2e-non-cri |non-cri node e2e )test this"
 
   kubernetes-security/kubernetes: # TODO(fejta, spxr): find way to not duplicate these
   - name: pull-security-kubernetes-bazel
@@ -319,10 +315,9 @@ presubmits:
     trigger: "@k8s-bot (verify )?test this"
 
   - name: pull-security-kubernetes-e2e-gce
-    always_run: true
-    context: Jenkins GCE e2e
-    rerun_command: "@k8s-bot cvm gce e2e test this"
-    trigger: "@k8s-bot (cvm )?(gce )?(e2e )?test this"
+    context: pull-security-kubernetes-e2e-gce
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-e2e-gce |cvm gce e2e )test this"
 
   - name: pull-security-kubernetes-e2e-gce-canary
     context: pull-security-kubernetes-e2e-gce-canary
@@ -346,10 +341,9 @@ presubmits:
     trigger: "@k8s-bot pull-security-kubernetes-e2e-gke-gci test this"
 
   - name: pull-security-kubernetes-e2e-gce-gci
-    always_run: true
-    context: Jenkins GCI GCE e2e
-    rerun_command: "@k8s-bot gci gce e2e test this"
-    trigger: "@k8s-bot (gci )?(gce )?(e2e )?test this"
+    context: pull-security-kubernetes-e2e-gce-gci
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce-gci test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-e2e-gce-gci |gci gce e2e )test this"
 
   - name: pull-security-kubernetes-e2e-kops-aws
     always_run: true
@@ -366,7 +360,7 @@ presubmits:
     skip_report: true
     context: pull-security-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-security-kubernetes-federation-e2e-gce test this"
-    trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce |federation gce e2e )?test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce )?test this"
 
   - name: pull-security-kubernetes-kubemark-e2e-gce
     trigger: "@k8s-bot (kubemark )?(e2e )?test this"
@@ -388,19 +382,17 @@ presubmits:
   - name: pull-security-kubernetes-e2e-gce-non-cri
     branches:
     - master
-    always_run: true
-    context: Jenkins non-CRI GCE e2e
-    rerun_command: "@k8s-bot non-cri e2e test this"
-    trigger: "@k8s-bot (non-cri e2e )?test this"
+    context: pull-security-kubernetes-e2e-gce-non-cri
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce-non-cri test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-e2e-gce-non-cri |non-cri node e2e )test this"
 
   - name: pull-security-kubernetes-node-e2e-non-cri
     skip_branches:
     - release-1.3
     - release-1.4
-    always_run: true
-    context: Jenkins non-CRI GCE Node e2e
-    rerun_command: "@k8s-bot non-cri node e2e test this"
-    trigger: "@k8s-bot (non-cri node e2e )?test this"
+    context: pull-security-kubernetes-node-e2e-non-cri
+    rerun_command: "@k8s-bot pull-security-kubernetes-node-e2e-non-cri test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-node-e2e-non-cri |non-cri node e2e )test this"
 
   kubernetes/test-infra:
   - name: pull-test-infra-bazel


### PR DESCRIPTION
We will only block on etcd3 failures. We will catch etcd2 problems in a non-blocking manner

Also:
* Only auto-trigger jobs that need to pass to merge
* Run a variety of non-blocking `e2e-gce` flavors only when requested
* Update the context and rerun command to match the job name for any non-blocking job.

/assign @krzyzacy @spxtr 