### PR TITLE
Gather test suite metrics for e2e-gce-etcd3

### DIFF
--- a/jobs/pull-kubernetes-e2e-gce-etcd3.env
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.env
@@ -6,3 +6,5 @@ ENABLE_CACHE_MUTATION_DETECTOR=true
 
 PROJECT=k8s-jkns-pr-gce-etcd3
 KUBEKINS_TIMEOUT=55m
+
+GINKGO_TEST_ARGS=--gather-suite-metrics-at-teardown=true


### PR DESCRIPTION
Gather test suite metrics for the `pull-kubernetes-e2e-gce-etcd3` job. Depends on https://github.com/kubernetes/kubernetes/pull/46461 being merged first.

cc @wojtek-t @krzyzacy @ixdy @spxtr - please let me know if I did this correctly 😄.