### PR TITLE
enforces code freeze for 1.7

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -113,7 +113,7 @@ data:
     kubernetes-pull-build-test-gci-e2e-gke,\
     kubernetes-pull-build-test-gci-kubemark-e2e-gce"
   submit-queue.weak-stable-jobs: "\"\""
-  submit-queue.do-not-merge-milestones: "\"\""
+  submit-queue.do-not-merge-milestones: "v1.8,v1.9,next-candidate,"
   submit-queue.admin-port: "9999"
   submit-queue.chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
   submit-queue.history-url: https://storage.googleapis.com/kubernetes-test-history/static/index.html


### PR DESCRIPTION
all pull requests must have the 1.7 milestone in order to enter the submit queue

**cc: @dchen1107, @kubernetes/release-maintainers**