### PR TITLE
test-infra bazel job: handle renames correctly

### DIFF
--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -29,7 +29,10 @@ export TEST_TMPDIR="/root/.cache/bazel"
 # Compute list of modified files in bazel package form.
 commit_range="${PULL_BASE_SHA}..${PULL_PULL_SHA}"
 files=()
-for file in $(git diff --name-only --diff-filter=d "${commit_range}" ); do
+# git diff --name-only only prints the original (old) filename for renames
+# git diff --name-status prints the new name followed by the old name for
+# renames, so use it instead (after cutting out the first field, the status)
+for file in $(git diff --name-status --diff-filter=d "${commit_range}" | cut -f2); do
   files+=($(bazel query "${file}"))
 done
 


### PR DESCRIPTION
My PR [keeps failing tests](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/test-infra/2885/pull-test-infra-bazel/3558/): 
```
W0531 01:03:35.242] ERROR: no such target '//jobs:ci-kubernetes-e2e-gce-gci-qa-m55.env': target 'ci-kubernetes-e2e-gce-gci-qa-m55.env' not declared in package 'jobs' (did you mean 'ci-kubernetes-e2e-gce-gci-qa-m56.env'?) defined by /workspace/k8s.io/test-infra/jobs/BUILD.
E0531 01:03:35.244] Build failed
```

It seems like `git diff --name-only` doesn't do what we want:
```console
$ git diff --name-only --diff-filter=d "7cb6f5b5..ad05424e" 
experiment/find-merge-conflicts.sh
images/e2e-prow/Dockerfile
jenkins/bootstrap_test.py
jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
jobs/ci-kubernetes-e2e-gce-gci-qa-m55.env
jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.env
jobs/config.json
jobs/pull-test-infra-bazel.sh
prow/config.yaml
testgrid/config/config.yaml
```

`git-diff --name-status` makes it clearer what's happening - we renamed `ci-kubernetes-e2e-gce-gci-qa-m55.env` to `ci-kubernetes-e2e-gce-gci-qa-m60.env`, but `--name-only` only gives us the old name.
```console
$ git diff --name-status --diff-filter=d "7cb6f5b5..ad05424e"
M       experiment/find-merge-conflicts.sh
M       images/e2e-prow/Dockerfile
M       jenkins/bootstrap_test.py
M       jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
M       jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
R077    jobs/ci-kubernetes-e2e-gce-gci-qa-m60.env       jobs/ci-kubernetes-e2e-gce-gci-qa-m55.env
R077    jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m60.env  jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m55.env
M       jobs/config.json
M       jobs/pull-test-infra-bazel.sh
M       prow/config.yaml
M       testgrid/config/config.yaml
```

This fix is a little hack, but it seems to work.
/assign @apelisse @spxtr 