### PR TITLE
kubernetes_e2e: Use a more prow-friendly cluster name

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -396,12 +396,9 @@ def main(args):
     if args.timeout:
         runner_args.append('--timeout=%s' % args.timeout)
 
-    cluster = args.cluster or 'e2e-gce-%s-%s' % (
-        os.environ['NODE_NAME'], os.getenv('EXECUTOR_NUMBER', 0))
+    cluster = args.cluster or 'e2e-%s' % os.getenv('BUILD_NUMBER', 0)
 
     if args.kubeadm:
-        # Not from Jenkins
-        cluster = args.cluster or 'e2e-kubeadm-%s' % os.getenv('BUILD_NUMBER', 0)
         version = kubeadm_version(args.kubeadm)
         opt = ' --kubernetes-anywhere-path /workspace/kubernetes-anywhere' \
             ' --kubernetes-anywhere-phase2-provider kubeadm' \


### PR DESCRIPTION
Rather than using NODE_NAME + EXECUTOR_NUMBER, just use BUILD_NUMBER,
which is even more unique per-project.

The main motivation is that some resources (such as firewall names) are
based on the cluster name, and they have length limits. On prow, the
auto-generated cluster name was too long.

One of the reasons for originally using NODE_NAME + EXECUTOR NUMBER was
to clean up leaked resources from previous runs. With the janitor, this
is no longer necessary.

/assign @fejta @krzyzacy 