### PR TITLE
Changes name of the Ubuntu node e2e tests on GCE

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -812,11 +812,8 @@ test_groups:
   gcs_prefix: upstream-jenkins-logs/logs/ci-tectonic-e2e-aws-serial
 - name: ci-tectonic-e2e-etcd-serial
   gcs_prefix: upstream-jenkins-logs/logs/ci-tectonic-e2e-etcd-serial
-# Canonical Distribution of Kubernetes (contact: @chuckbutler on github)
-- name: canonical-kubernetes-e2e-gce
-  gcs_prefix: canonical-kubernetes-tests/logs/kubernetes-gce-e2e-node
-# Ubuntu GKE (contact: @vorlonofportland on github)
-- name: ubuntu-gke
+# Ubuntu node e2e tests on GCE (contact: @kubernetes/ubuntu-image on github)
+- name: gce-ubuntu-node
   gcs_prefix: canonical-kubernetes-tests/logs-gke/kubernetes-gce-e2e-node
 # kopeio (contact: @justinsb on github)
 - name: kopeio-kubernetes-e2e-aws
@@ -883,10 +880,8 @@ test_groups:
 dashboards:
 - name: canonical-kubernetes
   dashboard_tab:
-  - name: cdk-gce
-    test_group_name: canonical-kubernetes-e2e-gce
-  - name: ubuntu-gke
-    test_group_name: ubuntu-gke
+  - name: gce-ubuntu-node
+    test_group_name: gce-ubuntu-node
 
 - name: kopeio
   dashboard_tab:


### PR DESCRIPTION
This will change the name of the Ubuntu node e2e tests on GCE in https://k8s-testgrid.appspot.com/canonical-kubernetes from `ubuntu-gke` to `gce-ubuntu-1604-v20170420-node`.