### PR TITLE
Adding canary prow jobs for federation pre-submits

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1885,6 +1885,8 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-e2e-gce-federation.env': 'ci-kubernetes-federation-*',
             'pull-kubernetes-federation-e2e-gce.env': 'pull-kubernetes-federation-e2e-gce-*',
             'ci-kubernetes-pull-gce-federation-deploy.env': 'pull-kubernetes-federation-e2e-gce-*',
+            'pull-kubernetes-federation-e2e-gce-canary.env': 'pull-kubernetes-federation-e2e-gce-*',
+            'ci-kubernetes-pull-gce-federation-deploy-canary.env': 'pull-kubernetes-federation-e2e-gce-*',
             'pull-kubernetes-e2e-gce.env': 'pull-kubernetes-e2e-gce-*',
             'pull-kubernetes-e2e-gce-canary.env': 'pull-kubernetes-e2e-gce-*',
         }

--- a/jobs/ci-kubernetes-pull-gce-federation-deploy-canary.env
+++ b/jobs/ci-kubernetes-pull-gce-federation-deploy-canary.env
@@ -1,0 +1,2 @@
+PROJECT=k8s-jkns-pr-cnry-e2e-gce-fdrtn
+KUBE_REGISTRY=gcr.io/k8s-jkns-pr-cnry-e2e-gce-fdrtn

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3618,6 +3618,20 @@
       "UNKNOWN"
     ]
   }, 
+  "ci-kubernetes-pull-gce-federation-deploy-canary": {
+    "args": [
+      "--env-file=platforms/gce.env", 
+      "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy.env", 
+      "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy-canary.env", 
+      "--test=false", 
+      "--down=false", 
+      "--mode=local"
+    ], 
+    "scenario": "kubernetes_e2e", 
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  }, 
   "ci-kubernetes-soak-cos-docker-validation-deploy": {
     "args": [
       "--env-file=platforms/gce.env", 
@@ -4237,6 +4251,23 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce", 
       "--cluster=", 
       "--multiple-federations"
+    ], 
+    "scenario": "kubernetes_e2e", 
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  }, 
+  "pull-kubernetes-federation-e2e-gce-canary": {
+    "args": [
+      "--env-file=platforms/gce.env", 
+      "--env-file=jobs/pull-kubernetes-e2e.env", 
+      "--env-file=jobs/pull-kubernetes-federation-e2e-gce.env", 
+      "--env-file=jobs/pull-kubernetes-federation-e2e-gce-canary.env", 
+      "--build", 
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce-canary", 
+      "--cluster=", 
+      "--multiple-federations", 
+      "--mode=local"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [

--- a/jobs/pull-kubernetes-federation-e2e-gce-canary.env
+++ b/jobs/pull-kubernetes-federation-e2e-gce-canary.env
@@ -1,0 +1,11 @@
+PROJECT=k8s-jkns-pr-cnry-e2e-gce-fdrtn
+KUBE_REGISTRY=gcr.io/k8s-jkns-pr-cnry-e2e-gce-fdrtn
+
+# Federation control plane options.
+FEDERATION_DNS_ZONE_NAME=presubmit-canary.test-f8n.k8s.io.
+
+# Federated clusters are turned up and torn down by a separate CI
+# job. `ci-kubernetes-pull-gce-federation-deploy-canary` is the name of
+# job and it writes the required kubeconfig file to a GCS bucket
+# with its name. We need to read the kubeconfig from that bucket.
+JENKINS_FEDERATION_PREFIX=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy-canary

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -187,6 +187,58 @@ presubmits:
     rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce )?test this"
 
+  - name: pull-kubernetes-federation-e2e-gce-canary
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    - release-1.6
+    always_run: false
+    skip_report: true
+    context: pull-kubernetes-federation-e2e-gce-canary
+    rerun_command: "@k8s-bot pull-kubernetes-federation-e2e-gce-canary test this"
+    trigger: "@k8s-bot (pull-kubernetes-federation-e2e-gce-canary )?test this"
+    spec:
+      containers:
+      - args:
+        - --pull=$(PULL_REFS)
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --json
+        - --timeout=90
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
+
   - name: pull-kubernetes-kubemark-e2e-gce
     always_run: true
     context: pull-kubernetes-kubemark-e2e-gce
@@ -348,6 +400,58 @@ presubmits:
     context: pull-security-kubernetes-federation-e2e-gce
     rerun_command: "@k8s-bot pull-security-kubernetes-federation-e2e-gce test this"
     trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce )?test this"
+
+  - name: pull-security-kubernetes-federation-e2e-gce-canary
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    - release-1.6
+    always_run: false
+    skip_report: true
+    context: pull-security-kubernetes-federation-e2e-gce-canary
+    rerun_command: "@k8s-bot pull-security-kubernetes-federation-e2e-gce-canary test this"
+    trigger: "@k8s-bot (pull-security-kubernetes-federation-e2e-gce-canary )?test this"
+    spec:
+      containers:
+      - args:
+        - --pull=$(PULL_REFS)
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --json
+        - --timeout=90
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
 
   - name: pull-security-kubernetes-kubemark-e2e-gce
     always_run: true
@@ -2899,6 +3003,44 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - mountPath: /root/.cache
+        name: cache-ssd
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - hostPath:
+        path: /mnt/disks/ssd0
+      name: cache-ssd
+
+- name: ci-kubernetes-pull-gce-federation-deploy-canary
+  interval: 24h
+  spec:
+    containers:
+    - args:
+      - --timeout=90
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
       volumeMounts:
       - mountPath: /etc/service-account
         name: service

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -155,6 +155,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-federation-test
 - name: ci-kubernetes-pull-gce-federation-deploy
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-pull-gce-federation-deploy
+- name: ci-kubernetes-pull-gce-federation-deploy-canary
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-pull-gce-federation-deploy-canary
 - name: ci-kubernetes-federation-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build
 - name: ci-kubernetes-federation-build-1.6
@@ -1741,6 +1743,8 @@ dashboards:
     test_group_name: ci-kubernetes-soak-gce-federation-test
   - name: pull-gce-deploy
     test_group_name: ci-kubernetes-pull-gce-federation-deploy
+  - name: pull-gce-deploy-canary
+    test_group_name: ci-kubernetes-pull-gce-federation-deploy-canary
   - name: build
     test_group_name: ci-kubernetes-federation-build
   - name: build-1.6


### PR DESCRIPTION
Here we are adding canary jobs for federation pre-submits which has `skip_report: true` and `always_run: false`. These jobs will be used for experimenting on PR but without reporting them.

/assign @madhusudancs 
/cc @nikhiljindal, @krzyzacy @fejta 