### PR TITLE
remove vendor folder before running godep save

### DIFF
--- a/mungegithub/mungers/publish_scripts/util.sh
+++ b/mungegithub/mungers/publish_scripts/util.sh
@@ -151,6 +151,8 @@ restore_vendor() {
     godep restore
     # need to remove the Godeps folder, otherwise godep won't save source code to vendor/
     rm -rf ./Godeps
+    # otherwise `godep save` might fail, see https://github.com/kubernetes/test-infra/issues/2684
+    rm -rf ./vendor
     godep save ./...
     if [ "${is_library}" = "true" ]; then
         echo "remove k8s.io/* and glog from vendor/"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/2684.

@sttts could you do a sanity check? Thanks. It's too bad that we are the only two people understand the robot code.

(How I verified the fix: I logged into the pod and ran `godep save` and reproduced the bug. I removed the vendor/ and then `godep save` succeeded.)