### PR TITLE
Setup credentials even if we blow up early

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -857,6 +857,7 @@ def bootstrap(args):
 
     version = 'unknown'
     exc_type = None
+    setup_creds = False
 
     try:
         setup_root(call, args.root, repos, args.ssh, args.git_cache, args.clean)
@@ -867,6 +868,7 @@ def bootstrap(args):
             version = ''
         setup_magic_environment(job)
         setup_credentials(call, args.service_account, upload)
+        setup_creds = True
         logging.info('Start %s at %s...', build, version)
         if upload:
             start(gsutil, paths, started, node(), version, repos)
@@ -881,6 +883,8 @@ def bootstrap(args):
         exc_type, exc_value, exc_traceback = sys.exc_info()
         logging.exception('unexpected error')
         success = False
+    if not setup_creds:
+        setup_credentials(call, args.service_account, upload)
     if upload:
         logging.info('Upload result and artifacts...')
         logging.info('Gubernator results at %s', gubernator_uri(paths))

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1030,6 +1030,18 @@ class BootstrapTest(unittest.TestCase):
             with stub:  # Leaving with restores things
                 pass
 
+    def testSetupCredsWhenSetupRootFails(self):
+        """We should still call setup_credentials even if setup_root blows up."""
+        called = set()
+        with Stub(bootstrap, 'setup_root', Bomb):
+            with Stub(bootstrap, 'setup_credentials', lambda *a, **kw: called.add('setup_credentials')):
+                with Stub(bootstrap, 'finish', lambda *a, **kw: called.add('finish')):
+                    with self.assertRaises(AssertionError):
+                        test_bootstrap()
+
+        for needed in ['setup_credentials', 'finish']:
+            self.assertIn(needed, called)
+
     def testEmptyRepo(self):
         repo = None
         with Stub(bootstrap, 'checkout', Bomb):


### PR DESCRIPTION
/assign @rmmh 
/cc @krzyzacy 

fixes https://github.com/kubernetes/test-infra/issues/2589

We need to have setup_credentials where it is because we expect to write the gcloud config inside root. However if we blow up before we setup creds we can detect this and call it any way