### PR TITLE
Remove NUM_NODES=4 from serial and slow tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-serial.env
@@ -4,7 +4,6 @@ GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\
 JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gce-ubuntu-1-6-serial
-NUM_NODES=4
 
 KUBE_NODE_OS_DISTRIBUTION=ubuntu
 KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1

--- a/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-slow.env
@@ -6,7 +6,6 @@ GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]
 JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gce-ubuntu-1-6-slow
-NUM_NODES=4
 
 KUBE_NODE_OS_DISTRIBUTION=ubuntu
 KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1

--- a/jobs/ci-kubernetes-e2e-gce-ubuntu-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntu-serial.env
@@ -2,7 +2,6 @@
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 PROJECT=k8s-jkns-e2e-gce-ubuntu-serial
-NUM_NODES=4
 
 KUBE_NODE_OS_DISTRIBUTION=ubuntu
 KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1

--- a/jobs/ci-kubernetes-e2e-gce-ubuntu-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntu-slow.env
@@ -4,7 +4,6 @@ GINKGO_PARALLEL_NODES=30
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 PROJECT=k8s-jkns-e2e-gce-ubuntu-slow
-NUM_NODES=4
 
 KUBE_NODE_OS_DISTRIBUTION=ubuntu
 KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1


### PR DESCRIPTION
In https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntu-1-6-serial/206, the resource usage test failed. This test creates (100 * num_nodes) pods and asserts that the memory usage does not exceed the limit. The Ubuntu tests incorrectly use 4 nodes, which causes more memory to be used than expected, while other (correct) tests use default 3 nodes. Remove `NUM_NODES=4` should fix the tests.

The regular tests `ci-kubernetes-e2e-gce-ubuntu-1-6` and `ci-kubernetes-e2e-gce-ubuntu` can use 4 nodes.
