### PR TITLE
Update e2e-prow image to be based on kubekins-e2e:v20170525-59b0e879

### DIFF
--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170515-3c63b511
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170525-59b0e879
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /


### PR DESCRIPTION
/assign @krzyzacy 

This should update the e2e-prow image to include bazel, which will in turn support bazel-built e2e PR tests on prow.