### PR TITLE
Fix triage test

### DIFF
--- a/triage/BUILD
+++ b/triage/BUILD
@@ -17,10 +17,16 @@ py_test(
     ],
 )
 
-#mocha_test(
-#    name = "script_test",
-#    main = "script_test.js",
-#)
+mocha_test(
+    name = "script_test",
+    data = ["js-srcs"],
+    main = "script_test.js",
+)
+
+filegroup(
+    name = "js-srcs",
+    srcs = glob(["*.js"]),
+)
 
 filegroup(
     name = "package-srcs",

--- a/triage/model.js
+++ b/triage/model.js
@@ -188,7 +188,7 @@ class Clusters {
     if (opts.sort) {
       var keyFunc = {
         total: c => [-clustersSum(c.tests)],
-        message: c => [c[0]],
+        message: c => [c.text],
         day: c => [-getHitsInLastDay(c), -clustersSum(c.tests)],
       }[opts.sort];
       out = sortByKey(out, keyFunc);

--- a/triage/script_test.js
+++ b/triage/script_test.js
@@ -21,18 +21,18 @@ describe('Clusters', () => {
                 assert.deepEqual(c.refilter(opts).data, expected);
             });
         }
-        let ham = ['ham', '', 'ham', [
-            ['volume', [['cure', [1, 2]]]],
-        ]];
-        let spam = ['spam', '', 'spam', [
-            ['networking', [['g', [2]]]]
-        ]];
-        let pr = ['bam', '', 'bam', [
-            ['new', [['pr:verify', [3]]]],
-        ]];
-        let first = ['afirst', '', 'afirst', [
-            ['something', [['firstjob', [5, 6]]]],
-        ]];
+        let ham = {text: 'ham', key: 'ham', id: '1234', tests: [
+            {name: 'volume', jobs: [{name: 'cure', builds: [1, 2]}]},
+        ]};
+        let spam = {text: 'spam', key: 'spam', id: '5678', tests: [
+            {name: 'networking', jobs: [{name: 'g', builds: [2]}]},
+        ]};
+        let pr = {text: 'bam', key: 'bam', id: '9abc', tests: [
+            {name: 'new', jobs: [{name: 'pr:verify', builds: [3]}]},
+        ]};
+        let first = {text: 'afirst', key: 'afirst', id: 'def0', tests: [
+            {name: 'something', jobs: [{name: 'firstjob', builds: [5, 6]}]},
+        ]};
         expect('filters by text', [ham], [ham, spam], {reText: /ham/im, ci: true});
         expect('filters by test', [ham], [ham, spam], {reTest: /volume/im, ci: true});
         expect('filters by job', [ham], [ham, spam], {reJob: /cure/im, ci: true});


### PR DESCRIPTION
Fixes #2502.

The mocha_test wasn't depending on all of it inputs. There's another bug in the rules_node bazel specs that makes data= not work, which should be fixed once pubref/rules_node#12 is merged.