### PR TITLE
Add CI job running perf-tests/benchmark on kubemark-100 vs gce-100

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2763,6 +2763,12 @@
     ], 
     "scenario": "kubernetes_e2e"
   }, 
+  "ci-perf-tests-kubemark-100-benchmark": {
+    "args": [
+      "./benchmark/runner.sh"
+    ], 
+    "scenario": "execute"
+  }, 
   "ci-test-infra-test-history": {
     "args": [
       "./jenkins/test_history/gen_history"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1902,6 +1902,34 @@ periodics:
       hostPath:
         path: /mnt/disks/ssd0
 
+- name: ci-perf-tests-kubemark-100-benchmark
+  interval: 2h
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+      args:
+      - "--repo=k8s.io/perf-tests=master"
+      - "--root=/go/src"
+      - "--timeout=10"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: cache-ssd
+        mountPath: /root/.cache
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: cache-ssd
+      hostPath:
+        path: /mnt/disks/ssd0
+
 - interval: 6h
   name: ci-kubernetes-e2e-gci-gce-release-1-4
   spec:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -874,6 +874,8 @@ test_groups:
 # perf tests
 - name: ci-perf-tests-e2e-gce-clusterloader
   gcs_prefix: kubernetes-jenkins/logs/ci-perf-tests-e2e-gce-clusterloader
+- name: ci-perf-tests-kubemark-100-benchmark
+  gcs_prefix: kubernetes-jenkins/logs/ci-perf-tests-kubemark-100-benchmark
 # Add New Testgroups Here
 
 #
@@ -2249,3 +2251,5 @@ dashboards:
   dashboard_tab:
   - name: cluster-loader
     test_group_name: ci-perf-tests-e2e-gce-clusterloader
+  - name: kubemark-100-benchmark
+    test_group_name: ci-perf-tests-kubemark-100-benchmark


### PR DESCRIPTION
Add new job for benchmark to the jobs/config.json, prow and dashboard.
I've tested that it works locally (against PR https://github.com/kubernetes/perf-tests/pull/61 of perf-tests).

cc @fejta @wojtek-t @gmarek 