### PR TITLE
Use release/push-build.sh in ci-kubernetes-bazel-build

### DIFF
--- a/jobs/ci-kubernetes-bazel-build.sh
+++ b/jobs/ci-kubernetes-bazel-build.sh
@@ -34,7 +34,14 @@ if [[ "${rc}" == 0 ]]; then
     echo "Kubernetes version missing; not uploading ci artifacts."
     rc=1
   else
-    bazel run //:ci-artifacts -- "gs://kubernetes-release-dev/bazel/${version}" && rc=$? || rc=$?
+    push_build="../release/push-build.sh"
+    if [[ -x "${push_build}" ]]; then
+      "${push_build}" --bucket=kubernetes-release-dev --nomock --verbose --ci \
+        --gcs-suffix=-bazel && rc=$? || rc=$?
+    else
+      echo "release repository missing; using Bazel gcs upload rule directly"
+      bazel run //:ci-artifacts -- "gs://kubernetes-release-dev/bazel/${version}" && rc=$? || rc=$?
+    fi
   fi
 fi
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -52,9 +52,8 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
-        - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--git-cache=/root/.cache/git"
         - "--clean"
@@ -214,9 +213,8 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
-        - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--git-cache=/root/.cache/git"
         - "--clean"
@@ -469,9 +467,9 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.11
+      - image: gcr.io/k8s-testimages/bazelbuild:0.12
         args:
-        - "--branch=$(PULL_REFS)"
+        - "--repo=k8s.io/release=master"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
         - "--clean"
@@ -498,9 +496,8 @@ postsubmits:
     - name: ci-kubernetes-bazel-test
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:0.11
+        - image: gcr.io/k8s-testimages/bazelbuild:0.12
           args:
-          - "--branch=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/logs"
           - "--git-cache=/root/.cache/git"
           - "--clean"


### PR DESCRIPTION
This will upload the Bazel-built release artifacts to `gs://kubernetes-release-dev/ci-bazel/$version`, and will also generate the `gs://kubernetes-release-dev/ci-bazel/latest*.txt` files we need for CI.

Dependent on #2731.
x-ref #2704 

@pipejakob this is changing the GCS paths for debs yet again (but hopefully for the last time)... is this going to break kubeadm CI?