### PR TITLE
Enable metrics gathering for all kubemark tests

### DIFF
--- a/jobs/ci-kubernetes-kubemark-5-gce-1.5.env
+++ b/jobs/ci-kubernetes-kubemark-5-gce-1.5.env
@@ -4,7 +4,7 @@ ENABLE_GARBAGE_COLLECTOR=true
 PROJECT=k8s-kubemark-1-5
 USE_KUBEMARK=true
 KUBEMARK_TESTS=\[Feature:Empty\]
-KUBEMARK_TEST_ARGS=--gather-resource-usage=true --output-print-type=json
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json
 FAIL_ON_GCP_RESOURCE_LEAK=false
 # Override defaults to be independent from GCE defaults and set kubemark parameters
 NUM_NODES=1

--- a/jobs/ci-kubernetes-kubemark-5-gce.env
+++ b/jobs/ci-kubernetes-kubemark-5-gce.env
@@ -2,7 +2,7 @@
 PROJECT=k8s-jenkins-kubemark
 USE_KUBEMARK=true
 KUBEMARK_TESTS=\[Feature:Empty\]
-KUBEMARK_TEST_ARGS=--gather-resource-usage=true --output-print-type=json
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json
 FAIL_ON_GCP_RESOURCE_LEAK=false
 # Override defaults to be independent from GCE defaults and set kubemark parameters
 NUM_NODES=1

--- a/jobs/ci-kubernetes-kubemark-500-gce.env
+++ b/jobs/ci-kubernetes-kubemark-500-gce.env
@@ -2,7 +2,7 @@
 PROJECT=k8s-jenkins-blocking-kubemark
 USE_KUBEMARK=true
 KUBEMARK_TESTS=\[Feature:Performance\]
-KUBEMARK_TEST_ARGS=--gather-resource-usage=true --output-print-type=json
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json
 # Increase throughput in Kubemark master components.
 KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS=--kube-api-qps=100 --kube-api-burst=100
 # Increase throughput in Load test.

--- a/jobs/ci-kubernetes-kubemark-gce-scale.env
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.env
@@ -3,7 +3,7 @@
 PROJECT=kubernetes-scale
 USE_KUBEMARK=true
 KUBEMARK_TESTS=\[Feature:Performance\]
-KUBEMARK_TEST_ARGS=--gather-resource-usage=true --output-print-type=json
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json
 # Increase throughput in Kubemark master components.
 KUBEMARK_MASTER_COMPONENTS_QPS_LIMITS=--kube-api-qps=100 --kube-api-burst=100
 # Increase limit for inflight requests in apiserver (we do the same in production clusters).

--- a/jobs/ci-kubernetes-kubemark-high-density-100-gce.env
+++ b/jobs/ci-kubernetes-kubemark-high-density-100-gce.env
@@ -2,7 +2,7 @@
 PROJECT=k8s-jenkins-kubemark
 USE_KUBEMARK=true
 KUBEMARK_TESTS=\[Feature:HighDensityPerformance\]
-KUBEMARK_TEST_ARGS=--gather-resource-usage=true --output-print-type=json
+KUBEMARK_TEST_ARGS=--gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json
 FAIL_ON_GCP_RESOURCE_LEAK=false
 # Override defaults to be independent from GCE defaults and set kubemark parameters
 NUM_NODES=8


### PR DESCRIPTION
Ref kubernetes/kubernetes#44701
(Follow up from https://github.com/kubernetes/test-infra/pull/2587)

Now we can enable metrics gathering for all of our kubemark tests (even large ones) as we disabled kubelet metrics gathering for kubemark.

cc @kubernetes/sig-scalability-misc @wojtek-t @gmarek 