### PR TITLE
Saying the timeout for every command is spammy and boring.

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -240,7 +240,7 @@ def checkout(call, repo, branch, pull, ssh='', git_cache='', clean=False):
     retries = 3
     for attempt in range(retries):
         try:
-            call([git, 'fetch', '--tags', repository(repo, ssh)] + refs)
+            call([git, 'fetch', '--quiet', '--tags', repository(repo, ssh)] + refs)
             break
         except subprocess.CalledProcessError as cpe:
             if attempt >= retries - 1:

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -101,7 +101,6 @@ def _call(end, cmd, stdin=None, check=True, output=None):
     begin = time.time()
     if end:
         end = max(end, time.time() + 60)  # Allow at least 60s per command
-        logging.info('Limiting call to %.1f minutes', (end - begin) / 60)
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE if stdin is not None else None,


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-perf-tests-e2e-gce-clusterloader/864/build-log.txt