### PR TITLE
bootstrap: add option to disable overriding HOME

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -894,6 +894,21 @@ class SetupMagicEnvironmentTest(unittest.TestCase):
         self.assertEquals(env[bootstrap.HOME_ENV], env[bootstrap.WORKSPACE_ENV])
         self.assertEquals(cwd, env[bootstrap.WORKSPACE_ENV])
 
+    def testWorkspaceNoOverrideHome(self):
+        """WORKSPACE exists and is set to cwd; HOME is unchanged."""
+        env = FakeEnviron()
+        cwd = '/fake/random-location'
+        old_home = env[bootstrap.HOME_ENV]
+        with Stub(os, 'environ', env):
+            with Stub(os, 'getcwd', lambda: cwd):
+                bootstrap.setup_magic_environment(JOB, override_home_env=False)
+
+        self.assertIn(bootstrap.WORKSPACE_ENV, env)
+        self.assertEquals(old_home, env[bootstrap.HOME_ENV])
+        self.assertNotEquals(env[bootstrap.HOME_ENV],
+                             env[bootstrap.WORKSPACE_ENV])
+        self.assertEquals(cwd, env[bootstrap.WORKSPACE_ENV])
+
     def testJobEnvMismatch(self):
         env = FakeEnviron()
         with Stub(os, 'environ', env):
@@ -1017,6 +1032,7 @@ class FakeArgs(object):
     timeout = 0
     upload = UPLOAD
     json = False
+    override_home_env = True
 
     def __init__(self, **kw):
         self.branch = BRANCH

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -169,6 +169,7 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        - --override-home-env=False
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -444,6 +445,7 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        - --override-home-env=False
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -102,8 +102,8 @@ class LocalMode(object):
         self.env = []
         self.os_env = []
         self.env_files = []
+        # Do we need to add these, given that we have self.os_env?
         self.add_environment(
-            'HOME=%s' % workspace,
             'WORKSPACE=%s' % workspace,
             'PATH=%s' % os.getenv('PATH'),
         )


### PR DESCRIPTION
Bazel stores stuff in `$HOME/.cache`, and since we're setting `HOME` to the checkout directory, it's getting super confused when it encounters its own cache.

We probably shouldn't be overriding `HOME` anymore, but I'm not sure what might break if we stop doing that.
As a start, add a flag to disable this behavior, which we can test on a few canary jobs first.

/assign @fejta @krzyzacy 