### PR TITLE
Let COS docker validation tests against gci-next-canary

### DIFF
--- a/jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env
@@ -1,12 +1,9 @@
-# Use fixed k8s version.
-JENKINS_PUBLISHED_VERSION=v1.6.1
+# Use GCI builtin k8s version.
+JENKINS_USE_GCI_VERSION=y
 
 ### job-env
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-next-canary
 KUBE_OS_DISTRIBUTION=gci
-KUBE_GCE_MASTER_PROJECT=cos-docker-validation
-KUBE_GCE_MASTER_IMAGE=cos-docker-13
-KUBE_GCE_NODE_PROJECT=cos-docker-validation
-KUBE_GCE_NODE_IMAGE=cos-docker-13
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-cos-docker-val-serial
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env
@@ -1,12 +1,9 @@
-# Use fixed k8s version.
-JENKINS_PUBLISHED_VERSION=v1.6.1
+# Use GCI builtin k8s version.
+JENKINS_USE_GCI_VERSION=y
 
 ### job-env
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-next-canary
 KUBE_OS_DISTRIBUTION=gci
-KUBE_GCE_MASTER_PROJECT=cos-docker-validation
-KUBE_GCE_MASTER_IMAGE=cos-docker-13
-KUBE_GCE_NODE_PROJECT=cos-docker-validation
-KUBE_GCE_NODE_IMAGE=cos-docker-13
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-cos-docker-val-slow

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation.env
@@ -1,12 +1,9 @@
-# Use fixed k8s version.
-JENKINS_PUBLISHED_VERSION=v1.6.1
+# Use GCI builtin k8s version.
+JENKINS_USE_GCI_VERSION=y
 
 ### job-env
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-next-canary
 KUBE_OS_DISTRIBUTION=gci
-KUBE_GCE_MASTER_PROJECT=cos-docker-validation
-KUBE_GCE_MASTER_IMAGE=cos-docker-13
-KUBE_GCE_NODE_PROJECT=cos-docker-validation
-KUBE_GCE_NODE_IMAGE=cos-docker-13
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-cos-docker-val

--- a/jobs/ci-kubernetes-soak-cos-docker-validation-deploy.env
+++ b/jobs/ci-kubernetes-soak-cos-docker-validation-deploy.env
@@ -1,13 +1,11 @@
-KUBE_OS_DISTRIBUTION=gci
+# Use GCI builtin k8s version.
+JENKINS_USE_GCI_VERSION=y
 
 ### soak-env
 FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-next-canary
 PROJECT=cos-docker-validation-soak
 KUBE_OS_DISTRIBUTION=gci
-KUBE_GCE_MASTER_PROJECT=cos-docker-validation
-KUBE_GCE_MASTER_IMAGE=cos-docker-13
-KUBE_GCE_NODE_PROJECT=cos-docker-validation
-KUBE_GCE_NODE_IMAGE=cos-docker-13
 

--- a/jobs/ci-kubernetes-soak-cos-docker-validation-test.env
+++ b/jobs/ci-kubernetes-soak-cos-docker-validation-test.env
@@ -1,4 +1,5 @@
-KUBE_OS_DISTRIBUTION=gci
+# Use GCI builtin k8s version.
+JENKINS_USE_GCI_VERSION=y
 
 ### soak-env
 FAIL_ON_GCP_RESOURCE_LEAK=false
@@ -14,8 +15,5 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 ### job-env
 PROJECT=cos-docker-validation-soak
 KUBE_OS_DISTRIBUTION=gci
-KUBE_GCE_MASTER_PROJECT=cos-docker-validation
-KUBE_GCE_MASTER_IMAGE=cos-docker-13
-KUBE_GCE_NODE_PROJECT=cos-docker-validation
-KUBE_GCE_NODE_IMAGE=cos-docker-13
+JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-next-canary
 


### PR DESCRIPTION
We are seeing some failures in the COS Docker soak test. But we find
that the soak test is running against the head of Kubernetes. For this
case, we prefer the soak test to run on a fixed k8s version (i.e. v1.6.1,
which is the k8s version that COS currently supporting).