### PR TITLE
Don't update the ProwJob with environment variables.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -22,7 +22,7 @@ SPLICE_VERSION     = 0.19
 TOT_VERSION        = 0.0
 CRIER_VERSION      = 0.5
 HOROLOGIUM_VERSION = 0.3
-PLANK_VERSION      = 0.10
+PLANK_VERSION      = 0.11
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -29,7 +29,7 @@ spec:
         role: prow
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.10
+        image: gcr.io/k8s-prow/plank:0.11
         volumeMounts:
         - mountPath: /etc/jenkins
           name: jenkins


### PR DESCRIPTION
@pipejakob noticed that the `BUILD_NUMBER` env had found its way into the prow job spec for a running job. It's not a big problem, since it will get overwritten if you start a new job, but it shouldn't be there in the first place.

Turns out lists are pointer types and I was updating it in place when I set the env vars before starting the pod.