### PR TITLE
Federation e2e tests. Remove blocking to unclog the queue

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -92,7 +92,7 @@
         repo-name: 'k8s.io/kubernetes'
         timeout: 75
     - kubernetes-federation-e2e-gce:
-        max-total: 12
+        max-total: 6
         job-name: pull-kubernetes-federation-e2e-gce
         repo-name: 'k8s.io/kubernetes'
         timeout: 110

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -24,8 +24,7 @@ data:
     \"pull-kubernetes-kubemark-e2e-gce\",\
     \"pull-kubernetes-e2e-gce-etcd3\",\
     \"pull-kubernetes-bazel\",\
-    \"pull-kubernetes-e2e-kops-aws\",\
-    \"pull-kubernetes-federation-e2e-gce\""
+    \"pull-kubernetes-e2e-kops-aws\""
 
   submit-queue.protected-branches: "master"
   submit-queue.protected-branches-extra-contexts: "cla/linuxfoundation"


### PR DESCRIPTION
Reduce concurrent runs to 6 instead of default 12.
No changes to run & reporting on pull jobs.