### PR TITLE
Add "undefined" to highlight words in log parser

### DIFF
--- a/gubernator/kubelet_parser.py
+++ b/gubernator/kubelet_parser.py
@@ -20,37 +20,37 @@ import jinja2
 
 import regex
 
-def parse(lines, hilight_words, filters, objref_dict):
+def parse(lines, highlight_words, filters, objref_dict):
     """
     Given filters returns indeces of wanted lines from log
 
     Args:
         lines: array of log lines
-        hilight_words: array of words that need to be bolded
+        highlight_words: array of words that need to be bolded
         filters: dictionary of which filters to apply
         objref_dict: a dictionary where the keys are possible filters
-        and the values are the words to be hilighted
+        and the values are the words to be highlighted
     Returns:
         matched_lines: ordered array of indeces of lines to display
-        hilight_words: updated hilight_words
+        highlight_words: updated highlight_words
     """
     matched_lines = []
 
     if not filters["pod"] and objref_dict:
-        hilight_words = []
+        highlight_words = []
 
     # If the filter is on, look for it in the objref_dict
     for k in filters:
         if k != "pod" and filters[k] and k in objref_dict:
-            hilight_words.append(objref_dict[k])
+            highlight_words.append(objref_dict[k])
 
-    words_re = regex.combine_wordsRE(hilight_words)
+    words_re = regex.combine_wordsRE(highlight_words)
 
     for n, line in enumerate(lines):
         if words_re.search(line):
             matched_lines.append(n)
 
-    return matched_lines, hilight_words
+    return matched_lines, highlight_words
 
 
 def make_dict(data, pod_re, objref_dict):

--- a/gubernator/kubelet_parser_test.py
+++ b/gubernator/kubelet_parser_test.py
@@ -27,35 +27,35 @@ filters = {"UID": "", "pod": "", "Namespace": ""}
 class KubeletParserTest(unittest.TestCase):
     def test_parse_error_re(self):
         """Test for build-log.txt filtering by error_re"""
-        matched_lines, hilight_words = kubelet_parser.parse(lines,
+        matched_lines, highlight_words = kubelet_parser.parse(lines,
             ["error", "fatal", "failed", "build timed out"], filters, {})
         self.assertEqual(matched_lines, [4])
-        self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
+        self.assertEqual(highlight_words, ["error", "fatal", "failed", "build timed out"])
 
     def test_parse_empty_lines(self):
         """Test that it doesn't fail when files are empty"""
-        matched_lines, hilight_words = kubelet_parser.parse([],
+        matched_lines, highlight_words = kubelet_parser.parse([],
             ["error", "fatal", "failed", "build timed out"], filters, {})
         self.assertEqual(matched_lines, [])
-        self.assertEqual(hilight_words, ["error", "fatal", "failed", "build timed out"])
+        self.assertEqual(highlight_words, ["error", "fatal", "failed", "build timed out"])
 
     def test_parse_pod_RE(self):
         """Test for initial pod filtering"""
         filters["pod"] = "pod"
-        matched_lines, hilight_words = kubelet_parser.parse(lines,
+        matched_lines, highlight_words = kubelet_parser.parse(lines,
             ["pod"], filters, {})
         self.assertEqual(matched_lines, [1])
-        self.assertEqual(hilight_words, ["pod"])
+        self.assertEqual(highlight_words, ["pod"])
 
     def test_parse_filters(self):
         """Test for filters"""
         filters["pod"] = "pod"
         filters["UID"] = "on"
         filters["Namespace"] = "on"
-        matched_lines, hilight_words = kubelet_parser.parse(lines,
+        matched_lines, highlight_words = kubelet_parser.parse(lines,
             ["pod"], filters, {"UID":"uid", "Namespace":"podName", "ContainerID":""})
         self.assertEqual(matched_lines, [1, 2, 5, 6])
-        self.assertEqual(hilight_words, ["pod", "podName", "uid"])
+        self.assertEqual(highlight_words, ["pod", "podName", "uid"])
 
     def test_make_dict(self):
         """Test make_dict works"""

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -107,7 +107,10 @@ def digest(data, objref_dict=None, filters=None, error_re=regex.error_re,
     if filters is None:
         filters = {'Namespace': '', 'UID': '', 'pod': '', 'ContainerID':''}
 
-    highlight_words = ["error", "fatal", "fail", "failed", "build timed out"]
+    highlight_words = [
+        "build timed out", "error", "fail", "failed", "fatal", "undefined"
+    ]
+
     if filters["pod"]:
         highlight_words = [filters["pod"]]
 

--- a/gubernator/log_parser.py
+++ b/gubernator/log_parser.py
@@ -24,24 +24,24 @@ CONTEXT_DEFAULT = 6
 MAX_BUFFER = 5000000  # GAE has RAM limits.
 
 
-def hilight(line, hilight_words):
+def highlight(line, highlight_words):
     # Join all the words that need to be bolded into one regex
-    words_re = regex.combine_wordsRE(hilight_words)
+    words_re = regex.combine_wordsRE(highlight_words)
     line = words_re.sub(r'<span class="keyword">\1</span>', line)
-    return '<span class="hilight">%s</span>' % line
+    return '<span class="highlight">%s</span>' % line
 
 
-def log_html(lines, matched_lines, hilight_words, skip_fmt):
+def log_html(lines, matched_lines, highlight_words, skip_fmt):
     """
     Constructs the html for the filtered log
     Given:
         lines: list of all lines in the log
         matched_lines: list of lines that have a filtered string in them
-        hilight_words: list of words to be bolded
+        highlight_words: list of words to be bolded
         skip_fmt: function producing string to replace the skipped lines
     Returns:
         output: list of a lines HTML code suitable for inclusion in a <pre>
-        tag, with "interesting" errors hilighted
+        tag, with "interesting" errors highlighted
     """
     output = []
 
@@ -70,7 +70,7 @@ def log_html(lines, matched_lines, hilight_words, skip_fmt):
         if match == len(lines):
             break
         output.extend(lines[max(previous_end, match - context_lines): match])
-        output.append(hilight(lines[match], hilight_words))
+        output.append(highlight(lines[match], highlight_words))
         last_match = match
 
     return output
@@ -96,7 +96,7 @@ def digest(data, objref_dict=None, filters=None, error_re=regex.error_re,
     # pylint: disable=too-many-arguments
     """
     Given a build log, return a chunk of HTML code suitable for
-    inclusion in a <pre> tag, with "interesting" errors hilighted.
+    inclusion in a <pre> tag, with "interesting" errors highlighted.
 
     This is similar to the output of `grep -C4` with an appropriate regex.
     """
@@ -107,17 +107,17 @@ def digest(data, objref_dict=None, filters=None, error_re=regex.error_re,
     if filters is None:
         filters = {'Namespace': '', 'UID': '', 'pod': '', 'ContainerID':''}
 
-    hilight_words = ["error", "fatal", "fail", "failed", "build timed out"]
+    highlight_words = ["error", "fatal", "fail", "failed", "build timed out"]
     if filters["pod"]:
-        hilight_words = [filters["pod"]]
+        highlight_words = [filters["pod"]]
 
     if not (filters["UID"] or filters["Namespace"] or filters["ContainerID"]):
         matched_lines = [n for n, line in enumerate(lines) if error_re.search(line)]
     else:
-        matched_lines, hilight_words = kubelet_parser.parse(lines,
-            hilight_words, filters, objref_dict)
+        matched_lines, highlight_words = kubelet_parser.parse(lines,
+            highlight_words, filters, objref_dict)
 
-    output = log_html(lines, matched_lines, hilight_words, skip_fmt)
+    output = log_html(lines, matched_lines, highlight_words, skip_fmt)
     output.append('')
 
     return '\n'.join(output)

--- a/gubernator/log_parser_test.py
+++ b/gubernator/log_parser_test.py
@@ -65,23 +65,23 @@ class LogParserTest(unittest.TestCase):
 
     def test_html(self):
         self.assertEqual(digest('error-blah', strip=False), ''
-                         '<span class="hilight"><span class="keyword">'
+                         '<span class="highlight"><span class="keyword">'
                          'error</span>-blah</span>')
 
     def test_html_range(self):
         self.assertEqual(digest('error 1 2 3 4 5 6 7 8', strip=False),
-            '<span class="hilight"><span class="keyword">error</span></span>'
+            '<span class="highlight"><span class="keyword">error</span></span>'
             ' 1 2 3 4 <span class="skip" data-range="5-9">s4</span>')
 
     def test_unicode(self):
         self.assertEqual(log_parser.digest(u'error \xb5s'),
-            u'<span class="hilight"><span class="keyword">'
+            u'<span class="highlight"><span class="keyword">'
             u'error</span> \xb5s</span>\n')
 
     def test_pod(self):
         self.assertEqual(digest(
             'pod-blah', error_re=regex.wordRE("pod"), strip=False),
-            '<span class="hilight">pod-blah</span>')
+            '<span class="highlight">pod-blah</span>')
         self.assertEqual(digest('0 1 2 3 4 5 pod 6 7 8 9 10',
             error_re=regex.wordRE("pod"),
             filters={"pod": "pod", "UID": "", "Namespace": "", "ContainerID":""}),

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -173,7 +173,7 @@ class AppTest(TestBase):
         write(kubeapi_filepath,
             '0101 01:01:01.000 kubeapi\n0101 01:01:01.002 pod\n01-01T01:01:01.005Z last line')
         expected = ('0101 01:01:01.000 kubeapi\n'
-                    '<span class="hilight">abc0101 01:01:01.001 Event(api.ObjectReference{Name:'
+                    '<span class="highlight">abc0101 01:01:01.001 Event(api.ObjectReference{Name:'
                     '&#34;<span class="keyword">abc</span>&#34;, UID:&#34;podabc&#34;})</span>\n'
                     '0101 01:01:01.002 pod\n'
                     '01-01T01:01:01.005Z last line')
@@ -199,7 +199,7 @@ class AppTest(TestBase):
         write(proxy_filepath,
             '0101 01:01:01.000 proxy\n0101 01:01:01.002 pod\n01-01T01:01:01.005Z last line')
         expected = ('0101 01:01:01.000 proxy\n'
-                    '<span class="hilight">abc0101 01:01:01.001 Event(api.ObjectReference{Name:'
+                    '<span class="highlight">abc0101 01:01:01.001 Event(api.ObjectReference{Name:'
                     '&#34;<span class="keyword">abc</span>&#34;, UID:&#34;podabc&#34;})</span>\n'
                     '0101 01:01:01.002 pod\n'
                     '01-01T01:01:01.005Z last line')

--- a/gubernator/static/style.css
+++ b/gubernator/static/style.css
@@ -60,7 +60,7 @@ pre.cmd {
 pre.cmd::before {
     content: "Command: ";  /* This text isn't selectable */
 }
-span.hilight {
+span.highlight {
     background-color: palegoldenrod;
 }
 span.keyword {

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -88,7 +88,7 @@ def build_details(build_dir):
         started: value from started.json {'version': ..., 'timestamp': ...}
         finished: value from finished.json {'timestamp': ..., 'result': ...}
         failures: list of (name, duration, text) tuples
-        build_log: a hilighted portion of errors in the build log. May be None.
+        build_log: a highlighted portion of errors in the build log. May be None.
     """
     started_fut = gcs_async.read(build_dir + '/started.json')
     finished = gcs_async.read(build_dir + '/finished.json').get_result()


### PR DESCRIPTION
Fixes #2783.

Also fixes spelling of "highlight".