### PR TITLE
find-merge-conflicts: add reset in git loop

### DIFF
--- a/experiment/find-merge-conflicts.sh
+++ b/experiment/find-merge-conflicts.sh
@@ -94,6 +94,7 @@ for pr in ${conflicting_prs[@]}; do
   PAGER=cat git diff --name-only --diff-filter=UXB
   # Abort so we can reset
   git merge --abort >/dev/null 2>/dev/null || true
+  git reset -q --hard
   git checkout -q master
   git branch -q -D merge-test
   git prune 2>/dev/null


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/36412 was causing the script to abort with
```
# Fetching refs/pull/36412/head
error: you need to resolve your current index first
```

With this change, it completes.