### PR TITLE
Update release-note permissions in commands.md

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -22,9 +22,9 @@ Command | Implemented By | Who can run it | Description
 `/approve cancel` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | removes your approval on this pull-request
 `/close` | prow [close](./prow/plugins/close) | authors and assignees | closes the issue
 `/reopen` | prow [reopen](./prow/plugins/reopen) | authors and assignees | reopens a closed issue
-`/release-note` | prow [releasenote](./prow/plugins/releasenote) | authors and assignees | adds the `release-note` label
-`/release-note-none` | prow [releasenote](./prow/plugins/releasenote) | authors and assignees | adds the `release-note-none` label
-`@kubernetes/sig-<some-github-team>` | prow [label](./prow/plugins/label) | kubernetes org members| adds the corresponding `sig` label
+`/release-note` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note` label
+`/release-note-none` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-none` label
+`@kubernetes/sig-<some-github-team>` | prow [label](./prow/plugins/label) | kubernetes org members | adds the corresponding `sig` label
 `@k8s-bot test this` | prow [trigger](./prow/plugins/trigger) | kubernetes org members | runs tests defined in [config.yaml](./prow/config.yaml)
 `@k8s-bot ok to test` | prow [trigger](./prow/plugins/trigger) | kubernetes org members | allows the PR author to `@k8s-bot test this`
 `@k8s-bot tell me a joke` | prow [yuks](./prow/plugins/yuks) | anyone | tells a bad joke, sometimes


### PR DESCRIPTION
Update commands.md to reflect new permissions for release-note commands in #2508 . Any org member can now run these commands, not just assignees.