### PR TITLE
move ci-kubernetes-e2e-gce-reboot-release-1.4 to prow

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -417,12 +417,6 @@
         timeout: 70
         frequency: 'H H/6 * * *' # 4 times a day for older jobs.
         trigger-job: 'ci-kubernetes-build-1.4'
-    - kubernetes-e2e-gce-reboot-release-1.4:
-        job-name: ci-kubernetes-e2e-gce-reboot-release-1.4
-        jenkins-timeout: 300
-        timeout: 200
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
-        trigger-job: 'ci-kubernetes-build-1.4'
     - kubernetes-e2e-gce-slow-release-1.4:
         job-name: ci-kubernetes-e2e-gce-slow-release-1.4
         jenkins-timeout: 270

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -975,7 +975,8 @@
   "scenario": "kubernetes_e2e",
   "args": [
     "--env-file=platforms/gce.env",
-    "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.env"
+    "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1.4.env",
+    "--mode=local"
   ]
 },
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -928,3 +928,39 @@ periodics:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+
+- interval: 1h
+  name: ci-kubernetes-e2e-gce-reboot-release-1.4
+  spec:
+    containers:
+    - args:
+      - --timeout=200
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd


### PR DESCRIPTION
The job is currently [healthy](http://k8s-testgrid.appspot.com/release-1.4-all#gce-reboot-1.4) and in low priority, use it as a gene-picker.

Prow config is generated from the convert script, plus some manual work which I'll try to automate them in the script.

I'd like to see what side effects the migration will have, and how other components (gubernator, testgrid) will react between the builds.

/assign @spxtr @fejta 