### PR TITLE
only test changed files: ignore deleted files target

### DIFF
--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -29,7 +29,7 @@ export TEST_TMPDIR="/root/.cache/bazel"
 # Compute list of modified files in bazel package form.
 commit_range="${PULL_BASE_SHA}..${PULL_PULL_SHA}"
 files=()
-for file in $(git diff --name-only "${commit_range}" ); do
+for file in $(git diff --name-only --diff-filter=d "${commit_range}" ); do
   files+=($(bazel query "${file}"))
 done
 


### PR DESCRIPTION
Deleted files obviously don't have a target defined anymore. We
shouldn't fail while trying to figure that out.

This also happens if a file was removed between the merge-base of the pull-request and master.