### PR TITLE
Update triage-filer to explain why issues are assigned and sig labels are applied.

### DIFF
--- a/mungegithub/mungers/issue-creator.go
+++ b/mungegithub/mungers/issue-creator.go
@@ -323,28 +323,24 @@ func (c *IssueCreator) TestOwner(testName string) string {
 
 // TestSIG uses the IssueCreator's OwnerMapper to look up the SIGs for a list of tests.
 // The number of SIGs returned is limited by maxSIGCount.
-func (c *IssueCreator) TestsSIGs(testNames []string) []string {
+// The return value is a map from sigs to the tests from testNames that each sig owns.
+func (c *IssueCreator) TestsSIGs(testNames []string) map[string][]string {
 	if c.owners == nil {
-		return []string{}
+		return nil
 	}
-	var sigs []string
+	sigs := make(map[string][]string)
 	for _, test := range testNames {
 		sig := c.owners.TestSIG(test)
 		if sig == "" {
 			continue
 		}
-		found := false
-		for _, oldsig := range sigs {
-			if sig == oldsig {
-				found = true
-				break
+
+		if len(sigs) >= c.maxSIGCount {
+			if tests, ok := sigs[sig]; ok {
+				sigs[sig] = append(tests, test)
 			}
-		}
-		if !found {
-			sigs = append(sigs, sig)
-			if len(sigs) >= c.maxSIGCount {
-				break
-			}
+		} else {
+			sigs[sig] = append(sigs[sig], test)
 		}
 	}
 	return sigs
@@ -352,28 +348,24 @@ func (c *IssueCreator) TestsSIGs(testNames []string) []string {
 
 // TestOwner uses the IssueCreator's OwnerMapper to look up the users assigned to a list of tests.
 // The number of users returned is limited by maxAssignees.
-func (c *IssueCreator) TestsOwners(testNames []string) []string {
+// The return value is a map from users to the test names from testNames that each user owns.
+func (c *IssueCreator) TestsOwners(testNames []string) map[string][]string {
 	if c.owners == nil {
-		return []string{}
+		return nil
 	}
-	var users []string
+	users := make(map[string][]string)
 	for _, test := range testNames {
 		user := c.owners.TestOwner(test)
 		if user == "" {
 			continue
 		}
-		found := false
-		for _, olduser := range users {
-			if olduser == user {
-				found = true
-				break
+
+		if len(users) >= c.maxAssignees {
+			if tests, ok := users[user]; ok {
+				users[user] = append(tests, test)
 			}
-		}
-		if !found {
-			users = append(users, user)
-			if len(users) >= c.maxAssignees {
-				break
-			}
+		} else {
+			users[user] = append(users[user], test)
 		}
 	}
 	return users

--- a/mungegithub/mungers/triage-filer_test.go
+++ b/mungegithub/mungers/triage-filer_test.go
@@ -137,10 +137,10 @@ func init() {
 
 	sampleOwnerCSV = []byte(
 		`name,owner,auto-assigned,sig
-DEFAULT,rmmh/spxtr/ixdy/apelisse/fejta,0,
 Sysctls should support sysctls,Random-Liu,1,node
 Sysctls should support unsafe sysctls which are actually whitelisted,deads2k,1,node
-testname1,cjwagner,1,sigarea
+testname1,cjwagner ,1,sigarea
+testname2,spxtr,1,sigarea
 ThirdParty resources Simple Third Party creating/deleting thirdparty objects works,luxas,1,api-machinery
 Upgrade cluster upgrade should maintain a functioning cluster,luxas,1,cluster-lifecycle
 Upgrade master upgrade should maintain a functioning cluster,xiang90,1,cluster-lifecycle
@@ -355,6 +355,17 @@ func TestTFOwnersAndSIGs(t *testing.T) {
 	}
 	if !foundUser {
 		t.Errorf("Failed to get the owner for cluster: %s\n", clusters[0].Id)
+	}
+	// Check that the body contains a table that correctly explains why users and sig areas were assigned.
+	body := clusters[0].Body(nil)
+	if !strings.Contains(body, "| cjwagner | testname1 |") {
+		t.Errorf("Body should contain a table row to explain that 'cjwagner' was assigned due to ownership of 'testname1'.")
+	}
+	if !strings.Contains(body, "| spxtr | testname2 |") {
+		t.Errorf("Body should contain a table row to explain that 'spxtr' was assigned due to ownership of 'testname2'.")
+	}
+	if !strings.Contains(body, "| sig/sigarea | testname1; testname2 |") {
+		t.Errorf("Body should contain a table row to explain that 'sigarea' was set as a SIG due to ownership of 'testname1' and 'testname2'.")
 	}
 }
 


### PR DESCRIPTION
See my comment bellow for an example of what an issue will look like now if there are users or sig areas assigned to it. The change is the addition of the 'Rationale for assignments' collapsible section near the bottom. 
(Note: I removed the failure cluster key from the example to prevent this PR from interfering with the 'github search' button on the triage page for that cluster.)
