### PR TITLE
remove federation-build-soak job

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1880,8 +1880,6 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-e2e-gke-large-teardown.env': 'ci-kubernetes-scale-*',
             'ci-kubernetes-federation-build.sh': 'ci-kubernetes-federation-*',
             'ci-kubernetes-e2e-gce-federation.env': 'ci-kubernetes-federation-*',
-            'ci-kubernetes-federation-build-soak.sh': 'ci-kubernetes-federation-soak-*',
-            'ci-kubernetes-soak-gce-federation-*.sh': 'ci-kubernetes-federation-soak-*',
             'pull-kubernetes-federation-e2e-gce.env': 'pull-kubernetes-federation-e2e-gce-*',
             'ci-kubernetes-pull-gce-federation-deploy.env': 'pull-kubernetes-federation-e2e-gce-*',
             'pull-kubernetes-e2e-gce.env': 'pull-kubernetes-e2e-gce-*',

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -124,14 +124,6 @@
         commit-frequency: 'H/5 * * * *'
         timeout: 50
 
-    - kubernetes-federation-build-soak:
-        branch: master
-        commit-frequency: 'H 23 * * *'
-        giturl: 'https://github.com/kubernetes/kubernetes'
-        job-name: ci-kubernetes-federation-build-soak
-        repo-name: k8s.io/kubernetes
-        timeout: 50
-
     - kubernetes-build-debian-unstable:
         branch: master
         commit-frequency: 'H/5 * * * *'

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2297,14 +2297,6 @@
     ], 
     "scenario": "kubernetes_build"
   }, 
-  "ci-kubernetes-federation-build-soak": {
-    "args": [
-      "--fast", 
-      "--federation=k8s-jkns-gce-federation-soak", 
-      "--release=kubernetes-federation-release"
-    ], 
-    "scenario": "kubernetes_build"
-  }, 
   "ci-kubernetes-kubemark-100-gce": {
     "args": [
       "--env-file=platforms/gce.env", 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -142,8 +142,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build
 - name: ci-kubernetes-federation-build-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-1.6
-- name: ci-kubernetes-federation-build-soak
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build-soak
 - name: ci-kubernetes-e2e-gce-flaky
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-flaky
 - name: ci-kubernetes-e2e-gci-gce-flaky
@@ -1676,8 +1674,6 @@ dashboards:
     test_group_name: ci-kubernetes-federation-build
   - name: build-1.6
     test_group_name: ci-kubernetes-federation-build-1.6
-  - name: build-soak
-    test_group_name: ci-kubernetes-federation-build-soak
 
 - name: release-1.6-all
   dashboard_tab:


### PR DESCRIPTION
federation-build-soak job is no longer required as we build and push image in `soak-gce-federation-deploy`  job. Just cleaning up unnecessary ci job.

cc @madhusudancs 