### PR TITLE
Created tool to migrate status contexts.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,8 @@ filegroup(
         "//kettle:all-srcs",
         "//kubetest:all-srcs",
         "//logexporter/cmd:all-srcs",
+        "//maintenance/githubutil:all-srcs",
+        "//maintenance/migratestatus:all-srcs",
         "//metrics:all-srcs",
         "//mungegithub:all-srcs",
         "//prow:all-srcs",

--- a/maintenance/githubutil/BUILD
+++ b/maintenance/githubutil/BUILD
@@ -1,0 +1,41 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["githubutil.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:github.com/golang/glog",
+        "//vendor:github.com/google/go-github/github",
+        "//vendor:golang.org/x/oauth2",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["githubutil_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//vendor:github.com/google/go-github/github"],
+)

--- a/maintenance/githubutil/githubutil.go
+++ b/maintenance/githubutil/githubutil.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubutil
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+type repositoryService interface {
+	CreateStatus(org, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error)
+	GetCombinedStatus(org, repo, ref string, opt *github.ListOptions) (*github.CombinedStatus, *github.Response, error)
+}
+
+type pullRequestService interface {
+	List(org, repo string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error)
+}
+
+// Client is an augmentation of the go-github client that adds retry logic, rate limiting, and pagination
+// handling to some of the client functions.
+type Client struct {
+	prService   pullRequestService
+	repoService repositoryService
+
+	retries             int
+	retryInitialBackoff time.Duration
+
+	tokenReserve int
+	dryRun       bool
+}
+
+// NewClient makes a new githubutil client that does rate limiting and retries.
+func NewClient(token string, dryRun bool) *Client {
+	httpClient := &http.Client{
+		Transport: &oauth2.Transport{
+			Base:   http.DefaultTransport,
+			Source: oauth2.ReuseTokenSource(nil, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})),
+		},
+	}
+	client := github.NewClient(httpClient)
+	return &Client{
+		prService:           client.PullRequests,
+		repoService:         client.Repositories,
+		retries:             5,
+		retryInitialBackoff: time.Second,
+		tokenReserve:        50,
+		dryRun:              dryRun,
+	}
+}
+
+func (c *Client) sleepForAttempt(retryCount int) {
+	maxDelay := 20 * time.Second
+	delay := c.retryInitialBackoff * time.Duration(math.Exp2(float64(retryCount)))
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	time.Sleep(delay)
+}
+
+func (c *Client) limitRate(r *github.Rate) {
+	if r.Remaining <= c.tokenReserve {
+		sleepDuration := time.Until(r.Reset.Time) + (time.Second * 10)
+		if sleepDuration > 0 {
+			glog.Infof("--Rate Limiting-- Tokens reached minimum reserve %d. Sleeping until reset in %v.\n", c.tokenReserve, sleepDuration)
+			time.Sleep(sleepDuration)
+		}
+	}
+}
+
+// retry handles rate limiting and retry logic for a github API call.
+func (c *Client) retry(action string, call func() (*github.Response, error)) error {
+	var err error
+
+	for retryCount := 0; retryCount <= c.retries; retryCount++ {
+		var resp *github.Response
+		if resp, err = call(); err == nil {
+			c.limitRate(&resp.Rate)
+			return nil
+		} else if rlErr, ok := err.(*github.RateLimitError); ok {
+			c.limitRate(&rlErr.Rate)
+		} else if tfaErr, ok := err.(*github.TwoFactorAuthError); ok {
+			return tfaErr
+		}
+
+		if retryCount == c.retries {
+			return err
+		} else {
+			glog.Errorf("error %s: %v. Will retry.\n", action, err)
+			c.sleepForAttempt(retryCount)
+		}
+	}
+	return err
+}
+
+// CreateStatus creates or updates a status context on the indicated reference.
+// This function limits rate and does retries if needed.
+func (c *Client) CreateStatus(owner, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
+	glog.Infof("CreateStatus for ref '%s': %s:%s (%s)\n", ref, *status.Context, *status.State, *status.Description)
+	if c.dryRun {
+		return nil, nil, nil
+	}
+	var result *github.RepoStatus
+	var resp *github.Response
+	msg := fmt.Sprintf("creating status for ref '%s'", ref)
+	err := c.retry(msg, func() (*github.Response, error) {
+		var err error
+		result, resp, err = c.repoService.CreateStatus(owner, repo, ref, status)
+		return resp, err
+	})
+	return result, resp, err
+}
+
+// GetCombinedStatus retrieves the CominedStatus for the specified reference.
+// This function limits rate, does retries if needed and handles pagination.
+func (c *Client) GetCombinedStatus(owner, repo, ref string) (*github.CombinedStatus, *github.Response, error) {
+	var status, result *github.CombinedStatus
+	var resp *github.Response
+
+	listOpts := &github.ListOptions{Page: 1, PerPage: 100}
+	lastPage := 1
+	action := fmt.Sprintf("getting combined status for ref '%s'", ref)
+
+	for ; listOpts.Page <= lastPage; listOpts.Page++ {
+		err := c.retry(action, func() (*github.Response, error) {
+			var err error
+			status, resp, err = c.repoService.GetCombinedStatus(owner, repo, ref, listOpts)
+			return resp, err
+		})
+		if err != nil {
+			return result, resp, err
+		}
+		if resp.LastPage > 0 {
+			lastPage = resp.LastPage
+		}
+		if result == nil {
+			result = status
+		} else {
+			result.Statuses = append(result.Statuses, status.Statuses...)
+		}
+	}
+	return result, resp, nil
+}
+
+type PRMungeFunc func(*github.PullRequest) error
+
+// ForEachPR iterates over all PRs that fit the specified criteria, calling the munge function on every PR.
+// This function limits rate, does retries if needed, and handles pagination.
+// If the munge function returns a non-nil error, ForEachPR will return immediately with a non-nil
+// error unless continueOnError is true in which case an error will be logged and the remaining PRs will be munged.
+func (c *Client) ForEachPR(owner, repo string, opts *github.PullRequestListOptions, continueOnError bool, mungePR PRMungeFunc) error {
+	var list []*github.PullRequest
+	var resp *github.Response
+
+	opts.ListOptions.Page = 1
+	opts.ListOptions.PerPage = 100
+	lastPage := 1
+
+	for ; opts.ListOptions.Page <= lastPage; opts.ListOptions.Page++ {
+		err := c.retry("processing PRs", func() (*github.Response, error) {
+			var err error
+			list, resp, err = c.prService.List(owner, repo, opts)
+			return resp, err
+		})
+		if err != nil {
+			return err
+		}
+		if resp.LastPage > 0 {
+			lastPage = resp.LastPage
+		}
+		for _, pr := range list {
+			if err := mungePR(pr); err != nil {
+				if pr == nil {
+					err = fmt.Errorf("received a nil PR from go-github while listing PRs. Munge error: %v", err)
+				} else if pr.Number == nil {
+					err = fmt.Errorf("error munging pull request with nil Number field: %v", err)
+				} else {
+					err = fmt.Errorf("error munging pull request #%d: %v", *pr.Number, err)
+				}
+				if !continueOnError {
+					return err
+				}
+				glog.Errorf("%v\n", err)
+			}
+		}
+		glog.Infof("ForEachPR processed page %d/%d\n", opts.ListOptions.Page, lastPage)
+	}
+	return nil
+}

--- a/maintenance/githubutil/githubutil_test.go
+++ b/maintenance/githubutil/githubutil_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package githubutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+// fakeGithub is a fake go-github client that doubles as a test instance representation. This fake
+// client keeps track of the number of API calls made in order to test retry behavior and also allows
+// the number of pages of results to be configured.
+type fakeGithub struct {
+	// name is a string representation of this fakeGithub instance.
+	name string
+	// hits is a count of the number of API calls made to fakeGithub.
+	hits int
+	// hitsBeforeResponse is the number of hits that should be received before fakeGithub responds without error.
+	hitsBeforeResponse int
+	// shouldSucceed indicates if the githubutil client should get a valid response.
+	shouldSucceed bool
+	// pages is the number of pages to return for paginated data. (Should be 1 for non-paginated data)
+	pages int
+}
+
+// checkHits verifies that the githubutil client made the correct number of retries before returning.
+func (f *fakeGithub) checkHits() bool {
+	if f.shouldSucceed {
+		return f.hits-f.pages+1 == f.hitsBeforeResponse
+	}
+	return f.hitsBeforeResponse > f.hits
+}
+
+// newTestClient creates a new githubutil client from a fakeGithub test instance.
+func newTestClient(f *fakeGithub) *Client {
+	return &Client{
+		prService:           f,
+		repoService:         f,
+		retries:             5,
+		retryInitialBackoff: time.Nanosecond,
+		tokenReserve:        50,
+		dryRun:              false,
+	}
+}
+
+func (f *fakeGithub) CreateStatus(org, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
+	f.hits++
+	if f.hits >= f.hitsBeforeResponse {
+		return status, &github.Response{Rate: github.Rate{Limit: 5000, Remaining: 1000, Reset: github.Timestamp{time.Now()}}}, nil
+	}
+	return nil, nil, fmt.Errorf("some error that forces a retry")
+}
+
+func (f *fakeGithub) GetCombinedStatus(org, repo, ref string, opts *github.ListOptions) (*github.CombinedStatus, *github.Response, error) {
+	f.hits++
+	context := fmt.Sprintf("context %d", f.hits-f.hitsBeforeResponse+1)
+	combStatus := &github.CombinedStatus{Statuses: []github.RepoStatus{github.RepoStatus{Context: &context}}}
+	if f.hits >= f.hitsBeforeResponse {
+		return combStatus, &github.Response{Rate: github.Rate{Limit: 5000, Remaining: 1000, Reset: github.Timestamp{time.Now()}}, LastPage: f.pages}, nil
+	}
+	return nil, nil, fmt.Errorf("some error that forces a retry")
+}
+
+func (f *fakeGithub) List(org, repo string, opts *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
+	f.hits++
+	title := fmt.Sprintf("pr %d", f.hits-f.hitsBeforeResponse+1)
+	list := []*github.PullRequest{&github.PullRequest{Title: &title}}
+	if f.hits >= f.hitsBeforeResponse {
+		return list, &github.Response{Rate: github.Rate{Limit: 5000, Remaining: 1000, Reset: github.Timestamp{time.Now()}}, LastPage: f.pages}, nil
+	}
+	return nil, nil, fmt.Errorf("some error that forces a retry")
+}
+
+// TestCreateStatus tests the CreateStatus function to ensure that it does retries and returns the correct result.
+func TestCreateStatus(t *testing.T) {
+	contextStr := "context"
+	stateStr := "some state"
+	descStr := "descriptive description"
+	urlStr := "link"
+	sampleStatus := &github.RepoStatus{
+		Context:     &contextStr,
+		State:       &stateStr,
+		Description: &descStr,
+		TargetURL:   &urlStr,
+	}
+	tests := []*fakeGithub{
+		&fakeGithub{name: "no retries", hitsBeforeResponse: 1, shouldSucceed: true, pages: 1},
+		&fakeGithub{name: "max retries", hitsBeforeResponse: 6, shouldSucceed: true, pages: 1},
+		&fakeGithub{name: "1 too many retries needed", hitsBeforeResponse: 7, shouldSucceed: false, pages: 1},
+		&fakeGithub{name: "3 too many retries needed", hitsBeforeResponse: 10, shouldSucceed: false, pages: 1},
+	}
+	for _, test := range tests {
+		client := newTestClient(test)
+		status, _, err := client.CreateStatus("org", "repo", "ref", sampleStatus)
+		if (err == nil) != test.shouldSucceed {
+			t.Errorf("CreateStatus test '%s' failed because the error value was unexpected: %v", test.name, err)
+		}
+		if !test.checkHits() {
+			t.Errorf("CreateStatus test '%s' failed with the wrong number of hits: %d", test.name, test.hits)
+		}
+		if test.shouldSucceed {
+			if status == nil {
+				t.Fatalf("CreateStatus test '%s' failed because the returned status was nil", test.name)
+			}
+			if status.Context == nil || *status.Context != contextStr {
+				t.Errorf("CreateStatus test '%s' failed because the returned RepoStatus had a context of '%v' instead of '%s'", test.name, *status.Context, contextStr)
+			}
+			if status.State == nil || *status.State != stateStr {
+				t.Errorf("CreateStatus test '%s' failed because the returned RepoStatus had a state of '%v' instead of '%s'", test.name, *status.State, stateStr)
+			}
+			if status.Description == nil || *status.Description != descStr {
+				t.Errorf("CreateStatus test '%s' failed because the returned RepoStatus had a description of '%v' instead of '%s'", test.name, *status.Description, descStr)
+			}
+			if status.TargetURL == nil || *status.TargetURL != urlStr {
+				t.Errorf("CreateStatus test '%s' failed because the returned RepoStatus had a target URL of '%v' instead of '%s'", test.name, *status.TargetURL, urlStr)
+			}
+		}
+	}
+}
+
+// TestGetCombinedStatus tests the GetCombinedStatus function to ensure it does retries, handles pagination,
+// and returns the correct result.
+func TestGetCombinedStatus(t *testing.T) {
+	tests := []*fakeGithub{
+		&fakeGithub{name: "no retries", hitsBeforeResponse: 1, shouldSucceed: true, pages: 1},
+		&fakeGithub{name: "max retries", hitsBeforeResponse: 6, shouldSucceed: true, pages: 1},
+		&fakeGithub{name: "1 too many retries needed", hitsBeforeResponse: 7, shouldSucceed: false, pages: 1},
+		&fakeGithub{name: "3 too many retries needed", hitsBeforeResponse: 10, shouldSucceed: false, pages: 1},
+		&fakeGithub{name: "2 pages", hitsBeforeResponse: 1, shouldSucceed: true, pages: 2},
+		&fakeGithub{name: "10 pages", hitsBeforeResponse: 1, shouldSucceed: true, pages: 10},
+		&fakeGithub{name: "2 pages 2 retries", hitsBeforeResponse: 3, shouldSucceed: true, pages: 2},
+		&fakeGithub{name: "10 pages max retries", hitsBeforeResponse: 6, shouldSucceed: true, pages: 10},
+		&fakeGithub{name: "10 pages one too many retries", hitsBeforeResponse: 7, shouldSucceed: false, pages: 10},
+	}
+
+	for _, test := range tests {
+		client := newTestClient(test)
+		combStatus, _, err := client.GetCombinedStatus("org", "repo", "ref")
+		if (err == nil) != test.shouldSucceed {
+			t.Errorf("GetCombinedStatus test '%s' failed because the error value was unexpected: %v", test.name, err)
+		}
+		if !test.checkHits() {
+			t.Errorf("GetCombinedStatus test '%s' failed with the wrong number of hits: %d", test.name, test.hits)
+		}
+		if test.shouldSucceed {
+			if combStatus == nil {
+				t.Fatalf("GetCombinedStatus test '%s' failed because the combined status was nil.", test.name)
+			}
+			if len(combStatus.Statuses) != test.pages {
+				t.Errorf("GetCombinedStatus test '%s' failed because the number of pages returned was %d instead of %d.", test.name, len(combStatus.Statuses), test.pages)
+			}
+			for index, status := range combStatus.Statuses {
+				if status.Context == nil {
+					t.Fatalf("GetCombinedStatus test '%s' failed because the status at index %d had a nil Context field.", test.name, index)
+				}
+				expectedContext := fmt.Sprintf("context %d", index+1)
+				if *status.Context != expectedContext {
+					t.Errorf("GetCombinedStatus test '%s' failed because the status at index %d had a context of '%s' instead of '%s'.", test.name, index, *status.Context, expectedContext)
+				}
+			}
+		}
+	}
+}
+
+// TestForEachPR tests the ForEachPR function to ensure it does retries properly, can handle pagination,
+// and returns the correct result.
+func TestForEachPR(t *testing.T) {
+	tests := []*fakeGithub{
+		&fakeGithub{name: "no retries", hitsBeforeResponse: 1, shouldSucceed: true, pages: 1},
+		&fakeGithub{name: "max retries", hitsBeforeResponse: 6, shouldSucceed: true, pages: 1},
+		&fakeGithub{name: "1 too many retries needed", hitsBeforeResponse: 7, shouldSucceed: false, pages: 1},
+		&fakeGithub{name: "3 too many retries needed", hitsBeforeResponse: 10, shouldSucceed: false, pages: 1},
+		&fakeGithub{name: "2 pages", hitsBeforeResponse: 1, shouldSucceed: true, pages: 2},
+		&fakeGithub{name: "10 pages", hitsBeforeResponse: 1, shouldSucceed: true, pages: 10},
+		&fakeGithub{name: "2 pages 2 retries", hitsBeforeResponse: 3, shouldSucceed: true, pages: 2},
+		&fakeGithub{name: "10 pages max retries", hitsBeforeResponse: 6, shouldSucceed: true, pages: 10},
+		&fakeGithub{name: "10 pages one too many retries", hitsBeforeResponse: 7, shouldSucceed: false, pages: 10},
+		&fakeGithub{name: "continue on final error", hitsBeforeResponse: 1, shouldSucceed: true, pages: 13},
+		&fakeGithub{name: "continue on error", hitsBeforeResponse: 1, shouldSucceed: true, pages: 16},
+	}
+
+	for _, test := range tests {
+		client := newTestClient(test)
+
+		processed := 0
+		process := func(pr *github.PullRequest) error {
+			if pr == nil || pr.Title == nil {
+				return fmt.Errorf("pr %d was invalid", processed+1)
+			}
+			expectedTitle := fmt.Sprintf("pr %d", processed+1)
+			if *pr.Title != expectedTitle {
+				return fmt.Errorf("expected pr title '%s' but got '%s'", expectedTitle, *pr.Title)
+			}
+			processed++
+			if processed == 13 {
+				// 13th PR processed returns an error.
+				return fmt.Errorf("some munge error")
+			}
+			return nil
+		}
+		continueOnError := test.pages >= 13
+		err := client.ForEachPR("org", "repo", &github.PullRequestListOptions{}, continueOnError, process)
+		if (err == nil) != test.shouldSucceed {
+			t.Errorf("ForEachPR test '%s' failed because the error value was unexpected: %v", test.name, err)
+		}
+		if !test.checkHits() {
+			t.Errorf("ForEachPR test '%s' failed with the wrong number of hits: %d", test.name, test.hits)
+		}
+		if test.shouldSucceed && processed != test.pages {
+			t.Errorf("ForEachPR test '%s' processed %d PRs, but there were only %d single entry pages.", test.name, processed, test.pages)
+		}
+	}
+}

--- a/maintenance/migratestatus/.gitignore
+++ b/maintenance/migratestatus/.gitignore
@@ -1,0 +1,1 @@
+migratestatus

--- a/maintenance/migratestatus/BUILD
+++ b/maintenance/migratestatus/BUILD
@@ -1,0 +1,42 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+)
+
+go_binary(
+    name = "migratestatus",
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["migratestatus.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//maintenance/migratestatus/migrator:go_default_library",
+        "//vendor:github.com/golang/glog",
+        "//vendor:github.com/google/go-github/github",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//maintenance/migratestatus/migrator:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/maintenance/migratestatus/README.md
+++ b/maintenance/migratestatus/README.md
@@ -1,0 +1,30 @@
+# Status Context Migrator
+The migratestatus tool is a maintenance utility used to safely switch a repo from one status context to another.
+For example if there is a context named "CI tests" that needs to be moved by "CI tests v2" this tool can be used to copy every "CI tests" status into a "CI tests v2" status context and then mark every "CI tests" context as passing and retired. This ensures that no PRs are ever passing when they shouldn't be and doesn't block PRs that should be passing. The copy and retire phases can be run seperately or together at once in move mode.
+
+### Usage
+###### Modes
+This tool runs in one of three modes. Each mode is defined as a set of conditions on the statuses and an action to take if the conditions are met.
+- **copy** mode conditions on PRs that have the context to copy, but not the destination context. For each of these PRs, the 'copy' context's status is copied to the destination context.
+	- `$ ./migratestatus --copy="CI tests" --dest="CI tests v2" --tokenfile=$TOKEN_FILE --org=$ORG --repo=$REPO`
+- **retire** mode can be used to retire an old context with or without replacement. By setting the context's state to "success" the retired context can be ignored.
+	- With a replacement specified, the mode conditions on PRs that have the context to retire and the context that replaced the retired context. For each of these PRs, the context to retire has its state set to "success" and its description set to a message of the form "Context retired. Status moved to 'CI tests v2'.".
+	- Without a replacement specified, the mode conditions on PRs that have the context to retire. For each of these PRs, the context has its state set to "success" and its description set to "Context retired without replacement."
+	- `$ ./migratestatus --retire="CI tests" --dest="CI tests v2" --tokenfile=$TOKEN_FILE --org=$ORG --repo=$REPO`
+- **move** mode conditions on PRs that have the context to move, but not the destination context. For each of these PRs, a copy and retire action are performed. In other words, the status of the context to move is copied to the 'dest' context and then retired with 'dest' as the replacement.
+	- `$ ./migratestatus --move="CI tests" --dest="CI tests v2" --tokenfile=$TOKEN_FILE --org=$ORG --repo=$REPO`
+###### Flags
+The migratestatus binary is run locally and can be built by running `go build` from this directory. The binary accepts the following parameters:
+- `--tokenfile` The file containing the github authentication token to use.
+- `--org` The organization that owns the repository to migrate contexts in. (Kubernetes)
+- `--repo` The repository to migrate contexts in.
+- Exactly one of the following flags must appear. Each indicates a mode and specifies a context:
+	- `--copy` The context to copy.
+	- `--retire` The context to retire.
+	- `--move` The context to move (copy and retire).
+- `--dest` The destination context. This is the context that is copied **to** and/or the context that replaces the retired context. This flag may only be omitted if retire mode is specified and the old context is being retired without a replacement.
+
+The binary also accepts the following optional parameters:
+- `--dry-run` A bool indicating whether or not modifying actions should be disabled. Defaults to `true`.
+- `--continue-on-error` A bool indicating whether or not the migration should continue if context migration fails for an individual PR. Defaults to false.
+- `--alsologtostderr` A flag that sends logs to stderr in addition to temporary log files.

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/google/go-github/github"
+	"k8s.io/test-infra/maintenance/migratestatus/migrator"
+)
+
+func main() {
+	var tokenFile, org, repo, copyContext, moveContext, retireContext, destContext string
+	var dryRun, continueOnError bool
+
+	flag.StringVar(&tokenFile, "tokenfile", "", "The file containing the token to use for authentication.")
+	flag.StringVar(&org, "org", "", "The organization that owns the repo.")
+	flag.StringVar(&repo, "repo", "", "The repo needing status migration.")
+	flag.BoolVar(&dryRun, "dry-run", true, "In dry run mode, no modifying actions will be taken.")
+	flag.BoolVar(&continueOnError, "continue-on-error", false, "Indicates that the migration should continue if context migration fails for an individual PR.")
+
+	flag.StringVar(&copyContext, "copy", "", "Indicates copy mode and specifies the context to copy.")
+	flag.StringVar(&moveContext, "move", "", "Indicates move mode and specifies the context to move.")
+	flag.StringVar(&retireContext, "retire", "", "Indicates retire mode and specifies the context to retire.")
+	flag.StringVar(&destContext, "dest", "", "The destination context to copy or move to. For retire mode this is the context that replaced the retired context.")
+	flag.Parse()
+
+	if org == "" {
+		errorfExit("'--org' must be set.\n")
+	}
+	if repo == "" {
+		errorfExit("'--repo' must be set.\n")
+	}
+	if tokenFile == "" {
+		errorfExit("'--tokenfile' must be set.\n")
+	}
+	tokenData, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		errorfExit("Error loading token file: %v\n", err)
+	}
+
+	if destContext == "" && retireContext == "" {
+		errorfExit("'--dest' is required unless using '--retire' mode.\n")
+	}
+
+	var mode *migrator.Mode
+	modeMsg := "Exactly one mode must be specified [--copy|--retire|--move].\n"
+	if copyContext != "" {
+		mode = migrator.CopyMode(copyContext, destContext)
+	}
+	if moveContext != "" {
+		if mode != nil {
+			errorfExit(modeMsg)
+		}
+		mode = migrator.MoveMode(moveContext, destContext)
+	}
+	if retireContext != "" {
+		if mode != nil {
+			errorfExit(modeMsg)
+		}
+		mode = migrator.RetireMode(retireContext, destContext)
+	}
+	if mode == nil {
+		errorfExit(modeMsg)
+	}
+
+	// Note that continueOnError is false by default so that errors can be addressed when they occur
+	// instead of blindly continueing to the next PR, possibly continuing to error.
+	m := migrator.New(*mode, strings.TrimSpace(string(tokenData)), org, repo, dryRun, continueOnError)
+
+	prOptions := &github.PullRequestListOptions{
+		State: "all",
+	}
+	if err := m.Migrate(prOptions); err != nil {
+		errorfExit("Error during status migration: %v\n", err)
+	}
+	glog.Flush()
+	os.Exit(0)
+}
+
+func errorfExit(format string, args ...interface{}) {
+	glog.Errorf(format, args...)
+	glog.Flush()
+	os.Exit(1)
+}

--- a/maintenance/migratestatus/migrator/BUILD
+++ b/maintenance/migratestatus/migrator/BUILD
@@ -1,0 +1,41 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["migrator_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//vendor:github.com/google/go-github/github"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["migrator.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//maintenance/githubutil:go_default_library",
+        "//vendor:github.com/golang/glog",
+        "//vendor:github.com/google/go-github/github",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/maintenance/migratestatus/migrator/migrator.go
+++ b/maintenance/migratestatus/migrator/migrator.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrator
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/google/go-github/github"
+	"k8s.io/test-infra/maintenance/githubutil"
+)
+
+var (
+	stateAny = "ANY_STATE"
+	stateDNE = "DOES_NOT_EXIST"
+)
+
+// contextCondition is a struct that describes a condition about the state or existance of a context.
+type contextCondition struct {
+	// context is the status context that this condition applies to.
+	context string
+	// state is the status state that the condition accepts, or one of the special values "ANY_STATE"
+	// and "DOES_NOT_EXIST".
+	state string
+}
+
+// Mode is a struct that describes the behavior of a status migration. The behavior is described as
+// a list of conditions and a function that determines the actions to be taken when the conditions
+// are met.
+type Mode struct {
+	conditions []*contextCondition
+	// actions returns the status updates to make based on the current statuses and the sha.
+	// When actions is called, the Mode may assume that it's conditions are met.
+	actions func(statuses []github.RepoStatus, sha string) []*github.RepoStatus
+}
+
+// MoveMode creates a mode that both copies and retires.
+// The mode creates a new context on every PR with the old context but not the new one, setting the
+// state of the new context to that of the old context before retiring the old context.
+func MoveMode(origContext, newContext string) *Mode {
+	dup := copyAction(origContext, newContext)
+	dep := retireAction(origContext, newContext)
+
+	return &Mode{
+		conditions: []*contextCondition{
+			&contextCondition{context: origContext, state: stateAny},
+			&contextCondition{context: newContext, state: stateDNE},
+		},
+		actions: func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
+			return append(dup(statuses, sha), dep(statuses, sha)...)
+		},
+	}
+}
+
+// CopyMode makes a mode that creates a new context in every PR that has the old context, but not the new one.
+// The state, description and target URL of the new context are made the same as those of the old context.
+func CopyMode(origContext, newContext string) *Mode {
+	return &Mode{
+		conditions: []*contextCondition{
+			&contextCondition{context: origContext, state: stateAny},
+			&contextCondition{context: newContext, state: stateDNE},
+		},
+		actions: copyAction(origContext, newContext),
+	}
+}
+
+// RetireMode creates a mode that retires an old context on all PRs.
+// If newContext is the empty string, origContext is retired without replacement. Its state is set to
+// 'success' and its description is set to indicate that the context is retired.
+// If newContext is not the empty string it is considered the replacement of origContext. This means
+// that only PRs that have the newContext in addition to the origContext will be considered and the
+// description of the retired context will indicate that it was replaced by newContext.
+func RetireMode(origContext, newContext string) *Mode {
+	conditions := []*contextCondition{&contextCondition{context: origContext, state: stateAny}}
+	if newContext != "" {
+		conditions = append(conditions, &contextCondition{context: newContext, state: stateAny})
+	}
+	return &Mode{
+		conditions: conditions,
+		actions:    retireAction(origContext, newContext),
+	}
+}
+
+// copyAction creates a function that returns a copy action.
+// Specifically the returned function returns a RepoStatus that will create a status for newContext
+// with state set to the state of origContext.
+func copyAction(origContext, newContext string) func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
+	return func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
+		var oldStatus *github.RepoStatus
+		for _, status := range statuses {
+			if status.Context != nil && *status.Context == origContext {
+				oldStatus = &status
+				break
+			}
+		}
+		if oldStatus == nil {
+			// This means the conditions were not met! Should never have called this function, but it is a recoverable error.
+			glog.Errorf("failed to find original context in status list thus conditions for this duplicate action were not met. This should never happen!")
+			return nil
+		}
+		return []*github.RepoStatus{
+			&github.RepoStatus{
+				Context:     &newContext,
+				State:       oldStatus.State,
+				TargetURL:   oldStatus.TargetURL,
+				Description: oldStatus.Description,
+			},
+		}
+	}
+}
+
+// retireAction creates a function that returns a retire action.
+// Specifically the returned function returns a RepoStatus that will update the origContext status
+// to 'success' and set it's description to mark it as retired and replaced by newContext.
+func retireAction(origContext, newContext string) func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
+	stateSuccess := "success"
+	var desc string
+	if newContext == "" {
+		desc = fmt.Sprint("Context retired without replacement.")
+	} else {
+		desc = fmt.Sprintf("Context retired. Status moved to \"%s\".", newContext)
+	}
+	return func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
+		return []*github.RepoStatus{
+			&github.RepoStatus{
+				Context:     &origContext,
+				State:       &stateSuccess,
+				TargetURL:   nil,
+				Description: &desc,
+			},
+		}
+	}
+}
+
+// ProcessStatuses checks the mode against the combined status of a PR and emits the actions to take.
+func (m Mode) ProcessStatuses(combStatus *github.CombinedStatus) []*github.RepoStatus {
+	var sha string
+	if combStatus.SHA != nil {
+		sha = *combStatus.SHA
+	}
+
+	for _, cond := range m.conditions {
+		var match *github.RepoStatus
+		match = nil
+		for _, status := range combStatus.Statuses {
+			if status.Context == nil {
+				glog.Errorf("a status context for SHA ref '%s' had a nil Context field.", sha)
+				continue
+			}
+			if *status.Context == cond.context {
+				match = &status
+				break
+			}
+		}
+
+		switch cond.state {
+		case stateDNE:
+			if match != nil {
+				return nil
+			}
+		case stateAny:
+			if match == nil {
+				return nil
+			}
+		default:
+			// Looking for a specific state in this case.
+			if match == nil {
+				// Did not find the context.
+				return nil
+			}
+			if match.State == nil {
+				glog.Errorf("context '%s' of SHA ref '%s' has a nil state.", cond.context, sha)
+				return nil
+			}
+			if *match.State != cond.state {
+				// Context had a different state than what the condition requires.
+				return nil
+			}
+		}
+	}
+	return m.actions(combStatus.Statuses, sha)
+}
+
+type Migrator struct {
+	org             string
+	repo            string
+	continueOnError bool
+
+	client *githubutil.Client
+	Mode
+}
+
+func New(mode Mode, token, org, repo string, dryRun, continueOnError bool) *Migrator {
+	return &Migrator{
+		org:             org,
+		repo:            repo,
+		continueOnError: continueOnError,
+		client:          githubutil.NewClient(token, dryRun),
+		Mode:            mode,
+	}
+}
+
+func (m *Migrator) ProcessPR(pr *github.PullRequest) error {
+	if pr == nil {
+		return fmt.Errorf("migrator cannot process a nil PullRequest.")
+	}
+	if pr.Head == nil {
+		return fmt.Errorf("migrator cannot process a PullRequest with a nil 'Head' field.")
+	}
+	if pr.Head.SHA == nil {
+		return fmt.Errorf("migrator cannot process a PullRequest with a nil 'Head.SHA' field.")
+	}
+
+	combined, _, err := m.client.GetCombinedStatus(m.org, m.repo, *pr.Head.SHA)
+	if err != nil {
+		return err
+	}
+	actions := m.ProcessStatuses(combined)
+
+	for _, action := range actions {
+		if _, _, err = m.client.CreateStatus(m.org, m.repo, *pr.Head.SHA, action); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migrator) Migrate(prOptions *github.PullRequestListOptions) error {
+	return m.client.ForEachPR(m.org, m.repo, prOptions, m.continueOnError, m.ProcessPR)
+}

--- a/maintenance/migratestatus/migrator/migrator_test.go
+++ b/maintenance/migratestatus/migrator/migrator_test.go
@@ -1,0 +1,373 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+type modeTest struct {
+	name          string
+	start         []github.RepoStatus
+	expectedDiffs []*github.RepoStatus
+}
+
+// compareDiffs checks if a list of status updates matches an expected list of status updates.
+func compareDiffs(diffs []*github.RepoStatus, expectedDiffs []*github.RepoStatus) error {
+	if len(diffs) != len(expectedDiffs) {
+		return fmt.Errorf("failed because the returned diff had %d changes instead of %d.", len(diffs), len(expectedDiffs))
+	}
+	for _, diff := range diffs {
+		if diff == nil {
+			return fmt.Errorf("failed because the returned diff contained a nil RepoStatus.")
+		}
+		if diff.Context == nil {
+			return fmt.Errorf("failed because the returned diff contained a RepoStatus with a nil Context field.")
+		}
+		if diff.Description == nil {
+			return fmt.Errorf("failed because the returned diff contained a RepoStatus with a nil Description field.")
+		}
+		if diff.State == nil {
+			return fmt.Errorf("failed because the returned diff contained a RepoStatus with a nil State field.")
+		}
+		var match *github.RepoStatus
+		for _, expected := range expectedDiffs {
+			if *expected.Context == *diff.Context {
+				match = expected
+				break
+			}
+		}
+		if match == nil {
+			return fmt.Errorf("failed because the returned diff contained an unexpected change to context '%s'.", *diff.Context)
+		}
+		// Found a matching context. Make sure that fields are equal.
+		if *match.Description != *diff.Description {
+			return fmt.Errorf("failed because the returned diff for context '%s' had Description '%s' instead of '%s'.", *diff.Context, *diff.Description, *match.Description)
+		}
+		if *match.State != *diff.State {
+			return fmt.Errorf("failed because the returned diff for context '%s' had State '%s' instead of '%s'.", *diff.Context, *diff.State, *match.State)
+		}
+
+		if match.TargetURL == nil {
+			if diff.TargetURL != nil {
+				return fmt.Errorf("failed because the returned diff for context '%s' had a non-nil TargetURL.", *diff.Context)
+			}
+		} else if diff.TargetURL == nil {
+			return fmt.Errorf("failed because the returned diff for context '%s' had a nil TargetURL.", *diff.Context)
+		} else if *match.TargetURL != *diff.TargetURL {
+			return fmt.Errorf("failed because the returned diff for context '%s' had TargetURL '%s' instead of '%s'.", *diff.Context, *diff.TargetURL, *match.TargetURL)
+		}
+	}
+	return nil
+}
+
+func TestMoveMode(t *testing.T) {
+	contextA := "context A"
+	contextB := "context B"
+	desc := "Context retired. Status moved to \"context B\"."
+
+	tests := []*modeTest{
+		&modeTest{
+			name: "simple",
+			start: []github.RepoStatus{
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextA, "success", desc, ""),
+				makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+		},
+		&modeTest{
+			name: "unrelated contexts",
+			start: []github.RepoStatus{
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextA, "success", desc, ""),
+				makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+		},
+		&modeTest{
+			name: "unrelated contexts; missing context A",
+			start: []github.RepoStatus{
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "unrelated contexts; already have context A and B",
+			start: []github.RepoStatus{
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "unrelated contexts; already have context B; no context A",
+			start: []github.RepoStatus{
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name:          "no contexts",
+			start:         []github.RepoStatus{},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+	}
+
+	m := *MoveMode(contextA, contextB)
+	for _, test := range tests {
+		diff := m.ProcessStatuses(&github.CombinedStatus{Statuses: test.start})
+		if err := compareDiffs(diff, test.expectedDiffs); err != nil {
+			t.Errorf("MoveMode test '%s' %v\n", test.name, err)
+		}
+	}
+}
+
+func TestCopyMode(t *testing.T) {
+	contextA := "context A"
+	contextB := "context B"
+
+	tests := []*modeTest{
+		&modeTest{
+			name: "simple",
+			start: []github.RepoStatus{
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+		},
+		&modeTest{
+			name: "unrelated contexts",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+		},
+		&modeTest{
+			name: "already have context B",
+			start: []github.RepoStatus{
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "already have updated context B",
+			start: []github.RepoStatus{
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus(contextB, "success", "description 2", "url 2"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "unrelated contexts already have updated context B",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+				*makeStatus(contextB, "error", "description 3", "url 3"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "only have context B",
+			start: []github.RepoStatus{
+				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "unrelated contexts; context B but not A",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextB, "failure", "description 1", "url 1"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name:          "no contexts",
+			start:         []github.RepoStatus{},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+	}
+
+	m := *CopyMode(contextA, contextB)
+	for _, test := range tests {
+		diff := m.ProcessStatuses(&github.CombinedStatus{Statuses: test.start})
+		if err := compareDiffs(diff, test.expectedDiffs); err != nil {
+			t.Errorf("CopyMode test '%s' %v\n", test.name, err)
+		}
+	}
+}
+
+func TestRetireModeReplacement(t *testing.T) {
+	contextA := "context A"
+	contextB := "context B"
+	desc := "Context retired. Status moved to \"context B\"."
+
+	tests := []*modeTest{
+		&modeTest{
+			name: "simple",
+			start: []github.RepoStatus{
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextA, "success", desc, ""),
+			},
+		},
+		&modeTest{
+			name: "unrelated contexts;updated context B",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+				*makeStatus(contextB, "success", "description 3", "url 3"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextA, "success", desc, ""),
+			},
+		},
+		&modeTest{
+			name: "missing context B",
+			start: []github.RepoStatus{
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "unrelated contexts;missing context B",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "missing context A",
+			start: []github.RepoStatus{
+				*makeStatus(contextB, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "unrelated contexts;missing context A",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+				*makeStatus(contextB, "success", "description 3", "url 3"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name:          "no contexts",
+			start:         []github.RepoStatus{},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+	}
+
+	m := *RetireMode(contextA, contextB)
+	for _, test := range tests {
+		diff := m.ProcessStatuses(&github.CombinedStatus{Statuses: test.start})
+		if err := compareDiffs(diff, test.expectedDiffs); err != nil {
+			t.Errorf("RetireMode(Replacement) test '%s' %v\n", test.name, err)
+		}
+	}
+}
+
+func TestRetireModeNoReplacement(t *testing.T) {
+	contextA := "context A"
+	desc := "Context retired without replacement."
+
+	tests := []*modeTest{
+		&modeTest{
+			name: "simple",
+			start: []github.RepoStatus{
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextA, "success", desc, ""),
+			},
+		},
+		&modeTest{
+			name: "unrelated contexts",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus(contextA, "failure", "description 1", "url 1"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+			},
+			expectedDiffs: []*github.RepoStatus{
+				makeStatus(contextA, "success", desc, ""),
+			},
+		},
+		&modeTest{
+			name:          "missing context A",
+			start:         []github.RepoStatus{},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+		&modeTest{
+			name: "unrelated contexts;missing context A",
+			start: []github.RepoStatus{
+				*makeStatus("unrelated context", "success", "description 2", "url 2"),
+				*makeStatus("also not related", "error", "description 4", "url 4"),
+			},
+			expectedDiffs: []*github.RepoStatus{},
+		},
+	}
+
+	m := *RetireMode(contextA, "")
+	for _, test := range tests {
+		diff := m.ProcessStatuses(&github.CombinedStatus{Statuses: test.start})
+		if err := compareDiffs(diff, test.expectedDiffs); err != nil {
+			t.Errorf("RetireMode(NoReplace) test '%s' %v\n", test.name, err)
+		}
+	}
+}
+
+// makeStatus returns a new RepoStatus struct with the specified fields.
+// targetURL=="" means TargetURL==nil
+func makeStatus(context, state, description, targetURL string) *github.RepoStatus {
+	var url *string
+	if targetURL != "" {
+		url = &targetURL
+	}
+	return &github.RepoStatus{
+		Context:     &context,
+		State:       &state,
+		Description: &description,
+		TargetURL:   url,
+	}
+}


### PR DESCRIPTION
Locally run tool that migrates status contexts with one of three modes:
-Duplicate creates copies of a status with a different context name for all PRs that only have the original status context.
-Deprecate marks the original context as deprecated, but succeeding, for all PRs that have both the old and new context
-Replace combines the actions of the above two modes. It duplicates the original status (giving the duplicate status a different context name) and marks the original status context as deprecated.

The limiting factor on the run time of this tool is github token availability.
/assign @fejta @spxtr 