### PR TITLE
Fix gci-gke-prod/staging to also skip the default tags

### DIFF
--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.env
@@ -6,6 +6,6 @@ JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-jkns-e2e-gci-gke-prod
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-b
-GINKGO_TEST_ARGS=--ginkgo.skip=NFSv3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|NFSv3
 
 KUBEKINS_TIMEOUT=480m

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.env
@@ -5,6 +5,6 @@ E2E_OPT=--check_version_skew=false
 JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-jkns-e2e-gci-gke-staging
 KUBE_GKE_IMAGE_TYPE=gci
-GINKGO_TEST_ARGS=--ginkgo.skip=NFSv3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|NFSv3
 
 KUBEKINS_TIMEOUT=480m


### PR DESCRIPTION
When disabling the nfs3 tests, I added a new GINGKO_TEST_ARGS line to the .env files.  Normally, if you don't specify it, then it will by default skip a few tags.  So after the change, a bunch of tests ended up running that shouldn't have been run because the default tags weren't skipped anymore.

This change explicitly specifies the default tags to skip.