### PR TITLE
Make the federation presubmit job blocking.

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -24,7 +24,8 @@ data:
     \"Jenkins Kubemark GCE e2e\",\
     \"Jenkins GCE etcd3 e2e\",\
     \"Jenkins Bazel Build\",\
-    \"Jenkins kops AWS e2e\""
+    \"Jenkins kops AWS e2e\",\
+    \"pull-kubernetes-federation-e2e-gce\""
 
   submit-queue.protected-branches: "master"
   submit-queue.protected-branches-extra-contexts: "cla/linuxfoundation"


### PR DESCRIPTION
It has been a little over a week since we started reporting the results of this job on all the PRs. We did not have any major issues. We had a couple of minor hiccups: Issues https://github.com/kubernetes/kubernetes/issues/45795 and https://github.com/kubernetes/kubernetes/issues/45978. We had foreseen problems of the first type but the second one was a little surprising.

SIG-Federation is starting a buildcop rotation and the buildcops should be able to handle both these types of situations. We don't have all the tooling in place for non-Googlers to handle these issues because it
needs access to Jenkins, so they still need to ping a Googler when they see a problem. We are working on moving these jobs out of Jenkins to prow (Issue #2791).

Empirically, these problems have been uncommon and shouldn't affect the submit queue often.

/assign @fejta @spxtr 

cc @csbell @kubernetes/sig-federation-pr-reviews 