### PR TITLE
Fix pull-etcd3 job

### DIFF
--- a/jobs/pull-kubernetes-e2e-gce-etcd3.env
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.env
@@ -7,4 +7,4 @@ ENABLE_CACHE_MUTATION_DETECTOR=true
 PROJECT=k8s-jkns-pr-gce-etcd3
 KUBEKINS_TIMEOUT=55m
 
-GINKGO_TEST_ARGS=--gather-suite-metrics-at-teardown=true
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --gather-suite-metrics-at-teardown=true


### PR DESCRIPTION
The definition of pull-etcd3 job is:
```
  "pull-kubernetes-e2e-gce-etcd3": {
    "args": [
      "--env-file=platforms/gce.env", 
      "--env-file=jobs/pull-kubernetes-e2e.env", 
      "--env-file=jobs/pull-kubernetes-e2e-gce-etcd3.env", 
```
where the `GINKGO_TEST_ARGS` is from jobs/pull-kubernetes-e2e.env, and https://github.com/kubernetes/test-infra/pull/2874 overwrites it, thus it runs everything now.

https://github.com/kubernetes/kubernetes/issues/46713

cc @ncdc @wojtek-t 
/assign @MrHohn @bowei 