### PR TITLE
The skip tags were too aggressive.  Allowing [SLOW] and [DISRUPTIVE]

### DIFF
--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.env
@@ -6,6 +6,6 @@ JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-jkns-e2e-gci-gke-prod
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-b
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|NFSv3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Flaky\]|\[Feature:.+\]|NFSv3
 
 KUBEKINS_TIMEOUT=480m

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.env
@@ -5,6 +5,6 @@ E2E_OPT=--check_version_skew=false
 JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-jkns-e2e-gci-gke-staging
 KUBE_GKE_IMAGE_TYPE=gci
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|NFSv3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Flaky\]|\[Feature:.+\]|NFSv3
 
 KUBEKINS_TIMEOUT=480m


### PR DESCRIPTION
When I explicitly added skip tags, I included [SLOW] and [DISRUPTIVE].  But when I took a look at the non-gci suites, I saw they were still including them.  So I am removing them here to mirror the non-gci suites.