### PR TITLE
Migrate jobs to --skew and --extract=JENKINS_PUBLISHED_VERSION

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -47,31 +47,6 @@ e2e_go_args=( \
   --dump="${ARTIFACTS}" \
 )
 
-# Allow download & unpack of alternate version of tests, for cross-version & upgrade testing.
-#
-# JENKINS_PUBLISHED_SKEW_VERSION adds a second --extract before the other one.
-# The JENKINS_PUBLISHED_SKEW_VERSION extracts to kubernetes_skew.
-# The JENKINS_PUBLISHED_VERSION extracts to kubernetes.
-#
-# For upgrades, PUBLISHED_SKEW should be a new release than PUBLISHED.
-if [[ -n "${JENKINS_PUBLISHED_SKEW_VERSION:-}" ]]; then
-  e2e_go_args+=(--extract="${JENKINS_PUBLISHED_SKEW_VERSION}")
-  # Assume JENKINS_USE_SKEW_KUBECTL == true for backward compatibility
-  : ${JENKINS_USE_SKEW_KUBECTL:=true}
-  if [[ "${JENKINS_USE_SKEW_TESTS:-}" == "true" ]]; then
-    e2e_go_args+=(--skew)  # Get kubectl as well as test code from kubernetes_skew
-  elif [[ "${JENKINS_USE_SKEW_KUBECTL}" == "true" ]]; then
-    # Append kubectl-path of skewed kubectl to test args, since we always
-    # want that to use the skewed kubectl version:
-    #  - for upgrade jobs, we want kubectl to be at the same version as
-    #    master.
-    #  - for client skew tests, we want to use the skewed kubectl
-    #    (that's what we're testing).
-    GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/kubernetes_skew/cluster/kubectl.sh"
-  fi
-fi
-
-
 # We get the Kubernetes tarballs unless we are going to use old ones
 if [[ -n "${RAW_EXTRACT:-}" ]]; then
   echo 'RAW_EXTRACT is set, --extract set by $@'
@@ -93,9 +68,9 @@ elif [[ "${JENKINS_USE_GCI_VERSION:-}" =~ ^[yY]$ ]]; then
   echo 'Send --extract=gci/FAMILY to scenarios/kubernetes_e2e.py'
   exit 1
 else
-  # use JENKINS_PUBLISHED_VERSION, default to 'ci/latest', since that's
-  # usually what we're testing.
-  e2e_go_args+=(--extract="${JENKINS_PUBLISHED_VERSION:-ci/latest}")
+  echo 'ERROR: RAW_EXTRACT is unset. Please set to signal --extract set by $@'
+  echo 'This requirement will disappear after migration to --extract is finished'
+  exit 1
 fi
 
 if [[ "${FAIL_ON_GCP_RESOURCE_LEAK:-true}" == "true" ]]; then
@@ -108,6 +83,9 @@ fi
 
 if [[ "${E2E_TEST:-}" == "true" ]]; then
   e2e_go_args+=(--test)
+  if [[ "${SKEW_KUBECTL:-}" == 'y' ]]; then
+      GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/kubernetes_skew/cluster/kubectl.sh"
+  fi
   if [[ -n "${GINKGO_TEST_ARGS:-}" ]]; then
     e2e_go_args+=(--test_args="${GINKGO_TEST_ARGS}")
   fi

--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.env
@@ -15,6 +15,5 @@ GINKGO_PARALLEL=y
 # expected empty
 
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector
 

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env
@@ -1,8 +1,5 @@
-# Use GCI builtin k8s version.
-
 ### job-env
 KUBE_OS_DISTRIBUTION=gci
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-cos-docker-val-serial
 JENKINS_GCI_PATCH_K8S=n
-

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env
@@ -1,5 +1,3 @@
-# Use GCI builtin k8s version.
-
 ### job-env
 KUBE_OS_DISTRIBUTION=gci
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation.env
@@ -1,9 +1,6 @@
-# Use GCI builtin k8s version.
-
 ### job-env
 KUBE_OS_DISTRIBUTION=gci
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-cos-docker-val
 JENKINS_GCI_PATCH_K8S=n
-

--- a/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-g1-4-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster.env
@@ -5,8 +5,8 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-g1-4-up-clu
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-master.env
@@ -5,8 +5,8 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-g1-4-up-mas
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env
@@ -1,11 +1,11 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gce-cvm-1-5-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env
@@ -1,11 +1,11 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gce-gci-1-5-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_USE_SKEW_TESTS=true
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-gce-upg-1-5-1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env
@@ -4,11 +4,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-gce-upg-1-5-1-6-up-clu
 
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env
@@ -4,11 +4,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-gce-upg-1-5-1-6-up-mas
 
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gce-cvm-1-6-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env
@@ -4,10 +4,6 @@ E2E_OPT=--check_version_skew=false
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-gce-dg-1-6-1-5-dwngr-clu
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_USE_SKEW_KUBECTL=false
-JENKINS_USE_SKEW_TESTS=false
 
 # Make sure we set up etcd with json storage. Rolling back from proto
 # (default for 1.6) is not possible. This is specific to the 1.6 to

--- a/jobs/ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gce-gci-1-6-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew-serial.env
@@ -1,8 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gce-cvm-1-6-m-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=debian
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew.env
@@ -1,8 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gce-cvm-1-6-mstr-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew-serial.env
@@ -1,8 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gce-gci-1-6-m-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=gci
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew.env
@@ -1,8 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gce-gci-1-6-mstr-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-4.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
 PROJECT=k8s-jkns-e2e-gce-alpha1-4
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]|ScheduledJob
 PROJECT=k8s-e2e-gce-alpha1-5
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-6.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]|ScheduledJob
 PROJECT=k8s-jkns-gce-alpha-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-canary.env
+++ b/jobs/ci-kubernetes-e2e-gce-canary.env
@@ -8,6 +8,6 @@ CLOUDSDK_BUCKET=gs://cloud-sdk-testing/ci/staging
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.5
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_NODE_OS_DISTRIBUTION=debian
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-etcd2-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd2-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-etcd2-1-6

--- a/jobs/ci-kubernetes-e2e-gce-etcd3-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gce-etcd3-1-5

--- a/jobs/ci-kubernetes-e2e-gce-gci-1.5-rollback-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-1.5-rollback-etcd.env
@@ -11,8 +11,8 @@ STORAGE_MEDIA_TYPE=application/json
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:EtcdUpgrade\] --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-5-rb-etcd
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-1.5-upgrade-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-1.5-upgrade-etcd.env
@@ -11,8 +11,8 @@ STORAGE_MEDIA_TYPE=application/json
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:EtcdUpgrade\] --etcd-upgrade-storage=etcd3 --etcd-upgrade-version=3.0.17
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-5-up-etcd
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 # To qualify GCI milestone 56 for k8s release-1.4.
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 # To qualify GCI milestone 56 for k8s release-1.4.
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=kubekins-gce-gci-ci-serial-1-5

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 # To qualify GCI milestone 56 for k8s release-1.4.
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd.env
@@ -8,8 +8,8 @@ STORAGE_MEDIA_TYPE=application/json
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:EtcdUpgrade\] --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-glat-rb-etcd
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd.env
@@ -8,8 +8,8 @@ STORAGE_MEDIA_TYPE=application/json
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:EtcdUpgrade\] --etcd-upgrade-storage=etcd3 --etcd-upgrade-version=3.0.17
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-glat-up-etcd
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew.env
@@ -1,8 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 PROJECT=gce-cvm-upg-1-4-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew.env
@@ -1,8 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 PROJECT=gce-gci-upg-1-4-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-cvm-kubectl-skew.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=gce-cvm-upg-1-5-1-4-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-gci-kubectl-skew.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=gce-gci-upg-1-5-1-4-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
@@ -3,9 +3,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 E2E_OPT=--check_version_skew=false
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-lat-cluster
 

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
@@ -3,9 +3,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 E2E_OPT=--check_version_skew=false
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-lat-master
 

--- a/jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew-serial.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gce-cvm-m-1-6-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gce-cvm-mstr-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew-serial.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gce-gci-m-1-6-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew.env
@@ -1,11 +1,8 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gce-gci-mstr-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gce-reboot-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-gce-reboot-1-5
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gce-reboot-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-1-4

--- a/jobs/ci-kubernetes-e2e-gce-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gce-1-5

--- a/jobs/ci-kubernetes-e2e-gce-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-gce-1-6

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.env
@@ -1,7 +1,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 # Use the 1.1 project for now, since it has quota.
 # TODO: create a project k8s-e2e-gce-scalability-release and move this test there

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1.6.env
@@ -1,7 +1,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 # Use the 1.1 project for now, since it has quota.
 # TODO: create a project k8s-e2e-gce-scalability-release and move this test there

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gce-serial-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-gce-serial-1-5
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gce-serial-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-slow-1-4

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gce-slow-1-5

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-slow-1-6

--- a/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-serial.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gce-ubuntu-1-6-serial
 

--- a/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-slow.env
@@ -3,7 +3,6 @@ GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gce-ubuntu-1-6-slow
 

--- a/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntu-1-6.env
@@ -3,7 +3,6 @@ GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gce-ubuntu-1-6
 NUM_NODES=4

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
 PROJECT=k8s-jkns-e2e-gci-gce-alpha1-4
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]|ScheduledJob
 PROJECT=k8s-e2e-gci-gce-alpha1-5
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
 PROJECT=k8s-jkns-gci-gce-alpha-1-6
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-jkns-gci-gce-ingress1-4
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-gci-gce-ingress1-5
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-jkns-gci-gce-ingress-1-6
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gci-gce-reboot-1-4
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-gci-gce-reboot-1-5
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gci-gce-reboot-1-6
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-1-4

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-1-5

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-gci-gce-1-6

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.env
@@ -2,7 +2,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 
 # Use the 1.1 project for now, since it has quota.

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env
@@ -2,7 +2,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 
 # Use the 1.4 project for now, since it has quota.

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-ci-serial-1-4
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-ci-serial-1-5
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gce-serial-1-6
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-slow-1-4

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-slow-1-5

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-gce-slow-1-6

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gci-gke-ingress-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gci-gke-ingress-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-pre-release.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-pre-release.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
-JENKINS_PUBLISHED_VERSION=release/latest
 PROJECT=k8s-jkns-e2e-gci-gke-prerel
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gci-gke-reboot-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.6.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gci-gke-reboot-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.5.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gci-gke-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1.6.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gci-gke-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gci-gke-serial-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.6.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gci-gke-serial-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gci-gke-slow-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.6.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gci-gke-slow-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew.env
@@ -1,9 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 PROJECT=kube-gke-upg-1-4-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew.env
@@ -1,9 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 PROJECT=gke-gci-upg-1-4-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=kube-gke-upg-1-5-1-4-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=gke-gci-upg-1-5-1-4-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env
@@ -1,8 +1,6 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gke-cvm-1-5-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
@@ -10,3 +8,5 @@ ZONE=us-central1-c
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env
@@ -1,8 +1,6 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gke-gci-1-5-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
@@ -10,3 +8,5 @@ ZONE=us-central1-c
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gke-cvm-1-6-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gke-gci-1-6-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew-serial.env
@@ -1,9 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gke-cvm-1-6-m-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew.env
@@ -1,9 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gke-cvm-1-6-mstr-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew-serial.env
@@ -1,9 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gke-gci-1-6-m-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew.env
@@ -1,9 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-gke-gci-1-6-mstr-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.env
@@ -1,7 +1,6 @@
 ### job-env
 PROJECT=k8s-e2e-gke-alpha-1-5
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly)\]|ScheduledJob
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.6.env
@@ -1,7 +1,6 @@
 ### job-env
 PROJECT=k8s-jkns-gke-alpha-1-6
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]|ScheduledJob
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.5 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-4-c1-5-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-4-c1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-4-c1-6-up-clu
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-4-c1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-4-clat-up-clu-n
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-4-g1-5-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-4-g1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env
@@ -5,8 +5,6 @@ E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
 GINKGO_TEST_ARGS=--ginkgo.skip=Inter-pod-Affinity|InterPodAntiAffinity
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-4-g1-6-up-clu
 
@@ -16,3 +14,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-4-g1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-4-glat-up-clu-n
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-5-c1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf::
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-5-c1-6-up-clu
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-5-c1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-5-g1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-5-g1-6-up-clu
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=k8s-gke-upg-c1-5-g1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
-JENKINS_USE_SKEW_TESTS=true
 PROJECT=gke-up-c1-3-clat-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-cluster.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-clat-up-clu
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-master.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-clat-up-mas
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
-JENKINS_USE_SKEW_TESTS=true
 PROJECT=gke-up-c1-3-glat-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-cluster.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-glat-up-clu
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-master.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-glat-up-mas
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=kube-gke-upg-1-3-1-4-upg-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf::
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=kube-gke-upg-1-3-1-4-upg-clu
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=kube-gke-upg-1-3-1-4-upg-mas
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-g1-4-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-g1-4-up-clu
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-g1-4-up-mas
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
-JENKINS_USE_SKEW_TESTS=true
 PROJECT=gke-up-g1-3-clat-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-cluster.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-clat-up-clu
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-master.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-clat-up-mas
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
-JENKINS_USE_SKEW_TESTS=true
 PROJECT=gke-up-g1-3-glat-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-cluster.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-glat-up-clu
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-master.env
@@ -5,9 +5,9 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade}\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-glat-up-mas
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-c1-4-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-c1-4-up-clu
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-c1-4-up-mas
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new.env
@@ -5,9 +5,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-g1-4-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-g1-4-up-clu
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master.env
@@ -5,11 +5,11 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-g1-4-up-mas
 
 ### version-env
 ZONE=us-central1-a
 
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.5 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-4-c1-5-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-4-c1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-4-c1-6-up-clu
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-4-c1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-4-clat-up-clu-n
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-4-g1-5-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-4-g1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-4-g1-6-up-clu
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-4-g1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.env
@@ -3,9 +3,6 @@
 E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-4-glat-up-clu-n
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-5-c1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-5-c1-6-up-clu
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-5-c1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env
@@ -4,9 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
-JENKINS_USE_SKEW_TESTS=true
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-5-g1-6-up-clu-n
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-5-g1-6-up-clu
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env
@@ -4,8 +4,6 @@ E2E_OPT=--check_version_skew=false
 E2E_UPGRADE_TEST=true
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 GINKGO_UPGRADE_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-upg-g1-5-g1-6-up-mas
 
@@ -15,3 +13,5 @@ ZONE=us-central1-a
 
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
+
+SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster.env
@@ -3,10 +3,6 @@ E2E_OPT=--check_version_skew=false
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=k8s-gke-dg-g1-6-g1-5-dwngr-clu
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.5
-JENKINS_USE_SKEW_KUBECTL=false
-JENKINS_USE_SKEW_TESTS=false
 
 # Rather than downgrading and then running e2e tests, just downgrade.
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
@@ -3,9 +3,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 E2E_OPT=--check_version_skew=false
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gke-upg-lat-cluster
 

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
@@ -3,9 +3,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 E2E_OPT=--check_version_skew=false
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
-JENKINS_USE_SKEW_TESTS=true
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gke-upg-lat-master
 

--- a/jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew-serial.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gke-cvm-m-1-6-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gke-cvm-mstr-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew-serial.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gke-gci-m-1-6-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew.env
@@ -1,12 +1,9 @@
 E2E_OPT=--check_version_skew=false
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
-JENKINS_PUBLISHED_SKEW_VERSION=ci/latest-1.6
-JENKINS_PUBLISHED_VERSION=ci/latest
 PROJECT=k8s-gke-gci-mstr-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 ### version-env
-JENKINS_USE_SKEW_TESTS=true
 

--- a/jobs/ci-kubernetes-e2e-gke-pre-release.env
+++ b/jobs/ci-kubernetes-e2e-gke-pre-release.env
@@ -1,5 +1,4 @@
 ### job-env
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
-JENKINS_PUBLISHED_VERSION=release/latest
 PROJECT=k8s-jkns-e2e-gke-prerel
 

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gke-reboot-1-5
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1.6.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gke-reboot-1-6
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.5.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gke-1-5
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-release-1.6.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gke-1-6
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.5.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gke-serial-1-5
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1.6.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gke-serial-1-6
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.5.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 PROJECT=k8s-gke-slow-1-5
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1.6.env
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1.6.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 PROJECT=k8s-jkns-gke-slow-1-6
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env
@@ -2,7 +2,6 @@
 
 PROJECT=k8s-jkns-e2e-kubeadm-ci-1-6
 KUBERNETES_PROVIDER=kubernetes-anywhere
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(PetSet|DynamicKubeletConfig)\]|ScheduledJob
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-alpha
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env
@@ -2,7 +2,6 @@
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 NUM_NODES=3
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-as
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env
@@ -1,7 +1,6 @@
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-flaky
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress.env
@@ -3,7 +3,6 @@ CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-ingres
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-reboot.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-reboot.env
@@ -3,7 +3,6 @@ CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-reboot
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-serial.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-serial.env
@@ -3,7 +3,6 @@ CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-serial
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-slow.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-slow.env
@@ -4,7 +4,6 @@ CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-slow
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env
@@ -2,7 +2,6 @@
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-updown
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6.env
@@ -4,7 +4,6 @@ CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6
 

--- a/jobs/ci-kubernetes-kubemark-5-gce-1.5.env
+++ b/jobs/ci-kubernetes-kubemark-5-gce-1.5.env
@@ -1,5 +1,4 @@
 ### job-env
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 ENABLE_GARBAGE_COLLECTOR=true
 PROJECT=k8s-kubemark-1-5
 KUBEMARK_TESTS=\[Feature:Empty\]

--- a/jobs/ci-kubernetes-soak-gce-1.4-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-1.4-deploy.env
@@ -5,5 +5,4 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak-1-4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 

--- a/jobs/ci-kubernetes-soak-gce-1.4-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.4-test.env
@@ -13,5 +13,4 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak-1-4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 

--- a/jobs/ci-kubernetes-soak-gce-1.5-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-1.5-deploy.env
@@ -5,5 +5,4 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
 PROJECT=k8s-gce-soak-1-5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 

--- a/jobs/ci-kubernetes-soak-gce-1.5-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.5-test.env
@@ -13,5 +13,4 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-gce-soak-1-5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 

--- a/jobs/ci-kubernetes-soak-gce-1.6-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-1.6-deploy.env
@@ -5,5 +5,4 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak-1-6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 

--- a/jobs/ci-kubernetes-soak-gce-1.6-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.6-test.env
@@ -13,5 +13,4 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak-1-6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.env
@@ -5,5 +5,4 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
 PROJECT=k8s-jkns-gci-gce-soak-1-4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-test.env
@@ -13,5 +13,4 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gci-gce-soak-1-4
-JENKINS_PUBLISHED_VERSION=ci/latest-1.4
 

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.env
@@ -5,5 +5,4 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
 PROJECT=k8s-gci-gce-soak-1-5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-test.env
@@ -13,5 +13,4 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-gci-gce-soak-1-5
-JENKINS_PUBLISHED_VERSION=ci/latest-1.5
 

--- a/jobs/ci-kubernetes-soak-gci-gce-1.6-deploy.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.6-deploy.env
@@ -5,5 +5,4 @@ FAIL_ON_GCP_RESOURCE_LEAK=false
 
 ### job-env
 PROJECT=k8s-jkns-gci-gce-soak-1-6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 

--- a/jobs/ci-kubernetes-soak-gci-gce-1.6-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.6-test.env
@@ -13,5 +13,4 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gci-gce-soak-1-6
-JENKINS_PUBLISHED_VERSION=ci/latest-1.6
 

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -79,7 +79,8 @@
       "--test=false", 
       "--mount-paths=$GOPATH/src/k8s.io/charts:/src/k8s.io/charts", 
       "--charts-tests", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -100,7 +101,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-aws-release-1.5.env", 
       "--aws", 
       "--cluster=e2e-aws-1-5", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -148,7 +150,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce.env", 
       "--publish=gs://kubernetes-release-dev/ci/latest-green.txt", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -160,7 +163,9 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -172,7 +177,10 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -184,7 +192,9 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -195,7 +205,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -206,7 +218,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -217,7 +231,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -228,7 +244,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -239,7 +258,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.5-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -250,7 +271,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-1.5-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -261,7 +285,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-1.5-downgrade-cluster.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -272,7 +298,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-1.5-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -283,7 +312,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -294,7 +325,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-master-cvm-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -305,7 +338,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -316,7 +351,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-1.6-master-gci-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -327,7 +364,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -339,7 +377,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-4.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -351,7 +390,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-5.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -363,7 +403,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-6.env", 
       "--timeout=180m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -374,7 +415,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-autoscaling.env", 
-      "--timeout=210m"
+      "--timeout=210m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -385,7 +427,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-autoscaling-migs.env", 
-      "--timeout=210m"
+      "--timeout=210m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -400,7 +443,9 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-canary.env", 
       "--publish=gs://kubernetes-release-dev/ci/latest-canarygreen.txt", 
       "--tag=latest", 
-      "--timeout=40m"
+      "--timeout=40m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -411,7 +456,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-container-vm.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -423,7 +469,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-enormous-cluster.env", 
       "--cluster=e2e-enormous-cluster", 
       "--down=false", 
-      "--timeout=1400m"
+      "--timeout=1400m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -435,7 +482,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-enormous-deploy.env", 
       "--cluster=e2e-enormous-deploy", 
       "--down=false", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -448,7 +496,8 @@
       "--cluster=e2e-enormous-deploy", 
       "--up=false", 
       "--test=false", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -459,7 +508,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-es-logging.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -471,7 +521,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd2-release-1-6.env", 
       "--timeout=50m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -482,7 +533,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -494,7 +546,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3-release-1-5.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -505,7 +558,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-examples.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -517,7 +571,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation.env", 
       "--federation", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -529,7 +584,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-release-1.6.env", 
       "--federation", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -541,7 +597,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-serial.env", 
       "--federation", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -552,7 +609,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-flaky.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -564,7 +622,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-garbage.env", 
       "--cluster=gc-feature", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -576,7 +635,9 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-1.5-rollback-etcd.env", 
       "--test=false", 
-      "--timeout=60m"
+      "--timeout=60m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -588,7 +649,9 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-1.5-upgrade-etcd.env", 
       "--test=false", 
-      "--timeout=60m"
+      "--timeout=60m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -599,7 +662,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-master.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -610,7 +674,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.4.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -621,7 +686,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1.5.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -632,7 +698,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -643,7 +710,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.4.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -654,7 +722,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1.5.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -665,7 +734,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -676,7 +746,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.4.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -687,7 +758,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1.5.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -699,7 +771,9 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd.env", 
       "--test=false", 
-      "--timeout=60m"
+      "--timeout=60m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -711,7 +785,9 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd.env", 
       "--test=false", 
-      "--timeout=60m"
+      "--timeout=60m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -939,7 +1015,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-gpu.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -950,7 +1027,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ha-master.env", 
-      "--timeout=220m"
+      "--timeout=220m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -961,7 +1039,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ingress.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -972,7 +1051,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -983,7 +1064,9 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-latest-1.4-latest-1.5-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -994,7 +1077,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.4", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1005,7 +1091,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-latest-1.5-latest-1.4-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.4", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1016,7 +1105,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1027,7 +1119,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1038,7 +1133,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1049,7 +1147,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-master-1.6-cvm-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1060,7 +1161,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1071,7 +1175,10 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-master-1.6-gci-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1083,7 +1190,8 @@
       "--cluster=bootstrap-e2e-gce-mz", 
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-multizone.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1094,7 +1202,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-proto.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1105,7 +1214,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1118,7 +1228,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-4.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1130,7 +1241,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-5.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1143,7 +1255,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-6.env", 
       "--timeout=180m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1155,7 +1268,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-4.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1167,7 +1281,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-5.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1179,7 +1294,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-6.env", 
       "--timeout=50m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1191,7 +1307,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-scalability.env", 
       "--cluster=e2e-scalability", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1203,7 +1320,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-scalability-release-1.5.env", 
       "--cluster=e2e-scalability-1-5", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1215,7 +1333,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-scalability-release-1.6.env", 
       "--cluster=e2e-scalability-1-6", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1226,7 +1345,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-sd-logging.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1237,7 +1357,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial.env", 
-      "--timeout=500m"
+      "--timeout=500m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1249,7 +1370,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-4.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1261,7 +1383,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-5.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1273,7 +1396,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-6.env", 
       "--timeout=300m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1284,7 +1408,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1296,7 +1421,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-4.env", 
       "--mode=local", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1308,7 +1434,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-5.env", 
       "--mode=local", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1320,7 +1447,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-6.env", 
       "--timeout=150m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1331,7 +1459,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-stackdriver.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1342,7 +1471,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-statefulset.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1353,7 +1483,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-taint-evict.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1365,7 +1496,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntu.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1377,7 +1509,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntu-1-6.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1409,7 +1542,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-serial.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1421,7 +1555,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntu-1-6-slow.env", 
       "--mode=local", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1451,7 +1586,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntu-serial.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1463,7 +1599,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntu-slow.env", 
       "--mode=local", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1474,7 +1611,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1485,7 +1623,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1497,7 +1636,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1509,7 +1649,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5.env", 
       "--timeout=180m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1521,7 +1662,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6.env", 
       "--timeout=180m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1532,7 +1674,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-autoscaling.env", 
-      "--timeout=210m"
+      "--timeout=210m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1543,7 +1686,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env", 
-      "--timeout=210m"
+      "--timeout=210m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1554,7 +1698,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-docker.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1565,7 +1710,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-es-logging.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1576,7 +1722,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-etcd3.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1587,7 +1734,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-examples.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1598,7 +1746,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-flaky.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1610,7 +1759,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-garbage.env", 
       "--cluster=gc-feature", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1621,7 +1771,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1633,7 +1784,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-4.env", 
       "--mode=local", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1645,7 +1797,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-5.env", 
       "--timeout=90m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1657,7 +1810,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-6.env", 
       "--timeout=90m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1668,7 +1822,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ip-alias.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1679,7 +1834,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-proto.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1691,7 +1847,8 @@
       "--cluster=err-e2e", 
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1703,7 +1860,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-4.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1715,7 +1873,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-5.env", 
       "--timeout=180m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1727,7 +1886,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-6.env", 
       "--timeout=180m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1739,7 +1899,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-4.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1751,7 +1912,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-5.env", 
       "--timeout=50m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1763,7 +1925,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-6.env", 
       "--timeout=50m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1775,7 +1938,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability.env", 
       "--cluster=e2e-scalability", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1787,7 +1951,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.5.env", 
       "--cluster=e2e-scalability-1-5", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1799,7 +1964,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1.6.env", 
       "--cluster=e2e-scalability-1-6", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1810,7 +1976,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-sd-logging.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1821,7 +1988,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial.env", 
-      "--timeout=500m"
+      "--timeout=500m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1833,7 +2001,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-4.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1845,7 +2014,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-5.env", 
       "--timeout=300m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1857,7 +2027,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-6.env", 
       "--timeout=300m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1868,7 +2039,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1880,7 +2052,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-4.env", 
       "--mode=local", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1892,7 +2065,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-5.env", 
       "--timeout=150m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1904,7 +2078,8 @@
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-6.env", 
       "--timeout=150m", 
-      "--mode=local"
+      "--mode=local", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1915,7 +2090,8 @@
     "args": [
       "--env-file=platforms/gce.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-statefulset.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1926,7 +2102,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1937,7 +2114,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-alpha-features.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1948,7 +2126,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-autoscaling.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1959,7 +2138,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-flaky.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1970,7 +2150,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1981,7 +2162,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.5.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -1992,7 +2174,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1.6.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2003,7 +2186,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-multizone.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2014,7 +2198,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-pre-release.env", 
-      "--timeout=480m"
+      "--timeout=480m", 
+      "--extract=release/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2061,7 +2246,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2072,7 +2258,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.5.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2083,7 +2270,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1.6.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2094,7 +2282,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1.5.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2105,7 +2294,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1.6.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2116,7 +2306,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2127,7 +2318,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.5.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2138,7 +2330,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1.6.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2149,7 +2342,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2160,7 +2354,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.5.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2171,7 +2366,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1.6.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2231,7 +2427,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-updown.env", 
-      "--timeout=30m"
+      "--timeout=30m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2242,7 +2439,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2253,7 +2451,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.4-1.5-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2264,7 +2464,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.4-1.5-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2275,7 +2477,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.5-1.4-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.4", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2286,7 +2491,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.5-1.4-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.4", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2297,7 +2505,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.5-1.6-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2308,7 +2518,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.5-1.6-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2319,7 +2531,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-1.5-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2330,7 +2545,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-1.5-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2341,7 +2559,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2352,7 +2572,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-master-cvm-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2363,7 +2585,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2374,7 +2598,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-1.6-master-gci-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2385,7 +2611,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2397,7 +2624,8 @@
       "--cluster=err-e2e", 
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.5.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2408,7 +2636,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1.6.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2419,7 +2648,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-autoscaling.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2430,7 +2660,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.5-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2441,7 +2674,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2452,7 +2687,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2463,7 +2701,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2474,7 +2714,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-container_vm-latest-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2485,7 +2728,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.5-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2496,7 +2742,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2507,7 +2755,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2518,7 +2769,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2529,7 +2782,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.4-gci-latest-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2540,7 +2796,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2551,7 +2809,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2562,7 +2823,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-container_vm-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2573,7 +2836,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2584,7 +2849,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2595,7 +2863,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-container_vm-1.5-gci-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2607,7 +2877,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2619,7 +2891,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2631,7 +2906,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2643,7 +2920,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2655,7 +2934,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2667,7 +2949,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2679,7 +2963,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2691,7 +2977,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2703,7 +2992,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2715,7 +3006,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2727,7 +3020,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2739,7 +3035,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2750,7 +3048,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-flaky.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2762,7 +3061,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2774,7 +3075,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2786,7 +3090,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2798,7 +3104,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2810,7 +3118,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2822,7 +3133,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2834,7 +3147,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2846,7 +3161,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2858,7 +3176,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2870,7 +3190,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2882,7 +3204,10 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-cluster-new.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2894,7 +3219,9 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-master-upgrade-master.env", 
       "--mode=local", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2905,7 +3232,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.5-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2916,7 +3246,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2927,7 +3259,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2938,7 +3273,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2949,7 +3286,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-container_vm-latest-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2960,7 +3300,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.5-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.5", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2971,7 +3314,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2982,7 +3327,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -2993,7 +3341,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3004,7 +3354,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.4-gci-latest-upgrade-cluster-new.env", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3015,7 +3368,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3026,7 +3381,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3037,7 +3395,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-container_vm-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3048,7 +3408,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3059,7 +3421,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3070,7 +3435,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-master.env", 
-      "--timeout=900m"
+      "--timeout=900m", 
+      "--extract=ci/latest-1.6", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3081,7 +3448,9 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1.6-gci-1.5-downgrade-cluster.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.5", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3092,7 +3461,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-ci-master.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3103,7 +3473,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-ingress.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3115,7 +3486,8 @@
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-large-cluster.env", 
       "--cluster=gke-large-cluster", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3128,7 +3500,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-large-deploy.env", 
       "--cluster=gke-large-deploy", 
       "--down=false", 
-      "--timeout=1200m"
+      "--timeout=1200m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3142,7 +3515,8 @@
       "--cluster=gke-large-deploy", 
       "--up=false", 
       "--test=false", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3153,7 +3527,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3164,7 +3541,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest", 
+      "--skew", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3175,7 +3555,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3186,7 +3569,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-master-1.6-cvm-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3197,7 +3583,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3208,7 +3597,10 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-master-1.6-gci-kubectl-skew-serial.env", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest-1.6", 
+      "--skew", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3219,7 +3611,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-multizone.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3230,7 +3623,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-pre-release.env", 
-      "--timeout=480m"
+      "--timeout=480m", 
+      "--extract=release/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3277,7 +3671,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3288,7 +3683,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1.5.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3299,7 +3695,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1.6.env", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3310,7 +3707,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1.5.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3322,7 +3720,8 @@
       "--cluster=err-e2e", 
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1.6.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3333,7 +3732,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3344,7 +3744,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1.5.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3355,7 +3756,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1.6.env", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3366,7 +3768,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3377,7 +3780,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1.5.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3388,7 +3792,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1.6.env", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3399,7 +3804,8 @@
     "args": [
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-stackdriver.env", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3460,7 +3866,8 @@
       "--cluster=err-e2e", 
       "--env-file=platforms/gke.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gke-updown.env", 
-      "--timeout=30m"
+      "--timeout=30m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3580,7 +3987,8 @@
       "--kubeadm=ci", 
       "--deployment=kubernetes-anywhere", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3595,7 +4003,8 @@
       "--kubeadm=ci", 
       "--deployment=kubernetes-anywhere", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3610,7 +4019,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-prow-canary.env", 
       "--mode=local", 
       "--tag=latest", 
-      "--timeout=40m"
+      "--timeout=40m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3622,7 +4032,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3634,7 +4045,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=50m"
+      "--timeout=50m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3646,7 +4058,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3658,7 +4071,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3670,7 +4084,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3682,7 +4097,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3694,7 +4110,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-reboot.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3706,7 +4123,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-serial.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3718,7 +4136,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-slow.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3730,7 +4149,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=30m"
+      "--timeout=30m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3742,7 +4162,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-alpha-features.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3754,7 +4175,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-autoscaling.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3766,7 +4188,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-flaky.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3778,7 +4201,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-ingress.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3790,7 +4214,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-reboot.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=180m"
+      "--timeout=180m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3802,7 +4227,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-serial.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3814,7 +4240,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-slow.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=150m"
+      "--timeout=150m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3826,7 +4253,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-updown.env", 
       "--env-file=platforms/gke.env", 
       "--mode=local", 
-      "--timeout=30m"
+      "--timeout=30m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3874,7 +4302,8 @@
       "--cluster=kubemark-100", 
       "--test=false", 
       "--kubemark", 
-      "--timeout=240m"
+      "--timeout=240m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3889,7 +4318,8 @@
       "--cluster=kubemark-5", 
       "--test=false", 
       "--kubemark", 
-      "--timeout=60m"
+      "--timeout=60m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3904,7 +4334,8 @@
       "--cluster=kubemark-5-1-5", 
       "--test=false", 
       "--kubemark", 
-      "--timeout=60m"
+      "--timeout=60m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3919,7 +4350,8 @@
       "--cluster=kubemark-500", 
       "--test=false", 
       "--kubemark", 
-      "--timeout=120m"
+      "--timeout=120m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3934,7 +4366,8 @@
       "--test=false", 
       "--docker-in-docker", 
       "--kubemark", 
-      "--timeout=1080m"
+      "--timeout=1080m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -3949,7 +4382,8 @@
       "--cluster=kubemark-100pods", 
       "--test=false", 
       "--kubemark", 
-      "--timeout=280m"
+      "--timeout=280m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4079,7 +4513,8 @@
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4094,7 +4529,8 @@
       "--test=false", 
       "--down=false", 
       "--mode=local", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4138,7 +4574,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.4-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4152,7 +4589,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.4-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4166,7 +4604,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.5-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4180,7 +4619,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.5-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4194,7 +4634,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.6-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4208,7 +4649,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.6-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4222,7 +4664,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-2-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4236,7 +4679,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-2-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4250,7 +4694,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4268,7 +4713,8 @@
       "--stage=gs://kubernetes-release-dev/ci/ci-kubernetes-soak-gce-federation-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4283,7 +4729,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-federation-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4297,7 +4744,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-gci-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4311,7 +4759,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-gci-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4325,7 +4774,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4339,7 +4789,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.4-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4353,7 +4804,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.4-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.4"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4367,7 +4819,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.5-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4381,7 +4834,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.5-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.5"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4395,7 +4849,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.6-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4409,7 +4864,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.6-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest-1.6"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4423,7 +4879,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4437,7 +4894,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-gci-deploy", 
       "--test=false", 
       "--down=false", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4451,7 +4909,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-gci-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4465,7 +4924,8 @@
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-deploy", 
       "--up=false", 
       "--down=false", 
-      "--timeout=600m"
+      "--timeout=600m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4584,7 +5044,8 @@
       "--test=false", 
       "--mode=local", 
       "--perf-tests", 
-      "--timeout=60m"
+      "--timeout=60m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4638,7 +5099,8 @@
       "--kubeadm=periodic", 
       "--deployment=kubernetes-anywhere", 
       "--mode=local", 
-      "--timeout=300m"
+      "--timeout=300m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4690,7 +5152,8 @@
       "--build", 
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce", 
       "--cluster=", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4707,7 +5170,8 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-bazel", 
       "--cluster=", 
       "--mode=local", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4723,7 +5187,8 @@
       "--build", 
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary", 
       "--cluster=", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4739,7 +5204,8 @@
       "--build", 
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-etcd3", 
       "--cluster=", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4755,7 +5221,8 @@
       "--build", 
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gci", 
       "--cluster=", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4772,7 +5239,8 @@
       "--stage=gs://kubernetes-release-dev/ci", 
       "--stage-suffix=pull-gke", 
       "--cluster=", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4789,7 +5257,8 @@
       "--stage=gs://kubernetes-release-dev/ci", 
       "--stage-suffix=pull-gke-gci", 
       "--cluster=", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4804,7 +5273,8 @@
       "--kubeadm=pull", 
       "--deployment=kubernetes-anywhere", 
       "--mode=local", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4824,7 +5294,8 @@
       "--federation", 
       "--deployment=none", 
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4846,7 +5317,8 @@
       "--deployment=none", 
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy-canary", 
       "--mode=local", 
-      "--timeout=90m"
+      "--timeout=90m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4864,7 +5336,8 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce", 
       "--test=false", 
       "--kubemark", 
-      "--timeout=45m"
+      "--timeout=45m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -4882,7 +5355,8 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce-gci", 
       "--test=false", 
       "--kubemark", 
-      "--timeout=55m"
+      "--timeout=55m", 
+      "--extract=ci/latest"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/2829

Using a `SKEW_KUBECTL=y` for the time being, will migrate that one in the future.