### PR TITLE
Fix federation soak tests

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -136,7 +136,7 @@ if [[ "${E2E_DOWN:-}" == "true" ]] || [[ "${FEDERATION_DOWN:-}" == "true" ]]; th
   e2e_go_args+=(--down)
 fi
 
-if [[ "${FEDERATION_UP:-}" == "true" ]] || [[ "${FEDERATION_DOWN:-}" == "true" ]]; then
+if [[ "${FEDERATION_UP:-}" == "true" ]] || [[ "${FEDERATION_DOWN:-}" == "true" ]] || [[ "${FEDERATION:-}" == "true" ]]; then
   e2e_go_args+=(--federation)
   if [[ -z "${FEDERATION_CLUSTERS:-}" ]]; then
     e2e_go_args+=("--deployment=none")


### PR DESCRIPTION
We see failures in federation soak tests recently.
In federation soak tests we don't bring up/bring down federated clusters as well as federation control plane and just do tests.
Recently the kubetest was introduced with a [change](https://github.com/kubernetes/test-infra/commit/ba0d5c56186a451f0f166bfd111cb0599707ca81) to run federation tests only when `--federation` flag is passed and earlier just setting `FEDERATION` env var true was enough. 
So this PR adds a `--federation` flag to kubetest if `FEDERATION` env var is set to true in e2e-runner.sh.

Probably this issue will not get fixed until new `gcr.io/k8s-testimages/kubekins-e2e` is built and pushed and we start using that image in our federation soak tests.

/assign @madhusudancs 
cc @fejta @krzyzacy 