### PR TITLE
velodrome/test_config: Change from sh to bash

### DIFF
--- a/velodrome/test_config.sh
+++ b/velodrome/test_config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2017 The Kubernetes Authors.
 #


### PR DESCRIPTION
The script is using some options that may not be available in all `sh` version.