### PR TITLE
Fix e2e-kubeadm release-1.6 job.

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -79,6 +79,12 @@ def kubeadm_version(mode):
             raise ValueError('STABLE_BUILD_SCM_REVISION not found')
         version = status.group(1)
 
+        # Work-around for release-1.6 jobs, which still upload debs to an older
+        # location (without os/arch prefixes).
+        # TODO(pipejakob): remove this when we no longer support 1.6.x.
+        if version.startswith("v1.6."):
+            return 'gs://kubernetes-release-dev/bazel/%s/build/debs/' % version
+
     elif mode == 'pull':
         version = '%s/%s' % (os.environ['PULL_NUMBER'], os.getenv('PULL_REFS'))
 


### PR DESCRIPTION
Recent changes to kubernetes/master moved where bazel `.deb` files get pushed. The `kubernetes_e2e.py` scenario was updated to accommodate this change, but the kubernetes/release-1.6 branch still pushes these `.debs` to the old location. Since we only support ci/periodic jobs for release-1.6, and we expect to use the new location from now on, consider this a special case for now and we can remove this code when we no longer support the 1.6.x series.