### PR TITLE
Attempts to fix ssh creds issue by unsetting GCP key env vars

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -971,10 +971,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
       volumeMounts:
       - mountPath: /etc/service-account
@@ -1007,10 +1003,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
       volumeMounts:
       - mountPath: /etc/service-account
@@ -1043,10 +1035,6 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
       volumeMounts:
       - mountPath: /etc/service-account


### PR DESCRIPTION
This is an *attempt* to fix https://github.com/kubernetes/test-infra/issues/2602, where SSHing to a node failed because of key error. I don't quite understand why `JENKINS_GCE_SSH_PRIVATE_KEY_FILE` and `JENKINS_GCE_SSH_PUBLIC_KEY_FILE` need to be set though, so I just unset them in prow configuration. I expect the bootstrap.py would set it correctly (as it works from jenkins).