### PR TITLE
Enable metrics gathering for kubemark 100-node test

### DIFF
--- a/jobs/ci-kubernetes-kubemark-100-gce.env
+++ b/jobs/ci-kubernetes-kubemark-100-gce.env
@@ -2,7 +2,7 @@
 PROJECT=k8s-jenkins-kubemark
 USE_KUBEMARK=true
 KUBEMARK_TESTS=\[Feature:Performance\]
-KUBEMARK_TEST_ARGS=--gather-resource-usage=true --output-print-type=json
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json
 FAIL_ON_GCP_RESOURCE_LEAK=false
 # Override defaults to be independent from GCE defaults and set kubemark parameters
 NUM_NODES=3


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/44701

We need more information about the no. of requests of different kinds to the apiserver. Let's turn on metrics gathering for sometime and see.
Not doing this for other larger tests as the size of the metrics json file may just overwhelm the test due to metrics from each hollow node.

cc @kubernetes/sig-scalability-misc @wojtek-t @gmarek 