### PR TITLE
Add env var for overriding Stackdriver endpoint (GKE tests only)

### DIFF
--- a/jobs/ci-kubernetes-e2e-gke-stackdriver.env
+++ b/jobs/ci-kubernetes-e2e-gke-stackdriver.env
@@ -3,4 +3,6 @@ CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StackdriverMonitoring\]
 PROJECT=k8s-jkns-e2e-gke-stackdriver
 
+STACKDRIVER_API_ENDPOINT_OVERRIDE=https://test-monitoring.sandbox.googleapis.com/
+
 KUBEKINS_TIMEOUT=50m


### PR DESCRIPTION
Default Stackdriver endpoint is prod, it has to be overridden as in GKE tests metrics are published to test environment.

cc @piosz 
