### PR TITLE
Makes project name uniqueness check only apply to "PROJECT=".

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1873,7 +1873,8 @@ class JobTest(unittest.TestCase):
             with open(job_path) as fp:
                 lines = list(fp)
             for line in lines:
-                if 'PROJECT=' not in line:
+                line = line.strip()
+                if not line.startswith('PROJECT='):
                     continue
                 if '-soak-' in job:  # Soak jobs have deploy/test pairs
                     job = job.replace('-test', '-*').replace('-deploy', '-*')


### PR DESCRIPTION
Otherwise, valid job configurations using the same image projects (e.g., by setting KUBE_GCE_NODE_PROJECT) would be rejected by mistake. This is needed by #2591.