### PR TITLE
Let janitor also clean up leaking http-health-checks

### DIFF
--- a/jenkins/janitor.py
+++ b/jenkins/janitor.py
@@ -39,6 +39,7 @@ DEMOLISH_ORDER = [
     Resource('url-maps', None, None),
     Resource('backend-services', 'region', None),
     Resource('health-checks', None, None),
+    Resource('http-health-checks', None, None),
     Resource('target-pools', 'region', None),
     Resource('instance-groups', 'zone', 'Yes'),
     Resource('instance-groups', 'zone', 'No'),


### PR DESCRIPTION
Continue PR of #2245.

I just realize that we are using http-health-checks for GCP network load-balancer and for some reasons they are leaking (see k8s-jkns-e2e-gke-slow, k8s-e2e-gce-alpha1-5 and e2e-gce-gci-ci-master-slow) :(

/assign @krzyzacy 