### PR TITLE
Run federation-soak-deploy job in the same cluster everytime

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1979,7 +1979,6 @@
     "--env-file=jobs/ci-kubernetes-soak-gce-federation-deploy.env",
     "--build",
     "--stage=gs://kubernetes-release-dev/ci/ci-kubernetes-soak-gce-federation-deploy",
-    "--cluster=",
     "--test=false",
     "--down=false"
   ]


### PR DESCRIPTION
Currently federation-soak-deploy job is set to run on different cluster every time since `--cluster` flag for kubernetes_e2e.py is set to empty string.
So removing the flag, which causes it to use the default cluster name(bootstrap-e2e) always.

cc @madhusudancs