### PR TITLE
Re-enable NFSv3 tests on GKE staging and prod

### DIFF
--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.env
@@ -3,7 +3,7 @@ CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|NFSv3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-e2e-gci-gke-prod-parallel
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.env
@@ -6,6 +6,5 @@ JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-jkns-e2e-gci-gke-prod
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-b
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Flaky\]|\[Feature:.+\]|NFSv3
 
 KUBEKINS_TIMEOUT=480m

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.env
@@ -3,7 +3,7 @@ CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.goog
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|NFSv3
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-e2e-gci-gke-staging-plel
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.env
@@ -5,6 +5,5 @@ E2E_OPT=--check_version_skew=false
 JENKINS_USE_SERVER_VERSION=y
 PROJECT=k8s-jkns-e2e-gci-gke-staging
 KUBE_GKE_IMAGE_TYPE=gci
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Flaky\]|\[Feature:.+\]|NFSv3
 
 KUBEKINS_TIMEOUT=480m


### PR DESCRIPTION
Now that GKE is on 1.5.8, we can enable the NFSv3 tests.

See #2534 that disabled the tests.

Fixes #2540