### PR TITLE
Delete index.lock file before resetting 'git_cache'd repos

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -225,6 +225,7 @@ def checkout(call, repo, branch, pull, ssh='', git_cache='', clean=False):
         except OSError:
             pass
         call([git, 'init', repo, '--separate-git-dir=%s' % cache_dir])
+        call(['rm', '-f', '%s/index.lock' % cache_dir])
     else:
         call([git, 'init', repo])
     os.chdir(repo)


### PR DESCRIPTION
'Jenkins Bazel Build' pre-commit failed for PR https://github.com/kubernetes/kubernetes/pull/45672 in this run -> https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/45672/pull-kubernetes-bazel/19577/. And the reason was the index lock file `/root/.cache/git/k8s.io/kubernetes/index.lock` already existing while trying to `git reset`.
Added a line to now delete it (ref http://stackoverflow.com/a/7860765).

cc @fejta