### PR TITLE
Bump the kubernetes-e2e image version.

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -439,7 +439,7 @@ def create_parser():
     parser.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     parser.add_argument(
-        '--tag', default='v20170403-d0327c02', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170410-a59092bd', help='Use a specific kubekins-e2e tag if set')
     parser.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     parser.add_argument(


### PR DESCRIPTION
We need a new image for #2231.

I built this image on 04-10-2017. Canary passed on 04-12-2017 and 04-13-2017 (except for the resource leak today).