### PR TITLE
Revert gather test suite metrics for e2e-gce-etcd3

### DIFF
--- a/jobs/pull-kubernetes-e2e-gce-etcd3.env
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.env
@@ -5,4 +5,3 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 ENABLE_CACHE_MUTATION_DETECTOR=true
 
 PROJECT=k8s-jkns-pr-gce-etcd3
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --gather-suite-metrics-at-teardown=true


### PR DESCRIPTION
This broke PRs on release branches because the new flag does not exist
there, preventing cherrypicks from merging.

This effectively reverts both https://github.com/kubernetes/test-infra/pull/2874 and the follow-up https://github.com/kubernetes/test-infra/pull/2902.

See https://github.com/kubernetes/test-infra/pull/2874#issuecomment-305637390 for details.

@ncdc @wojtek-t 