### PR TITLE
Add GOOS/GOARCH so that image can be built from mac.

### DIFF
--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -18,8 +18,7 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 all: build
 
 kubetest:
-	go build -o kubetest ../../kubetest
-
+	GOOS=linux GOARCH=amd64 go build -o kubetest ../../kubetest
 
 build: kubetest
 	docker build -t $(IMG):$(TAG) .


### PR DESCRIPTION
So that Jenkins will show some more love for go binary from mac :-|