### PR TITLE
Failure cluster issue assignment fixes

### DIFF
--- a/mungegithub/mungers/issue-creator.go
+++ b/mungegithub/mungers/issue-creator.go
@@ -292,10 +292,11 @@ func (c *IssueCreator) Sync(issue Issue) {
 	}
 	labels = c.filterValidLabels(labels)
 
+	glog.Infof("Create Issue:\nTitle:%s\nBody:\n%s\nLabels:%v\nAssigned to:%v\n", title, body, labels, owners)
 	if c.config.isDryRun() {
-		glog.Infof("DryRun--Create Issue:\nTitle:%s\nBody:\n%s\nLabels:%v\nAssigned to:%s\n", title, body, labels, owners)
 		return
 	}
+
 	obj, err := c.config.NewIssue(title, body, labels, owners)
 	if err != nil {
 		glog.Errorf("Failed to create a new github issue for issue ID '%s'.\n", id)

--- a/mungegithub/mungers/testowner/owner.go
+++ b/mungegithub/mungers/testowner/owner.go
@@ -85,20 +85,11 @@ func (o *OwnerList) get(testName string) (owner *OwnerInfo) {
 	return
 }
 
-// TestOwner returns the owner for a test, an owner from default if present,
-// or else the empty string if none is found.
+// TestOwner returns the owner for a test or the empty string if none is found.
 func (o *OwnerList) TestOwner(testName string) (owner string) {
 	ownerInfo := o.get(testName)
 	if ownerInfo != nil {
 		owner = ownerInfo.User
-	}
-
-	// falls into default
-	if owner == "" {
-		ownerInfo, _ = o.mapping["default"]
-		if ownerInfo != nil {
-			owner = ownerInfo.User
-		}
 	}
 
 	if strings.Contains(owner, "/") {

--- a/mungegithub/mungers/testowner/owner.go
+++ b/mungegithub/mungers/testowner/owner.go
@@ -105,7 +105,7 @@ func (o *OwnerList) TestOwner(testName string) (owner string) {
 		ownerSet := strings.Split(owner, "/")
 		owner = ownerSet[o.rng.Intn(len(ownerSet))]
 	}
-	return owner
+	return strings.TrimSpace(owner)
 }
 
 // TestSIG returns the SIG assigned to a test, or else the empty string if none is found.
@@ -114,7 +114,7 @@ func (o *OwnerList) TestSIG(testName string) string {
 	if ownerInfo == nil {
 		return ""
 	}
-	return ownerInfo.SIG
+	return strings.TrimSpace(ownerInfo.SIG)
 }
 
 // NewOwnerList constructs an OwnerList given a mapping from test names to test owners.

--- a/mungegithub/mungers/testowner/owner_test.go
+++ b/mungegithub/mungers/testowner/owner_test.go
@@ -117,7 +117,7 @@ func TestOwnerListFromCsv(t *testing.T) {
 	r := bytes.NewReader([]byte(",,,header nonsense,\n" +
 		",owner,suggested owner,name,sig\n" +
 		",foo,other,Test name,Node\n" +
-		",bar,foo,other test,Windows\n"))
+		", bar,foo,other test, Windows\n"))
 	list, err := NewOwnerListFromCsv(r)
 	if err != nil {
 		t.Error(err)

--- a/mungegithub/mungers/testowner/owner_test.go
+++ b/mungegithub/mungers/testowner/owner_test.go
@@ -86,18 +86,6 @@ func TestOwnerGlob(t *testing.T) {
 	}
 }
 
-func TestOwnerListDefault(t *testing.T) {
-	list := NewOwnerList(map[string]*OwnerInfo{"DEFAULT": {
-		User: "elves",
-		SIG:  "group",
-	}})
-
-	owner := list.TestOwner("some random new test")
-	if owner != "elves" {
-		t.Error("Unexpected return value ", owner)
-	}
-}
-
 func TestOwnerListRandom(t *testing.T) {
 	list := NewOwnerList(map[string]*OwnerInfo{"testname": {
 		User: "a/b/c/d",


### PR DESCRIPTION
Fixes to issue assignment behavior:
-OwnerList now ignores leading and trailing spaces for fields in test_owners.csv.
-OwnerList no longer assigns to the default owners if it can't find owners for a specific test.

Also added more logging for issue creation (Full issue contents is now logged).

/assign @rmmh