### PR TITLE
Periodic jobs don't have REPO_NAME set automatically

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -895,6 +895,8 @@ periodics:
       securityContext:
         privileged: true
       env:
+      - name: REPO_NAME
+        value: test-infra
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       volumeMounts:


### PR DESCRIPTION
Fix breakage caused by #2731.

/assign @spxtr @krzyzacy 