### PR TITLE
Clarify when a milestone will affect queue order

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -1526,8 +1526,8 @@ func (sq *SubmitQueue) servePriorityInfo(res http.ResponseWriter, req *http.Requ
 	res.Write([]byte(`  <li>Release milestone due date
     <ul>
       <li>Release milestones are of the form vX.Y where X and Y are integers</li>
-      <li>Other milestones are ignored.
-      <li>PR with no release milestone will be considered after any PR with a milestone</li>
+      <li>The release milestore must have a due date set to affect queue order</li>
+      <li>Other milestones are ignored</li>
     </ul>
   </li>
 `))


### PR DESCRIPTION
I always wondered why certain milestones (like 1.6 currently) would affect queue order, when others (like 1.7 currently) would not. This helps clarify the language in the SQ Queue Order page.