### PR TITLE
Update docker image used by ci-kubernetes-e2e-gce-gpu.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1387,7 +1387,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170418-c08e1094
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
The existing docker image had an old version of gcloud which didn't have
--accelerator support.