### PR TITLE
Fix GOPATH in federation pre-submit jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -190,6 +190,7 @@ presubmits:
       containers:
       - args:
         - --pull=$(PULL_REFS)
+        - --root=/go/src
         - --repo=k8s.io/kubernetes
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --git-cache=/root/.cache/git
@@ -392,6 +393,7 @@ presubmits:
       containers:
       - args:
         - --pull=$(PULL_REFS)
+        - --root=/go/src
         - --repo=k8s.io/kubernetes
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --git-cache=/root/.cache/git


### PR DESCRIPTION
While continuing our story to migrate federation pre-submit jobs to prow. we find that the GOPATH is set to /go in local mode (which is coming from docker image probably). 
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/45614/pull-kubernetes-federation-e2e-gce/81/build-log.txt

The pre-submit tests checkout the code to `/workspace/k8s.io/kubernetes`
```
I0523 00:53:03.468] Checkout: /workspace/k8s.io/kubernetes master:8e98f1dfec9d1f3a100fe9af9588bcbedc0ab801,45614:965912447c68d57359ed7771e284f5f6affb3a63
```
So we should probably fix the working directory. So this PR tries to fix by setting `--root` flag to bootstrap.py in federation presubmit jobs.

/cc @nikhiljindal, @madhusudancs 
/assign @krzyzacy @fejta 