### PR TITLE
Revert moving federation pre-submit jobs to prow

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -91,6 +91,11 @@
         job-name: pull-kubernetes-e2e-gce-etcd3
         repo-name: 'k8s.io/kubernetes'
         timeout: 75
+    - kubernetes-federation-e2e-gce:
+        max-total: 12
+        job-name: pull-kubernetes-federation-e2e-gce
+        repo-name: 'k8s.io/kubernetes'
+        timeout: 110
     - kubernetes-kubemark-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-kubemark-e2e-gce

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-soak.yaml
@@ -227,3 +227,13 @@
         scan: ALL
         timeout: 620
         soak-repos: '--bare'
+    # Although this job is a dependency for a pull job, this is
+    # being deployed as a CI soak job to periodically bring up
+    # and tear down the clusters for the federation pull job.
+    - kubernetes-pull-gce-federation-deploy:
+        blocker: pull-kubernetes-federation-e2e-gce
+        job-name: ci-kubernetes-pull-gce-federation-deploy
+        frequency: 'H 0 * * *'
+        scan: DISABLED
+        timeout: 90
+        soak-repos: '--bare'

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3611,8 +3611,7 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy.env", 
       "--test=false", 
-      "--down=false", 
-      "--mode=local"
+      "--down=false"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4237,8 +4236,7 @@
       "--build", 
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce", 
       "--cluster=", 
-      "--multiple-federations", 
-      "--mode=local"
+      "--multiple-federations"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -186,47 +186,6 @@ presubmits:
     context: pull-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce )?test this"
-    spec:
-      containers:
-      - args:
-        - --pull=$(PULL_REFS)
-        - --root=/go/src
-        - --repo=k8s.io/kubernetes
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
-        - --clean
-        - --json
-        - --timeout=90
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        - name: USER
-          value: prow
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - mountPath: /root/.cache
-          name: cache-ssd
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
 
   - name: pull-kubernetes-kubemark-e2e-gce
     always_run: true
@@ -389,47 +348,6 @@ presubmits:
     context: pull-security-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-security-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce )?test this"
-    spec:
-      containers:
-      - args:
-        - --pull=$(PULL_REFS)
-        - --root=/go/src
-        - --repo=k8s.io/kubernetes
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
-        - --clean
-        - --json
-        - --timeout=90
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        - name: USER
-          value: prow
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - mountPath: /root/.cache
-          name: cache-ssd
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
 
   - name: pull-security-kubernetes-kubemark-e2e-gce
     always_run: true
@@ -2981,44 +2899,6 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
-      - mountPath: /root/.cache
-        name: cache-ssd
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
-    - hostPath:
-        path: /mnt/disks/ssd0
-      name: cache-ssd
-
-- name: ci-kubernetes-pull-gce-federation-deploy
-  interval: 24h
-  spec:
-    containers:
-    - args:
-      - --timeout=90
-      - --bare
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: USER
-        value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
We met up with issues while migrating federation pre-submit jobs to prow from jenkins.
So reverting them back so that federation PR's can be unblocked.

We will continue to test the pre-submit jobs using canary jobs, which i would submit in another PR.

/assign @madhusudancs 
cc @nikhiljindal @krzyzacy @fejta 