### PR TITLE
Fix clusterloader job by using /go instead of $GOPATH

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1568,7 +1568,7 @@ periodics:
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
-      - "--root=${GOPATH}/src"
+      - "--root=/go/src"
       - "--timeout=60"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
Fixes #2716.

/assign @wojtek-t 