### PR TITLE
Use latest kubekins-e2e-prow image for federation pull deploy

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2936,7 +2936,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
After analyzing the recent failures in federation pre-submit tests. @madhusudancs figured out there is difference in args which we used to pass in jenkins job vs prow job. Basically we are missing one arg `--save`

Further to this finding when i debug using logs, i find that the bash tracing is not the same with latest `e2e-runner.sh` script. So whatever we are running now is older version. @madhusudancs, had introduced this change in https://github.com/kubernetes/test-infra/commit/4f0029329e4892236bfdfa15714333711d158c56 on March 1st 2017. The gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4 contains older version prior to March 1st.

So if i use the latest image of gcr.io/k8s-testimages/kubekins-e2e-prow, the problem of missing `--save` in federation-pull-deploy job should be solved.

/assign @madhusudancs
cc  @fejta @krzyzacy 