### PR TITLE
Fix KeyError for 3-part versions.

### DIFF
--- a/scenarios/kubernetes_kubelet.py
+++ b/scenarios/kubernetes_kubelet.py
@@ -52,10 +52,11 @@ def var(path):
 
 def main(script, properties, branch, ssh, ssh_pub, robot):
     """Test node branch by sending script specified properties and creds."""
+    # If branch has 3-part version, only take first 2 parts.
     mat = re.match(r'master|release-\d+\.\d+', branch)
     if not mat:
         raise ValueError(branch)
-    tag = VERSION_TAG[BRANCH_VERSION.get(branch, branch)]
+    tag = VERSION_TAG[BRANCH_VERSION.get(mat.group(0), mat.group(0))]
     img = 'gcr.io/k8s-testimages/kubekins-node:%s' % tag
     artifacts = '%s/_artifacts' % os.environ['WORKSPACE']
     if not os.path.isdir(artifacts):

--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -54,10 +54,12 @@ def check(*cmd):
 
 def main(branch, script, force):
     """Test branch using script, optionally forcing verify checks."""
-    verify_branch = re.match(r'.*(master|\d+\.\d+)', branch)
+    # If branch has 3-part version, only take first 2 parts.
+    verify_branch = re.match(r'master|release-(\d+\.\d+)', branch)
     if not verify_branch:
         raise ValueError(branch)
-    ver = verify_branch.group(1)
+    # Extract version if any.
+    ver = verify_branch.group(1) or verify_branch.group(0)
     tag = VERSION_TAG[BRANCH_VERSION.get(ver, ver)]
     force = 'y' if force else 'n'
     artifacts = '%s/_artifacts' % os.environ['WORKSPACE']


### PR DESCRIPTION
Fixes #2778.

cc @fejta @david-mcmahon 

This is blocking https://github.com/kubernetes/kubernetes/pull/46046 and https://github.com/kubernetes/kubernetes/pull/46049, which are needed for the emergency v1.6.4 release.

What is needed to push changes in these files to Jenkins?