### PR TITLE
Real fix for the pod name regex

### DIFF
--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 )
 
-var podRe = regexp.MustCompile(`[a-z0-9]([-a-z0-9]*[a-z0-9])?`)
+var podRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 const testThis = "@k8s-bot test this"
 


### PR DESCRIPTION
#2552 

ref https://github.com/kubernetes/kubernetes/blob/616038db1b0d1e852b4a3d10c8c512a052f91fba/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L94