### PR TITLE
Refactor bigquery scenario, include more than 100 rows

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -6,22 +6,24 @@ database. The config files are consumed by the metrics-bigquery periodic prow jo
 ## Metrics
 
 * failures - find jobs that have been failing the longest
-    - Config: [failures-config.yaml](failures-config.yaml)
-    - [Latest results](http://storage.googleapis.com/k8s-metrics/failures/failures-latest.json)
+    - [Config](failures-config.yaml)
+    - [failures-latest.json](http://storage.googleapis.com/k8s-metrics/failures-latest.json)
 * flakes - find the flakiest jobs this week (and the flakiest tests in each job).
-    - Config: [flakes-config.yaml](flakes-config.yaml)
-    - [Latest results](http://storage.googleapis.com/k8s-metrics/flakes/flakes-latest.json)
+    - [Config](flakes-config.yaml)
+    - [flakes-latest.json](http://storage.googleapis.com/k8s-metrics/flakes-latest.json)
 * job-flakes - compute consistency of all jobs
-    - Config: [job-flakes-config.yaml](job-flakes-config.yaml)
-    - [Latest results](http://storage.googleapis.com/k8s-metrics/job-flakes/job-flakes-latest.json)
+    - [Config](job-flakes-config.yaml)
+    - [job-flakes-latest.json](http://storage.googleapis.com/k8s-metrics/job-flakes-latest.json)
 * weekly-consistency - compute overall weekly consistency for PRs
-    - Config: [weekly-consistency-config.yaml](weekly-consistency-config.yaml)
-    - [Latest results](http://storage.googleapis.com/k8s-metrics/weekly-consistency/weekly-consistency-latest.json)
+    - [Config](weekly-consistency-config.yaml)
+    - [weekly-consistency-latest.json](http://storage.googleapis.com/k8s-metrics/weekly-consistency-latest.json)
 
 ## Adding a new metric
 
-To add a new metric, create a PR that adds a new yaml config file specifying the metric name, the bigquery query to execute, and a jq filter to filter the data for the "METRICNAME-latest.json" file.
-Then add the path to the config file as a --config flag value under the args key of the metrics-bigquery job in [test-infra/jobs/config.json](../jobs/config.json). The new metric should have data available on GCS within 24 hours of the changes being merged into the test-infra repo.
+To add a new metric, create a PR that adds a new yaml config file
+specifying the metric name, the bigquery query to execute, and a
+jq filter to filter the data for the `METRICNAME-latest.json`
+file. Find the new metrics on GCS 24 hours after merging.
 
 ## Consistency
 
@@ -30,6 +32,3 @@ example suppose we run a build of a job 5 times at the same commit:
 * 5 passing runs, 0 failing runs: consistent
 * 0 passing runs, 5 failing runs: consistent
 * 1-4 passing runs, 1-4 failing runs: inconsistent aka flaked
-
-
-Future PRs will migrate other queries from [this spreadsheet](https://docs.google.com/spreadsheets/d/16nQPj_40xBgPLprj1DkKVTQ-BgQzO4A707q_JPsdxzY/edit).

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,7 +1,17 @@
 # Bigquery metrics
 
-This folder contains config files describing metrics that summarize data in our Bigquery test result
-database. The config files are consumed by the metrics-bigquery periodic prow job that runs the bigquery image and scenario. Each metric consists of a bigquery query and a jq filter.  The query is run every 24 hours to produce a json data file containing the complete query results named with the format METRICNAME-yyyy-mm-dd.json. These files persist for a year after their creation. Additionally, every time a query completes the associated jq filter is applied to the complete query results and the output is stored in the METRICNAME-latest.json file.
+This folder contains config files describing metrics that summarize data
+in our Bigquery test result database. Config files are consumed
+by the `metrics-bigquery` periodic prow job that runs the bigquery
+image and scenario.  Each metric consists of a bigquery query and
+a jq filter. The query is run every 24 hours to produce a json data
+file containing the complete raw query results named with the format
+'raw-yyyy-mm-dd.json'. The raw file is then filtered with the associated
+jq filter and the results are stored in 'daily-yyyy-mm-dd.json'.  These
+files are stored in the k8s-metrics GCS bucket in a directory named with
+the metric name and persist for a year after their creation. Additionally,
+the latest filtered results for a metric are stored in the root of the
+k8s-metrics bucket and named with the format 'METRICNAME-latest.json'.
 
 ## Metrics
 

--- a/metrics/flakes-config.yaml
+++ b/metrics/flakes-config.yaml
@@ -94,9 +94,9 @@ query: |
   order by flakes desc, build_consistency, commit_consistency, job /* flakiest jobs first */
 
 jqfilter: |
-  [(.[] | select(.flakes|tonumber > 21) | {(.job): {
+  [(.[] | select(.job | contains("pr:")) | {(.job): {
       consistency: (.commit_consistency|tonumber),
       flakes: (.flakes|tonumber),
-      flakiest: ([(.flakiest[] | select(.flakes|tonumber >= 7) | {
+      flakiest: ([(.flakiest[] | select(.flakes|tonumber >= 4) | {
         (.name): (.flakes|tonumber)}) ])| add
   }})] | add

--- a/pylintrc
+++ b/pylintrc
@@ -5,7 +5,7 @@ disable=fixme,locally-disabled,locally-enabled,relative-import
 reports=no
 
 [BASIC]
-good-names=fp
+good-names=fp,_
 
 [DESIGN]
 max-args=12

--- a/scenarios/bigquery.py
+++ b/scenarios/bigquery.py
@@ -14,14 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Runs a bigquery query, filters the results, and uploads the filtered and complete data to GCS."""
+"""Runs bigquery metrics and uploads the result to GCS."""
 
 import argparse
 import glob
+import os
 import re
 import subprocess
 import sys
 import time
+import traceback
 
 import yaml
 
@@ -38,83 +40,96 @@ def check(*cmd, **keyargs):
     subprocess.check_call(*cmd, **keyargs)
 
 def validate_metric_name(name):
-    """Validates that a string is useable as a metric name (Can be used as GCS object name)."""
-    # Regex '$' symbol matches an optional terminating new line so we have to check that the name
+    """Raise if name is non-trivial."""
+    # Regex '$' symbol matches an optional terminating new line
+    # so we have to check that the name
     # doesn't have one if the regex matches.
     if not re.match(r'^[\w-]+$', name) or name[-1] == '\n':
-        raise ValueError('metric name must match the regular expression r\'^[\\w-]+$\'.')
+        raise ValueError(name)
 
 def do_query(query, out_filename, project):
     """Executes a bigquery query, outputting the results to a file."""
     with open(out_filename, 'w') as out_file:
-        check(['bq', 'query', '--format=prettyjson', '--project_id='+project], stdin=query,
-              stdout=out_file)
+        cmd = [
+            'bq', 'query', '-n100000', '--format=prettyjson', '--project_id=%s' % project]
+        check(cmd, stdin=query, stdout=out_file)
 
 def do_jq(jqfilter, data_filename, out_filename, jq_bin='jq'):
-    """Executes a jq command on a data file and outputs the results to a file."""
+    """Executes jq on a data file and outputs the results to a file."""
     with open(out_filename, 'w') as out_file:
         check([jq_bin, jqfilter, data_filename], stdout=out_file)
 
-def run_metric(project, bucket_path, metric, query, jqfilter):
-    """Executes a query, filters the results, and uploads filtered and complete results to GCS."""
-    fulldata_filename = metric + time.strftime('-%Y-%m-%d.json')
-    latest_filename = metric + '-latest.json'
+def run_metric(project, prefix, metric, query, jqfilter):
+    """Runs query and filters results, uploading data to GCS."""
+    stamp = time.strftime('%Y-%m-%d')
+    raw = 'raw-%s.json' % stamp
+    filtered = 'daily-%s.json' % stamp
+    latest = '%s-latest.json' % metric
 
-    do_query(query, fulldata_filename, project)
-    do_jq(jqfilter, fulldata_filename, latest_filename)
-    check(['gsutil', '-h', 'Cache-Control:private, max-age=0, no-transform', 'cp',
-           fulldata_filename, latest_filename, bucket_path + metric + '/'])
+    do_query(query, raw, project)
+    do_jq(jqfilter, raw, filtered)
+    def copy(src, dst):
+        """Use gsutil to copy src to test with minimal caching."""
+        check([
+            'gsutil', '-h', 'Cache-Control:max-age=60', 'cp', src, dst])
 
-def main(configs, project, bucket_path):
+    copy(raw, os.path.join(prefix, metric, raw))
+    copy(filtered, os.path.join(prefix, metric, filtered))
+    copy(filtered, os.path.join(prefix, latest))
+
+def main(configs, project, bucket_path, nonsense=True):
     """Loads metric config files and runs each metric."""
     if not project:
-        raise ValueError('project-id cannot be an empty string.')
+        raise ValueError('project', project)
     if not bucket_path:
-        raise ValueError('bucket cannot be an empty string.')
-    if bucket_path[-1] != '/':
-        bucket_path += '/'
+        raise ValueError('bucket_path', bucket_path)
 
     # the 'bq show' command is called as a hack to dodge the config prompts that bq presents
     # the first time it is run. A newline is passed to stdin to skip the prompt for default project
     # when the service account in use has access to multiple projects.
-    check(['bq', 'show'], stdin='\n')
-
-    if not configs:
-        configs = [open(path) for path in glob.glob("test-infra/metrics/*.yaml")]
+    if nonsense:
+        check(['bq', 'show'], stdin='\n')
 
     errs = []
-    for config_raw in configs:
+    root = os.path.join(os.path.dirname(__file__), '../metrics/*.yaml')
+    for path in configs or glob.glob(root):
         try:
-            config = yaml.safe_load(config_raw)
+            with open(path) as config_raw:
+                config = yaml.safe_load(config_raw)
             if not config:
-                raise ValueError('{} does not contain a valid yaml document.'
-                                 ''.format(config_raw.name))
+                raise ValueError('invalid yaml: %s.' % path)
             metric = config['metric'].strip()
             validate_metric_name(metric)
-            run_metric(project, bucket_path, metric, config['query'], config['jqfilter'])
-        except Exception as exception: # pylint: disable=broad-except
-            errs += exception
-        finally:
-            config_raw.close()
+            run_metric(
+                project,
+                bucket_path,
+                metric,
+                config['query'],
+                config['jqfilter'],
+            )
+        except (ValueError, KeyError, IOError, subprocess.CalledProcessError):
+            print >>sys.stderr, traceback.format_exc()
+            errs += path
 
-    if len(errs) > 0:
-        raise Exception(*errs)
+    if errs:
+        print 'Failed %d configs: %s' % (len(errs), ', '.join(errs))
+        sys.exit(1)
 
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser()
-    PARSER.add_argument('--config',
-                        action='append',
-                        type=argparse.FileType('r'),
-                        help='A yaml config file describing a metric. Configs are taken from '
-                        'test-infra/metrics if not specified.')
-    PARSER.add_argument('--project',
-                        default='k8s-gubernator',
-                        help='The GCS project id to use for the bigquery query.')
-    PARSER.add_argument('--bucket',
-                        default='gs://k8s-metrics',
-                        help='The GCS bucket path to upload output to. Files will be uploaded to a'
-                        ' subdir rooted at this path and named with the metric name.')
+    PARSER.add_argument(
+        '--config', action='append', help='yaml file describing a metric.')
+    PARSER.add_argument(
+        '--project',
+        default='k8s-gubernator',
+        help='Charge the specified account for bigquery usage')
+    PARSER.add_argument(
+        '--bucket',
+        default='gs://k8s-metrics',
+        help='Upload results to the specified gcs bucket.')
+    PARSER.add_argument(
+        '--human', action='store_true', help='Add this for more fast.')
 
     ARGS = PARSER.parse_args()
-    main(ARGS.config, ARGS.project, ARGS.bucket)
+    main(ARGS.config, ARGS.project, ARGS.bucket, not ARGS.human)

--- a/scenarios/bigquery_test.py
+++ b/scenarios/bigquery_test.py
@@ -17,7 +17,6 @@
 """Tests for bigquery.py"""
 
 import argparse
-import glob
 import os
 import shutil
 import sys
@@ -32,35 +31,58 @@ class TestBigquery(unittest.TestCase):
     """Tests the bigquery scenario."""
 
     def test_configs(self):
-        """Test that the yaml config files in test-infra/metrics/ are valid metric config files."""
-        for path in glob.glob('metrics/*.yaml'):
-            with open(path) as config_file:
-                config = yaml.safe_load(config_file)
-                self.assertTrue(config)
-                self.assertTrue(config['metric'])
-                self.assertTrue(config['query'])
-                self.assertTrue(config['jqfilter'])
-                bigquery.validate_metric_name(config['metric'].strip())
+        """All yaml files in metrics are valid."""
+        start = os.path.join(os.path.dirname(__file__), '../metrics')
+        for root, _, names in os.walk(start):
+            for name in names:
+                if name in ['BUILD', 'README.md']:
+                    continue
+                if not name.endswith('.yaml'):
+                    self.fail('Only .yaml files allowed: %s' % name)
+
+                path = os.path.join(root, name)
+                with open(path) as config_file:
+                    config = yaml.safe_load(config_file)
+                    if not config:
+                        self.fail(path)
+                    self.assertIn('metric', config)
+                    self.assertIn('query', config)
+                    self.assertIn('jqfilter', config)
+                    bigquery.validate_metric_name(config['metric'].strip())
 
     def test_jq(self):
-        """Test that the do_jq function can execute a jq filter properly."""
+        """do_jq executes a jq filter properly."""
         # [filter, data, expected output]
-        tests = [['.', '{ "field": "value" }', '{"field":"value"}'],
-                 ['.field', '{ "field": "value" }', '"value"']]
+        tests = [
+            ['.', '{ "field": "value" }', '{"field":"value"}'],
+            ['.field', '{ "field": "value" }', '"value"'],
+        ]
         for test in tests:
             with open(self.data_filename, 'w') as data_file:
                 data_file.write(test[1])
-            bigquery.do_jq(test[0], self.data_filename, self.out_filename, jq_bin=ARGS.jq)
+            bigquery.do_jq(
+                test[0],
+                self.data_filename,
+                self.out_filename,
+                jq_bin=ARGS.jq,
+            )
             with open(self.out_filename) as out_file:
                 actual = out_file.read().replace(' ', '').replace('\n', '')
-                self.assertEqual(actual, test[2], msg='expected jq "{}" on data: {} to output {}'
-                                 ' but got {}'.format(test[0], test[1], test[2], actual))
+                self.assertEqual(actual, test[2])
 
     def test_validate_metric_name(self):
-        """Test the the validate_metric_name function rejects invalid metric names."""
-        tests = ['invalid#metric', 'invalid/metric', 'in\\valid', 'invalid?yes', '*invalid',
-                 '[metric]', 'metric\n', 'met\ric', 'metric& invalid']
-        for test in tests:
+        """validate_metric_name rejects invalid metric names."""
+        for test in [
+                'invalid#metric',
+                'invalid/metric',
+                'in\\valid',
+                'invalid?yes',
+                '*invalid',
+                '[metric]',
+                'metric\n',
+                'met\ric',
+                'metric& invalid',
+        ]:
             self.assertRaises(ValueError, bigquery.validate_metric_name, test)
 
     def setUp(self):
@@ -74,9 +96,7 @@ class TestBigquery(unittest.TestCase):
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser()
-    PARSER.add_argument('--jq',
-                        required=True,
-                        help='The path to the "jq" command.')
+    PARSER.add_argument('--jq', default='jq', help='path to jq binary')
     ARGS, _ = PARSER.parse_known_args()
 
     # Remove the --jq flag and its value so that unittest.main can parse the remaining args without


### PR DESCRIPTION
/assign @cjwagner @rmmh 

* Make scenario pass `pylint`
* Make `--jq` argument optional
* Fix a variety of line breaks
* Require all files in metrics to be yaml files
* Make it faster to find the latest results by using a different name for each one.
* Make initial pydoc line less than 80 chars to match style guidelines.
* Include daily filtered result
* Put latest result in root
* Catch specific exceptions
