### PR TITLE
Make flake-manager robust to malformed test_owners.csv

### DIFF
--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -5,7 +5,7 @@ GIT := $(shell git rev-parse --short HEAD)
 
 TAG ?= $(DATE)-$(GIT)
 
-DEFAULTREPO := gcr.io/google_containers
+DEFAULTREPO := gcr.io/k8s-testimages
 REPO ?= $(DEFAULTREPO)
 APP ?= submit-queue
 CONTAINER := $(REPO)/$(APP):$(TAG)

--- a/mungegithub/mungers/flake-manager.go
+++ b/mungegithub/mungers/flake-manager.go
@@ -109,7 +109,10 @@ func (p *FlakeManager) Initialize(config *github.Config, features *features.Feat
 	if p.OwnerPath != "" {
 		owner, err = testowner.NewReloadingOwnerList(p.OwnerPath)
 		if err != nil {
-			return err
+			// Ignore BadCsv errors on load
+			if _, ok := err.(testowner.BadCsv); !ok {
+				return err
+			}
 		}
 	}
 	p.syncer = sync.NewIssueSyncer(config, p.finder, owner)

--- a/mungegithub/mungers/mungers.go
+++ b/mungegithub/mungers/mungers.go
@@ -86,11 +86,12 @@ func RegisterMungers(requestedMungers []string) error {
 // InitializeMungers will call munger.Initialize() for the requested mungers.
 func InitializeMungers(config *github.Config, features *features.Features) error {
 	for _, munger := range mungers {
+		m := munger.Name()
 		if err := munger.Initialize(config, features); err != nil {
-			return err
+			return fmt.Errorf("could not initialize %s: %v", m, err)
 		}
 		glog.Infof(mungerutil.PrettyString(munger))
-		glog.Infof("Initialized munger: %s", munger.Name())
+		glog.Infof("Initialized munger: %s", m)
 	}
 	return nil
 }

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - --use-reviewers=$(APPROVAL_ACTIVATED)
         - --gate-approved=$(APPROVAL_ACTIVATED)
         - --github-key=$(GITHUB_KEY)
-        image: gcr.io/google_containers/submit-queue:2016-05-24-86f86cd
+        image: gcr.io/k8s-testimages/submit-queue:2017-05-02-90fe8836
         env:
           - name: HTTP_CACHE_DIR
             valueFrom:


### PR DESCRIPTION
/cc @eparis @rmmh 

Fixes https://github.com/kubernetes/test-infra/issues/2630
Also move the default repo out of google_containers to k8s-testimages (where the rest of our images live).
Make `NewReloadingOwnerList()` log an error if `reload()` fails but still return the `ReloadingOwnerList` if the error is because it cannot parse the csv (which may change later).
Update the flake-manager to expect this scenario and not fail initialization.
Add unit test to cover this scenario