### PR TITLE
Make hook throw 400 error on incorrect content-type.  Add webhook configuration info to README

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>test-infra</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/prow/README.md
+++ b/prow/README.md
@@ -174,3 +174,7 @@ traffic to reach your hook and deck deployments.
  ```
 
 9. Add the webhook to GitHub.
+
+Hook processes the following events: issues, issue_comment, pull_request, push, status so github web hooks should be configured to send these event types. We suggest configuring your webhooks to send everything so that future event types are covered.
+
+The content-type for all webhooks type must be application/json.  This is selectable via a dropdown in the webhook configuration page.

--- a/prow/cmd/hook/server.go
+++ b/prow/cmd/hook/server.go
@@ -55,6 +55,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "403 Forbidden: Missing X-Hub-Signature", http.StatusForbidden)
 		return
 	}
+	contentType := r.Header.Get("content-type")
+	if contentType != "application/json" {
+		http.Error(w, "400 Bad Request: Hook only accepts content-type: application/json - please reconfigure this hook on GitHub", http.StatusBadRequest)
+		return
+	}
 
 	payload, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/prow/cmd/hook/server_test.go
+++ b/prow/cmd/hook/server_test.go
@@ -43,6 +43,7 @@ func TestServeHTTPErrors(t *testing.T) {
 			Header: map[string]string{
 				"X-GitHub-Event":  "ping",
 				"X-Hub-Signature": hmac,
+				"content-type":    "application/json",
 			},
 			Body: body,
 			Code: http.StatusMethodNotAllowed,
@@ -52,6 +53,7 @@ func TestServeHTTPErrors(t *testing.T) {
 			Method: http.MethodPost,
 			Header: map[string]string{
 				"X-Hub-Signature": hmac,
+				"content-type":    "application/json",
 			},
 			Body: body,
 			Code: http.StatusBadRequest,
@@ -71,6 +73,7 @@ func TestServeHTTPErrors(t *testing.T) {
 			Header: map[string]string{
 				"X-GitHub-Event":  "ping",
 				"X-Hub-Signature": "this doesn't work",
+				"content-type":    "application/json",
 			},
 			Body: body,
 			Code: http.StatusForbidden,
@@ -81,6 +84,7 @@ func TestServeHTTPErrors(t *testing.T) {
 			Header: map[string]string{
 				"X-GitHub-Event":  "ping",
 				"X-Hub-Signature": hmac,
+				"content-type":    "application/json",
 			},
 			Body: body,
 			Code: http.StatusOK,

--- a/prow/cmd/phony/main.go
+++ b/prow/cmd/phony/main.go
@@ -54,6 +54,7 @@ func main() {
 	}
 	req.Header.Set("X-GitHub-Event", *event)
 	req.Header.Set("X-Hub-Signature", github.PayloadSignature(body, []byte(*hmac)))
+	req.Header.Set("content-type", "application/json")
 
 	c := &http.Client{}
 	resp, err := c.Do(req)


### PR DESCRIPTION
The purpose of this PR is to make hook more user friendly by throwing errors for the wrong content-type.  There are also some updates to the README for explicit webhook settings needed on github.