### PR TITLE
Use GOPATH instead of WORKSPACE for clusterloader --root

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1564,7 +1564,7 @@ periodics:
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
-      - "--root=$(WORKSPACE)/src/k8s.io"
+      - "--root=${GOPATH}/src"
       - "--timeout=60"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
Ref #2709, I believe this is a more proper fix than #2710.
I think we also want to use `${var}` rather than `$(var)` since the environment variable is defined in the docker image, not in the kubernetes pod spec. @spxtr am I understanding this correctly?

/assign @wojtek-t @gmarek 