### PR TITLE
Don't print node list result to test logs.

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -241,9 +241,6 @@ func run(deploy deployer, o options) error {
 
 func listNodes(dump string) error {
 	b, err := output(exec.Command("./cluster/kubectl.sh", "--match-server-version=false", "get", "nodes", "-oyaml"))
-	if verbose {
-		log.Printf("kubectl get nodes:\n%s", string(b))
-	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We do print it to file and I don't think there's good enough reason for this redundancy. Plus it takes half of the logs in large clusters.

cc @wojtek-t @kubernetes/test-infra-maintainers 