### PR TITLE
Make prow-e2e use date-commit tag, and move --bare out of the runner

### DIFF
--- a/images/e2e-prow/Makefile
+++ b/images/e2e-prow/Makefile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.3
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 image:
-	docker build -t "gcr.io/k8s-testimages/kubekins-e2e-prow:$(VERSION)" .
+	docker build -t "gcr.io/k8s-testimages/kubekins-e2e-prow:$(TAG)" .
 
 push:
-	gcloud docker -- push "gcr.io/k8s-testimages/kubekins-e2e-prow:$(VERSION)"
+	gcloud docker -- push "gcr.io/k8s-testimages/kubekins-e2e-prow:$(TAG)"
 
 .PHONY: image push

--- a/images/e2e-prow/runner
+++ b/images/e2e-prow/runner
@@ -19,7 +19,6 @@ set -o pipefail
 
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
-    --bare \
     --job=${JOB_NAME} \
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     --upload='gs://kubernetes-jenkins/logs' \

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -781,9 +781,10 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:0.3
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
       args:
-      - "--timeout=60"
+      - --bare
+      - --timeout=60
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json


### PR DESCRIPTION
Not every job likes `--bare`, so we'd better move it out of the image. (Already pushed)

I feel like args don't need the quotes, but tell me otherwise.

/assign @spxtr 

Prep for #2522