### PR TITLE
increase timeout for gci-gce-serial

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -271,8 +271,8 @@
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gci-gce-serial:
         job-name: ci-kubernetes-e2e-gci-gce-serial
-        jenkins-timeout: 420
-        timeout: 320
+        jenkins-timeout: 620
+        timeout: 520
         frequency: 'H/5 * * * *' # At least every 30m
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gci-gce-reboot:

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial.env
@@ -3,4 +3,4 @@ GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\
 PROJECT=k8s-jkns-e2e-gce-gci-serial
 KUBE_OS_DISTRIBUTION=gci
 
-KUBEKINS_TIMEOUT=300m
+KUBEKINS_TIMEOUT=500m


### PR DESCRIPTION
Increase the timeout to match the gce-serial timeout changed in #2299

Tests have been constantly timing out[1] and the gce-serial test are just above 300m[2].

[1] https://k8s-testgrid.appspot.com/google-gce#gci-gce-serial
[2] https://k8s-testgrid.appspot.com/google-gce#gce-serial&graph-metrics=test-duration-minutes