### PR TITLE
Update bazel image to use multirepo-compatible bootstrap args

### DIFF
--- a/images/pull_kubernetes_bazel/Dockerfile
+++ b/images/pull_kubernetes_bazel/Dockerfile
@@ -30,24 +30,24 @@ RUN apt-get update && apt-get install -y \
     python-pip && \
     apt-get clean
 
-ENV BAZEL_VERSION 0.4.5
-RUN wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
+ENV BAZEL_VERSION 0.5.0
+RUN wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     rm "bazel_${BAZEL_VERSION}-linux-x86_64.deb"
 
-ENV GCLOUD_VERSION 149.0.0
-RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
+ENV GCLOUD_VERSION 156.0.0
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     tar xf google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     rm google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     ./google-cloud-sdk/install.sh
 ENV PATH "/google-cloud-sdk/bin:${PATH}"
 
 ENV NODE_VERSION 6.10.0
-RUN wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && \
+RUN wget -q https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && \
     tar xf node-v${NODE_VERSION}-linux-x64.tar.xz --strip-components=1 -C /usr && \
     rm node-v${NODE_VERSION}-linux-x64.tar.xz && \
     npm install -g mocha
 
 WORKDIR /workspace
-ADD runner /
-ENTRYPOINT ["/bin/bash", "/runner"]
+COPY runner coalesce.py /usr/local/bin/
+ENTRYPOINT ["/bin/bash", "/usr/local/bin/runner"]

--- a/images/pull_kubernetes_bazel/Makefile
+++ b/images/pull_kubernetes_bazel/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.11
+VERSION = 0.12
 
 image:
 	docker build -t "gcr.io/k8s-testimages/bazelbuild:$(VERSION)" .

--- a/images/pull_kubernetes_bazel/runner
+++ b/images/pull_kubernetes_bazel/runner
@@ -19,7 +19,7 @@ set -o pipefail
 
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
-    --repo="k8s.io/${REPO_NAME:-test-infra}" \
+    --repo="k8s.io/${REPO_NAME}=${PULL_REFS:-master}" \
     --job=${JOB_NAME} \
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     "$@"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -498,9 +498,8 @@ presubmits:
     trigger: "@k8s-bot (pull-test-infra-bazel |bazel )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
-        - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--git-cache=/root/.cache/git"
         - "--clean"
@@ -815,9 +814,8 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
-        - "--branch=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
         - "--clean"
@@ -888,9 +886,8 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.11
+    - image: gcr.io/k8s-testimages/bazelbuild:0.12
       args:
-      - "--branch=master"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--git-cache=/root/.cache/git"
       - "--clean"


### PR DESCRIPTION
Additionally, update test-infra jobs to use new bazelbuild image.

Part of #2704.

I think this might work, but I have no idea how to test it. As such, I'm planning to test only on the test-infra repo to start.

/assign @spxtr 