### PR TITLE
Make migratestatus log include PR number

### DIFF
--- a/maintenance/githubutil/githubutil.go
+++ b/maintenance/githubutil/githubutil.go
@@ -115,8 +115,9 @@ func (c *Client) retry(action string, call func() (*github.Response, error)) err
 
 // CreateStatus creates or updates a status context on the indicated reference.
 // This function limits rate and does retries if needed.
-func (c *Client) CreateStatus(owner, repo, ref string, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
-	glog.Infof("CreateStatus for ref '%s': %s:%s (%s)\n", ref, *status.Context, *status.State, *status.Description)
+func (c *Client) CreateStatus(owner, repo string, pr *github.PullRequest, status *github.RepoStatus) (*github.RepoStatus, *github.Response, error) {
+	ref := *pr.Head.SHA
+	glog.Infof("CreateStatus(dry=%t) %d:%s: %s:%s", c.dryRun, *pr.Number, ref, *status.Context, *status.State)
 	if c.dryRun {
 		return nil, nil, nil
 	}

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -29,12 +29,12 @@ import (
 
 func main() {
 	var tokenFile, org, repo, copyContext, moveContext, retireContext, destContext string
-	var dryRun, continueOnError bool
+	var modify, continueOnError bool
 
 	flag.StringVar(&tokenFile, "tokenfile", "", "The file containing the token to use for authentication.")
 	flag.StringVar(&org, "org", "", "The organization that owns the repo.")
 	flag.StringVar(&repo, "repo", "", "The repo needing status migration.")
-	flag.BoolVar(&dryRun, "dry-run", true, "In dry run mode, no modifying actions will be taken.")
+	flag.BoolVar(&modify, "modify", false, "Perform modifying actions when set, otherwise dry-run.")
 	flag.BoolVar(&continueOnError, "continue-on-error", false, "Indicates that the migration should continue if context migration fails for an individual PR.")
 
 	flag.StringVar(&copyContext, "copy", "", "Indicates copy mode and specifies the context to copy.")
@@ -84,11 +84,10 @@ func main() {
 
 	// Note that continueOnError is false by default so that errors can be addressed when they occur
 	// instead of blindly continueing to the next PR, possibly continuing to error.
+	dryRun := !modify
 	m := migrator.New(*mode, strings.TrimSpace(string(tokenData)), org, repo, dryRun, continueOnError)
 
-	prOptions := &github.PullRequestListOptions{
-		State: "all",
-	}
+	prOptions := &github.PullRequestListOptions{}
 	if err := m.Migrate(prOptions); err != nil {
 		errorfExit("Error during status migration: %v\n", err)
 	}

--- a/maintenance/migratestatus/migrator/migrator.go
+++ b/maintenance/migratestatus/migrator/migrator.go
@@ -57,8 +57,8 @@ func MoveMode(origContext, newContext string) *Mode {
 
 	return &Mode{
 		conditions: []*contextCondition{
-			&contextCondition{context: origContext, state: stateAny},
-			&contextCondition{context: newContext, state: stateDNE},
+			{context: origContext, state: stateAny},
+			{context: newContext, state: stateDNE},
 		},
 		actions: func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
 			return append(dup(statuses, sha), dep(statuses, sha)...)
@@ -71,8 +71,8 @@ func MoveMode(origContext, newContext string) *Mode {
 func CopyMode(origContext, newContext string) *Mode {
 	return &Mode{
 		conditions: []*contextCondition{
-			&contextCondition{context: origContext, state: stateAny},
-			&contextCondition{context: newContext, state: stateDNE},
+			{context: origContext, state: stateAny},
+			{context: newContext, state: stateDNE},
 		},
 		actions: copyAction(origContext, newContext),
 	}
@@ -85,7 +85,7 @@ func CopyMode(origContext, newContext string) *Mode {
 // that only PRs that have the newContext in addition to the origContext will be considered and the
 // description of the retired context will indicate that it was replaced by newContext.
 func RetireMode(origContext, newContext string) *Mode {
-	conditions := []*contextCondition{&contextCondition{context: origContext, state: stateAny}}
+	conditions := []*contextCondition{{context: origContext, state: stateAny}}
 	if newContext != "" {
 		conditions = append(conditions, &contextCondition{context: newContext, state: stateAny})
 	}
@@ -113,7 +113,7 @@ func copyAction(origContext, newContext string) func(statuses []github.RepoStatu
 			return nil
 		}
 		return []*github.RepoStatus{
-			&github.RepoStatus{
+			{
 				Context:     &newContext,
 				State:       oldStatus.State,
 				TargetURL:   oldStatus.TargetURL,
@@ -136,7 +136,7 @@ func retireAction(origContext, newContext string) func(statuses []github.RepoSta
 	}
 	return func(statuses []github.RepoStatus, sha string) []*github.RepoStatus {
 		return []*github.RepoStatus{
-			&github.RepoStatus{
+			{
 				Context:     &origContext,
 				State:       &stateSuccess,
 				TargetURL:   nil,
@@ -232,7 +232,7 @@ func (m *Migrator) ProcessPR(pr *github.PullRequest) error {
 	actions := m.ProcessStatuses(combined)
 
 	for _, action := range actions {
-		if _, _, err = m.client.CreateStatus(m.org, m.repo, *pr.Head.SHA, action); err != nil {
+		if _, _, err = m.client.CreateStatus(m.org, m.repo, pr, action); err != nil {
 			return err
 		}
 	}

--- a/maintenance/migratestatus/migrator/migrator_test.go
+++ b/maintenance/migratestatus/migrator/migrator_test.go
@@ -84,7 +84,7 @@ func TestMoveMode(t *testing.T) {
 	desc := "Context retired. Status moved to \"context B\"."
 
 	tests := []*modeTest{
-		&modeTest{
+		{
 			name: "simple",
 			start: []github.RepoStatus{
 				*makeStatus(contextA, "failure", "description 1", "url 1"),
@@ -94,7 +94,7 @@ func TestMoveMode(t *testing.T) {
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts",
 			start: []github.RepoStatus{
 				*makeStatus("also not related", "error", "description 4", "url 4"),
@@ -106,7 +106,7 @@ func TestMoveMode(t *testing.T) {
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts; missing context A",
 			start: []github.RepoStatus{
 				*makeStatus("also not related", "error", "description 4", "url 4"),
@@ -114,7 +114,7 @@ func TestMoveMode(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts; already have context A and B",
 			start: []github.RepoStatus{
 				*makeStatus("also not related", "error", "description 4", "url 4"),
@@ -124,7 +124,7 @@ func TestMoveMode(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts; already have context B; no context A",
 			start: []github.RepoStatus{
 				*makeStatus("also not related", "error", "description 4", "url 4"),
@@ -133,7 +133,7 @@ func TestMoveMode(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name:          "no contexts",
 			start:         []github.RepoStatus{},
 			expectedDiffs: []*github.RepoStatus{},
@@ -154,7 +154,7 @@ func TestCopyMode(t *testing.T) {
 	contextB := "context B"
 
 	tests := []*modeTest{
-		&modeTest{
+		{
 			name: "simple",
 			start: []github.RepoStatus{
 				*makeStatus(contextA, "failure", "description 1", "url 1"),
@@ -163,7 +163,7 @@ func TestCopyMode(t *testing.T) {
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),
@@ -174,7 +174,7 @@ func TestCopyMode(t *testing.T) {
 				makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 		},
-		&modeTest{
+		{
 			name: "already have context B",
 			start: []github.RepoStatus{
 				*makeStatus(contextA, "failure", "description 1", "url 1"),
@@ -182,7 +182,7 @@ func TestCopyMode(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "already have updated context B",
 			start: []github.RepoStatus{
 				*makeStatus(contextA, "failure", "description 1", "url 1"),
@@ -190,7 +190,7 @@ func TestCopyMode(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts already have updated context B",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),
@@ -200,14 +200,14 @@ func TestCopyMode(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "only have context B",
 			start: []github.RepoStatus{
 				*makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts; context B but not A",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),
@@ -216,7 +216,7 @@ func TestCopyMode(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name:          "no contexts",
 			start:         []github.RepoStatus{},
 			expectedDiffs: []*github.RepoStatus{},
@@ -238,7 +238,7 @@ func TestRetireModeReplacement(t *testing.T) {
 	desc := "Context retired. Status moved to \"context B\"."
 
 	tests := []*modeTest{
-		&modeTest{
+		{
 			name: "simple",
 			start: []github.RepoStatus{
 				*makeStatus(contextA, "failure", "description 1", "url 1"),
@@ -248,7 +248,7 @@ func TestRetireModeReplacement(t *testing.T) {
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts;updated context B",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),
@@ -260,14 +260,14 @@ func TestRetireModeReplacement(t *testing.T) {
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
-		&modeTest{
+		{
 			name: "missing context B",
 			start: []github.RepoStatus{
 				*makeStatus(contextA, "failure", "description 1", "url 1"),
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts;missing context B",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),
@@ -276,14 +276,14 @@ func TestRetireModeReplacement(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "missing context A",
 			start: []github.RepoStatus{
 				*makeStatus(contextB, "failure", "description 1", "url 1"),
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts;missing context A",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),
@@ -292,7 +292,7 @@ func TestRetireModeReplacement(t *testing.T) {
 			},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name:          "no contexts",
 			start:         []github.RepoStatus{},
 			expectedDiffs: []*github.RepoStatus{},
@@ -313,7 +313,7 @@ func TestRetireModeNoReplacement(t *testing.T) {
 	desc := "Context retired without replacement."
 
 	tests := []*modeTest{
-		&modeTest{
+		{
 			name: "simple",
 			start: []github.RepoStatus{
 				*makeStatus(contextA, "failure", "description 1", "url 1"),
@@ -322,7 +322,7 @@ func TestRetireModeNoReplacement(t *testing.T) {
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),
@@ -333,12 +333,12 @@ func TestRetireModeNoReplacement(t *testing.T) {
 				makeStatus(contextA, "success", desc, ""),
 			},
 		},
-		&modeTest{
+		{
 			name:          "missing context A",
 			start:         []github.RepoStatus{},
 			expectedDiffs: []*github.RepoStatus{},
 		},
-		&modeTest{
+		{
 			name: "unrelated contexts;missing context A",
 			start: []github.RepoStatus{
 				*makeStatus("unrelated context", "success", "description 2", "url 2"),


### PR DESCRIPTION
Also switch `--dry-run=false` to `--modify` to make it more obvious that the default state won't change anything.
And run `gofmt` on things

/assign @cjwagner 

ref https://github.com/kubernetes/test-infra/issues/2059