### PR TITLE
Format triage data as arrays of dicts, instead of arrays of arrays.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -816,7 +816,7 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/triage:v20170412-c3a86a40
+    - image: gcr.io/k8s-testimages/triage:v20170413-d9593942
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json

--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -3,7 +3,7 @@ FROM jamiehewland/alpine-pypy:2
 RUN apk add --no-cache jq
 RUN curl -o installer https://sdk.cloud.google.com && bash installer --disable-prompts --install-dir=/ && rm installer && ln -s /google-cloud-sdk/bin/* /bin/
 
-ADD *.css *.py *.html *.js update_summaries.sh /
+ADD *.py update_summaries.sh /
 
 # Point GOOGLE_APPLICATION_CREDENTIALS at a serviceaccount.json with the necessary permissions.
 CMD ["/update_summaries.sh"]

--- a/triage/Makefile
+++ b/triage/Makefile
@@ -25,6 +25,9 @@ push:
 	gcloud docker -- push $(IMG):latest
 	echo Pushed $(IMG):latest and $(IMG):$(TAG)
 
-.PHONY: all build push
+push_static:
+	gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z -a public-read index.html interactive.js model.js render.js style.css gs://k8s-gubernator/triage/
+
+.PHONY: all build push push_static
 
 all: build

--- a/triage/berghelroach.py
+++ b/triage/berghelroach.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=invalid-name,missing-docstring
+
 # Ported from Java com.google.gwt.dev.util.editdistance, which is:
 # Copyright 2010 Google Inc.
 #
@@ -194,6 +196,8 @@ class BerghelRoach(object):
         self.priorRight = []
 
     def getDistance(self, target, limit):
+        # pylint: disable=too-many-branches
+
         # Compute the main diagonal number.
         # The final result lies on this diagonal.
         main = len(self.pattern) - len(target)
@@ -281,7 +285,7 @@ class BerghelRoach(object):
 
             # We are done if the main diagonal has distance in the last row.
             mainRow = computeRow(main, distance, self.pattern, target,
-                immediateLeft, self.lastLeft[0], immediateRight)
+                                 immediateLeft, self.lastLeft[0], immediateRight)
 
             if mainRow == len(target):
                 break

--- a/triage/berghelroach_test.py
+++ b/triage/berghelroach_test.py
@@ -29,6 +29,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# pylint: disable=missing-docstring,invalid-name
 
 import random
 import unittest
@@ -50,12 +51,13 @@ MAGNA = (
 # A small set of words for testing, including at least some of
 # each of these: empty, very short, more than 32/64 character,
 # punctuation, non-ASCII characters
-words = [ "", "a", "b", "c", "ab", "ace",
-    "fortressing",      "inadequately", "prank",        "authored",
-    "fortresing",       "inadeqautely", "prang",        "awthered",
-    "cruller's",        "fanatic",      "Laplace",      "recollections",
-    "Kevlar",           "underpays",    "jalape\u00f1o","ch\u00e2telaine",
-    "kevlar",           "overpaid",     "jalapeno",     "chatelaine",
+words = [
+    "", "a", "b", "c", "ab", "ace",
+    "fortressing", "inadequately", "prank", "authored",
+    "fortresing", "inadeqautely", "prang", "awthered",
+    "cruller's", "fanatic", "Laplace", "recollections",
+    "Kevlar", "underpays", u"jalape\u00f1o", u"ch\u00e2telaine",
+    "kevlar", "overpaid", "jalapeno", "chatelaine",
     "A survey of algorithms for running text search by Navarro appeared",
     "in ACM Computing Surveys 33#1: http://portal.acm.org/citation.cfm?...",
     "Another algorithm (Four Russians) that Navarro",
@@ -75,10 +77,10 @@ def dynamicProgrammingLevenshtein(s1, s2):
     for j in range(0, len(s2)):
         thisRow = [0] * len(lastRow)
         thisRow[0] = j + 1
-        s2c = s2[j]
         for i in range(1, len(thisRow)):
-            thisRow[i] = min(lastRow[i] + 1, thisRow[i - 1] + 1,
-                                             lastRow[i - 1] + int(s2[j] != s1[i-1]))
+            thisRow[i] = min(lastRow[i] + 1,
+                             thisRow[i - 1] + 1,
+                             lastRow[i - 1] + int(s2[j] != s1[i-1]))
         lastRow = thisRow
     return lastRow[-1]
 
@@ -88,21 +90,21 @@ for wordA in words:
 
 
 class AbstractLevenshteinTestCase(object):
+    # pylint: disable=no-member
+
     # Tests a Levenshtein engine against the DP-based computation
     # for a bunch of string pairs.
     def testLevenshteinOnWords(self):
         for a in words:
             for b in words:
                 ed = self.getInstance(a)
-                self.specificAlgorithmVerify(ed,
-                                                                a, b,
-                                                                wordDistances[a, b])
+                self.specificAlgorithmVerify(ed, a, b, wordDistances[a, b])
 
     # Tests Levenshtein edit distance on a longer pattern
     def testLongerPattern(self):
         self.genericLevenshteinVerify("abcdefghijklmnopqrstuvwxyz",
-                                                         "abcefghijklMnopqrStuvwxyz..",
-                                                         5)  # dMS..
+                                      "abcefghijklMnopqrStuvwxyz..",
+                                      5)  # dMS..
 
     # Tests Levenshtein edit distance on a very short pattern
     def testShortPattern(self):
@@ -124,7 +126,8 @@ class AbstractLevenshteinTestCase(object):
     # @param replaces how many single-character replacements to try
     # @param inserts how many characters to insert
     # @return the number of edits actually performed, the new string
-    def performSomeEdits(self, b, alphabet, replaces, inserts):
+    @staticmethod
+    def performSomeEdits(b, alphabet, replaces, inserts):
         r = random.Random(768614336404564651L)
         edits = 0
         b = list(b)
@@ -144,7 +147,8 @@ class AbstractLevenshteinTestCase(object):
     # @param size desired string length
     # @param seed random number generator seed
     # @return random alphabetic string of the requested length
-    def generateRandomString(self, size, seed):
+    @staticmethod
+    def generateRandomString(size, seed):
         alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
         # Create a (repeatable) random string from the alphabet
@@ -168,7 +172,7 @@ class AbstractLevenshteinTestCase(object):
             for k in range(max(4, expectedResult - 4), expectedResult + 4):
                 self.verifyResult(s1, s2, expectedResult, k, ed.getDistance(s2, k))
             self.verifyResult(s1, s2, expectedResult, len(s2),
-                                     ed.getDistance(s2, len(s2)))
+                              ed.getDistance(s2, len(s2)))
 
         # Always try near MAX_VALUE
         self.assertEquals(ed.getDistance(s2, 2**63 - 1), expectedResult)
@@ -192,7 +196,8 @@ class AbstractLevenshteinTestCase(object):
         self.specificAlgorithmVerify(self.getInstance(modified), modified, original, edits)
 
         # we don't have duplicate() in Python, so...
-        # self.specificAlgorithmVerify(self.getInstance(modified).duplicate(), modified, original, edits)
+        # self.specificAlgorithmVerify(self.getInstance(modified).duplicate(),
+        #                              modified, original, edits)
 
     # Verifies a single edit distance result.
     # If the expected distance is within limit, result must b
@@ -205,11 +210,13 @@ class AbstractLevenshteinTestCase(object):
     # @param d distance computed
     def verifyResult(self, s1, s2, expectedResult, k, d):
         if k >= expectedResult:
-            self.assertEquals(expectedResult, d,
+            self.assertEquals(
+                expectedResult, d,
                 'Distance from %r to %r should be %d (within limit=%d) but was %d' %
                 (s1, s2, expectedResult, k, d))
         else:
-            self.assertTrue(d > k,
+            self.assertTrue(
+                d > k,
                 'Distance from %r to %r should be %d (exceeding limit=%d) but was %d' %
                 (s1, s2, expectedResult, k, d))
 

--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -102,9 +102,9 @@ function renderSubset(start, count) {
   var top = document.getElementById('clusters');
   var n = 0;
   var shown = 0;
-  for (let [key, keyId, text, clusters] of clustered.data) {
+  for (let c of clustered.data) {
     if (n++ < start) continue;
-    shown += renderCluster(top, key, keyId, text, clusters);
+    shown += renderCluster(top, c.key, c.id, c.text, c.tests);
     lastClusterRendered = n;
     if (shown >= count) break;
   }

--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -230,7 +230,7 @@ function load() {
   var setLoading = t => document.getElementById("loading-progress").innerText = t;
   var toMB = b => Math.round(b / 1024 / 1024 * 100) / 100;
 
-  get('/k8s-gubernator/triage/failure_data.json',
+  get('/k8s-gubernator/triage/failure_data.json' && 'failure_data.json',
     req => {
       setLoading(`parsing ${toMB(req.response.length)}MB.`);
       var data = JSON.parse(req.response);

--- a/triage/render.js
+++ b/triage/render.js
@@ -119,7 +119,7 @@ function renderJobs(parent, buildsIterator) {
 
 // Render a section for each cluster, including the text, a graph, and expandable sections
 // to dive into failures for each test or job.
-function renderCluster(top, key, keyId, text, clusters) {
+function renderCluster(top, key, keyId, text, tests) {
   function pickArrow(count) {
     return count > kCollapseThreshold ? rightArrow : downArrow;
   }
@@ -128,7 +128,7 @@ function renderCluster(top, key, keyId, text, clusters) {
     return count == 1 ? count + ' ' + word : count + ' ' + word + suffix;
   }
 
-  var clusterSum = clustersSum(clusters);
+  var clusterSum = clustersSum(tests);
   var recentCount = clustered.getHitsInLastDayById(keyId);
   var failureNode = addElement(top, 'div', {id: keyId}, [
     createElement('h2',
@@ -143,24 +143,24 @@ function renderCluster(top, key, keyId, text, clusters) {
 
   var testList = createElement('ul');
 
-  addElement(list, 'li', null, [`${plural(clusters.length, 'Test', 's')} ${pickArrow(clusters.length)}`, testList]);
-  if (clusters.length > kCollapseThreshold) {
+  addElement(list, 'li', null, [`${plural(tests.length, 'Test', 's')} ${pickArrow(tests.length)}`, testList]);
+  if (tests.length > kCollapseThreshold) {
     testList.style.display = 'none';
   }
 
   // If we expanded all the tests and jobs, how many rows would it take?
-  var jobCount = sum(clusters, c => c[1].length);
+  var jobCount = sum(tests, t => t.jobs.length);
 
-  for (var [testName, testsGrouped] of clusters) {
-    var testCount = sum(testsGrouped, t => t[1].length);
-    var el = addElement(testList, 'li', null, `${testCount} ${testName} ${pickArrow(jobCount)}`);
+  for (var test of tests) {
+    var testCount = sum(test.jobs, j => j.builds.length);
+    var el = addElement(testList, 'li', null, `${testCount} ${test.name} ${pickArrow(jobCount)}`);
     var jobList = addElement(el, 'ul');
     if (jobCount > kCollapseThreshold) {
       jobList.style.display = 'none';
     }
-    for (var [job, buildNumbers] of testsGrouped) {
-      jobSet.add(job);
-      addBuildListItem(jobList, job, buildNumbers);
+    for (var job of test.jobs) {
+      jobSet.add(job.name);
+      addBuildListItem(jobList, job.name, job.builds);
     }
   }
 

--- a/triage/summarize.py
+++ b/triage/summarize.py
@@ -272,13 +272,18 @@ def tests_group_by_job(tests, builds):
 
 def clusters_to_display(clustered, builds):
     """Transpose and sort the output of cluster_global."""
-    return [
-        [key, key_id, clusters[0][1][0]['failure_text'],
-            [
-                [test_name, tests_group_by_job(tests, builds)]
+    return [{
+            "key": key,
+            "id": key_id,
+            "text": clusters[0][1][0]['failure_text'],
+            "tests": [{
+                "name": test_name,
+                "jobs": [{"name": n, "builds": b}
+                         for n, b in tests_group_by_job(tests, builds)]
+                }
                 for test_name, tests in sorted(clusters, key=lambda (n, t): (-len(t), n))
             ]
-        ]
+        }
         for key, key_id, clusters in clustered
     ]
 

--- a/triage/summarize_test.py
+++ b/triage/summarize_test.py
@@ -165,32 +165,41 @@ class IntegrationTest(unittest.TestCase):
 		# import pprint; pprint.pprint(output)
 
 		self.assertEqual(output['builds'],
-			{'cols': {'elapsed': [8, 8, 4, 4, 4, 4],
-                      'executor': [None, None, None, None, None, None],
-                      'pr': [None, None, None, None, None, None],
-                      'result': ['SUCCESS',
-                                 'FAILURE',
-                                 'SUCCESS',
-                                 'SUCCESS',
-                                 'SUCCESS',
-                                 'SUCCESS'],
-                      'started': [1234, 1234, 1234, 1234, 1234, 1234],
-                      'tests_failed': [1, 1, 1, 1, 1, 1],
-                      'tests_run': [2, 2, 2, 2, 2, 2]},
-             'job_paths': {'other-job': 'gs://logs/other-job',
-                            'some-job': 'gs://logs/some-job'},
-             'jobs': {'other-job': {'5': 0, '7': 1},
-                       'some-job': [1, 4, 2]}})
+            {'cols': {'elapsed': [8, 8, 4, 4, 4, 4],
+                     'executor': [None, None, None, None, None, None],
+                     'pr': [None, None, None, None, None, None],
+                     'result': ['SUCCESS',
+                                'FAILURE',
+                                'SUCCESS',
+                                'SUCCESS',
+                                'SUCCESS',
+                                'SUCCESS'],
+                     'started': [1234, 1234, 1234, 1234, 1234, 1234],
+                     'tests_failed': [1, 1, 1, 1, 1, 1],
+                     'tests_run': [2, 2, 2, 2, 2, 2]},
+            'job_paths': {'other-job': 'gs://logs/other-job',
+                          'some-job': 'gs://logs/some-job'},
+            'jobs': {'other-job': {'5': 0, '7': 1}, 'some-job': [1, 4, 2]}})
 
-		random_hash_1 = output['clustered'][0][1]
-		random_hash_2 = output['clustered'][1][1]
+		random_hash_1 = output['clustered'][0]['id']
+		random_hash_2 = output['clustered'][1]['id']
 		self.assertEqual(output['clustered'],
-			[['some awful stack trace exit 1', random_hash_1, 'some awful stack trace exit 1',
-              [['example test', [['some-job', [1, 2, 3, 4]]]]]],
-             ['some other error message', random_hash_2, 'some other error message',
-              [['unrelated test', [['other-job', [5, 7]]]],
-               ['example test', [['some-job', [4]]]]]]]
+            [{'id': random_hash_1,
+                        'key': 'some awful stack trace exit 1',
+                        'tests': [{'jobs': [{'builds': [1, 2, 3, 4],
+                                             'name': 'some-job'}],
+                                   'name': 'example test'}],
+                        'text': 'some awful stack trace exit 1'},
+           {'id': random_hash_2,
+            'key': 'some other error message',
+            'tests': [{'jobs': [{'builds': [5, 7],
+                                 'name': 'other-job'}],
+                       'name': 'unrelated test'},
+                      {'jobs': [{'builds': [4], 'name': 'some-job'}],
+                       'name': 'example test'}],
+            'text': 'some other error message'}]
         )
+
 
 
 if __name__ == '__main__':

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -40,5 +40,5 @@ gsutil_cp() {
   gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z -a public-read "$@"
 }
 
-gsutil_cp failure_data.json index.html {interactive,model,render}.js style.css gs://k8s-gubernator/triage/
+gsutil_cp failure_data.json gs://k8s-gubernator/triage/
 gsutil_cp failure_data.json "gs://k8s-gubernator/triage/history/$(date -u +%Y%m%d).json"

--- a/verify/verify-pylint.sh
+++ b/verify/verify-pylint.sh
@@ -23,3 +23,4 @@ pylint jenkins/bootstrap.py
 pylint jenkins/janitor.py
 pylint queue-health/graph/graph.py
 pylint queue-health/weekly_commit_stats.py
+pylint triage/*.py


### PR DESCRIPTION
This is much easier to handle in statically typed languages, and avoids
having to remember arbitrary array indices to write code effectively.

Before:
```python
  [['some awful stack trace exit 1', random_hash_1, 'some awful stack trace exit 1',
    [['example test', [['some-job', [1, 2, 3, 4]]]]]
   ],
   ['some other error message', random_hash_2, 'some other error message',
    [['unrelated test', [['other-job', [5, 7]]]],
     ['example test', [['some-job', [4]]]]]
   ]
  ]
```

After:
```python
  [{'id': random_hash_1,
    'key': 'some awful stack trace exit 1',
    'tests': [{'jobs': [{'builds': [1, 2, 3, 4],
                         'name': 'some-job'}],
               'name': 'example test'}],
    'text': 'some awful stack trace exit 1'},
   {'id': random_hash_2,
    'key': 'some other error message',
    'tests': [{'jobs': [{'builds': [5, 7],
                         'name': 'other-job'}],
               'name': 'unrelated test'},
              {'jobs': [{'builds': [4], 'name': 'some-job'}],
               'name': 'example test'}],
    'text': 'some other error message'}]
```

This increases the JSON size by ~2% before compression, and <1% after.