### PR TITLE
Update Bazel to 0.5.0 in kubekins-e2e and use Bazel's self-hosted JDK

### DIFF
--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170525-59b0e879
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170601-6bed4385
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -18,17 +18,18 @@
 FROM gcr.io/k8s-testimages/kubekins-test:1.7-v20170418-f54c7fbd
 MAINTAINER  Erick Fejta <fejta@google.com>
 
-# Since golang is based on debian, we need to use jdk1.7, rather than bazel's default jdk1.8.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash-completion \
-    openjdk-7-jdk \
+    pkg-config \
+    zip \
+    unzip \
+    xz-utils \
     zlib1g-dev \
     && apt-get clean
 
-ENV BAZEL_VERSION 0.4.5
-RUN DEB="bazel_${BAZEL_VERSION}-jdk7-linux-x86_64.deb"; \
-    wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${DEB}" && \
-    dpkg -i "${DEB}" && rm "${DEB}"
+ENV BAZEL_VERSION 0.5.0
+RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
+    wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}" && \
+    chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"
 
 # Defaults of all e2e runs
 ENV E2E_UP=true \

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -169,6 +169,9 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -178,7 +181,10 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170530-7cb6f5b5
+        # Make Bazel use shared cache for its root
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170601-727dd8f5
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -444,6 +450,9 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -453,7 +462,10 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170530-7cb6f5b5
+        # Make Bazel use shared cache for its root
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170601-727dd8f5
         volumeMounts:
         - mountPath: /etc/service-account
           name: service


### PR DESCRIPTION
As I somewhat suspected, it seems like bazel + jdk7 doesn't really work correctly, and jdk7 is going to stop being supported in 0.5.1 anyway.

Thankfully Bazel now ships with an installer with a self-hosted JDK for places where a JDK isn't already installed, like our `kubekins-e2e` container. As an added bonus, this image is also ~245MB smaller.

[Early test results](http://prow.k8s.io/log?pod=pull-kubernetes-e2e-gce-bazel-14) look promising...

(Also enabled privileged mode for `pull-kubernetes-e2e-gce-bazel`, since that's apparently needed for Bazel sandboxing.)