### PR TITLE
triage: Don't include builds multiple times.

### DIFF
--- a/triage/summarize.py
+++ b/triage/summarize.py
@@ -285,10 +285,9 @@ def tests_group_by_job(tests, builds):
         except KeyError:
             continue
         if 'number' in build:
-            groups.setdefault(build['job'], []).append(build['number'])
-    for value in groups.itervalues():
-        value.sort(reverse=True)
-    return sorted(groups.iteritems(), key=lambda (k, v): (-len(v), k))
+            groups.setdefault(build['job'], set()).add(build['number'])
+    return sorted(((key, sorted(value, reverse=True)) for key, value in groups.iteritems()),
+                  key=lambda (k, v): (-len(v), k))
 
 
 def clusters_to_display(clustered, builds):

--- a/triage/summarize_test.py
+++ b/triage/summarize_test.py
@@ -162,6 +162,7 @@ class IntegrationTest(unittest.TestCase):
             {'build': 'gs://logs/some-job/4'},
             {'failure_text': 'some other error message'},
             {'name': 'unrelated test', 'build': 'gs://logs/other-job/5'},
+            {},  # intentional dupe
             {'build': 'gs://logs/other-job/7'},
         ]), open('tests.json', 'w'))
         summarize.main(summarize.parse_args(


### PR DESCRIPTION
Some tests (e.g. BeforeSuite) can run and fail multiple times.