### PR TITLE
Keep ProwJobs that are up to a week old.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -16,7 +16,7 @@ all: build test
 
 
 HOOK_VERSION       = 0.108
-SINKER_VERSION     = 0.9
+SINKER_VERSION     = 0.10
 DECK_VERSION       = 0.27
 SPLICE_VERSION     = 0.20
 TOT_VERSION        = 0.0

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,4 +15,4 @@ spec:
         role: prow
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.9
+        image: gcr.io/k8s-prow/sinker:0.10

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	period        = time.Hour
-	maxProwJobAge = 24 * time.Hour
+	maxProwJobAge = 7 * 24 * time.Hour
 	maxPodAge     = 12 * time.Hour
 )
 


### PR DESCRIPTION
We still clean up pods frequently enough to avoid running out of disk
space.

This will cause the LIST call to be a bit laggier, and we might need to
make cmd/deck only send a maximum number of entries.