### PR TITLE
approvers: Pull-request must have associated issue

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -17,6 +17,9 @@ limitations under the License.
 package mungers
 
 import (
+	"regexp"
+	"strconv"
+
 	githubapi "github.com/google/go-github/github"
 	"github.com/spf13/cobra"
 
@@ -28,10 +31,13 @@ import (
 )
 
 const (
-	approveCommand = "APPROVE"
-	lgtmCommand    = "LGTM"
-	cancel         = "cancel"
+	approveCommand  = "APPROVE"
+	lgtmCommand     = "LGTM"
+	cancelArgument  = "cancel"
+	noIssueArgument = "no-issue"
 )
+
+var AssociatedIssueRegex = regexp.MustCompile(`#(\d+)`)
 
 // ApprovalHandler will try to add "approved" label once
 // all files of change has been approved by approvers.
@@ -63,6 +69,23 @@ func (*ApprovalHandler) EachLoop() error { return nil }
 
 // AddFlags will add any request flags to the cobra `cmd`
 func (*ApprovalHandler) AddFlags(cmd *cobra.Command, config *github.Config) {}
+
+// Returns associated issue, or 0 if it can't find any.
+// This is really simple, and could be improved later.
+func findAssociatedIssue(body *string) int {
+	if body == nil {
+		return 0
+	}
+	match := AssociatedIssueRegex.FindStringSubmatch(*body)
+	if len(match) == 0 {
+		return 0
+	}
+	v, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0
+	}
+	return v
+}
 
 // Munge is the workhorse the will actually make updates to the PR
 // The algorithm goes as:
@@ -98,6 +121,7 @@ func (h *ApprovalHandler) Munge(obj *github.MungeObject) {
 			filenames,
 			approvers.NewRepoAlias(h.features.Repos, *h.features.Aliases),
 			int64(*obj.Issue.Number)))
+	approversHandler.AssociatedIssue = findAssociatedIssue(obj.Issue.Body)
 	addApprovers(&approversHandler, comments)
 	// Author implicitly approves their own PR
 	if obj.Issue.User != nil && obj.Issue.User.Login != nil {
@@ -127,7 +151,7 @@ func (h *ApprovalHandler) Munge(obj *github.MungeObject) {
 		obj.WriteComment(*newMessage)
 	}
 
-	if !approversHandler.IsApproved() {
+	if !approversHandler.IsApprovedWithIssue() {
 		if obj.HasLabel(approvedLabel) && !humanAddedApproved(obj) {
 			obj.RemoveLabel(approvedLabel)
 		}
@@ -186,7 +210,7 @@ func addApprovers(approversHandler *approvers.Approvers, comments []*githubapi.I
 				continue
 			}
 
-			if cmd.Arguments == cancel {
+			if cmd.Arguments == cancelArgument {
 				approversHandler.RemoveApprover(*comment.User.Login)
 			} else {
 				url := ""
@@ -198,11 +222,13 @@ func addApprovers(approversHandler *approvers.Approvers, comments []*githubapi.I
 					approversHandler.AddApprover(
 						*comment.User.Login,
 						url,
+						cmd.Arguments == noIssueArgument,
 					)
 				} else {
 					approversHandler.AddLGTMer(
 						*comment.User.Login,
 						url,
+						cmd.Arguments == noIssueArgument,
 					)
 				}
 

--- a/mungegithub/mungers/approvers/approvers_test.go
+++ b/mungegithub/mungers/approvers/approvers_test.go
@@ -104,7 +104,7 @@ func TestUnapprovedFiles(t *testing.T) {
 	for _, test := range tests {
 		testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: TEST_SEED})
 		for approver := range test.currentlyApproved {
-			testApprovers.AddApprover(approver, "REFERENCE")
+			testApprovers.AddApprover(approver, "REFERENCE", false)
 		}
 		calculated := testApprovers.UnapprovedFiles()
 		if !test.expectedUnapproved.Equal(calculated) {
@@ -216,7 +216,7 @@ func TestGetFiles(t *testing.T) {
 	for _, test := range tests {
 		testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: TEST_SEED})
 		for approver := range test.currentlyApproved {
-			testApprovers.AddApprover(approver, "REFERENCE")
+			testApprovers.AddApprover(approver, "REFERENCE", false)
 		}
 		calculated := testApprovers.GetFiles("org", "project")
 		if !reflect.DeepEqual(test.expectedFiles, calculated) {
@@ -360,7 +360,7 @@ func TestGetCCs(t *testing.T) {
 	for _, test := range tests {
 		testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: test.testSeed})
 		for approver := range test.currentlyApproved {
-			testApprovers.AddApprover(approver, "REFERENCE")
+			testApprovers.AddApprover(approver, "REFERENCE", false)
 		}
 		testApprovers.AddAssignees(test.assignees...)
 		calculated := testApprovers.GetCCs()
@@ -461,7 +461,7 @@ func TestIsApproved(t *testing.T) {
 	for _, test := range tests {
 		testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(FakeRepoMap), seed: test.testSeed})
 		for approver := range test.currentlyApproved {
-			testApprovers.AddApprover(approver, "REFERENCE")
+			testApprovers.AddApprover(approver, "REFERENCE", false)
 		}
 		calculated := testApprovers.IsApproved()
 		if test.isApproved != calculated {
@@ -537,7 +537,7 @@ func TestGetFilesApprovers(t *testing.T) {
 	for _, test := range tests {
 		testApprovers := NewApprovers(Owners{filenames: test.filenames, repo: createFakeRepo(test.owners)})
 		for _, approver := range test.approvers {
-			testApprovers.AddApprover(approver, "REFERENCE")
+			testApprovers.AddApprover(approver, "REFERENCE", false)
 		}
 		calculated := testApprovers.GetFilesApprovers()
 		if !reflect.DeepEqual(test.expectedStatus, calculated) {
@@ -556,7 +556,7 @@ func TestGetMessage(t *testing.T) {
 			}),
 		},
 	)
-	ap.AddApprover("Bill", "REFERENCE")
+	ap.AddApprover("Bill", "REFERENCE", false)
 
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
@@ -564,6 +564,8 @@ This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Bi
 We suggest the following additional approver: **Alice**
 
 Assign the PR to them by writing ` + "`/assign @Alice`" + ` in a comment when ready.
+
+*No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
 The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
 
@@ -594,12 +596,14 @@ func TestGetMessageAllApproved(t *testing.T) {
 			}),
 		},
 	)
-	ap.AddApprover("Alice", "REFERENCE")
-	ap.AddLGTMer("Bill", "REFERENCE")
+	ap.AddApprover("Alice", "REFERENCE", false)
+	ap.AddLGTMer("Bill", "REFERENCE", false)
 
-	want := `[APPROVALNOTIFIER] This PR is **APPROVED**
+	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
 This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Alice</a>*, *<a href="REFERENCE" title="LGTM">Bill</a>*
+
+*No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
 The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
 
@@ -630,13 +634,16 @@ func TestGetMessageNoneApproved(t *testing.T) {
 			}),
 		},
 	)
+	ap.AddAuthorSelfApprover("John", "REFERENCE")
 
 	want := `[APPROVALNOTIFIER] This PR is **NOT APPROVED**
 
-This pull-request has been approved by: 
+This pull-request has been approved by: *<a href="REFERENCE" title="Author self-approved">John</a>*
 We suggest the following additional approvers: **Alice**, **Bill**
 
 Assign the PR to them by writing ` + "`/assign @Alice @Bill`" + ` in a comment when ready.
+
+*No associated issue*. Update pull-request body to add a reference to an issue, or get approval with ` + "`/approve no-issue`" + `
 
 The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
 
@@ -650,6 +657,85 @@ You can indicate your approval by writing ` + "`/approve`" + ` in a comment
 You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
 </details>
 <!-- META={"approvers":["Alice","Bill"]} -->`
+	if got := GetMessage(ap, "org", "project"); got == nil {
+		t.Error("GetMessage() failed")
+	} else if *got != want {
+		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+	}
+}
+
+func TestGetMessageApprovedIssueAssociated(t *testing.T) {
+	ap := NewApprovers(
+		Owners{
+			filenames: []string{"a/a.go", "b/b.go"},
+			repo: createFakeRepo(map[string]sets.String{
+				"a": sets.NewString("Alice"),
+				"b": sets.NewString("Bill"),
+			}),
+		},
+	)
+	ap.AssociatedIssue = 12345
+	ap.AddAuthorSelfApprover("John", "REFERENCE")
+	ap.AddApprover("Bill", "REFERENCE", false)
+	ap.AddApprover("Alice", "REFERENCE", false)
+
+	want := `[APPROVALNOTIFIER] This PR is **APPROVED**
+
+This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Alice</a>*, *<a href="REFERENCE" title="Approved">Bill</a>*, *<a href="REFERENCE" title="Author self-approved">John</a>*
+
+Associated issue: *12345*
+
+The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
+
+<details >
+Needs approval from an approver in each of these OWNERS Files:
+
+- ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
+- ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
+
+You can indicate your approval by writing ` + "`/approve`" + ` in a comment
+You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":[]} -->`
+	if got := GetMessage(ap, "org", "project"); got == nil {
+		t.Error("GetMessage() failed")
+	} else if *got != want {
+		t.Errorf("GetMessage() = %+v, want = %+v", *got, want)
+	}
+}
+
+func TestGetMessageApprovedNoIssueByPassed(t *testing.T) {
+	ap := NewApprovers(
+		Owners{
+			filenames: []string{"a/a.go", "b/b.go"},
+			repo: createFakeRepo(map[string]sets.String{
+				"a": sets.NewString("Alice"),
+				"b": sets.NewString("Bill"),
+			}),
+		},
+	)
+	ap.AddAuthorSelfApprover("John", "REFERENCE")
+	ap.AddApprover("Bill", "REFERENCE", true)
+	ap.AddApprover("Alice", "REFERENCE", true)
+
+	want := `[APPROVALNOTIFIER] This PR is **APPROVED**
+
+This pull-request has been approved by: *<a href="REFERENCE" title="Approved">Alice</a>*, *<a href="REFERENCE" title="Approved">Bill</a>*, *<a href="REFERENCE" title="Author self-approved">John</a>*
+
+Associated issue requirement bypassed by: *<a href="REFERENCE" title="Approved">Alice</a>*, *<a href="REFERENCE" title="Approved">Bill</a>*
+
+The full list of commands accepted by this bot can be found [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
+
+<details >
+Needs approval from an approver in each of these OWNERS Files:
+
+- ~~[a/OWNERS](https://github.com/org/project/blob/master/a/OWNERS)~~ [Alice]
+- ~~[b/OWNERS](https://github.com/org/project/blob/master/b/OWNERS)~~ [Bill]
+
+You can indicate your approval by writing ` + "`/approve`" + ` in a comment
+You can cancel your approval by writing ` + "`/approve cancel`" + ` in a comment
+</details>
+<!-- META={"approvers":[]} -->`
 	if got := GetMessage(ap, "org", "project"); got == nil {
 		t.Error("GetMessage() failed")
 	} else if *got != want {


### PR DESCRIPTION
If a pull-request doesn't have an associated issue, it must be approved
with: `/lgtm no-issue` or `/approve no-issue`.

A pull-request is associated to an issue if it has the hash sign
followed by digits in the body.