### PR TITLE
remove memcg test job added by #2266

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -133,12 +133,6 @@
         job-name: ci-kubernetes-node-kubelet-serial
         repo-name: k8s.io/kubernetes
         timeout: 240
-    - kubernetes-node-memcg-serial: # dashpole
-        branch: master
-        frequency: 'H H/2 * * *'
-        job-name: ci-kubernetes-node-memcg-serial
-        repo-name: k8s.io/kubernetes
-        timeout: 60
     - kubernetes-node-kubelet-benchmark:  # zhoufang
         branch: master
         frequency: 'H H/2 * * *'

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2367,12 +2367,6 @@
     ], 
     "scenario": "kubernetes_kubelet"
   }, 
-  "ci-kubernetes-node-memcg-serial": {
-    "args": [
-      "--properties=test/e2e_node/jenkins/jenkins-memcg-serial.properties"
-    ], 
-    "scenario": "kubernetes_kubelet"
-  }, 
   "ci-kubernetes-pull-gce-federation-deploy": {
     "args": [
       "--env-file=platforms/gce.env", 

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -58,8 +58,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet
 - name: ci-kubernetes-node-kubelet-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial
-- name: ci-kubernetes-node-memcg-serial
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-memcg-serial
 - name: ci-kubernetes-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
 - name: ci-kubernetes-build-1.4
@@ -1332,8 +1330,6 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet
   - name: kubelet-serial-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-serial
-  - name: kubelet-memcg-serial-gce-e2e
-    test_group_name: ci-kubernetes-node-memcg-serial
   - name: kubelet-flaky-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-flaky
   - name: kubelet-conformance-gce-e2e


### PR DESCRIPTION
Issue: https://github.com/kubernetes/kubernetes/issues/42676
Once https://github.com/kubernetes/kubernetes/pull/45602 is merged, all GCI test jobs are run with --enable-kernel-memcg-notifications=true.
The individual test job added by #2266 is no longer needed.
