### PR TITLE
Improve SQ GetPR function

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1562,12 +1562,11 @@ func (obj *MungeObject) GetPR() (*github.PullRequest, bool) {
 		return obj.pr, true
 	}
 	if !obj.IsPR() {
-		glog.Errorf("Issue: %d is not a PR", *obj.Issue.Number)
 		return nil, false
 	}
 	pr, err := obj.config.getPR(*obj.Issue.Number)
 	if err != nil {
-		glog.Errorf("Error in GetPR")
+		glog.Errorf("Error in GetPR: %v", err)
 		return nil, false
 	}
 	obj.pr = pr


### PR DESCRIPTION
- don't log an error when users call it without IsPR (it's really not a big deal)
- just return a pointer instead of a pointer and a bool indicating if the pointer is nonnull. This is more arguable, but I think it cleans up the code.