### PR TITLE
Propagate labels across all repos

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -35,6 +35,7 @@ filegroup(
         "//jobs:all-srcs",
         "//kettle:all-srcs",
         "//kubetest:all-srcs",
+        "//label_sync:all-srcs",
         "//logexporter/cmd:all-srcs",
         "//maintenance/githubutil:all-srcs",
         "//maintenance/migratestatus:all-srcs",

--- a/label_sync/BUILD
+++ b/label_sync/BUILD
@@ -1,0 +1,56 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+    "go_test",
+)
+
+go_binary(
+    name = "label_sync",
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    data = [
+        "//label_sync:test_examples",
+    ],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//prow/github:go_default_library"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/github.com/Sirupsen/logrus:go_default_library",
+        "//vendor/github.com/ghodss/yaml:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "test_examples",
+    srcs = glob(["*.yaml"]),
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/label_sync/Dockerfile
+++ b/label_sync/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM alpine:3.6
+MAINTAINER lukaszgryglicki@o2.pl
+
+ADD label_sync /label_sync
+RUN mkdir /etc/config
+ADD labels.yaml /etc/config/labels.yaml
+ADD repos.yaml /etc/config/repos.yaml
+
+ENTRYPOINT ["/label_sync"]

--- a/label_sync/Makefile
+++ b/label_sync/Makefile
@@ -1,0 +1,59 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: build test
+
+
+LABEL_SYNC_VERSION       ?= 0.1
+
+# These are the usual GKE variables.
+PROJECT       ?= k8s-prow
+BUILD_PROJECT ?= k8s-prow-builds
+ZONE          ?= us-central1-f
+CLUSTER       ?= prow
+
+# Build and push specific variables.
+REGISTRY ?= gcr.io
+PUSH     ?= gcloud docker -- push
+
+DOCKER_LABELS=--label io.k8s.prow.git-describe="$(shell git describe --tags --always --dirty)"
+
+get-cluster-credentials:
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+get-build-cluster-credentials:
+	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(BUILD_PROJECT)" --zone="$(ZONE)"
+
+build:
+	go install ./...
+
+test:
+	go test -race -cover $$(go list ./... | grep -v "\/vendor\/")
+
+.PHONY: build test get-cluster-credentials
+
+compile-static:
+	CGO_ENABLED=0 go build -o label_sync k8s.io/test-infra/label_sync
+
+label_sync-image: compile-static
+	docker build -t "$(REGISTRY)/$(PROJECT)/label_sync:$(LABEL_SYNC_VERSION)" $(DOCKER_LABELS) .
+	$(PUSH) "$(REGISTRY)/$(PROJECT)/label_sync:$(LABEL_SYNC_VERSION)"
+
+label_sync-deployment: get-cluster-credentials
+	kubectl apply -f cluster/label_sync_deployment.yaml
+
+label_sync-cronjob: get-cluster-credentials
+	kubectl apply -f cluster/label_sync_cron_job.yaml
+
+.PHONY: label_sync-image label_sync-deployment label_sync-cronjob

--- a/label_sync/README.md
+++ b/label_sync/README.md
@@ -1,0 +1,55 @@
+You can run it locally with repositories and labels data fetched into YAML files:
+
+Run (with go):
+`go run label_sync/main.go -help` (for help)
+`go run label_sync/main.go -labels-path label_sync/labels.yaml -local -repos label_sync/repos.yaml -repo-labels label_sync/repo_labels.yaml`
+
+Test (with go):
+`go test k8s.io/test-infra/label_sync`
+`make test`
+
+Bazel test:
+`bazel test //label_sync/...`
+
+Bazel build:
+`bazel build //label_sync/...`
+
+Bazel run:
+`./bazel-bin/label_sync/label_sync -labels-path bazel-test-infra/label_sync/labels.yaml -local -repos bazel-test-infra/label_sync/repos.yaml -repo-labels bazel-test-infra/label_sync/repo_labels.yaml`
+
+Build static binary:
+`make compile-static`
+
+You can run on Your own repository set (by passing special `user:user_name` to `-org` flag) and save repository data in local files, and then run program in local mode using those saved files.
+Assuming You have Your oauth github file in `/etc/github/oauth` or You can pass it with `-github-token-file /your/path/to/oauth/file`:
+`go run label_sync/main.go -labels-path label_sync/labels.yaml -org user:your_github_user_name -dump-repos your_repos.yaml -dump-repo-labels your_labels.yaml`
+
+It will save Your repositories and their labels in two YAML files, next time You can run/debug/test in `-local` mode:
+`go run label_sync.main.go -labels-path label_sync/labels.yaml -local -repos your_repos.yaml -repo-labels your_labels.yaml`
+This will allow debuging algorithms to sync labels.
+
+Actual label updates cannot be done in `-dry-run` or `-local` mode because it updates real repository labels.
+You can update list of labels from given repo by running:
+`go run label_sync/main.go -debug -dry-run -labels-path label_sync/labels_example.yaml -org kubernetes -github-token-file /etc/github/oauth -repos label_sync/single_repo_example.yaml -dump-repo-labels label_sync/kubernetes_labels.yaml`
+Parameters meaning:
+- `-debug`: to see more debugging info while doing so
+- `-dry-run`: not to try to update repo, but do actuall read calls on this repo
+- `-org` and `-github-token-file`: to allow You to use GitHub API calls
+- `-labels-path`: to provide required labels file to sync (it won't be used in `-dry-run` mode)
+- `-repos`: to provide list of repository (even single) to get labels from (You can manually put only kubernetes/kubernetes here)
+- `-dump-repo-labels`: to save them in the file
+
+You can tweak required labels `label_sync/labels.yaml` file and Your `-repos` and `-repo-labels` files to make it try to update single label on Your own repo etc.
+Real run should have all required files in default plases and should just go without parameters (`/etc/config/labels.yaml` for `-labels-path` and `/etc/github/oauth` for `-github-token-file`):
+`go run label_sync/main.go`
+
+If You want to build docker image manually and only locally, You need to build static binary for docker first:
+`make compile-static`
+
+You can specify to build docker image with (from `test-infra` root directory):
+From `label_sync` directory:
+`docker build -t label_sync .`
+And then run docker image via:
+`docker run label_sync` (eventuallu change entry point to `/bin/sh` and add `-ti` options for interactive shell)
+Currently this is an equivalent to: `go run label_sync/main.go -help` from Your local development (see `Dockerfile`) because I don't know yet how to put Github OAuth secret in that image (and have no access to real GitHub OAuth token for kubernetes repo).
+

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -1,0 +1,29 @@
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: label_sync_cron_job
+spec:
+  schedule: "17 23 * * 0"    # Every Sunday 23:17 / 11:17PM
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: label_sync
+              image: gcr.io/k8s-prow/label_sync:0.100
+          restartPolicy: OnFailure
+          concurrencyPolicy: Forbid

--- a/label_sync/cluster/label_sync_deployment.yaml
+++ b/label_sync/cluster/label_sync_deployment.yaml
@@ -1,0 +1,42 @@
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: label_sync
+  labels:
+    app: label_sync
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: label_sync
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: label_sync
+          image: gcr.io/k8s-prow/label_sync:0.100
+          args:
+          - --repos=/etc/config/repos.yaml
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+      volumes:
+        - name: oauth
+          secret:
+            secretName: oauth-token

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1,0 +1,367 @@
+# Standard labels set (common for all kubernetes repos)
+---
+labels:
+  - color: 0ffa16
+    name: approved
+  - color: fef2c0
+    name: approved-for-milestone
+#  - color: 0052cc
+#    name: area/admin
+#  - color: 0052cc
+#    name: area/admission-control
+#  - color: 0052cc
+#    name: area/api
+#  - color: 0052cc
+#    name: area/apiserver
+#  - color: 0052cc
+#    name: area/app-lifecycle
+#  - color: 0052cc
+#    name: area/batch
+#  - color: 0052cc
+#    name: area/build-release
+#  - color: 0052cc
+#    name: area/cadvisor
+#  - color: 0052cc
+#    name: area/client-libraries
+#  - color: 0052cc
+#    name: area/cloudprovider
+#  - color: 0052cc
+#    name: area/configmap-api
+#  - color: 0052cc
+#    name: area/controller-manager
+#  - color: 0052cc
+#    name: area/declarative-configuration
+#  - color: 0052cc
+#    name: area/dns
+#  - color: 0052cc
+#    name: area/docker
+#  - color: 0052cc
+#    name: area/downward-api
+#  - color: 0052cc
+#    name: area/ecosystem
+#  - color: 0052cc
+#    name: area/etcd
+#  - color: 0052cc
+#    name: area/example
+#  - color: 0052cc
+#    name: area/example/cassandra
+#  - color: 0052cc
+#    name: area/extensibility
+#  - color: 0052cc
+#    name: area/HA
+#  - color: 0052cc
+#    name: area/hw-accelerators
+#  - color: 0052cc
+#    name: area/images-registry
+#  - color: 0052cc
+#    name: area/ingress
+#  - color: 0052cc
+#    name: area/introspection
+#  - color: 0052cc
+#    name: area/ipv6
+#  - color: 0052cc
+#    name: area/isolation
+#  - color: 0052cc
+#    name: area/kube-proxy
+#  - color: 0052cc
+#    name: area/kubeadm
+#  - color: 0052cc
+#    name: area/kubectl
+#  - color: 0052cc
+#    name: area/kubelet
+#  - color: 0052cc
+#    name: area/kubelet-api
+#  - color: 0052cc
+#    name: area/logging
+#  - color: 0052cc
+#    name: area/monitoring
+#  - color: 0052cc
+#    name: area/node-e2e
+#  - color: 0052cc
+#    name: area/node-lifecycle
+#  - color: 0052cc
+#    name: area/nodecontroller
+#  - color: d4c5f9
+#    name: area/os/coreos
+#  - color: d4c5f9
+#    name: area/os/fedora
+#  - color: d4c5f9
+#    name: area/os/gci
+#  - color: d4c5f9
+#    name: area/os/ubuntu
+#  - color: d4c5f9
+#    name: area/platform/aws
+#  - color: d4c5f9
+#    name: area/platform/azure
+#  - color: d4c5f9
+#    name: area/platform/gce
+#  - color: d4c5f9
+#    name: area/platform/gke
+#  - color: d4c5f9
+#    name: area/platform/mesos
+#  - color: d4c5f9
+#    name: area/platform/vagrant
+#  - color: d4c5f9
+#    name: area/platform/vsphere
+#  - color: 0052cc
+#    name: area/release-infra
+#  - color: 0052cc
+#    name: area/reliability
+#  - color: 0052cc
+#    name: area/rkt
+#  - color: 0052cc
+#    name: area/secret-api
+#  - color: d93f0b
+#    name: area/security
+#  - color: 0052cc
+#    name: area/stateful-apps
+#  - color: 0052cc
+#    name: area/swagger
+#  - color: 0052cc
+#    name: area/system-requirement
+#  - color: 0052cc
+#    name: area/teardown
+#  - color: 0052cc
+#    name: area/test
+#  - color: 0052cc
+#    name: area/test-infra
+#  - color: 0052cc
+#    name: area/third-party-resource
+#  - color: 0052cc
+#    name: area/ui
+#  - color: 0052cc
+#    name: area/upgrade
+#  - color: 0052cc
+#    name: area/usability
+#  - color: 0052cc
+#    name: area/workload-api/cronjob
+#  - color: 0052cc
+#    name: area/workload-api/daemonset
+#  - color: 0052cc
+#    name: area/workload-api/deployment
+#  - color: 0052cc
+#    name: area/workload-api/job
+#  - color: 0052cc
+#    name: area/workload-api/replicaset
+#  - color: d93f0b
+#    name: beta-blocker
+  - color: fef2c0
+    name: cherrypick-approved
+  - color: fef2c0
+    name: cherrypick-candidate
+  - color: bfe5bf
+    name: 'cla: human-approved'
+  - color: e11d21
+    name: 'cla: no'
+  - color: bfe5bf
+    name: 'cla: yes'
+  - color: e11d21
+    name: 'cncf-cla: no'
+  - color: bfe5bf
+    name: 'cncf-cla: yes'
+  - color: e11d21
+    name: do-not-merge
+  - color: e11d21
+    name: do-not-merge/blocked-paths
+  - color: e11d21
+    name: do-not-merge/cherry-pick-not-approved
+  - color: e11d21
+    name: do-not-merge/hold
+  - color: e11d21
+    name: do-not-merge/release-note-label-needed
+  - color: e11d21
+    name: do-not-merge/work-in-progress
+#  - color: fbca04
+#    name: flake-has-meta
+#  - color: 006b75
+#    name: for-new-contributors
+#  - color: 006b75
+#    name: help-wanted
+  - color: fbca04
+    name: keep-open
+#  - color: c7def8
+#    name: kind/api-change
+  - color: e11d21
+    name: kind/bug
+#  - color: c7def8
+#    name: kind/cleanup
+#  - color: c7def8
+#    name: kind/design
+  - color: c7def8
+    name: kind/documentation
+#  - color: c7def8
+#    name: kind/enhancement
+  - color: c7def8
+    name: kind/feature
+#  - color: f7c6c7
+#    name: kind/flake
+#  - color: c7def8
+#    name: kind/friction
+#  - color: f7c6c7
+#    name: kind/mesos-flake
+#  - color: c7def8
+#    name: kind/new-api
+#  - color: c7def8
+#    name: kind/old-docs
+#  - color: bfe5bf
+#    name: kind/postmortem
+#  - color: eb6420
+#    name: kind/support
+#  - color: c7def8
+#    name: kind/technical-debt
+#  - color: fbca04
+#    name: kind/upgrade-test-failure
+  - color: 15dd18
+    name: lgtm
+#  - color: ededed
+#    name: needs-ok-to-merge
+  - color: b60205
+    name: needs-ok-to-test
+  - color: BDBDBD
+    name: needs-rebase
+  - color: ededed
+    name: needs-sig
+#  - color: 0e8a16
+#    name: non-release-blocker
+  - color: fbca04
+    name: ok-to-merge
+  - color: fef2c0
+    name: priority/awaiting-more-evidence
+  - color: fbca04
+    name: priority/backlog
+  - color: e11d21
+    name: priority/critical-urgent
+  - color: e11d21
+    name: priority/failing-test
+  - color: eb6420
+    name: priority/important-longterm
+  - color: eb6420
+    name: priority/important-soon
+#  - color: ff0000
+#    name: priority/P0
+#  - color: ededed
+#    name: priority/P1
+#  - color: ededed
+#    name: priority/P2
+#  - color: ededed
+#    name: priority/P3
+  - color: ffaa00
+    name: queue/blocks-others
+  - color: ffaa00
+    name: queue/critical-fix
+  - color: ffaa00
+    name: queue/fix
+  - color: ffaa00
+    name: queue/multiple-rebases
+#  - color: d93f0b
+#    name: release-blocker
+  - color: c2e0c6
+    name: release-note
+  - color: c2e0c6
+    name: release-note-action-required
+  - color: db5a64
+    name: release-note-label-needed
+  - color: c2e0c6
+    name: release-note-none
+  - color: d93f0b
+    name: requires-release-czar-attention
+  - color: eb6420
+    name: retest-not-required
+  - color: fbca04
+    name: retest-not-required-docs-only
+  - color: d2b48c
+    name: sig/api-machinery
+  - color: d2b48c
+    name: sig/apps
+  - color: d2b48c
+    name: sig/architecture
+  - color: d2b48c
+    name: sig/auth
+  - color: d2b48c
+    name: sig/autoscaling
+  - color: d2b48c
+    name: sig/aws
+  - color: d2b48c
+    name: sig/azure
+  - color: d2b48c
+    name: sig/big-data
+  - color: d2b48c
+    name: sig/cli
+  - color: d2b48c
+    name: sig/cluster-lifecycle
+  - color: d2b48c
+    name: sig/cluster-ops
+  - color: d2b48c
+    name: sig/contributor-experience
+  - color: d2b48c
+    name: sig/docs
+  - color: d2b48c
+    name: sig/federation
+  - color: d2b48c
+    name: sig/gcp
+  - color: d2b48c
+    name: sig/instrumentation
+  - color: d2b48c
+    name: sig/network
+  - color: d2b48c
+    name: sig/node
+  - color: d2b48c
+    name: sig/onprem
+  - color: d2b48c
+    name: sig/openstack
+  - color: d2b48c
+    name: sig/release
+  - color: d2b48c
+    name: sig/rktnetes
+  - color: d2b48c
+    name: sig/scalability
+  - color: d2b48c
+    name: sig/scheduling
+  - color: d2b48c
+    name: sig/service-catalog
+  - color: d2b48c
+    name: sig/storage
+  - color: d2b48c
+    name: sig/testing
+  - color: d2b48c
+    name: sig/ui
+  - color: d2b48c
+    name: sig/windows
+  - color: ee9900
+    name: size/L
+  - color: eebb00
+    name: size/M
+  - color: 77bb00
+    name: size/S
+  - color: ee5500
+    name: size/XL
+  - color: "009900"
+    name: size/XS
+  - color: ee0000
+    name: size/XXL
+#  - color: "795548"
+#    name: stale
+  - color: fef2c0
+    name: status/in-progress
+  - color: fef2c0
+    name: status/in-review
+#  - color: ededed
+#    name: team/api (deprecated - do not use)
+#  - color: ededed
+#    name: team/cluster (deprecated - do not use)
+#  - color: ededed
+#    name: team/control-plane (deprecated - do not use)
+#  - color: d2b48c
+#    name: team/gke
+#  - color: d2b48c
+#    name: team/huawei
+#  - color: d2b48c
+#    name: team/mesosphere
+#  - color: d2b48c
+#    name: team/redhat
+#  - color: ededed
+#    name: team/test-infra
+#  - color: ededed
+#    name: team/ux (deprecated - do not use)
+#  - color: d455d0
+#    name: triaged

--- a/label_sync/labels_example.yaml
+++ b/label_sync/labels_example.yaml
@@ -1,0 +1,8 @@
+# Standard labels set (common for all kubernetes repos)
+---
+labels:
+  - color: green
+    name: lgtm
+  - color: red
+    name: priority/P0
+...

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -1,0 +1,441 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is a label_sync tool, details in README.md
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/ghodss/yaml"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+// Label single label
+type Label struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// RequiredLabels is a list of Required Labels to sync in all kubernetes repos
+type RequiredLabels struct {
+	Labels []Label `json:"labels"`
+}
+
+// RepoList is a list of Repositories from Org to be checked by this program
+type RepoList struct {
+	Org   string        `json:"org"`
+	Repos []github.Repo `json:"repos"`
+}
+
+// RepoLabels is a mapping repository name --> current list of labels
+type RepoLabels struct {
+	Labels map[string][]github.Label
+}
+
+// UpdateItem is a single item to update
+// update can mean: update Label in repo or add missing label in repo
+type UpdateItem struct {
+	Why                         string
+	RequiredLabel, CurrentLabel Label
+}
+
+// UpdateData Repositories to update: map repo name --> list of Updates
+type UpdateData struct {
+	ReposToUpdate map[string][]UpdateItem
+}
+
+var (
+	labelsPath         = flag.String("labels-path", "/etc/config/labels.yaml", "Path to labels.yaml.")
+	githubTokenFile    = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	org                = flag.String("org", "kubernetes", "Organization to fetch repository list from, to fetch user's public repositories, use user:user_name")
+	dry                = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	local              = flag.Bool("local", false, "Run locally for testing purposes only. Does not require secret files.")
+	reposData          = flag.String("repos", "", "Repository file saved as YAML to save GitHub API points, can be used to specify repositories to run")
+	repoLabelsData     = flag.String("repo-labels", "", "Repository Labels file saved as YAML to save GitHub API points")
+	dumpReposData      = flag.String("dump-repos", "", "Save repositories found as YAML (so this file can be used again with -repos without using Gihub API points in -local mode)")
+	dumpRepoLabelsData = flag.String("dump-repo-labels", "", "Save repositories labels found as YAML (so this file can be used again with -repo-labels without using Gihub API points in -local mode)")
+	debug              = flag.Bool("debug", false, "Turn on debug to be more verbose")
+	endPoint           = flag.String("endpoint", "https://api.github.com", "GitHub's API endpoint")
+)
+
+// Load labels from labels.yaml file
+func (rl *RequiredLabels) Load(path string) (err error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+	return yaml.Unmarshal(data, rl)
+}
+
+// GetOrg returns organization from "org" or "user:name"
+// Org can be organization name like "kubernetes"
+// But we can also request all user's public repos via user:github_user_name
+func GetOrg(org string) (outOrg string, isUser bool) {
+	data, isUser, outOrg := strings.Split(org, ":"), false, org
+	if len(data) == 2 && data[0] == "user" {
+		outOrg = data[1]
+		isUser = true
+	}
+	return
+}
+
+// Get reads repository list for given org
+// Use provided githubClient (real, dry, fake)
+// Uses GitHub: /orgs/:org/repos
+func (rl *RepoList) Get(gc *github.Client) (err error) {
+	org, isUser := GetOrg(*org)
+	repos, err := gc.GetRepos(org, isUser)
+	if err != nil {
+		return
+	}
+	rl.Repos = repos
+	rl.Org = org
+	return
+}
+
+// Get reads repository's labels list
+// Use provided githubClient (real, dry, fake)
+// Uses GitHub: /repos/:org/:repo/labels
+func (rl *RepoLabels) Get(gc *github.Client, repos *RepoList) error {
+	for _, repo := range repos.Repos {
+		labels, err := gc.GetRepoLabels(repos.Org, repo.Name)
+		if err != nil {
+			logrus.Errorf("Error getting labels for %s/%s", repos.Org, repo.Name)
+			return err
+		}
+		rl.Labels[repo.Name] = labels
+	}
+	return nil
+}
+
+// UnmarshalReposData returns GitHub data recorded to YAML file via -dump-repos
+// This data can be saved in repos.yaml
+// This is to save GitHub API points and speedup local development
+// This file can also be used to overwite repository list to run this program on
+func UnmarshalReposData(repos *RepoList) error {
+	data, err := ioutil.ReadFile(*reposData)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(data, repos)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// UnmarshalRepoLabelsData returns GitHub data recorded to YAML file via -dump-repo-labels
+// This data can be saved in repo_labels.yaml
+// This is to save GitHub API points and speedup local development
+func UnmarshalRepoLabelsData(repoLabels *RepoLabels) error {
+	data, err := ioutil.ReadFile(*repoLabelsData)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(data, repoLabels)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalReposData is used to save repos data into YAML file
+// If -dump-repos parameter is used
+func MarshalReposData(repos *RepoList) error {
+	data, err := yaml.Marshal(repos)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(*dumpReposData, []byte(data), 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalReposLabelsData is used to save repo labels data into YAML file
+// If -dump-repo-labels parameter is used
+func MarshalReposLabelsData(repoLabels *RepoLabels) error {
+	data, err := yaml.Marshal(repoLabels)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(*dumpRepoLabelsData, []byte(data), 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+// InitWithRepo initialize (possibly empty UpdatesData)
+// Create map if not yet created
+// Create empty list for given repo if this repo is not in the map
+func (ud *UpdateData) InitWithRepo(repo string) {
+	if ud.ReposToUpdate == nil {
+		ud.ReposToUpdate = make(map[string][]UpdateItem)
+	}
+	if _, foundRepo := ud.ReposToUpdate[repo]; !foundRepo {
+		ud.ReposToUpdate[repo] = []UpdateItem{}
+	}
+}
+
+// Eq compares two labels - they're equal if their Name and Color match
+func (l *Label) Eq(otherLabel *Label) bool {
+	return l.Name == otherLabel.Name && l.Color == otherLabel.Color
+}
+
+// SyncLabels this is a main workhorse.
+// Pre requisites:
+// `labels.yaml` file should should have unique labels with a case insensitive comparison! Otherwise it reports FATAL and exits
+// Each repository's labels should be unique when comapred witout case sensitive, if not it reports FATAL and exits
+// Labels can be non-unique (without case sensitive) in different repos - because that mean each wrong case label is unique per repo so can be updated there.
+// It iterates all repos to see if they have required labels
+// Possible cases (for each label on each repo compared with required) iteration: all repos, then all required labels
+// 1. Exact match - all OK
+// 2. Name exact match - wrong color --> add this label to update list
+// 3. If required label (downcased) matches some repo's label (downcased) - wrong name --> add this label to update list
+// In this case we have actual repo's label (wrong case) and required (with correct case) we will update name (using wrong case as key) and evetually color too
+// 4. Not found (no exact name match and no match without case) --> add this label to update list (with mising flag which mean that it needs to be added)
+func SyncLabels(required *RequiredLabels, curr *RepoLabels) (updates UpdateData, err error) {
+	var (
+		currMap      map[string]map[string]Label
+		currMapLower map[string]map[string]Label
+		reqMap       map[string]Label
+		reqMapLower  map[string]Label
+	)
+
+	// Create mapping of required labels --> their label data (name & color)
+	// Make sure that downcased names are unique (required labels are constant from labels.yaml file)
+	reqMap = make(map[string]Label)
+	reqMapLower = make(map[string]Label)
+	for _, label := range required.Labels {
+		lbl := Label{Name: label.Name, Color: label.Color}
+		reqMap[label.Name] = lbl
+		lowerName := strings.ToLower(label.Name)
+		if _, ok := reqMapLower[lowerName]; ok {
+			logrus.Errorf("ERROR: label %s is not unique when downcased", label.Name)
+			err = errors.New("label " + label.Name + " is not unique when downcased in input config")
+			return
+		}
+		reqMapLower[lowerName] = lbl
+	}
+	reqMapLower = nil
+
+	// create map of [repo][label anme] --> label data
+	// Also create map with downcased names
+	// Warn if downcased label names are not unique
+	currMap = make(map[string]map[string]Label)
+	currMapLower = make(map[string]map[string]Label)
+	for repo, labels := range curr.Labels {
+		currMap[repo] = make(map[string]Label)
+		currMapLower[repo] = make(map[string]Label)
+		for _, label := range labels {
+			lbl := Label{Name: label.Name, Color: label.Color}
+			currMap[repo][label.Name] = lbl
+			lowerName := strings.ToLower(label.Name)
+			if _, ok := currMapLower[repo][lowerName]; ok {
+				logrus.Infof("ERROR: repo %s, label %s is not unique when downcased", repo, label.Name)
+				err = errors.New("repository: " + repo + ", label " + label.Name + " is not unique when downcased in input config")
+				return
+			}
+			currMapLower[repo][lowerName] = lbl
+		}
+	}
+
+	// Iterate all repos
+	for repo, repoLabels := range currMap {
+		repoLabelsLower := currMapLower[repo]
+		//logrus.Infof("Checking repo: %s, %T", repo, repoLabels)
+		// Iterate required labels
+		for requiredName, requiredLab := range reqMap {
+			//logrus.Infof("Checking for label: %s, %T", requiredName, requiredLab)
+			foundLabel, ok := repoLabels[requiredName]
+			if ok && foundLabel.Eq(&requiredLab) {
+				// Case 1 - exact label found
+				//logrus.Infof("Repo: %s, Label: %s - found exact", repo, requiredName)
+				continue
+			}
+			if ok {
+				// Case 2: Wrong label color
+				//logrus.Infof("Repo: %s, Label: %s - found but needs color update %s --> %s", repo, requiredName, foundLabel.Color, requiredLab.Color)
+				updates.InitWithRepo(repo)
+				updates.ReposToUpdate[repo] = append(updates.ReposToUpdate[repo], UpdateItem{Why: "invalid_color", RequiredLabel: requiredLab, CurrentLabel: foundLabel})
+				continue
+			}
+			requiredNameLower := strings.ToLower(requiredName)
+			foundLabel, ok = repoLabelsLower[requiredNameLower]
+			if ok {
+				// Case 3 - wrong label name (wrong case) and possibly color too (it needs update anyway)
+				//logrus.Infof("Repo: %s, Label: %s - found but needs name update (and maybe color): %v --> %v", repo, requiredName, foundLabel, requiredLab)
+				updates.InitWithRepo(repo)
+				updates.ReposToUpdate[repo] = append(updates.ReposToUpdate[repo], UpdateItem{Why: "invalid_name", RequiredLabel: requiredLab, CurrentLabel: foundLabel})
+				continue
+			}
+			// Case 4: label not found - add to missing labels
+			//logrus.Infof("Repo: %s, Label: %s - not found %v", repo, requiredName, requiredLab)
+			updates.InitWithRepo(repo)
+			updates.ReposToUpdate[repo] = append(updates.ReposToUpdate[repo], UpdateItem{Why: "missing", RequiredLabel: requiredLab, CurrentLabel: Label{}})
+		}
+	}
+	return
+}
+
+// DoUpdates iterates generated update data and adds and/or modifies labels on repositories
+// Uses AddLabel GH API to add missing labels
+// And UpdateLabel GH API to update color or name (name only when case differs)
+func (ud *UpdateData) DoUpdates(gc *github.Client) error {
+	org, _ := GetOrg(*org)
+	for repo, list := range ud.ReposToUpdate {
+		for _, item := range list {
+			if *debug {
+				fmt.Printf("%s/%s: %s %+v\n", org, repo, item.Why, item.RequiredLabel)
+			}
+			if item.Why == "missing" {
+				err := gc.AddRepoLabel(org, repo, item.RequiredLabel.Name, item.RequiredLabel.Color)
+				if err != nil {
+					return err
+				}
+			} else if item.Why == "invalid_color" || item.Why == "invalid_name" {
+				err := gc.UpdateRepoLabel(org, repo, item.RequiredLabel.Name, item.RequiredLabel.Color)
+				if err != nil {
+					return err
+				}
+			} else {
+				return errors.New("unknown label operation: " + item.Why)
+			}
+		}
+	}
+	return nil
+}
+
+// Main function
+// Typical run with production configuartion should require no parameters
+// It expects:
+// "labels" file in "/etc/config/labels.yaml"
+// github OAuth2 token in "/etc/github/oauth", this token must have write access to all org's repos
+// default org is "kubernetes"
+// It uses request retrying (in case of run out of GH API points)
+// It took about 10 minutes to process all my 8 repos with all required "kubernetes" labels (70+)
+// Next run takes about 22 seconds to check if all labels are correct on all repos
+func main() {
+	flag.Parse()
+
+	var (
+		labels       RequiredLabels
+		repos        RepoList
+		currLabels   RepoLabels
+		githubClient *github.Client
+	)
+	currLabels.Labels = make(map[string][]github.Label)
+
+	if err := labels.Load(*labelsPath); err != nil {
+		logrus.WithError(err).Fatalf("cannot read labels file: %v", *labelsPath)
+	}
+
+	if *local {
+		githubClient = github.NewFakeClient()
+		githubClient.Logger = logrus.StandardLogger()
+
+		if *reposData != "" {
+			if err := UnmarshalReposData(&repos); err != nil {
+				logrus.WithError(err).Fatalf("cannot unmarshal repositories from %s", *reposData)
+			}
+		}
+		if *repoLabelsData != "" {
+			if err := UnmarshalRepoLabelsData(&currLabels); err != nil {
+				logrus.WithError(err).Fatalf("cannot unmarshal repositories labels from %s", *repoLabelsData)
+			}
+		}
+
+		if *reposData == "" || *repoLabelsData == "" {
+			logrus.Infof("Cannot get repository and labels data in -local mode without generated YAML files.")
+			logrus.Infof("Please provide example data with -repos and -repo-labels (eventually generate it from non-local run via -dump-repos and -dump-repo-labels)")
+			logrus.Fatalf("No example data provided for -local mode")
+		}
+
+	} else {
+		oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
+		if err != nil {
+			logrus.WithError(err).Fatal("could not read oauth secret file.")
+		}
+		oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
+
+		if *dry {
+			githubClient = github.NewDryRunClient(oauthSecret, *endPoint)
+		} else {
+			githubClient = github.NewClient(oauthSecret, *endPoint)
+		}
+
+		if *reposData != "" {
+			if err := UnmarshalReposData(&repos); err != nil {
+				logrus.WithError(err).Fatalf("cannot unmarshal repositories from %s", *reposData)
+			}
+		} else {
+			// This is a real GH API call to get repos and labels, please avoid in local dev if possible
+			// Just run once with -dump-repos and -dump-repo-labels and then use generated YAML files to save GH API points
+			if err := repos.Get(githubClient); err != nil {
+				logrus.WithError(err).Fatalf("cannot read %v repositories", *org)
+			}
+		}
+
+		if *repoLabelsData != "" {
+			if err := UnmarshalRepoLabelsData(&currLabels); err != nil {
+				logrus.WithError(err).Fatalf("cannot unmarshal repositories labels from %s", *repoLabelsData)
+			}
+		} else {
+			if err := currLabels.Get(githubClient, &repos); err != nil {
+				logrus.WithError(err).Fatalf("cannot read %v repositories labels", *org)
+			}
+		}
+	}
+
+	if *dumpReposData != "" {
+		if err := MarshalReposData(&repos); err != nil {
+			logrus.WithError(err).Fatalf("cannot marshal repositories to %s", *dumpReposData)
+		}
+	}
+
+	if *dumpRepoLabelsData != "" {
+		if err := MarshalReposLabelsData(&currLabels); err != nil {
+			logrus.WithError(err).Fatalf("cannot marshal repositories labels data to %s", *dumpRepoLabelsData)
+		}
+	}
+
+	updates, err := SyncLabels(&labels, &currLabels)
+	if err != nil {
+		logrus.WithError(err).Fatalf("failed to sync labels")
+	}
+	y, err := yaml.Marshal(&updates)
+	if *debug {
+		fmt.Printf(string(y))
+	}
+
+	if *dry || *local {
+		logrus.Infof("No real update labels in -dry-run or local -mode, exiting")
+		return
+	}
+
+	err = updates.DoUpdates(githubClient)
+	if err != nil {
+		logrus.WithError(err).Fatalf("failed to update labels")
+	}
+}

--- a/label_sync/main_test.go
+++ b/label_sync/main_test.go
@@ -1,0 +1,338 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+// Tests for getting data from GitHub are not needed:
+// The would have to use real API point or test stubs
+
+// Test SyncLabels(required *RequiredLabels, curr *RepoLabels) (updates UpdateData, err error)
+// Input: RequiredLabels list and Current labels list on multiple repos
+// Output: list of required label updates (update due to name or color) addition due to missing labels
+// This is main testing for this program
+func TestSyncLabels(t *testing.T) {
+	var testcases = []struct {
+		name            string
+		requiredLabels  RequiredLabels
+		currentLabels   RepoLabels
+		expectedUpdates UpdateData
+		expectedError   error
+	}{
+		{
+			name:            "All empty",
+			requiredLabels:  RequiredLabels{},
+			currentLabels:   RepoLabels{},
+			expectedUpdates: UpdateData{},
+		},
+		{
+			name: "Duplicate required label",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "lab1", Color: "deadbe"},
+				{Name: "lab1", Color: "befade"},
+			}},
+			currentLabels:   RepoLabels{},
+			expectedUpdates: UpdateData{},
+			expectedError:   errors.New("label lab1 is not unique when downcased in input config"),
+		},
+		{
+			name: "Required label has non unique labels when downcased",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "lab1", Color: "deadbe"},
+				{Name: "LAB1", Color: "deadbe"},
+			}},
+			currentLabels:   RepoLabels{},
+			expectedUpdates: UpdateData{},
+			expectedError:   errors.New("label LAB1 is not unique when downcased in input config"),
+		},
+		{
+			name:           "Duplicate label on repo1",
+			requiredLabels: RequiredLabels{},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {
+					{Name: "lab1", Color: "deadbe"},
+					{Name: "lab1", Color: "befade"},
+				},
+			}},
+			expectedUpdates: UpdateData{},
+			expectedError:   errors.New("repository: repo1, label lab1 is not unique when downcased in input config"),
+		},
+		{
+			name:           "Non unique label on repo1 when downcased",
+			requiredLabels: RequiredLabels{},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {
+					{Name: "lab1", Color: "deadbe"},
+					{Name: "LAB1", Color: "deadbe"},
+				},
+			}},
+			expectedUpdates: UpdateData{},
+			expectedError:   errors.New("repository: repo1, label LAB1 is not unique when downcased in input config"),
+		},
+		{
+			name:           "Non unique label but on different repos - allowed",
+			requiredLabels: RequiredLabels{},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {{Name: "lab1", Color: "deadbe"}},
+				"repo2": {{Name: "lab1", Color: "deadbe"}},
+			}},
+			expectedUpdates: UpdateData{},
+		},
+		{
+			name: "Repo has exactly all required labels",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "lab1", Color: "deadbe"},
+			}},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {
+					{Name: "lab1", Color: "deadbe"},
+				},
+			}},
+			expectedUpdates: UpdateData{},
+		},
+		{
+			name: "Repo has label with wrong color",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "lab1", Color: "deadbe"},
+			}},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {
+					{Name: "lab1", Color: "bebeef"},
+				},
+			}},
+			expectedUpdates: UpdateData{ReposToUpdate: map[string][]UpdateItem{
+				"repo1": {
+					{Why: "invalid_color", RequiredLabel: Label{Name: "lab1", Color: "deadbe"}, CurrentLabel: Label{Name: "lab1", Color: "bebeef"}},
+				},
+			}},
+		},
+		{
+			name: "Repo has label with wrong name (different case)",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "Lab1", Color: "deadbe"},
+			}},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {
+					{Name: "laB1", Color: "deadbe"},
+				},
+			}},
+			expectedUpdates: UpdateData{ReposToUpdate: map[string][]UpdateItem{
+				"repo1": {
+					{Why: "invalid_name", RequiredLabel: Label{Name: "Lab1", Color: "deadbe"}, CurrentLabel: Label{Name: "laB1", Color: "deadbe"}},
+				},
+			}},
+		},
+		{
+			name: "Repo is missing a label",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "Lab1", Color: "deadbe"},
+			}},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {},
+			}},
+			expectedUpdates: UpdateData{ReposToUpdate: map[string][]UpdateItem{
+				"repo1": {
+					{Why: "missing", RequiredLabel: Label{Name: "Lab1", Color: "deadbe"}, CurrentLabel: Label{}},
+				},
+			}},
+		},
+		{
+			name: "Repo is missing multiple labels, and expected labels order is changed",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "Lab1", Color: "deadbe"},
+				{Name: "Lab2", Color: "000000"},
+				{Name: "Lab3", Color: "ffffff"},
+			}},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {},
+				"repo2": {
+					{Name: "Lab2", Color: "000000"},
+				},
+			}},
+			expectedUpdates: UpdateData{ReposToUpdate: map[string][]UpdateItem{
+				"repo2": {
+					{Why: "missing", RequiredLabel: Label{Name: "Lab3", Color: "ffffff"}, CurrentLabel: Label{}},
+					{CurrentLabel: Label{}, Why: "missing", RequiredLabel: Label{Name: "Lab1", Color: "deadbe"}},
+				},
+				"repo1": {
+					{Why: "missing", RequiredLabel: Label{Color: "000000", Name: "Lab2"}, CurrentLabel: Label{}},
+					{Why: "missing", RequiredLabel: Label{Name: "Lab3", Color: "ffffff"}, CurrentLabel: Label{}},
+					{Why: "missing", RequiredLabel: Label{Name: "Lab1", Color: "deadbe"}, CurrentLabel: Label{}},
+				},
+			}},
+		},
+		{
+			name: "Multiple repos complex case",
+			requiredLabels: RequiredLabels{Labels: []Label{
+				{Name: "priority/P0", Color: "ff0000"},
+				{Name: "lgtm", Color: "00ff00"},
+			}},
+			currentLabels: RepoLabels{Labels: map[string][]github.Label{
+				"repo1": {
+					{Name: "Priority/P0", Color: "ee3333"},
+					{Name: "LGTM", Color: "00ff00"},
+				},
+				"repo2": {
+					{Name: "priority/P0", Color: "ee3333"},
+					{Name: "lgtm", Color: "00ff00"},
+				},
+				"repo3": {
+					{Name: "PRIORITY/P0", Color: "ff0000"},
+					{Name: "lgtm", Color: "0000ff"},
+				},
+				"repo4": {
+					{Name: "priority/P0", Color: "ff0000"},
+				},
+				"repo5": {
+					{Name: "lgtm", Color: "00ff00"},
+				},
+			}},
+			expectedUpdates: UpdateData{ReposToUpdate: map[string][]UpdateItem{
+				"repo1": {
+					{Why: "invalid_name", RequiredLabel: Label{Name: "priority/P0", Color: "ff0000"}, CurrentLabel: Label{Name: "Priority/P0", Color: "ee3333"}},
+					{Why: "invalid_name", RequiredLabel: Label{Name: "lgtm", Color: "00ff00"}, CurrentLabel: Label{Name: "LGTM", Color: "00ff00"}},
+				},
+				"repo2": {
+					{Why: "invalid_color", RequiredLabel: Label{Name: "priority/P0", Color: "ff0000"}, CurrentLabel: Label{Name: "priority/P0", Color: "ee3333"}},
+				},
+				"repo3": {
+					{Why: "invalid_name", RequiredLabel: Label{Name: "priority/P0", Color: "ff0000"}, CurrentLabel: Label{Name: "PRIORITY/P0", Color: "ff0000"}},
+					{Why: "invalid_color", RequiredLabel: Label{Name: "lgtm", Color: "00ff00"}, CurrentLabel: Label{Name: "lgtm", Color: "0000ff"}},
+				},
+				"repo4": {
+					{Why: "missing", RequiredLabel: Label{Name: "lgtm", Color: "00ff00"}, CurrentLabel: Label{}},
+				},
+				"repo5": {
+					{Why: "missing", RequiredLabel: Label{Name: "priority/P0", Color: "ff0000"}, CurrentLabel: Label{}},
+				},
+			}},
+		},
+	}
+
+	// Do tests
+	for i, tc := range testcases {
+		actualUpdates, err := SyncLabels(&tc.requiredLabels, &tc.currentLabels)
+		if err == nil && tc.expectedError != nil || err != nil && tc.expectedError == nil {
+			t.Errorf("TestSyncLabel: test case number %d: '%s': expected err '%+v', got '%+v'", i+1, tc.name, tc.expectedError, err)
+		}
+		if err != nil && tc.expectedError != nil && err.Error() != tc.expectedError.Error() {
+			t.Errorf("TestSyncLabel: test case number %d: '%s: expected err '%+v', got '%+v'", i+1, tc.name, tc.expectedError.Error(), err.Error())
+		}
+		if !equalUpdates(&actualUpdates, &tc.expectedUpdates, t) {
+			t.Errorf("TestSyncLabel: test case number %d: '%s': expected updates:\n%+v\ngot:\n%+v", i+1, tc.name, tc.expectedUpdates, actualUpdates)
+		}
+	}
+}
+
+// This is needed to compare Update sets, two update sets are equal
+// only if their maps have the same lists (but order can be different)
+// Using standard `reflect.DeepEqual` for entire structures makes tests flaky
+func equalUpdates(updateData1, updateData2 *UpdateData, t *testing.T) bool {
+	updates1, updates2 := updateData1.ReposToUpdate, updateData2.ReposToUpdate
+	if len(updates1) != len(updates2) {
+		t.Errorf("ERROR: expected and actual update sets have different repo sets")
+		return false
+	}
+	// Iterate per repository differences
+	for repo, list1 := range updates1 {
+		list2, ok := updates2[repo]
+		if !ok || len(list1) != len(list2) {
+			t.Errorf("ERROR: expected and actual update lists for repo %s have different lengths", repo)
+			return false
+		}
+		items1 := make(map[string]bool)
+		for _, item := range list1 {
+			j, err := json.Marshal(item)
+			if err != nil {
+				t.Errorf("ERROR: internal test error: unable to json.Marshal test item: %+v", item)
+				return false
+			}
+			items1[string(j)] = true
+		}
+		items2 := make(map[string]bool)
+		for _, item := range list2 {
+			j, err := json.Marshal(item)
+			if err != nil {
+				t.Errorf("ERROR: internal test error: unable to json.Marshal test item: %+v", item)
+				return false
+			}
+			items2[string(j)] = true
+		}
+		// Iterate list of label differences
+		for key := range items1 {
+			_, ok := items2[key]
+			if !ok {
+				t.Errorf("ERROR: difference: repo: %s, key: %s not found", repo, key)
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Test loading YAML file (labels.yaml)
+func TestLoadYAML(t *testing.T) {
+	var testcases = []struct {
+		path     string
+		expected RequiredLabels
+		ok       bool
+		errMsg   string
+	}{
+		{
+			path: "labels_example.yaml",
+			expected: RequiredLabels{Labels: []Label{
+				{Name: "lgtm", Color: "green"},
+				{Name: "priority/P0", Color: "red"},
+			}},
+			ok: true,
+		},
+		{
+			path:     "syntax_error_example.yaml",
+			expected: RequiredLabels{},
+			ok:       false,
+			errMsg:   "error converting",
+		},
+		{
+			path:     "no_such_file.yaml",
+			expected: RequiredLabels{},
+			ok:       false,
+			errMsg:   "no such file",
+		},
+	}
+	for i, tc := range testcases {
+		actual := RequiredLabels{}
+		err := actual.Load(tc.path)
+		errNil := (err == nil)
+		if errNil != tc.ok {
+			t.Errorf("TestLoadYAML: test case number %d, expected ok: %v, got %v (error=%v)", i+1, tc.ok, err == nil, err)
+		}
+		if !errNil && !strings.Contains(err.Error(), tc.errMsg) {
+			t.Errorf("TestLoadYAML: test case number %d, expected error '%v' to contain '%v'", i+1, err.Error(), tc.errMsg)
+		}
+		if errNil && !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("TestLoadYAML: test case number %d, expected labels %v, got %v", i+1, tc.expected, actual)
+		}
+	}
+}

--- a/label_sync/repos.yaml
+++ b/label_sync/repos.yaml
@@ -1,0 +1,6 @@
+org: kubernetes
+repos:
+- full_name: kubernetes/test-infra
+  name: test-infra
+- full_name: kubernetes/community
+  name: community

--- a/label_sync/syntax_error_example.yaml
+++ b/label_sync/syntax_error_example.yaml
@@ -1,0 +1,4 @@
+---
+labels:
+  - name: %invalid name ?
+    color: "abc


### PR DESCRIPTION
This PR adds `label_sync` tool: #2504 
It uses `labels.yaml` file to sync standard labels set across all `kubernetes` repos.
Please refer to `label_sync/README.md` for details.

This PR is *NOT* ready - I've created new tool, but it is not connected. I needs to be run `daily` like something like `prow` job, but I didn't yet have a time to figure out how to connect it. It is also my first task like it so *ANY* feedback about how to connect it is very very very welcomed.

Main souce files are: `label_test/main.go` and `label_sync/main_test.go`.
