### PR TITLE
Disable use of real proxier in kubemark-scale

### DIFF
--- a/jobs/ci-kubernetes-kubemark-gce-scale.env
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.env
@@ -34,5 +34,7 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 EVENT_PD=true
 # TODO: Reduce this once we have log rotation in Kubemark.
 KUBEMARK_MASTER_ROOT_DISK_SIZE=100GB
+# TODO: Remove this after kube-proxy improvements.
+USE_REAL_PROXIER=false
 
 KUBEKINS_TIMEOUT=1080m


### PR DESCRIPTION
Follows from https://github.com/kubernetes/kubernetes/pull/45950 (yet to be merged) and should fix kubemark-scale failures for now.
Will revert once kube-proxy improvements are made.

cc @wojtek-t 