### PR TITLE
Triage usability improvements

### DIFF
--- a/triage/index.html
+++ b/triage/index.html
@@ -6,7 +6,7 @@
 <title>Kubernetes Aggregated Test Results</title>
 </head>
 <body>
-<h1>Kubernetes Failures</h1>
+<h1>Kubernetes Aggregated Failures</h1>
 <form id="options" onchange="rerender();">
 Sort by
 <label><input id="sort" name="sort" type="radio" value="total">total count</label>

--- a/triage/render.js
+++ b/triage/render.js
@@ -118,11 +118,11 @@ function renderJobs(parent, clusterId) {
   }
 
   var clusterJobs = Object.entries(clusterJobs);
-  clusterJobs.sort();
+  sortByKey(clusterJobs, j => j[1].size);
 
   var jobList = addElement(parent, 'ul');
   for (let [job, buildNumbersSet] of clusterJobs) {
-    let buildNumbers = Array.from(buildNumbersSet).sort();
+    let buildNumbers = Array.from(buildNumbersSet).sort((a,b) => b - a);
     addBuildListItem(jobList, job, buildNumbers, counts[job]);
   }
 }

--- a/triage/render.js
+++ b/triage/render.js
@@ -168,6 +168,7 @@ function sparkLineSVG(arr) {
   var height = 16;
   var path = sparkLinePath(arr, width, height);
   return createElement('span', {
+    dataset: {tooltip: 'hits over last week, newest on the right'},
     innerHTML: `<svg height=${height} width='${(arr.length) * width}'><path d="${path}" /></svg>`,
   });
 }

--- a/triage/render.js
+++ b/triage/render.js
@@ -99,7 +99,7 @@ function addBuildListItem(jobList, job, buildNumbers, hits, test) {
   var jobEl = addElement(jobList, 'li', null, [sparkLineSVG(hits), ` ${buildNumbers.length} ${job} ${rightArrow}`,
     createElement('p', {
       style: {display: 'none'},
-      dataset: {job: job, test: test, buildNumbers: JSON.stringify(buildNumbers)},
+      dataset: {job: job, test: test || '', buildNumbers: JSON.stringify(buildNumbers)},
     })
   ]);
 }

--- a/triage/style.css
+++ b/triage/style.css
@@ -31,3 +31,21 @@ div.graph {
   width: 1200px;
   height: 200px;  /* keep synchronized with script.js:graphHeight */
 }
+
+/* http://stackoverflow.com/a/17579580/3694 */
+span[data-tooltip]:hover {
+  position: relative;
+}
+
+span[data-tooltip]:hover:after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 0;
+  top: 100%;
+  z-index: 1;
+  background: white;
+  white-space: nowrap;
+  padding: 4px 4px;
+  border: 1px solid black;
+  border-radius: 5px;
+}

--- a/triage/summarize_test.py
+++ b/triage/summarize_test.py
@@ -164,7 +164,8 @@ class IntegrationTest(unittest.TestCase):
             {'name': 'unrelated test', 'build': 'gs://logs/other-job/5'},
             {'build': 'gs://logs/other-job/7'},
         ]), open('tests.json', 'w'))
-        summarize.main(summarize.parse_args(['builds.json', 'tests.json']))
+        summarize.main(summarize.parse_args(
+            ['builds.json', 'tests.json', '--output_slices=failure_data_PREFIX.json']))
         output = json_load_byteified(open('failure_data.json'))
 
         # uncomment when output changes
@@ -190,6 +191,7 @@ class IntegrationTest(unittest.TestCase):
 
         random_hash_1 = output['clustered'][0]['id']
         random_hash_2 = output['clustered'][1]['id']
+
         self.assertEqual(
             output['clustered'],
             [{'id': random_hash_1,
@@ -208,6 +210,10 @@ class IntegrationTest(unittest.TestCase):
               'text': 'some other error message'}]
         )
 
+        slice_output = json_load_byteified(open('failure_data_%s.json' % random_hash_1[:2]))
+
+        self.assertEqual(slice_output['clustered'], [output['clustered'][0]])
+        self.assertEqual(slice_output['builds']['cols']['started'], [1234, 1234, 1234, 1234])
 
 
 if __name__ == '__main__':

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)
 if [[ -e ${GOOGLE_APPLICATION_CREDENTIALS-} ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
   gcloud config set project k8s-gubernator
-  bq show
+  bq show <<< $'\n'
 fi
 
 date

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -34,11 +34,16 @@ if [[ ! -e triage_builds.json ]] || [ $(stat -c%Y triage_builds.json) -lt $table
 fi
 #
 gsutil cp gs://k8s-gubernator/triage/failure_data.json failure_data_previous.json
-pypy summarize.py triage_builds.json triage_tests.json --previous failure_data_previous.json --output failure_data.json
+
+mkdir -p slices
+
+pypy summarize.py triage_builds.json triage_tests.json \
+  --previous failure_data_previous.json --output failure_data.json --output_slices slices/failure_data_%02x.json
 
 gsutil_cp() {
   gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z -a public-read "$@"
 }
 
 gsutil_cp failure_data.json gs://k8s-gubernator/triage/
+gsutil_cp slices/*.json gs://k8s-gubernator/triage/slices/
 gsutil_cp failure_data.json "gs://k8s-gubernator/triage/history/$(date -u +%Y%m%d).json"


### PR DESCRIPTION
- Better sorting for jobs and builds.
- You can now link to a specific cluster, and not have to view an overwhelming number of *other* clusters.
- There is a tooltip describing what the sparklines mean.

[staging](https://storage.googleapis.com/k8s-gubernator/triage/staging/index.html), [single-cluster link](https://storage.googleapis.com/k8s-gubernator/triage/staging/index.html#eba1ba01921bf541729e)

Loading a single cluster goes from 3.5s->.5s on a fast network link, with even more noticeable improvements on slower ones.