### PR TITLE
Bump kubekins-e2e image version to v20170414-ee5b0483.

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -439,7 +439,7 @@ def create_parser():
     parser.add_argument(
         '--soak-test', action='store_true', help='If the test is a soak test job')
     parser.add_argument(
-        '--tag', default='v20170403-d0327c02', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170414-ee5b0483', help='Use a specific kubekins-e2e tag if set')
     parser.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     parser.add_argument(


### PR DESCRIPTION
For PRs #2231 and #2494.

Passing canary run: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-canary/191


/assign @fejta 

