### PR TITLE
k8s-merge-robot: link to list of bot commands from approval notice

### DIFF
--- a/mungegithub/mungers/approvers/approvers_test.go
+++ b/mungegithub/mungers/approvers/approvers_test.go
@@ -565,6 +565,8 @@ We suggest the following additional approver: **Alice**
 
 Assign the PR to them by writing ` + "`/assign @Alice`" + ` in a comment when ready.
 
+The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
+
 <details open>
 Needs approval from an approver in each of these OWNERS Files:
 
@@ -598,6 +600,8 @@ func TestGetMessageAllApproved(t *testing.T) {
 	want := `[APPROVALNOTIFIER] This PR is **APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Alice</a>*, *<a href="REFERENCE" title="LGTM">Bill</a>*
+
+The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
 
 <details >
 Needs approval from an approver in each of these OWNERS Files:
@@ -633,6 +637,8 @@ This pull-request has been approved by:
 We suggest the following additional approvers: **Alice**, **Bill**
 
 Assign the PR to them by writing ` + "`/assign @Alice @Bill`" + ` in a comment when ready.
+
+The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
 
 <details open>
 Needs approval from an approver in each of these OWNERS Files:

--- a/mungegithub/mungers/approvers/owners.go
+++ b/mungegithub/mungers/approvers/owners.go
@@ -469,6 +469,8 @@ We suggest the following additional approver{{if ne 1 (len .ap.GetCCs)}}s{{end}}
 Assign the PR to them by writing `+"`/assign {{range $index, $cc := .ap.GetCCs}}{{if $index}} {{end}}@{{$cc}}{{end}}`"+` in a comment when ready.
 {{- end}}
 
+The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
+
 <details {{if not .ap.IsApproved}}open{{end}}>
 Needs approval from an approver in each of these OWNERS Files:
 


### PR DESCRIPTION
Since this comment is posted on all PRs, and already mentions the
`/assign` command, add a link to the list of the rest of the
commands understood by the k8s robots.

As discussed in https://github.com/kubernetes/community/issues/626