### PR TITLE
Add a "trigger" section to prow's config.yaml.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.113
+HOOK_VERSION       = 0.114
 SINKER_VERSION     = 0.10
 DECK_VERSION       = 0.30
 SPLICE_VERSION     = 0.20

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.113
+        image: gcr.io/k8s-prow/hook:0.114
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,4 +1,12 @@
 ---
+triggers:
+- repos:
+  - kubernetes
+  - kubernetes-incubator
+  - kubernetes-security
+  - google/cadvisor
+  trusted_org: kubernetes
+
 presubmits:
   # PR job triggering definitions.
   # Keys: Full repo name: "org/repo".

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -34,6 +34,17 @@ type Config struct {
 
 	// Periodics are not associated with any repo.
 	Periodics []Periodic `json:"periodics,omitempty"`
+
+	Triggers []Trigger `json:"triggers,omitempty"`
+}
+
+// Trigger is config for the trigger plugin.
+type Trigger struct {
+	// Repos is either of the form org/repos or just org.
+	Repos []string `json:"repos,omitempty"`
+	// TrustedOrg is the org whose members' PRs will be automatically built
+	// for PRs to the above repos.
+	TrustedOrg string `json:"trusted_org,omitempty"`
 }
 
 // Load loads and parses the config at path.

--- a/prow/plugins/trigger/pr_test.go
+++ b/prow/plugins/trigger/pr_test.go
@@ -261,7 +261,7 @@ func TestTrusted(t *testing.T) {
 				0: tc.Comments,
 			},
 		}
-		trusted, err := trustedPullRequest(g, tc.PR)
+		trusted, err := trustedPullRequest(g, tc.PR, "kubernetes")
 		if err != nil {
 			t.Fatalf("Didn't expect error: %s", err)
 		}

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -17,6 +17,8 @@ limitations under the License.
 package trigger
 
 import (
+	"fmt"
+
 	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/config"
@@ -28,7 +30,6 @@ import (
 const (
 	pluginName = "trigger"
 	lgtmLabel  = "lgtm"
-	trustedOrg = "kubernetes"
 )
 
 func init() {
@@ -60,6 +61,17 @@ type client struct {
 	KubeClient   kubeClient
 	Config       *config.Config
 	Logger       *logrus.Entry
+}
+
+func triggerConfig(c *config.Config, org, repo string) *config.Trigger {
+	for _, tr := range c.Triggers {
+		for _, r := range tr.Repos {
+			if r == org || r == fmt.Sprintf("%s/%s", org, repo) {
+				return &tr
+			}
+		}
+	}
+	return nil
 }
 
 func getClient(pc plugins.PluginClient) client {


### PR DESCRIPTION
It's current only entry is TrustedOrg, which was previously hardcoded to "kubernetes". This updates that to be configurable. Note that the trigger plugin was not written with this sort of configuration in mind and could really do with a refactor.

This is a start for #2546.