### PR TITLE
Adds Ubuntu node e2e tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -194,3 +194,16 @@
         job-name: ci-kubernetes-node-docker-benchmark
         repo-name: k8s.io/kubernetes
         timeout: 90
+
+    - kubernetes-e2e-gce-ubuntu-node:  # @kubernetes/ubuntu-image on github
+        branch: master
+        frequency: 'H/30 * * * *'
+        job-name: ci-kubernetes-e2e-gce-ubuntu-node
+        repo-name: k8s.io/kubernetes
+        timeout: 90
+    - kubernetes-e2e-gce-ubuntu-node-serial:  # @kubernetes/ubuntu-image on github
+        branch: master
+        frequency: 'H H/2 * * *'
+        job-name: ci-kubernetes-e2e-gce-ubuntu-node-serial
+        repo-name: k8s.io/kubernetes
+        timeout: 240

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3024,6 +3024,20 @@
   ]
 },
 
+"ci-kubernetes-e2e-gce-ubuntu-node": {
+  "scenario": "kubernetes_kubelet",
+  "args": [
+    "--properties=test/e2e_node/jenkins/jenkins-ci-ubuntu.properties"
+  ]
+},
+
+"ci-kubernetes-e2e-gce-ubuntu-node-serial": {
+  "scenario": "kubernetes_kubelet",
+  "args": [
+    "--properties=test/e2e_node/jenkins/jenkins-serial-ubuntu.properties"
+  ]
+},
+
 "ci-kubernetes-e2e-gce-ubuntu": {
   "scenario": "kubernetes_e2e",
   "args": [

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -748,7 +748,9 @@ test_groups:
   gcs_prefix: upstream-jenkins-logs/logs/ci-tectonic-e2e-etcd-serial
 # Ubuntu cluster/node e2e tests on GCE (contact: @kubernetes/ubuntu-image on github)
 - name: ci-kubernetes-e2e-gce-ubuntu-node
-  gcs_prefix: canonical-kubernetes-tests/logs-gke/kubernetes-gce-e2e-node
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntu-node
+- name: ci-kubernetes-e2e-gce-ubuntu-node-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntu-node-serial
 - name: ci-kubernetes-e2e-gce-ubuntu
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntu
 - name: ci-kubernetes-e2e-gce-ubuntu-serial
@@ -822,6 +824,8 @@ dashboards:
   dashboard_tab:
   - name: gce-ubuntu-node
     test_group_name: ci-kubernetes-e2e-gce-ubuntu-node
+  - name: gce-ubuntu-node-serial
+    test_group_name: ci-kubernetes-e2e-gce-ubuntu-node-serial
   - name: gce-ubuntu
     test_group_name: ci-kubernetes-e2e-gce-ubuntu
   - name: gce-ubuntu-serial


### PR DESCRIPTION
This PR adds two Ubuntu *node* e2e tests. It should be only merged after https://github.com/kubernetes/kubernetes/pull/45179 is merged.

@fejta and @krzyzacy, can you please double check the prow configurations? Is there a way to test them locally?