### PR TITLE
Migrate pull-gce-federation-deploy job to prow

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -227,13 +227,3 @@
         scan: ALL
         timeout: 620
         soak-repos: '--bare'
-    # Although this job is a dependency for a pull job, this is
-    # being deployed as a CI soak job to periodically bring up
-    # and tear down the clusters for the federation pull job.
-    - kubernetes-pull-gce-federation-deploy:
-        blocker: pull-kubernetes-federation-e2e-gce
-        job-name: ci-kubernetes-pull-gce-federation-deploy
-        frequency: 'H 0 * * *'
-        scan: DISABLED
-        timeout: 90
-        soak-repos: '--bare'

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2546,7 +2546,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy.env", 
       "--test=false", 
-      "--down=false"
+      "--down=false", 
+      "--mode=local"
     ], 
     "scenario": "kubernetes_e2e"
   }, 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2920,3 +2920,40 @@ periodics:
         path: /mnt/disks/ssd0
       name: cache-ssd
 
+- name: ci-kubernetes-pull-gce-federation-deploy
+  interval: 24h
+  spec:
+    containers:
+    - args:
+      - --timeout=90
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd


### PR DESCRIPTION
This is as per the discussion in https://github.com/kubernetes/test-infra/issues/2791

Still have to figure out how 2 jobs can be run mutually exclusively. This is required for this job as this is meant to recycle k8s clusters of federation everyday. But when this job is running pre-submits have to wait in queue and vice-versa.

@fejta request your opinion on this.
/cc @madhusudancs @kubernetes/sig-federation-pr-reviews 