### PR TITLE
Boskos reaper

### DIFF
--- a/boskos/reaper/BUILD
+++ b/boskos/reaper/BUILD
@@ -6,33 +6,20 @@ load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
-    "go_test",
 )
 
 go_binary(
-    name = "boskos",
+    name = "reaper",
     library = ":go_default_library",
     tags = ["automanaged"],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["boskos_test.go"],
-    data = ["resources.json"],
-    library = ":go_default_library",
-    tags = ["automanaged"],
-    deps = [
-        "//boskos/common:go_default_library",
-        "//boskos/ranch:go_default_library",
-    ],
 )
 
 go_library(
     name = "go_default_library",
-    srcs = ["boskos.go"],
+    srcs = ["reaper.go"],
     tags = ["automanaged"],
     deps = [
-        "//boskos/ranch:go_default_library",
+        "//boskos/client:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
     ],
 )
@@ -46,12 +33,6 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//boskos/client:all-srcs",
-        "//boskos/common:all-srcs",
-        "//boskos/ranch:all-srcs",
-        "//boskos/reaper:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
 )

--- a/boskos/reaper/Dockerfile
+++ b/boskos/reaper/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.5
+MAINTAINER senlu@google.com
+
+ADD ["reaper", "/"]
+ENTRYPOINT ["/reaper"]

--- a/boskos/reaper/deployment.yaml
+++ b/boskos/reaper/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: boskos-reaper
+  labels:
+    app: boskos-reaper
+spec:
+  replicas: 1  # one canonical source of resources
+  template:
+    metadata:
+      labels:
+        app: boskos-reaper
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: boskos-reaper
+        image: gcr.io/k8s-testimages/reaper:v20170502-1897e866
+        imagePullPolicy: IfNotPresent

--- a/boskos/reaper/reaper.go
+++ b/boskos/reaper/reaper.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"k8s.io/test-infra/boskos/client"
+)
+
+func main() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	boskos := client.NewClient("Reaper", "http://boskos")
+	logrus.Infof("Initialzied boskos client!")
+
+	for range time.Tick(time.Minute * 10) {
+		sync(boskos)
+	}
+}
+
+func sync(c *client.Client) {
+	if owners, err := c.Reset("project", "busy", time.Hour*2, "dirty"); err != nil {
+		logrus.WithError(err).Error("Reset Failed!")
+	} else {
+		logrus.Infof("Reset Succeeded! Proj-owner: %v", owners)
+	}
+}


### PR DESCRIPTION
Reaper is a component that moves zombie used `project` resource from `free` to `dirty` state.

Already deployed.

Also enforce GOOS=linux and GOARCH=amd64 for build from mac.

Nothing to really test yet, will add one when we make use of the return value later.