### PR TITLE
Fix federation pre-submit jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -91,11 +91,6 @@
         job-name: pull-kubernetes-e2e-gce-etcd3
         repo-name: 'k8s.io/kubernetes'
         timeout: 75
-    - kubernetes-federation-e2e-gce:
-        max-total: 12
-        job-name: pull-kubernetes-federation-e2e-gce
-        repo-name: 'k8s.io/kubernetes'
-        timeout: 110
     - kubernetes-kubemark-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-kubemark-e2e-gce

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4237,7 +4237,8 @@
       "--build", 
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce", 
       "--cluster=", 
-      "--multiple-federations"
+      "--multiple-federations", 
+      "--mode=local"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2932,17 +2932,10 @@ periodics:
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
         readOnly: true
       - mountPath: /root/.cache
         name: cache-ssd
@@ -2950,10 +2943,6 @@ periodics:
     - name: service
       secret:
         secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
     - hostPath:
         path: /mnt/disks/ssd0
       name: cache-ssd

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -186,6 +186,35 @@ presubmits:
     context: pull-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce )?test this"
+    spec:
+      containers:
+      - args:
+        - --pull=$(PULL_REFS)
+        - --repo=k8s.io/kubernetes
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --json
+        - --timeout=90
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
 
   - name: pull-kubernetes-kubemark-e2e-gce
     trigger: "@k8s-bot (kubemark )?(e2e )?test this"
@@ -348,6 +377,35 @@ presubmits:
     context: pull-security-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-security-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce )?test this"
+    spec:
+      containers:
+      - args:
+        - --pull=$(PULL_REFS)
+        - --repo=k8s.io/kubernetes
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --json
+        - --timeout=90
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
 
   - name: pull-security-kubernetes-kubemark-e2e-gce
     trigger: "@k8s-bot (kubemark )?(e2e )?test this"


### PR DESCRIPTION
Federation pre-submits still failing.
Debugging the logs found that the cluster-name used for deploy and test are different. basically it is `${USER}-${zone}`
In case of deploy the user is `prow` and in case of tests the user is `jenkins`
By default when there is no spec in prow job. it seems it is using `jenkins` user. So moving from jenkins to prow job the user got changed and we started seeing failures in test.
So we have 2 options. 
1. keep `prow` as user and add spec to federation-presubmit-test job.
2. keep `jenkins` as user and change user name in federation-presubmit-deploy job

This PR is doing the second options. Please do let me know if this is OK.

/assign @madhusudancs 
cc @fejta @krzyzacy 