### PR TITLE
Fix only run

### DIFF
--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -32,6 +32,10 @@ files=()
 for file in $(git diff --name-only --diff-filter=d "${commit_range}" ); do
   files+=($(bazel query "${file}"))
 done
+if [[ "${#files[@]}" == 0 ]]; then
+  echo "No bazel packages affected."
+  exit 0
+fi
 
 # Build modified packages.
 buildables=$(bazel query \

--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -28,10 +28,7 @@ export TEST_TMPDIR="/root/.cache/bazel"
 
 # Compute list of modified files in bazel package form.
 commit_range="${PULL_BASE_SHA}...${PULL_PULL_SHA}"
-files=()
-for file in $(git diff --name-only --diff-filter=d "${commit_range}" ); do
-  files+=($(bazel query "${file}"))
-done
+files=(bazel query "set($(git diff --name-only --diff-filter=d "${commit_range}"))")
 if [[ "${#files[@]}" == 0 ]]; then
   echo "No bazel packages affected."
   exit 0

--- a/jobs/pull-test-infra-bazel.sh
+++ b/jobs/pull-test-infra-bazel.sh
@@ -27,7 +27,7 @@ pip install -r jenkins/test_history/requirements.txt
 export TEST_TMPDIR="/root/.cache/bazel"
 
 # Compute list of modified files in bazel package form.
-commit_range="${PULL_BASE_SHA}..${PULL_PULL_SHA}"
+commit_range="${PULL_BASE_SHA}...${PULL_PULL_SHA}"
 files=()
 for file in $(git diff --name-only --diff-filter=d "${commit_range}" ); do
   files+=($(bazel query "${file}"))


### PR DESCRIPTION
Multiple fixes:
- Special case when array is empty (there is no files in the PR)
- Fix the way we run diff (to get the proper list of files)
- Reduce calls to `bazel query` from `O(n)` to `O(1)` where `n` is the number of changed files.