### PR TITLE
Lukaszgryglicki 1694 gubernator do not put PR in Needs Attention section when on push event, when LGTM label present

### DIFF
--- a/gubernator/github/classifier_test.py
+++ b/gubernator/github/classifier_test.py
@@ -211,17 +211,19 @@ class CalculateTest(unittest.TestCase):
         expect([('comment', 'other', 1), ('comment', 'other', 2)], ('address comments', 1, 2))
 
     def test_assignee_state(self):
-        def expect(events, result):
-            self.assertEqual(classifier.get_assignee_state('me', 'author', events),
+        def expect(events, labels, result):
+            self.assertEqual(classifier.get_assignee_state('me', 'author', labels, events),
                              result)
-        expect([], ('needs review', 0, 0))
-        expect([('comment', 'other', 1)], ('needs review', 0, 0))
-        expect([('comment', 'me', 1)], ('waiting', 1, 1))
-        expect([('label lgtm', 'other', 1)], ('needs review', 0, 0))
-        expect([('label lgtm', 'me', 1)], ('waiting', 1, 1))
-        expect([('comment', 'me', 1), ('push', 'author', 2)], ('needs review', 2, 2))
-        expect([('comment', 'me', 1), ('comment', 'author', 2)], ('needs review', 2, 2))
-        expect([('comment', 'me', 1), ('comment', 'author', 2), ('comment', 'author', 3)],
+        expect([], [], ('needs review', 0, 0))
+        expect([('comment', 'other', 1)], [], ('needs review', 0, 0))
+        expect([('comment', 'me', 1)], [], ('waiting', 1, 1))
+        expect([('label lgtm', 'other', 1)], [], ('needs review', 0, 0))
+        expect([('label lgtm', 'me', 1)], [], ('waiting', 1, 1))
+        expect([('comment', 'me', 1), ('push', 'author', 2)], [], ('needs review', 2, 2))
+        expect([('comment', 'me', 1), ('push', 'author', 2)], ['label'], ('needs review', 2, 2))
+        expect([('comment', 'me', 1), ('push', 'author', 2)], ['lgtm'], ('waiting', 1, 1))
+        expect([('comment', 'me', 1), ('comment', 'author', 2)], [], ('needs review', 2, 2))
+        expect([('comment', 'me', 1), ('comment', 'author', 2), ('comment', 'author', 3)], [],
                ('needs review', 2, 3))
 
     def test_xrefs(self):


### PR DESCRIPTION
This is a fix for #1694 

Implementation details:
-gubernator was putting PR in "attention" section for all assignees on push event. I've updated code to skip this when LGTM label is present.

This fixes case reported by @mml but I'm not sure if this is correct.
If PR already have LGTM and actor is pushing to its branch then LGTM is no more valid then.
Push usually means that something was changed, like feedback addressed etc.

So I would prefer to have some discussion on this PR.
