### PR TITLE
Convert pull-kubernetes-e2e-gce-bazel into a prow-native job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -61,11 +61,6 @@
     jobs:
     - 'pull-{jsonsuffix}'
     jsonsuffix:  # pull-<repo>-<suffix> is the expected format
-    - kubernetes-e2e-gce-bazel:
-        max-total: 12
-        job-name: pull-kubernetes-e2e-gce-bazel
-        repo-name: 'k8s.io/kubernetes'
-        timeout: 75
     - kubernetes-e2e-gce-canary:
         max-total: 12
         job-name: pull-kubernetes-e2e-gce-canary

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4082,7 +4082,8 @@
       "--env-file=jobs/pull-kubernetes-e2e-gce-bazel.env", 
       "--build=bazel", 
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-bazel", 
-      "--cluster="
+      "--cluster=", 
+      "--mode=local"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -155,6 +155,53 @@ presubmits:
     context: pull-kubernetes-e2e-gce-bazel
     rerun_command: "@k8s-bot pull-kubernetes-e2e-gce-bazel test this"
     trigger: "@k8s-bot pull-kubernetes-e2e-gce-bazel test this"
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    - release-1.6
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --timeout=90
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170530-7cb6f5b5
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
 
   - name: pull-kubernetes-e2e-gce-canary
     context: pull-kubernetes-e2e-gce-canary
@@ -383,6 +430,53 @@ presubmits:
     context: pull-security-kubernetes-e2e-gce-bazel
     rerun_command: "@k8s-bot pull-security-kubernetes-e2e-gce-bazel test this"
     trigger: "@k8s-bot pull-security-kubernetes-e2e-gce-bazel test this"
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    - release-1.6
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --timeout=90
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170530-7cb6f5b5
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
 
   - name: pull-security-kubernetes-e2e-gce-canary
     context: pull-security-kubernetes-e2e-gce-canary


### PR DESCRIPTION
The pull-kubernetes-e2e-gce-bazel job [doesn't seem to work](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/46662/pull-kubernetes-e2e-gce-bazel/1/) on Jenkins:
```
W0530 17:24:07.302] ERROR: /workspace/.cache/bazel/_bazel_jenkins/48d5366022b4e3197674c8d6e2bee219/external/io_bazel_rules_docker/docker/BUILD:90:1: Creating runfiles tree bazel-out/host/bin/external/io_bazel_rules_docker/docker/create_image_config.runfiles [for host] failed: build-runfiles failed: error executing command 
W0530 17:24:07.304]   (cd /workspace/.cache/bazel/_bazel_jenkins/48d5366022b4e3197674c8d6e2bee219/execroot/kubernetes && \
W0530 17:24:07.305]   exec env - \
W0530 17:24:07.305]     PATH=/google-cloud-sdk/bin:/workspace:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
W0530 17:24:07.306]   /workspace/.cache/bazel/_bazel_jenkins/48d5366022b4e3197674c8d6e2bee219/execroot/kubernetes/_bin/build-runfiles bazel-out/host/bin/external/io_bazel_rules_docker/docker/create_image_config.runfiles_manifest bazel-out/host/bin/external/io_bazel_rules_docker/docker/create_image_config.runfiles): com.google.devtools.build.lib.shell.AbnormalTerminationException: Process terminated by signal 15.
W0530 17:24:07.448] Target //build/release-tars:release-tars failed to build
```

I'm guessing this warning is related:
```
W0530 17:23:12.086] WARNING: Sandboxed execution is not supported on your system and thus hermeticity of actions cannot be guaranteed. See http://bazel.build/docs/bazel-user-manual.html#sandboxing for more information. You can turn off this warning via --ignore_unsupported_sandboxing.
```

We don't see this warning on the other bazel builds, so I'm guessing it's related to our Jenkins VM setup. It's not really worth debugging, since we eventually want to move away from Jenkins anyway; let's just take the leap instead.