### PR TITLE
Rename Stackdriver monitoring feature

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-stackdriver.env
+++ b/jobs/ci-kubernetes-e2e-gce-stackdriver.env
@@ -1,5 +1,5 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Stackdriver\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StackdriverMonitoring\]
 PROJECT=k8s-jkns-e2e-gce-stackdriver
 
 KUBE_ENABLE_CLUSTER_MONITORING=stackdriver

--- a/jobs/ci-kubernetes-e2e-gke-stackdriver.env
+++ b/jobs/ci-kubernetes-e2e-gke-stackdriver.env
@@ -1,6 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Stackdriver\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StackdriverMonitoring\]
 PROJECT=k8s-jkns-e2e-gke-stackdriver
 
 KUBEKINS_TIMEOUT=50m


### PR DESCRIPTION
Rename feature to avoid launching tests with [Feature:StackdriverLogging] in SD monitoring test suite.