### PR TITLE
Remove default envs from the e2e-image

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -18,23 +18,6 @@
 FROM gcr.io/google-containers/kubekins-test:v20160822
 MAINTAINER  Erick Fejta <fejta@google.com>
 
-# Defaults of all e2e runs
-ENV E2E_UP=true \
-    E2E_TEST=true \
-    E2E_DOWN=true
-
-# Customize these as appropriate
-ENV E2E_PUBLISH_PATH= \
-    INSTANCE_PREFIX=jenkins-e2e \
-    KUBERNETES_PROVIDER=gce
-
-# Variables specific to GCP
-ENV FAIL_ON_GCP_RESOURCE_LEAK=true \
-    JOB_NAME=kubernetes-e2e-gce-conformance \
-    KUBE_GCE_INSTANCE_PREFIX=jenkins-e2e \
-    KUBE_GCE_NETWORK=jenkins-e2e \
-    KUBE_GCE_ZONE=us-central1-f
-
 # Variable specific to the machine:
 # GOOGLE_APPLICATION_CREDENTIALS
 # JENKINS_GCE_SSH_PRIVATE_KEY_FILE


### PR DESCRIPTION
The issue currently we have is, in docker mode, `docker run -v --env-file` will overwrite image envs, however local mode will mix up all the envs, and the order of updating envs is:
```
        env = {}
        env.update(self.env_files)
        env.update(self.env)
```
which overwrites image envs onto env files..

However all these envs are handled by either the scenario or platform/gce or platform/gke already, thus seems it's just easier to get rid of them from the Dockerfile.

/assign @fejta 
cc @yguo0905 