### PR TITLE
triage: fix previous cluster seeding.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -812,7 +812,8 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/triage:v20170420-1ca6229c
+    - image: gcr.io/k8s-testimages/triage:latest
+      imagePullPolicy: Always
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json

--- a/triage/summarize.py
+++ b/triage/summarize.py
@@ -248,8 +248,9 @@ def cluster_global(clustered, previous_clustered):
 
     if previous_clustered:
         # seed clusters using output from the previous run
-        for key, _id, _ftext, _clusters in previous_clustered:
-            clusters[key] = {}
+        for cluster in previous_clustered:
+            clusters[cluster['key']] = {}
+        print 'Seeding with %d previous clusters' % len(clusters)
 
     for n, (test_name, cluster) in enumerate(
             sorted(clustered.iteritems(),
@@ -372,6 +373,7 @@ def main(args):
 
     previous_clustered = None
     if args.previous:
+        print 'loading previous'
         previous_clustered = json.load(open(args.previous))['clustered']
     clustered = cluster_global(clustered_local, previous_clustered)
 

--- a/triage/summarize_test.py
+++ b/triage/summarize_test.py
@@ -97,7 +97,7 @@ class ClusterTest(unittest.TestCase):
         t1 = make_test(textNew)
 
         self.assertEqual(
-            self.cluster_global({'test a': {textNew: [t1]}}, [[textOld, None, None, None]]),
+            self.cluster_global({'test a': {textNew: [t1]}}, [{'key': textOld}]),
             {textOld: {'test a': [t1]}})
 
 


### PR DESCRIPTION
Iterating through a dict yields its keys, so this line:

   for key, _id, _ftext, _clusters in previous_clustered:

Was assigning the variables the values:

   "id", "key", "tests", "text"

In random order.