### PR TITLE
Revert "Merge pull request #2530 from msau42/disable-gke-gcepd-multizone

### DIFF
--- a/jobs/ci-kubernetes-e2e-gci-gke-multizone.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-multizone.env
@@ -1,7 +1,7 @@
 ### job-env
 ADDITIONAL_ZONES=us-central1-a,us-central1-b
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|GCEPD
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gci-gke-multizone
 ZONE=us-central1-f
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gke-multizone.env
+++ b/jobs/ci-kubernetes-e2e-gke-multizone.env
@@ -1,7 +1,7 @@
 ### job-env
 ADDITIONAL_ZONES=us-central1-a,us-central1-b
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|GCEPD
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gke-multizone
 ZONE=us-central1-f
 


### PR DESCRIPTION
This reverts commit e674bafefc930d13435962e40d462848a6eb3019

The GKE change to enable the persistent volume admission controller was checked in last week, and will work with GKE 1.6.2+.  These CI tests are running off of 1.7+, so they should see the updates.
Fixes #2536