### PR TITLE
Remove unused RELEASE_BUCKET environment vars from federation jobs

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1.6.env
@@ -4,8 +4,6 @@ USE_KUBEFED=true
 
 PROJECT=k8s-jkns-e2e-gce-f8n-1-6
 KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-f8n-1-6
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release-1-6
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release-1-6
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created.

--- a/jobs/ci-kubernetes-e2e-gce-federation-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-serial.env
@@ -4,8 +4,6 @@ USE_KUBEFED=true
 
 PROJECT=k8s-jkns-e2e-gce-f8n-serial
 KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-federation
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created.

--- a/jobs/ci-kubernetes-e2e-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation.env
@@ -4,8 +4,6 @@ USE_KUBEFED=true
 
 PROJECT=k8s-jkns-e2e-gce-federation
 KUBE_REGISTRY=gcr.io/k8s-jkns-e2e-gce-federation
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created.

--- a/jobs/ci-kubernetes-pull-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-pull-gce-federation-deploy.env
@@ -7,8 +7,6 @@ FEDERATION=true
 
 PROJECT=k8s-jkns-pr-bldr-e2e-gce-fdrtn
 KUBE_REGISTRY=gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 FAIL_ON_GCP_RESOURCE_LEAK=false

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.env
@@ -6,10 +6,7 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
 PROJECT=k8s-jkns-gce-federation-soak
-
 KUBE_REGISTRY=gcr.io/k8s-jkns-gce-federation-soak
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 
 FEDERATION=true
 USE_KUBEFED=true

--- a/jobs/ci-kubernetes-soak-gce-federation-test.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.env
@@ -9,10 +9,7 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 
 ### job-env
 PROJECT=k8s-jkns-gce-federation-soak
-
 KUBE_REGISTRY=gcr.io/k8s-jkns-gce-federation-soak
-KUBE_GCS_RELEASE_BUCKET=kubernetes-federation-release
-KUBE_GCS_DEV_RELEASE_BUCKET=kubernetes-federation-release
 
 FEDERATION=true
 USE_KUBEFED=true


### PR DESCRIPTION
As per the discussion happened in https://github.com/kubernetes/kubernetes/issues/44402#issuecomment-293831667 and also verified from CI logs of federation jobs, we do not use a separate GCS bucket to download the k8s release binaries. The GCS bucket is always `kubernetes-release-dev` from which we download the version `ci/latest`.

federation jobs are still using these env variables and gives an impression that the job are run by downloading k8s binaries from those buckets. so removing them.

cc @madhusudancs @fejta 