### PR TITLE
Implement /retest to re-run all failing tests.

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -25,6 +25,7 @@ Command | Implemented By | Who can run it | Description
 `/release-note` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note` label
 `/release-note-none` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-none` label
 `@kubernetes/sig-<some-github-team>` | prow [label](./prow/plugins/label) | kubernetes org members | adds the corresponding `sig` label
-`@k8s-bot test this` | prow [trigger](./prow/plugins/trigger) | kubernetes org members | runs tests defined in [config.yaml](./prow/config.yaml)
+`/retest` | prow [trigger](./prow/plugins/trigger) | anyone on trusted PRs | reruns failed tests
+`@k8s-bot test this` | prow [trigger](./prow/plugins/trigger) | anyone on trusted PRs | runs tests defined in [config.yaml](./prow/config.yaml)
 `@k8s-bot ok to test` | prow [trigger](./prow/plugins/trigger) | kubernetes org members | allows the PR author to `@k8s-bot test this`
 `@k8s-bot tell me a joke` | prow [yuks](./prow/plugins/yuks) | anyone | tells a bad joke, sometimes

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.107
+HOOK_VERSION       = 0.108
 SINKER_VERSION     = 0.9
 DECK_VERSION       = 0.27
 SPLICE_VERSION     = 0.20

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.107
+        image: gcr.io/k8s-prow/hook:0.108
         imagePullPolicy: Always
         args:
         - "--github-bot-name=k8s-ci-robot"

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -133,6 +133,20 @@ func (c *Config) MatchingPresubmits(fullRepoName, body string, testAll *regexp.R
 	return result
 }
 
+// RetestPresubmits returns all presubmits that should be run given a /retest command.
+// This is the set of all presubmits intersected with ((alwaysRun + runContexts) - skipContexts)
+func (c *Config) RetestPresubmits(fullRepoName string, skipContexts, runContexts map[string]bool) []Presubmit {
+	var result []Presubmit
+	if jobs, ok := c.Presubmits[fullRepoName]; ok {
+		for _, job := range jobs {
+			if (job.AlwaysRun || runContexts[job.Context]) && !skipContexts[job.Context] {
+				result = append(result, job)
+			}
+		}
+	}
+	return result
+}
+
 func (c *Config) SetPresubmits(jobs map[string][]Presubmit) error {
 	nj := map[string][]Presubmit{}
 	for k, v := range jobs {

--- a/prow/crier/crier.go
+++ b/prow/crier/crier.go
@@ -213,8 +213,12 @@ func dashLink(r Report) string {
 // createComment takes a report and a list of entries generated with
 // createEntry and returns a nicely formatted comment.
 func createComment(r Report, entries []string) string {
+	plural := ""
+	if len(entries) > 1 {
+		plural = "s"
+	}
 	lines := []string{
-		fmt.Sprintf("@%s: The following test(s) **failed**:", r.Author),
+		fmt.Sprintf("@%s: The following test%s **failed**, say `/retest` to rerun them all:", r.Author, plural),
 		"",
 		"Test name | Commit | Details | Rerun command",
 		"--- | --- | --- | ---",

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -399,6 +399,18 @@ func (c *Client) CreateStatus(org, repo, ref string, s Status) error {
 	return err
 }
 
+// GetCombinedStatus returns the latest statuses for a given ref.
+func (c *Client) GetCombinedStatus(org, repo, ref string) (*CombinedStatus, error) {
+	c.log("GetCombinedStatus", org, repo, ref)
+	var combinedStatus CombinedStatus
+	_, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      fmt.Sprintf("%s/repos/%s/%s/commits/%s/status", c.base, org, repo, ref),
+		exitCodes: []int{200},
+	}, &combinedStatus)
+	return &combinedStatus, err
+}
+
 func (c *Client) GetLabels(org, repo string) ([]Label, error) {
 	c.log("GetLabel", org, repo)
 	if c.fake {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -30,6 +30,7 @@ type FakeClient struct {
 	IssueCommentID     int
 	PullRequests       map[int]*github.PullRequest
 	PullRequestChanges map[int][]github.PullRequestChange
+	CombinedStatuses   map[string]*github.CombinedStatus
 
 	//All Labels That Exist In The Repo
 	ExistingLabels []string
@@ -107,6 +108,10 @@ func (f *FakeClient) GetRef(owner, repo, ref string) (string, error) {
 
 func (f *FakeClient) CreateStatus(owner, repo, ref string, s github.Status) error {
 	return nil
+}
+
+func (f *FakeClient) GetCombinedStatus(owner, repo, ref string) (*github.CombinedStatus, error) {
+	return f.CombinedStatuses[ref], nil
 }
 
 func (f *FakeClient) GetLabels(owner, repo string) ([]github.Label, error) {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -50,6 +50,11 @@ type Status struct {
 	Context     string `json:"context,omitempty"`
 }
 
+// CombinedStatus is the latest statuses for a ref.
+type CombinedStatus struct {
+	Statuses []Status `json:"statuses"`
+}
+
 // User is a GitHub user account.
 type User struct {
 	Login string `json:"login"`

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -46,6 +46,7 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	ListIssueComments(owner, repo string, issue int) ([]github.IssueComment, error)
 	CreateStatus(owner, repo, ref string, status github.Status) error
+	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
 	GetPullRequestChanges(github.PullRequest) ([]github.PullRequestChange, error)
 	RemoveLabel(org, repo string, number int, label string) error
 }


### PR DESCRIPTION
This does *not* retrigger jobs for successful or pending presubmits. It
reruns all failed jobs, and any AlwaysRun jobs that have not yet
reported a context.

Hopefully this will make `@k8s-bot ... test this` unnecessary!

/cc @kubernetes/sig-contributor-experience-pr-reviews 