### PR TITLE
Create 1.6-master upgrade jobs

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new.env
@@ -1,0 +1,14 @@
+### job-env
+# Upgrade master and node, in gce(debian), from 1.6 to master, and run skewed e2e tests.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+JENKINS_USE_SKEW_TESTS=true
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=gce-up-c1-3-g1-4-up-clu-n
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster.env
@@ -1,0 +1,13 @@
+### job-env
+# Upgrade master and node, in gce(debian), from 1.6 to master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=gce-up-c1-3-g1-4-up-clu
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-master.env
@@ -1,0 +1,13 @@
+### job-env
+# Upgrade master only, in gce(debian), from 1.6 to master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_NODE_OS_DISTRIBUTION=debian
+PROJECT=gce-up-c1-3-g1-4-up-mas
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new.env
@@ -1,0 +1,17 @@
+### job-env
+# Upgrade master and node, in gke(container-vm), from 1.6 to master, and run skewed e2e tests.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=kube-gke-upg-1-3-1-4-upg-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master and node, in gke(container-vm), from 1.6 to master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf::
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=kube-gke-upg-1-3-1-4-upg-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master only, in gke(container-vm), from 1.6 to master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=kube-gke-upg-1-3-1-4-upg-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new.env
@@ -1,0 +1,17 @@
+### job-env
+# Upgrade master and node, in gke, from container-vm 1.6 to gci master, and run skewed e2e tests.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=gke-up-c1-3-g1-4-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master and node, in gke, from container-vm 1.6 to gci master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=gke-up-c1-3-g1-4-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master only, in gke(container-vm), from container-vm 1.6 to gci master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=container_vm
+PROJECT=gke-up-c1-3-g1-4-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new.env
@@ -1,0 +1,17 @@
+### job-env
+# Upgrade master and node, in gke, from gci 1.6 to container-vm master, and run skewed e2e tests.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=gke-up-g1-3-c1-4-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master and node, in gke, from gci 1.6 to container-vm master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=gke-up-g1-3-c1-4-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master only, in gke, from gci 1.6 to container-vm master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=gke-up-g1-3-c1-4-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new.env
@@ -1,0 +1,17 @@
+### job-env
+# Upgrade master and node, in gke(gci), from 1.6 to master, and run skewed e2e tests.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+JENKINS_USE_SKEW_TESTS=true
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=gke-up-g1-3-g1-4-up-clu-n
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master and node, in gke(gci), from 1.6 to master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=gke-up-g1-3-g1-4-up-clu
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master.env
@@ -1,0 +1,16 @@
+### job-env
+# Upgrade master only, in gke(gci), from 1.6 to master.
+
+E2E_OPT=--check_version_skew=false
+E2E_UPGRADE_TEST=true
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
+JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
+JENKINS_PUBLISHED_VERSION=ci/latest-1.6
+KUBE_GKE_IMAGE_TYPE=gci
+PROJECT=gke-up-g1-3-g1-4-up-mas
+
+### version-env
+ZONE=us-central1-a
+
+KUBEKINS_TIMEOUT=900m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -93,6 +93,27 @@
     ], 
     "scenario": "kubernetes_e2e"
   }, 
+  "ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster": {
+    "args": [
+      "--env-file=platforms/gce.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new": {
+    "args": [
+      "--env-file=platforms/gce.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gce-1-6-master-upgrade-master": {
+    "args": [
+      "--env-file=platforms/gce.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-master.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
   "ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew": {
     "args": [
       "--env-file=platforms/gce.env", 
@@ -1646,10 +1667,94 @@
     ], 
     "scenario": "kubernetes_e2e"
   }, 
+  "ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
   "ci-kubernetes-e2e-gke-flaky": {
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-flaky.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new.env"
+    ], 
+    "scenario": "kubernetes_e2e"
+  }, 
+  "ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master": {
+    "args": [
+      "--env-file=platforms/gke.env", 
+      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master.env"
     ], 
     "scenario": "kubernetes_e2e"
   }, 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2349,3 +2349,574 @@ periodics:
     - hostPath:
         path: /mnt/disks/ssd0
       name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-1-6-master-upgrade-master
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new
+  spec:
+    containers:
+    - args:
+      - --timeout=900
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -881,6 +881,37 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-perf-tests-e2e-gce-clusterloader
 - name: ci-perf-tests-kubemark-100-benchmark
   gcs_prefix: kubernetes-jenkins/logs/ci-perf-tests-kubemark-100-benchmark
+# 1.6-master upgrade jobs
+- name: ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster
+- name: ci-kubernetes-e2e-gce-1-6-master-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1-6-master-upgrade-master
+- name: ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master
+- name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master
+- name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master
+- name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new
+- name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster
+- name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master
+- name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new
 # Add New Testgroups Here
 
 #
@@ -2259,7 +2290,7 @@ dashboards:
   - name: kubemark-100-benchmark
     test_group_name: ci-perf-tests-kubemark-100-benchmark
 
-- name: release-1.7-kubectl-skew
+- name: 1.6-master-kubectl-skew
   dashboard_tab:
   - name: gce-1.6-master-cvm
     test_group_name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
@@ -2277,3 +2308,36 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
   - name: gke-master-1.6-gci
     test_group_name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew
+
+- name: 1.6-master-upgrade
+  dashboard_tab:
+  - name: gce-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster
+  - name: gce-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gce-1-6-master-upgrade-master
+  - name: gce-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new
+  - name: gke-cvm-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster
+  - name: gke-cvm-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master
+  - name: gke-cvm-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new
+  - name: gke-gci-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster
+  - name: gke-gci-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master
+  - name: gke-gci-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new
+  - name: gke-cvm-gci-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster
+  - name: gke-cvm-gci-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master
+  - name: gke-cvm-gci-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new
+  - name: gke-gci-cvm-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster
+  - name: gke-gci-cvm-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master
+  - name: gke-gci-cvm-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2258,3 +2258,22 @@ dashboards:
     test_group_name: ci-perf-tests-e2e-gce-clusterloader
   - name: kubemark-100-benchmark
     test_group_name: ci-perf-tests-kubemark-100-benchmark
+
+- name: release-1.7-kubectl-skew
+  dashboard_tab:
+  - name: gce-1.6-master-cvm
+    test_group_name: ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew
+  - name: gce-1.6-master-gci
+    test_group_name: ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew
+  - name: gce-master-1.6-cvm
+    test_group_name: ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew
+  - name: gce-master-1.6-gci
+    test_group_name: ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew
+  - name: gke-1.6-master-cvm
+    test_group_name: ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew
+  - name: gke-1.6-master-gci
+    test_group_name: ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew
+  - name: gke-master-1.6-cvm
+    test_group_name: ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew
+  - name: gke-master-1.6-gci
+    test_group_name: ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew


### PR DESCRIPTION
Add 1.6-master upgrade jobs.

We already have 1.6-master kubectl skew tests, put them into a separate 1.7 dashboard so it's clear to view.

/assign @dchen1107 

ref #2625 

And I'm recycling 1.3-1.4 upgrade projects so that we don't have to recreate new projects.