### PR TITLE
Only run affected part 2

### DIFF
--- a/images/pull_kubernetes_bazel/coalesce.py
+++ b/images/pull_kubernetes_bazel/coalesce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -41,10 +41,9 @@ buildables=$(bazel query \
 rc=0
 if [[ ! -z "${buildables}" ]]; then
   bazel build ${buildables} && rc=$? || rc=$?
+  # Clear test.xml so that we don't pick up old results.
+  find -L bazel-testlogs -name 'test.xml' -type f -exec rm '{}' +
 fi
-
-# Clear test.xml so that we don't pick up old results.
-find -L bazel-testlogs -name 'test.xml' -type f -exec rm '{}' +
 
 # Run affected tests.
 if [[ "${rc}" == 0 ]]; then


### PR DESCRIPTION
Revive #2414, as we probably found the reason why it failed:

When there is nothing to build, we just skip the `bazel build`
altogether and the `bazel-testlogs` directory is not created, causing
the find command to fail. Only try to remove test.xml from the
bazel-testlogs if we did run bazel.