### PR TITLE
Add pr-kubekins to default role

### DIFF
--- a/jenkins/check_projects.py
+++ b/jenkins/check_projects.py
@@ -53,6 +53,7 @@ helpers = {}  # People with owners rights to update error projects
 DEFAULT = {
     'roles/editor': [
         'serviceAccount:kubekins@kubernetes-jenkins.iam.gserviceaccount.com',
+        'serviceAccount:pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com',
     ],
 }
 


### PR DESCRIPTION
Build jobs are not in the `jobs/` dir, so this should be fine. #2531

/assign @fejta