### PR TITLE
Revert "Make federation presubmits "required"."

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -24,8 +24,7 @@ data:
     \"Jenkins Kubemark GCE e2e\",\
     \"Jenkins GCE etcd3 e2e\",\
     \"Jenkins Bazel Build\",\
-    \"Jenkins kops AWS e2e\",\
-    \"pull-kubernetes-federation-e2e-gce\""
+    \"Jenkins kops AWS e2e\""
 
   submit-queue.protected-branches: "master"
   submit-queue.protected-branches-extra-contexts: "cla/linuxfoundation"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -181,6 +181,7 @@ presubmits:
     - release-1.5
     - release-1.6
     always_run: true
+    skip_report: true  # Remove this once we are confident about this job
     context: pull-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce )?test this"
@@ -341,6 +342,7 @@ presubmits:
     - release-1.5
     - release-1.6
     always_run: true
+    skip_report: true
     context: pull-security-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-security-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce )?test this"


### PR DESCRIPTION
Reverts kubernetes/test-infra#2674

I am not entirely sure what happened in PR #2674. Federation presubmit is running on all the PRs but it is not reporting the status on the PRs which is stalling the entire submit queue. I will roll this PR back and investigate what's going on instead of blocking the PRs in core.

/assign @fejta 