### PR TITLE
Append [Context] tag to kubelet-1.6 job

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -521,6 +521,11 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.5
 - name: ci-kubernetes-node-kubelet-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.6
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
 - name: ci-kubernetes-node-kubelet-non-cri-1.6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-non-cri-1.6
 - name: ci-kops-build


### PR DESCRIPTION
[The kubelet-1.4 job](http://k8s-testgrid.appspot.com/sig-node#kubelet-1.4) shows that [Context] can be picked up now, however the xml name is not correct and it's waiting for the cherry pick to go into 1.4 - https://github.com/kubernetes/kubernetes/pull/45633, and 1.5 - https://github.com/kubernetes/kubernetes/pull/45636

The jobs beyond 1.6 are expected to work, switch over one job over and see how it looks.

/assign @fejta 