### PR TITLE
Move ExternalTrafficLocalOnly tests out of alpha CIs

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features.env
@@ -1,7 +1,7 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gce-alpha
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.env
@@ -1,7 +1,7 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gci-gce-alpha
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.env
@@ -1,7 +1,7 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gci-gke-alpha
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
 KUBE_GKE_IMAGE_TYPE=gci
 
 KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features.env
@@ -1,7 +1,7 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gke-alpha
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
 # Use gcloud credentials for authentication
 CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=false
 

--- a/jobs/ci-kubernetes-e2e-non-cri-gce-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gce-alpha-features.env
@@ -3,7 +3,7 @@ KUBELET_TEST_ARGS=--enable-cri=false
 
 PROJECT=k8s-jkns-e2e-cri-gce-alpha
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-non-cri-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-non-cri-gke-alpha-features.env
@@ -3,7 +3,7 @@ KUBELET_TEST_ARGS=--enable-cri=false
 
 PROJECT=k8s-jkns-e2e-cri-gke-alpha
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
 KUBE_GKE_IMAGE_TYPE=gci
 
 KUBEKINS_TIMEOUT=180m


### PR DESCRIPTION
All ESIPP relevant e2e tests have been moved to the slow suite from alpha feature suite (kubernetes/kubernetes#38149, kubernetes/kubernetes#44582).

This PR removes corresponding keyword in CI envs.

@krzyzacy 