### PR TITLE
Add apiVersion and kind to ProwJob.

### DIFF
--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -48,9 +48,11 @@ const (
 )
 
 type ProwJob struct {
-	Metadata ObjectMeta    `json:"metadata,omitempty"`
-	Spec     ProwJobSpec   `json:"spec,omitempty"`
-	Status   ProwJobStatus `json:"status,omitempty"`
+	APIVersion string        `json:"apiVersion,omitempty"`
+	Kind       string        `json:"kind,omitempty"`
+	Metadata   ObjectMeta    `json:"metadata,omitempty"`
+	Spec       ProwJobSpec   `json:"spec,omitempty"`
+	Status     ProwJobStatus `json:"status,omitempty"`
 }
 
 type ProwJobSpec struct {

--- a/prow/plank/plank.go
+++ b/prow/plank/plank.go
@@ -28,6 +28,8 @@ import (
 // NewProwJob initializes a ProwJob out of a ProwJobSpec.
 func NewProwJob(spec kube.ProwJobSpec) kube.ProwJob {
 	return kube.ProwJob{
+		APIVersion: "prow.k8s.io/v1",
+		Kind:       "ProwJob",
 		Metadata: kube.ObjectMeta{
 			// TODO(spxtr): Remove this, replace with cmd/tot usage.
 			Name: uuid.NewV1().String(),


### PR DESCRIPTION
This serves two purposes.
1. It fixes an annoying behavior where if you "kubectl get prowjob foo"
it will do the get properly but spit up an error about the kind. This
doesn't happen for other resource types, must be related to TPRs.
2. It is a step toward adding a command-line tool to start a ProwJob.