### PR TITLE
Fix ssh permission issue for clusterloader job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1919,6 +1919,8 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name:  JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
+      - name:  USER
+        value: prow
       volumeMounts:
       - name: service
         mountPath: /etc/service-account


### PR DESCRIPTION
ref https://github.com/kubernetes/perf-tests/issues/59#issuecomment-301707587

/assign @wojtek-t 

One other thing I noticed is that the clusterloader test does not output it's own xml, consider generate one so that testgrid can display per-test rows.