### PR TITLE
Set make rerun commands match job name

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -46,8 +46,8 @@ presubmits:
   - name: pull-kubernetes-bazel
     context: Jenkins Bazel Build
     always_run: true
-    rerun_command: "@k8s-bot bazel test this"
-    trigger: "@k8s-bot (bazel )?test this"
+    rerun_command: "@k8s-bot pull-kubernetes-bazel test this"
+    trigger: "@k8s-bot (pull-kubernetes-bazel )?test this"
     branches:
     - master
     spec:
@@ -79,11 +79,11 @@ presubmits:
           path: /mnt/disks/ssd0
     run_after_success:
     - name: pull-kubernetes-e2e-kubeadm-gce
-      context: Jenkins kubeadm e2e
+      context: pull-kubernetes-e2e-kubeadm-gce
       always_run: false
       skip_report: true
-      rerun_command: "@k8s-bot kubeadm e2e test this"
-      trigger: "@k8s-bot (kubeadm e2e )?test this"
+      rerun_command: "@k8s-bot pull-kubernetes-e2e-kubeadm-gce test this"
+      trigger: "@k8s-bot (pull-kubernetes-e2e-kubeadm-gce )?test this"
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
@@ -129,20 +129,20 @@ presubmits:
   - name: pull-kubernetes-unit
     always_run: true
     context: Jenkins unit/integration
-    rerun_command: "@k8s-bot unit test this"
-    trigger: "@k8s-bot (unit )?test this"
+    rerun_command: "@k8s-bot pull-kubernetes-unit test this"
+    trigger: "@k8s-bot (pull-kubernetes-unit )?test this"
 
   - name: pull-kubernetes-verify
     always_run: true
     context: Jenkins verification
-    rerun_command: "@k8s-bot verify test this"
-    trigger: "@k8s-bot (verify )?test this"
+    rerun_command: "@k8s-bot pull-kubernetes-verify test this"
+    trigger: "@k8s-bot (pull-kubernetes-verify )?test this"
 
   - name: pull-kubernetes-e2e-gce
     always_run: true
     context: Jenkins GCE e2e
-    rerun_command: "@k8s-bot cvm gce e2e test this"
-    trigger: "@k8s-bot (cvm )?(gce )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce test this"
+    trigger: "@k8s-bot (pull-kubernetes-e2e-gce )?test this"
 
   - name: pull-kubernetes-e2e-gce-canary
     context: pull-kubernetes-e2e-gce-canary
@@ -152,8 +152,8 @@ presubmits:
   - name: pull-kubernetes-e2e-gce-etcd3
     always_run: true
     context: Jenkins GCE etcd3 e2e
-    rerun_command: "@k8s-bot gce etcd3 e2e test this"
-    trigger: "@k8s-bot (gce )?(etcd3 )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce-etcd3 test this"
+    trigger: "@k8s-bot (pull-kubernetes-e2e-gce-etcd3 )?test this"
 
   - name: pull-kubernetes-e2e-gke
     context: pull-kubernetes-e2e-gke
@@ -166,16 +166,15 @@ presubmits:
     trigger: "@k8s-bot pull-kubernetes-e2e-gke-gci test this"
 
   - name: pull-kubernetes-e2e-gce-gci
-    always_run: true
-    context: Jenkins GCI GCE e2e
-    rerun_command: "@k8s-bot gci gce e2e test this"
-    trigger: "@k8s-bot (gci )?(gce )?(e2e )?test this"
+    context: pull-kubernetes-e2e-gce-gci
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce-gci test this"
+    trigger: "@k8s-bot pull-kubernetes-e2e-gce-gci test this"
 
   - name: pull-kubernetes-e2e-kops-aws
     always_run: true
     context: Jenkins kops AWS e2e
-    rerun_command: "@k8s-bot kops aws e2e test this"
-    trigger: "@k8s-bot (kops )?(aws )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-kops-aws test this"
+    trigger: "@k8s-bot (pull-kubernetes-e2e-kops-aws )?test this"
 
   - name: pull-kubernetes-federation-e2e-gce
     skip_branches:
@@ -186,13 +185,13 @@ presubmits:
     skip_report: true  # Remove this once we are confident about this job
     context: pull-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce test this"
-    trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce |federation gce e2e )?test this"
+    trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce )?test this"
 
   - name: pull-kubernetes-kubemark-e2e-gce
-    trigger: "@k8s-bot (kubemark )?(e2e )?test this"
     always_run: true
     context: Jenkins Kubemark GCE e2e
-    rerun_command: "@k8s-bot kubemark e2e test this"
+    rerun_command: "@k8s-bot pull-kubernetes-kubemark-e2e-gce test this"
+    trigger: "@k8s-bot (pull-kubernetes-kubemark-e2e-gce )?test this"
 
   - name: pull-kubernetes-kubemark-e2e-gce-gci
     context: pull-kubernetes-kubemark-e2e-gce-gci
@@ -202,32 +201,30 @@ presubmits:
   - name: pull-kubernetes-node-e2e
     always_run: true
     context: Jenkins GCE Node e2e
-    rerun_command: "@k8s-bot node e2e test this"
-    trigger: "@k8s-bot (node )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-kubernetes-node-e2e test this"
+    trigger: "@k8s-bot (pull-kubernetes-node-e2e )?test this"
 
   - name: pull-kubernetes-e2e-gce-non-cri
     branches:
     - master
-    always_run: true
-    context: Jenkins non-CRI GCE e2e
-    rerun_command: "@k8s-bot non-cri e2e test this"
-    trigger: "@k8s-bot (non-cri e2e )?test this"
+    context: pull-kubernetes-e2e-gce-non-cri
+    rerun_command: "@k8s-bot pull-kubernetes-e2e-gce-non-cri test this"
+    trigger: "@k8s-bot pull-kubernetes-e2e-gce-non-cri test this"
 
   - name: pull-kubernetes-node-e2e-non-cri
     skip_branches:
     - release-1.3
     - release-1.4
-    always_run: true
-    context: Jenkins non-CRI GCE Node e2e
-    rerun_command: "@k8s-bot non-cri node e2e test this"
-    trigger: "@k8s-bot (non-cri node e2e )?test this"
+    context: pull-kubernetes-node-e2e-non-cri
+    rerun_command: "@k8s-bot pull-kubernetes-node-e2e-non-cri test this"
+    trigger: "@k8s-bot pull-kubernetes-node-e2e-non-cri test this"
 
   kubernetes-security/kubernetes: # TODO(fejta, spxr): find way to not duplicate these
   - name: pull-security-kubernetes-bazel
     context: Jenkins Bazel Build
     always_run: true
-    rerun_command: "@k8s-bot bazel test this"
-    trigger: "@k8s-bot (bazel )?test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-bazel test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-bazel )?test this"
     branches:
     - master
     spec:
@@ -259,11 +256,11 @@ presubmits:
           path: /mnt/disks/ssd0
     run_after_success:
     - name: pull-security-kubernetes-e2e-kubeadm-gce
-      context: Jenkins kubeadm e2e
+      context: pull-security-kubernetes-e2e-kubeadm-gce
       always_run: false
       skip_report: true
-      rerun_command: "@k8s-bot kubeadm e2e test this"
-      trigger: "@k8s-bot (kubeadm e2e )?test this"
+      rerun_command: "@k8s-bot pull-security-kubernetes-e2e-kubeadm-gce test this"
+      trigger: "@k8s-bot (pull-security-kubernetes-e2e-kubeadm-gce )?test this"
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
@@ -309,20 +306,20 @@ presubmits:
   - name: pull-security-kubernetes-unit
     always_run: true
     context: Jenkins unit/integration
-    rerun_command: "@k8s-bot unit test this"
-    trigger: "@k8s-bot (unit )?test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-unit test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-unit )?test this"
 
   - name: pull-security-kubernetes-verify
     always_run: true
     context: Jenkins verification
-    rerun_command: "@k8s-bot verify test this"
-    trigger: "@k8s-bot (verify )?test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-verify test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-verify )?test this"
 
   - name: pull-security-kubernetes-e2e-gce
     always_run: true
     context: Jenkins GCE e2e
-    rerun_command: "@k8s-bot cvm gce e2e test this"
-    trigger: "@k8s-bot (cvm )?(gce )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-e2e-gce )?test this"
 
   - name: pull-security-kubernetes-e2e-gce-canary
     context: pull-security-kubernetes-e2e-gce-canary
@@ -332,8 +329,8 @@ presubmits:
   - name: pull-security-kubernetes-e2e-gce-etcd3
     always_run: true
     context: Jenkins GCE etcd3 e2e
-    rerun_command: "@k8s-bot gce etcd3 e2e test this"
-    trigger: "@k8s-bot (gce )?(etcd3 )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce-etcd3 test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-e2e-gce-etcd3 )?test this"
 
   - name: pull-security-kubernetes-e2e-gke
     context: pull-security-kubernetes-e2e-gke
@@ -346,16 +343,15 @@ presubmits:
     trigger: "@k8s-bot pull-security-kubernetes-e2e-gke-gci test this"
 
   - name: pull-security-kubernetes-e2e-gce-gci
-    always_run: true
-    context: Jenkins GCI GCE e2e
-    rerun_command: "@k8s-bot gci gce e2e test this"
-    trigger: "@k8s-bot (gci )?(gce )?(e2e )?test this"
+    context: pull-security-kubernetes-e2e-gce-gci
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce-gci test this"
+    trigger: "@k8s-bot pull-security-kubernetes-e2e-gce-gci test this"
 
   - name: pull-security-kubernetes-e2e-kops-aws
     always_run: true
     context: Jenkins kops AWS e2e
-    rerun_command: "@k8s-bot kops aws e2e test this"
-    trigger: "@k8s-bot (kops )?(aws )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-kops-aws test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-e2e-kops-aws )?test this"
 
   - name: pull-security-kubernetes-federation-e2e-gce
     skip_branches:
@@ -366,13 +362,13 @@ presubmits:
     skip_report: true
     context: pull-security-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-security-kubernetes-federation-e2e-gce test this"
-    trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce |federation gce e2e )?test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce )?test this"
 
   - name: pull-security-kubernetes-kubemark-e2e-gce
-    trigger: "@k8s-bot (kubemark )?(e2e )?test this"
     always_run: true
     context: Jenkins Kubemark GCE e2e
-    rerun_command: "@k8s-bot kubemark e2e test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-kubemark-e2e-gce test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-kubemark-e2e-gce )?test this"
 
   - name: pull-security-kubernetes-kubemark-e2e-gce-gci
     context: pull-security-kubernetes-kubemark-e2e-gce-gci
@@ -382,25 +378,23 @@ presubmits:
   - name: pull-security-kubernetes-node-e2e
     always_run: true
     context: Jenkins GCE Node e2e
-    rerun_command: "@k8s-bot node e2e test this"
-    trigger: "@k8s-bot (node )?(e2e )?test this"
+    rerun_command: "@k8s-bot pull-security-kubernetes-node-e2e test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-node-e2e )?test this"
 
   - name: pull-security-kubernetes-e2e-gce-non-cri
     branches:
     - master
-    always_run: true
-    context: Jenkins non-CRI GCE e2e
-    rerun_command: "@k8s-bot non-cri e2e test this"
-    trigger: "@k8s-bot (non-cri e2e )?test this"
+    context: pull-security-kubernetes-e2e-gce-non-cri
+    rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce-non-cri test this"
+    trigger: "@k8s-bot pull-security-kubernetes-e2e-gce-non-cri test this"
 
   - name: pull-security-kubernetes-node-e2e-non-cri
     skip_branches:
     - release-1.3
     - release-1.4
-    always_run: true
-    context: Jenkins non-CRI GCE Node e2e
-    rerun_command: "@k8s-bot non-cri node e2e test this"
-    trigger: "@k8s-bot (non-cri node e2e )?test this"
+    context: pull-security-kubernetes-node-e2e-non-cri
+    rerun_command: "@k8s-bot pull-security-kubernetes-node-e2e-non-cri test this"
+    trigger: "@k8s-bot pull-security-kubernetes-node-e2e-non-cri test this"
 
   kubernetes/test-infra:
   - name: pull-test-infra-bazel


### PR DESCRIPTION
/assign @krzyzacy @spxtr 

Also updates any non-blocking contexts to use the job name rather than some arbitrary string with Jenkins in the name.

Offshoot of https://github.com/kubernetes/test-infra/pull/2485 without the change to the etcd3 job