### PR TITLE
Use `make bazel-release` instead of `make bazel-build` in kubetest

### DIFF
--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -61,7 +61,7 @@ func (b *buildStrategy) Build() error {
 	var target string
 	switch *b {
 	case "bazel":
-		target = "bazel-build"
+		target = "bazel-release"
 	case "quick":
 		target = "quick-release"
 	case "release":


### PR DESCRIPTION
The `bazel-release` rule builds the release tars instead of all of the binary targets in the tree. `bazel-build` is appropriate for something like the unittest CI job, but `bazel-release` is more appropriate for e2e builds and kubetest.

/assign @fejta 
/cc @mikedanese @spxtr 