### PR TITLE
Add ssh-keys to federation pre-submit jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -201,10 +201,17 @@ presubmits:
           value: /etc/service-account/service-account.json
         - name: USER
           value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
           readOnly: true
         - mountPath: /root/.cache
           name: cache-ssd
@@ -212,6 +219,10 @@ presubmits:
       - name: service
         secret:
           secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
@@ -392,10 +403,17 @@ presubmits:
           value: /etc/service-account/service-account.json
         - name: USER
           value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
         image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
           readOnly: true
         - mountPath: /root/.cache
           name: cache-ssd
@@ -403,6 +421,10 @@ presubmits:
       - name: service
         secret:
           secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
@@ -2990,10 +3012,17 @@ periodics:
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
         readOnly: true
       - mountPath: /root/.cache
         name: cache-ssd
@@ -3001,6 +3030,10 @@ periodics:
     - name: service
       secret:
         secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
     - hostPath:
         path: /mnt/disks/ssd0
       name: cache-ssd


### PR DESCRIPTION
We were unsure of use of ssh-keys and had removed them from federation pre-submit jobs in PR #2818
But now its clear by look at logs from https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-federation-e2e-gce, that ssh-keys are required to setup the CI job.
```
I0522 18:43:35.143] Call:  /workspace/./test-infra/jenkins/../scenarios/kubernetes_e2e.py --env-file=platforms/gce.env --env-file=jobs/pull-kubernetes-e2e.env --env-file=jobs/pull-kubernetes-federation-e2e-gce.env --build --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce --cluster= --multiple-federations --mode=local
W0522 18:43:35.168] Traceback (most recent call last):
W0522 18:43:35.168]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_e2e.py", line 488, in <module>
W0522 18:43:35.169]     main(create_parser().parse_args())
W0522 18:43:35.169]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_e2e.py", line 355, in main
W0522 18:43:35.169]     mode.add_gce_ssh(args.gce_ssh, args.gce_pub)
W0522 18:43:35.169]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_e2e.py", line 142, in add_gce_ssh
W0522 18:43:35.169]     shutil.copy(priv, gce_ssh)
W0522 18:43:35.169]   File "/usr/lib/python2.7/shutil.py", line 119, in copy
W0522 18:43:35.187]     copyfile(src, dst)
W0522 18:43:35.187]   File "/usr/lib/python2.7/shutil.py", line 82, in copyfile
W0522 18:43:35.187]     with open(src, 'rb') as fsrc:
W0522 18:43:35.187] IOError: [Errno 2] No such file or directory: '/root/.ssh/google_compute_engine'
E0522 18:43:35.189] Build failed
```
So adding them back.

cc @nikhiljindal, @madhusudancs @fejta 
/assign @krzyzacy 