### PR TITLE
Don't make a comment if the labels don't exist.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.106
+HOOK_VERSION       = 0.107
 SINKER_VERSION     = 0.9
 DECK_VERSION       = 0.27
 SPLICE_VERSION     = 0.20

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.106
+        image: gcr.io/k8s-prow/hook:0.107
         imagePullPolicy: Always
         args:
         - "--github-bot-name=k8s-ci-robot"

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -46,7 +46,6 @@ var (
 	removeLabelRegex        = regexp.MustCompile(`(?m)^/remove-(area|priority|kind|sig)\s*(.*)$`)
 	sigMatcher              = regexp.MustCompile(`(?m)@kubernetes/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`)
 	chatBack                = "Reiterating the mentions to trigger a notification: \n%v"
-	nonExistentLabel        = "These labels do not exist in this repository: `%v`"
 	nonExistentLabelOnIssue = "Those labels are not set on the issue: `%v`"
 	kindMap                 = map[string]string{
 		"bugs":             "kind/bug",
@@ -242,11 +241,9 @@ func handle(gc githubClient, log *logrus.Entry, ae assignEvent) error {
 
 	}
 
+	//TODO(grodrigues3): Once labels are standardized, make this reply with a comment.
 	if len(nonexistent) > 0 {
-		msg := fmt.Sprintf(nonExistentLabel, strings.Join(nonexistent, ", "))
-		if err := gc.CreateComment(ae.org, ae.repo, ae.number, plugins.FormatResponseRaw(ae.body, ae.url, ae.login, msg)); err != nil {
-			log.WithError(err).Errorf("Could not create comment \"%s\".", msg)
-		}
+		log.Infof("Nonexistent labels: %v", nonexistent)
 	}
 
 	// Tried to remove Labels that were not present on the Issue


### PR DESCRIPTION
Right now this leads to an annoying useless comment whenever someone mentions a sig in another repo. We plan to standardize labels, but until then lets disable this comment.

For example, https://github.com/kubernetes/test-infra/issues/2820#issuecomment-303839766.

/assign @grodrigues3 