### PR TITLE
rollback 1.8 upgrade of kubekins-test

### DIFF
--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -29,7 +29,7 @@ import sys
 BRANCH_VERSION = {
     '1.2': '1.4',
     '1.3': '1.4',
-    'master': '1.7',
+    'master': '1.6',
 }
 
 VERSION_TAG = {


### PR DESCRIPTION
Rolls back one image upgrade made in https://github.com/kubernetes/test-infra/pull/2521 for the verify and test scenarios.