### PR TITLE
Add more ubuntu gke e2e tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env
@@ -1,0 +1,11 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
+
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+PROJECT=k8s-jkns-gke-ubuntu-1-6-alpha
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env
@@ -1,0 +1,12 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
+NUM_NODES=3
+
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+PROJECT=k8s-jkns-gke-ubuntu-1-6-as
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env
@@ -1,0 +1,11 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
+
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+PROJECT=k8s-jkns-gke-ubuntu-1-6-flaky
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env
@@ -1,0 +1,12 @@
+### job-env
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
+
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+
+PROJECT=k8s-jkns-gke-ubuntu-1-6-updown
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=30m

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-alpha-features.env
@@ -1,0 +1,9 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
+
+PROJECT=k8s-jkns-gke-ubuntu-alpha
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=180m

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-autoscaling.env
@@ -1,0 +1,10 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
+NUM_NODES=3
+
+PROJECT=k8s-jkns-gke-ubuntu-as
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-flaky.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-flaky.env
@@ -1,0 +1,9 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
+
+PROJECT=k8s-jkns-gke-ubuntu-flaky
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=300m

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-updown.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-updown.env
@@ -1,0 +1,10 @@
+### job-env
+GINKGO_PARALLEL=y
+GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
+
+PROJECT=k8s-jkns-gke-ubuntu-updown
+
+KUBE_GKE_IMAGE_TYPE=ubuntu
+KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
+
+KUBEKINS_TIMEOUT=30m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2132,6 +2132,30 @@
     ], 
     "scenario": "kubernetes_e2e"
   }, 
+  "ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-ubuntu-gke-1-6-flaky": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
   "ci-kubernetes-e2e-ubuntu-gke-1-6-ingress": {
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress.env", 
@@ -2164,6 +2188,38 @@
     ], 
     "scenario": "kubernetes_e2e"
   }, 
+  "ci-kubernetes-e2e-ubuntu-gke-1-6-updown": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-ubuntu-gke-alpha-features": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-alpha-features.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-ubuntu-gke-autoscaling": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-autoscaling.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-ubuntu-gke-flaky": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-flaky.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
   "ci-kubernetes-e2e-ubuntu-gke-ingress": {
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-ingress.env", 
@@ -2191,6 +2247,14 @@
   "ci-kubernetes-e2e-ubuntu-gke-slow": {
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-slow.env", 
+      "--env-file=platforms/gke.env", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-ubuntu-gke-updown": {
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-updown.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local"
     ], 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1218,6 +1218,120 @@ periodics:
         path: /mnt/disks/ssd0
       name: cache-ssd
 
+- name: ci-kubernetes-e2e-ubuntu-gke-alpha-features
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=300
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- name: ci-kubernetes-e2e-ubuntu-gke-autoscaling
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=420
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- name: ci-kubernetes-e2e-ubuntu-gke-flaky
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=420
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
 - name: ci-kubernetes-e2e-ubuntu-gke-ingress
   interval: 30m
   spec:
@@ -1370,12 +1484,164 @@ periodics:
         path: /mnt/disks/ssd0
       name: cache-ssd
 
+- name: ci-kubernetes-e2e-ubuntu-gke-updown
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=150
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
 - name: ci-kubernetes-e2e-ubuntu-gke-1-6
   interval: 30m
   spec:
     containers:
     - args:
       - --timeout=270
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=300
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=420
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-flaky
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=420
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -1528,6 +1794,44 @@ periodics:
     containers:
     - args:
       - --timeout=270
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-updown
+  interval: 30m
+  spec:
+    containers:
+    - args:
+      - --timeout=150
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -764,6 +764,12 @@ test_groups:
 # Ubuntu cluster e2e tests on GKE (contact: @kubernetes/ubuntu-image on github)
 - name: ci-kubernetes-e2e-ubuntu-gke
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke
+- name: ci-kubernetes-e2e-ubuntu-gke-alpha-features
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-alpha-features
+- name: ci-kubernetes-e2e-ubuntu-gke-autoscaling
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-autoscaling
+- name: ci-kubernetes-e2e-ubuntu-gke-flaky
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-flaky
 - name: ci-kubernetes-e2e-ubuntu-gke-ingress
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-ingress
 - name: ci-kubernetes-e2e-ubuntu-gke-reboot
@@ -772,8 +778,16 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-serial
 - name: ci-kubernetes-e2e-ubuntu-gke-slow
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-slow
+- name: ci-kubernetes-e2e-ubuntu-gke-updown
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-updown
 - name: ci-kubernetes-e2e-ubuntu-gke-1-6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-flaky
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky
 - name: ci-kubernetes-e2e-ubuntu-gke-1-6-ingress
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress
 - name: ci-kubernetes-e2e-ubuntu-gke-1-6-reboot
@@ -782,6 +796,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6-serial
 - name: ci-kubernetes-e2e-ubuntu-gke-1-6-slow
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6-slow
+- name: ci-kubernetes-e2e-ubuntu-gke-1-6-updown
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown
 # Canonical Distribution of Kubernetes (contact: @chuckbutler on github)
 - name: canonical-kubernetes-e2e-gce
   gcs_prefix: canonical-kubernetes-tests/logs/kubernetes-gce-e2e-node
@@ -1250,6 +1266,12 @@ dashboards:
     # Ubuntu cluster/node e2e tests on GKE (contact: @kubernetes/ubuntu-image on github)
   - name: ubuntu-gke
     test_group_name: ci-kubernetes-e2e-ubuntu-gke
+  - name: ubuntu-gke-alpha-features
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-alpha-features
+  - name: ubuntu-gke-autoscaling
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-autoscaling
+  - name: ubuntu-gke-flaky
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-flaky
   - name: ubuntu-gke-ingress
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-ingress
   - name: ubuntu-gke-reboot
@@ -1258,8 +1280,16 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-serial
   - name: ubuntu-gke-slow
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-slow
+  - name: ubuntu-gke-updown
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-updown
   - name: ubuntu-gke-1.6
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6
+  - name: ubuntu-gke-1.6-alpha-features
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features
+  - name: ubuntu-gke-1.6-autoscaling
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling
+  - name: ubuntu-gke-1.6-flaky
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-flaky
   - name: ubuntu-gke-1.6-ingress
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-ingress
   - name: ubuntu-gke-1.6-reboot
@@ -1268,6 +1298,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-serial
   - name: ubuntu-gke-1.6-slow
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-slow
+  - name: ubuntu-gke-1.6-updown
+    test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-updown
 
 - name: google-gke-staging
   dashboard_tab:


### PR DESCRIPTION
```
ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features
ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling
ci-kubernetes-e2e-ubuntu-gke-1-6-flaky
ci-kubernetes-e2e-ubuntu-gke-1-6-updown
ci-kubernetes-e2e-ubuntu-gke-alpha-features
ci-kubernetes-e2e-ubuntu-gke-autoscaling
ci-kubernetes-e2e-ubuntu-gke-flaky
ci-kubernetes-e2e-ubuntu-gke-updown
```