### PR TITLE
gubernator: Include approvers in "involved" set.

### DIFF
--- a/gubernator/github/classifier.py
+++ b/gubernator/github/classifier.py
@@ -217,7 +217,7 @@ def classify(events, statuses=None):
     is_open = merged['state'] != 'closed'
     author = merged['user']['login']
     assignees = sorted({assignee['login'] for assignee in merged['assignees']} | reviewers)
-    involved = [author] + assignees
+    involved = sorted(set([author] + assignees + approvers))
 
     payload = {
         'author': author,

--- a/gubernator/github/classifier_test.py
+++ b/gubernator/github/classifier_test.py
@@ -137,7 +137,7 @@ class CalculateTest(unittest.TestCase):
                 make_comment_event(2, 'k8s-merge-robot', '<!-- META={"approvers":["o"]} -->', ts=4),
             ], {'e2e': ['failure', None, 'stuff is broken']}
         ),
-        (True, True, ['a', 'b'],
+        (True, True, ['a', 'b', 'o'],
          {
             'author': 'a',
             'approvers': ['o'],


### PR DESCRIPTION
PRs are indexes by involved usernames, so without this an approvable PR
might not display on the dashboard.