### PR TITLE
Extends ubuntu e2e serial test timeout

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -993,7 +993,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=300
+      - --timeout=420
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
The tests are failing because of the short timeout. https://k8s-testgrid.appspot.com/canonical-kubernetes#gce-ubuntu-serial