### PR TITLE
Added more webhooks to prow and updated LGTM plugin to read review bodies and comments.

### DIFF
--- a/mungegithub/mungers/matchers/comment/BUILD
+++ b/mungegithub/mungers/matchers/comment/BUILD
@@ -21,7 +21,6 @@ go_test(
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//vendor:github.com/google/go-github/github"],
 )
 
 go_library(

--- a/mungegithub/mungers/matchers/comment/command.go
+++ b/mungegithub/mungers/matchers/comment/command.go
@@ -19,8 +19,6 @@ package comment
 import (
 	"regexp"
 	"strings"
-
-	"github.com/google/go-github/github"
 )
 
 // Command is a way for human to interact with the bot
@@ -39,7 +37,7 @@ var (
 
 // ParseCommands attempts to read a command from a comment
 // Returns nil if the comment doesn't contain a command
-func ParseCommands(comment *github.IssueComment) []*Command {
+func ParseCommands(comment *Comment) []*Command {
 	if comment == nil || comment.Body == nil {
 		return nil
 	}

--- a/mungegithub/mungers/matchers/comment/command_test.go
+++ b/mungegithub/mungers/matchers/comment/command_test.go
@@ -19,8 +19,6 @@ package comment
 import (
 	"reflect"
 	"testing"
-
-	"github.com/google/go-github/github"
 )
 
 func TestParseCommand(t *testing.T) {
@@ -82,7 +80,7 @@ func TestParseCommand(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actualCommand := ParseCommands(&github.IssueComment{Body: &test.comment})
+		actualCommand := ParseCommands(&Comment{Body: &test.comment})
 		if !reflect.DeepEqual(actualCommand, test.expectedCommands) {
 			t.Error(actualCommand, "doesn't match expected commands:", test.expectedCommands)
 		}

--- a/mungegithub/mungers/matchers/comment/comment.go
+++ b/mungegithub/mungers/matchers/comment/comment.go
@@ -23,16 +23,105 @@ import (
 	"github.com/google/go-github/github"
 )
 
+// Comment is a struct that represents a generic text post on github.
+type Comment struct {
+	Body      *string
+	Author    *string
+	CreatedAt *time.Time
+	UpdatedAt *time.Time
+	HTMLURL   *string
+
+	Source interface{}
+}
+
+func FromIssueComment(ic *github.IssueComment) *Comment {
+	if ic == nil {
+		return nil
+	}
+	var login *string = nil
+	if ic.User != nil {
+		login = ic.User.Login
+	}
+	return &Comment{
+		Body:      ic.Body,
+		Author:    login,
+		CreatedAt: ic.CreatedAt,
+		UpdatedAt: ic.UpdatedAt,
+		HTMLURL:   ic.HTMLURL,
+		Source:    ic,
+	}
+}
+
+func FromIssueComments(ics []*github.IssueComment) []*Comment {
+	comments := []*Comment{}
+	for _, ic := range ics {
+		comments = append(comments, FromIssueComment(ic))
+	}
+	return comments
+}
+
+func FromReviewComment(rc *github.PullRequestComment) *Comment {
+	if rc == nil {
+		return nil
+	}
+	var login *string = nil
+	if rc.User != nil {
+		login = rc.User.Login
+	}
+	return &Comment{
+		Body:      rc.Body,
+		Author:    login,
+		CreatedAt: rc.CreatedAt,
+		UpdatedAt: rc.UpdatedAt,
+		HTMLURL:   rc.HTMLURL,
+		Source:    rc,
+	}
+}
+
+func FromReviewComments(rcs []*github.PullRequestComment) []*Comment {
+	comments := []*Comment{}
+	for _, rc := range rcs {
+		comments = append(comments, FromReviewComment(rc))
+	}
+	return comments
+}
+
+func FromReview(review *github.PullRequestReview) *Comment {
+	if review == nil {
+		return nil
+	}
+	var login *string = nil
+	if review.User != nil {
+		login = review.User.Login
+	}
+	return &Comment{
+		Body:      review.Body,
+		Author:    login,
+		CreatedAt: review.SubmittedAt,
+		UpdatedAt: review.SubmittedAt,
+		HTMLURL:   review.HTMLURL,
+		Source:    review,
+	}
+}
+
+func FromReviews(reviews []*github.PullRequestReview) []*Comment {
+	comments := []*Comment{}
+	for _, review := range reviews {
+		comments = append(comments, FromReview(review))
+	}
+	return comments
+}
+
 // Matcher is an interface to match a comment
 type Matcher interface {
-	Match(comment *github.IssueComment) bool
+	Match(comment *Comment) bool
 }
 
 // CreatedAfter matches comments created after the time
 type CreatedAfter time.Time
 
 // Match returns true if the comment is created after the time
-func (c CreatedAfter) Match(comment *github.IssueComment) bool {
+func (c CreatedAfter) Match(comment *Comment) bool {
 	if comment == nil || comment.CreatedAt == nil {
 		return false
 	}
@@ -43,7 +132,7 @@ func (c CreatedAfter) Match(comment *github.IssueComment) bool {
 type CreatedBefore time.Time
 
 // Match returns true if the comment is created before the time
-func (c CreatedBefore) Match(comment *github.IssueComment) bool {
+func (c CreatedBefore) Match(comment *Comment) bool {
 	if comment == nil || comment.CreatedAt == nil {
 		return false
 	}
@@ -54,27 +143,27 @@ func (c CreatedBefore) Match(comment *github.IssueComment) bool {
 type ValidAuthor struct{}
 
 // Match if the comment has a valid author
-func (ValidAuthor) Match(comment *github.IssueComment) bool {
-	return comment != nil && comment.User != nil && comment.User.Login != nil
+func (ValidAuthor) Match(comment *Comment) bool {
+	return comment != nil && comment.Author != nil
 }
 
 // AuthorLogin matches comment made by this Author
 type AuthorLogin string
 
 // Match if the Author is a match (ignoring case)
-func (a AuthorLogin) Match(comment *github.IssueComment) bool {
+func (a AuthorLogin) Match(comment *Comment) bool {
 	if !(ValidAuthor{}).Match(comment) {
 		return false
 	}
 
-	return strings.ToLower(*comment.User.Login) == strings.ToLower(string(a))
+	return strings.ToLower(*comment.Author) == strings.ToLower(string(a))
 }
 
 // Author matches comment made by this github user.
 type Author github.User
 
 // Match if the Author is a match.
-func (a Author) Match(comment *github.IssueComment) bool {
+func (a Author) Match(comment *Comment) bool {
 	if !(ValidAuthor{}).Match(comment) {
 		return false
 	}

--- a/mungegithub/mungers/matchers/comment/comment_test.go
+++ b/mungegithub/mungers/matchers/comment/comment_test.go
@@ -19,8 +19,6 @@ package comment
 import (
 	"testing"
 	"time"
-
-	"github.com/google/go-github/github"
 )
 
 func getDate(year int, month time.Month, day, hour, min, sec int) *time.Time {
@@ -36,19 +34,19 @@ func TestCreationBefore(t *testing.T) {
 	}
 	if CreatedBefore(
 		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
-	).Match(&github.IssueComment{}) {
+	).Match(&Comment{}) {
 		t.Error("Shouldn't match nil CreatedAt")
 	}
 	if CreatedBefore(
 		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
-	).Match(&github.IssueComment{
+	).Match(&Comment{
 		CreatedAt: getDate(2000, 1, 1, 12, 0, 1),
 	}) {
 		t.Error("Should match later comment")
 	}
 	if !CreatedBefore(
 		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
-	).Match(&github.IssueComment{
+	).Match(&Comment{
 		CreatedAt: getDate(2000, 1, 1, 11, 0, 0),
 	}) {
 		t.Error("Shouldn't match earlier comment")
@@ -63,19 +61,19 @@ func TestCreationAfter(t *testing.T) {
 	}
 	if CreatedAfter(
 		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
-	).Match(&github.IssueComment{}) {
+	).Match(&Comment{}) {
 		t.Error("Shouldn't match nil CreatedAt")
 	}
 	if !CreatedAfter(
 		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
-	).Match(&github.IssueComment{
+	).Match(&Comment{
 		CreatedAt: getDate(2000, 1, 1, 12, 0, 1),
 	}) {
 		t.Error("Should match later comment")
 	}
 	if CreatedAfter(
 		time.Date(2000, 1, 1, 12, 0, 0, 0, time.UTC),
-	).Match(&github.IssueComment{
+	).Match(&Comment{
 		CreatedAt: getDate(2000, 1, 1, 11, 0, 0),
 	}) {
 		t.Error("Shouldn't match earlier comment")

--- a/mungegithub/mungers/matchers/comment/finder.go
+++ b/mungegithub/mungers/matchers/comment/finder.go
@@ -18,15 +18,13 @@ package comment
 
 import (
 	"time"
-
-	"github.com/google/go-github/github"
 )
 
 // FilteredComments is a list of comments
-type FilteredComments []*github.IssueComment
+type FilteredComments []*Comment
 
 // GetLast returns the last comment in a series of comments
-func (f FilteredComments) GetLast() *github.IssueComment {
+func (f FilteredComments) GetLast() *Comment {
 	if f.Empty() {
 		return nil
 	}
@@ -39,7 +37,7 @@ func (f FilteredComments) Empty() bool {
 }
 
 // FilterComments will return the list of matching comments
-func FilterComments(comments []*github.IssueComment, matcher Matcher) FilteredComments {
+func FilterComments(comments []*Comment, matcher Matcher) FilteredComments {
 	matches := FilteredComments{}
 
 	for _, comment := range comments {
@@ -52,7 +50,7 @@ func FilterComments(comments []*github.IssueComment, matcher Matcher) FilteredCo
 }
 
 // LastComment returns the creation date of the last comment that matches. Or deflt if there is no such comment.
-func LastComment(comments []*github.IssueComment, matcher Matcher, deflt *time.Time) *time.Time {
+func LastComment(comments []*Comment, matcher Matcher, deflt *time.Time) *time.Time {
 	matches := FilterComments(comments, matcher)
 	if matches.Empty() {
 		return deflt

--- a/mungegithub/mungers/matchers/comment/finder_test.go
+++ b/mungegithub/mungers/matchers/comment/finder_test.go
@@ -20,12 +20,10 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/google/go-github/github"
 )
 
 func TestFilterComments(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeCommentWithBody("1"),
 		makeCommentWithBody("2"),
 		makeCommentWithBody("3"),
@@ -38,14 +36,14 @@ func TestFilterComments(t *testing.T) {
 	}
 
 	fullList := FilterComments(comments, True{})
-	if !reflect.DeepEqual([]*github.IssueComment(fullList), comments) {
+	if !reflect.DeepEqual([]*Comment(fullList), comments) {
 		t.Error("True filter should have kept every element")
 	}
 }
 
-func makeCommentWithCreatedAt(year int, month time.Month, day int) *github.IssueComment {
+func makeCommentWithCreatedAt(year int, month time.Month, day int) *Comment {
 	date := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-	return &github.IssueComment{
+	return &Comment{
 		CreatedAt: &date,
 	}
 }
@@ -60,7 +58,7 @@ func TestLastCommentDefault(t *testing.T) {
 }
 
 func TestLastComment(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeCommentWithCreatedAt(2000, 1, 1),
 		makeCommentWithCreatedAt(2000, 1, 2),
 		makeCommentWithCreatedAt(2000, 1, 3),

--- a/mungegithub/mungers/matchers/comment/interactions.go
+++ b/mungegithub/mungers/matchers/comment/interactions.go
@@ -19,15 +19,13 @@ package comment
 import (
 	"regexp"
 	"strings"
-
-	"github.com/google/go-github/github"
 )
 
 // NotificationName identifies notifications by name
 type NotificationName string
 
 // Match returns true if the comment is a notification with the given name
-func (b NotificationName) Match(comment *github.IssueComment) bool {
+func (b NotificationName) Match(comment *Comment) bool {
 	notif := ParseNotification(comment)
 	if notif == nil {
 		return false
@@ -40,7 +38,7 @@ func (b NotificationName) Match(comment *github.IssueComment) bool {
 type CommandName string
 
 // Match if the comment contains a command with the given name
-func (c CommandName) Match(comment *github.IssueComment) bool {
+func (c CommandName) Match(comment *Comment) bool {
 	commands := ParseCommands(comment)
 	for _, command := range commands {
 		if strings.ToUpper(command.Name) == strings.ToUpper(string(c)) {
@@ -54,7 +52,7 @@ func (c CommandName) Match(comment *github.IssueComment) bool {
 type CommandArguments regexp.Regexp
 
 // Match if the comment contains a command whose arguments match the regexp
-func (c *CommandArguments) Match(comment *github.IssueComment) bool {
+func (c *CommandArguments) Match(comment *Comment) bool {
 	commands := ParseCommands(comment)
 	for _, command := range commands {
 		if (*regexp.Regexp)(c).MatchString(command.Arguments) {

--- a/mungegithub/mungers/matchers/comment/interactions_test.go
+++ b/mungegithub/mungers/matchers/comment/interactions_test.go
@@ -19,18 +19,16 @@ package comment
 import (
 	"regexp"
 	"testing"
-
-	"github.com/google/go-github/github"
 )
 
-func makeCommentWithBody(body string) *github.IssueComment {
-	return &github.IssueComment{
+func makeCommentWithBody(body string) *Comment {
+	return &Comment{
 		Body: &body,
 	}
 }
 
 func TestNotificationName(t *testing.T) {
-	if NotificationName("MESSAGE").Match(&github.IssueComment{}) {
+	if NotificationName("MESSAGE").Match(&Comment{}) {
 		t.Error("Shouldn't match nil body")
 	}
 	if NotificationName("MESSAGE").Match(makeCommentWithBody("MESSAGE WRONG FORMAT")) {
@@ -48,7 +46,7 @@ func TestNotificationName(t *testing.T) {
 }
 
 func TestCommandName(t *testing.T) {
-	if CommandName("COMMAND").Match(&github.IssueComment{}) {
+	if CommandName("COMMAND").Match(&Comment{}) {
 		t.Error("Shouldn't match nil body")
 	}
 	if CommandName("COMMAND").Match(makeCommentWithBody("COMMAND WRONG FORMAT")) {
@@ -69,13 +67,13 @@ func TestCommandArgmuents(t *testing.T) {
 	var testcases = []struct {
 		name        string
 		re          string
-		comment     *github.IssueComment
+		comment     *Comment
 		shouldMatch bool
 	}{
 		{
 			name:        "shouldn't match nil body",
 			re:          ".*",
-			comment:     &github.IssueComment{},
+			comment:     &Comment{},
 			shouldMatch: false,
 		},
 		{

--- a/mungegithub/mungers/matchers/comment/notification.go
+++ b/mungegithub/mungers/matchers/comment/notification.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/go-github/github"
 	mgh "k8s.io/test-infra/mungegithub/github"
 )
 
@@ -39,7 +38,7 @@ var (
 // ParseNotification attempts to read a notification from a comment
 // Returns nil if the comment doesn't contain a notification
 // Also note that Context is not parsed from the notification
-func ParseNotification(comment *github.IssueComment) *Notification {
+func ParseNotification(comment *Comment) *Notification {
 	if comment == nil || comment.Body == nil {
 		return nil
 	}

--- a/mungegithub/mungers/matchers/comment/notification_test.go
+++ b/mungegithub/mungers/matchers/comment/notification_test.go
@@ -19,8 +19,6 @@ package comment
 import (
 	"reflect"
 	"testing"
-
-	"github.com/google/go-github/github"
 )
 
 func TestParseNotification(t *testing.T) {
@@ -67,7 +65,7 @@ func TestParseNotification(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actualNotif := ParseNotification(&github.IssueComment{Body: &test.comment})
+		actualNotif := ParseNotification(&Comment{Body: &test.comment})
 		if !reflect.DeepEqual(actualNotif, test.notif) {
 			t.Error(actualNotif, "doesn't match expected notif:", test.notif)
 		}

--- a/mungegithub/mungers/matchers/comment/operators.go
+++ b/mungegithub/mungers/matchers/comment/operators.go
@@ -16,13 +16,11 @@ limitations under the License.
 
 package comment
 
-import "github.com/google/go-github/github"
-
 // True is a matcher that is always true
 type True struct{}
 
 // Match returns true no matter what
-func (t True) Match(comment *github.IssueComment) bool {
+func (t True) Match(comment *Comment) bool {
 	return true
 }
 
@@ -30,7 +28,7 @@ func (t True) Match(comment *github.IssueComment) bool {
 type False struct{}
 
 // Match returns false no matter what
-func (t False) Match(comment *github.IssueComment) bool {
+func (t False) Match(comment *Comment) bool {
 	return false
 }
 
@@ -38,7 +36,7 @@ func (t False) Match(comment *github.IssueComment) bool {
 type And []Matcher
 
 // Match returns true if all the matcher in the list matches
-func (a And) Match(comment *github.IssueComment) bool {
+func (a And) Match(comment *Comment) bool {
 	for _, matcher := range []Matcher(a) {
 		if !matcher.Match(comment) {
 			return false
@@ -51,7 +49,7 @@ func (a And) Match(comment *github.IssueComment) bool {
 type Or []Matcher
 
 // Match returns true if one of the matcher in the list matches
-func (o Or) Match(comment *github.IssueComment) bool {
+func (o Or) Match(comment *Comment) bool {
 	for _, matcher := range []Matcher(o) {
 		if matcher.Match(comment) {
 			return true
@@ -66,6 +64,6 @@ type Not struct {
 }
 
 // Match returns true if the matcher would return false, and vice-versa
-func (n Not) Match(comment *github.IssueComment) bool {
+func (n Not) Match(comment *Comment) bool {
 	return !n.Matcher.Match(comment)
 }

--- a/mungegithub/mungers/matchers/comment/pinger.go
+++ b/mungegithub/mungers/matchers/comment/pinger.go
@@ -18,8 +18,6 @@ package comment
 
 import (
 	"time"
-
-	"github.com/google/go-github/github"
 )
 
 // Pinger checks if it's time to send a ping.
@@ -60,7 +58,7 @@ func (p *Pinger) SetMaxCount(maxCount int) *Pinger {
 }
 
 // PingNotification creates a new notification to ping `who`
-func (p *Pinger) PingNotification(comments []*github.IssueComment, who string, startDate *time.Time) *Notification {
+func (p *Pinger) PingNotification(comments []*Comment, who string, startDate *time.Time) *Notification {
 	if startDate == nil {
 		startDate = &time.Time{}
 	}
@@ -90,7 +88,7 @@ func (p *Pinger) PingNotification(comments []*github.IssueComment, who string, s
 }
 
 // IsMaxReached tells you if you've reached the limit yet
-func (p *Pinger) IsMaxReached(comments []*github.IssueComment, startDate *time.Time) bool {
+func (p *Pinger) IsMaxReached(comments []*Comment, startDate *time.Time) bool {
 	if startDate == nil {
 		startDate = &time.Time{}
 	}

--- a/mungegithub/mungers/matchers/comment/pinger_test.go
+++ b/mungegithub/mungers/matchers/comment/pinger_test.go
@@ -19,8 +19,6 @@ package comment
 import (
 	"testing"
 	"time"
-
-	"github.com/google/go-github/github"
 )
 
 func timeAgo(d time.Duration) *time.Time {
@@ -28,16 +26,16 @@ func timeAgo(d time.Duration) *time.Time {
 	return &t
 }
 
-func makeComment(body, author string, beforeNow time.Duration) *github.IssueComment {
-	return &github.IssueComment{
+func makeComment(body, author string, beforeNow time.Duration) *Comment {
+	return &Comment{
 		Body:      &body,
-		User:      &github.User{Login: &author},
+		Author:    &author,
 		CreatedAt: timeAgo(beforeNow),
 	}
 }
 
 func TestMaxReachNotReachedNoStart(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 10*time.Hour),
 	}
@@ -50,7 +48,7 @@ func TestMaxReachNotReachedNoStart(t *testing.T) {
 }
 
 func TestMaxReachNotReachedWithStart(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 14*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 12*time.Hour),
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
@@ -65,7 +63,7 @@ func TestMaxReachNotReachedWithStart(t *testing.T) {
 }
 
 func TestMaxReachNoLimit(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 14*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 12*time.Hour),
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
@@ -80,7 +78,7 @@ func TestMaxReachNoLimit(t *testing.T) {
 }
 
 func TestNotification(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
 	}
 
@@ -95,7 +93,7 @@ func TestNotification(t *testing.T) {
 }
 
 func TestNotificationNilTimePeriod(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 14*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 13*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 12*time.Hour),
@@ -110,7 +108,7 @@ func TestNotificationNilTimePeriod(t *testing.T) {
 }
 
 func TestNotificationTimePeriodNotReached(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 5*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 3*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 1*time.Hour),
@@ -123,7 +121,7 @@ func TestNotificationTimePeriodNotReached(t *testing.T) {
 }
 
 func TestNotificationTimePeriodReached(t *testing.T) {
-	comments := []*github.IssueComment{
+	comments := []*Comment{
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 4*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 3*time.Hour),
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 2*time.Hour),
@@ -136,7 +134,7 @@ func TestNotificationTimePeriodReached(t *testing.T) {
 }
 
 func TestNotificationStartDate(t *testing.T) {
-	comments := []*github.IssueComment{}
+	comments := []*Comment{}
 	notif := NewPinger("NOTIF").SetTimePeriod(10*time.Hour).PingNotification(comments, "who", timeAgo(2*time.Hour))
 	if notif != nil {
 		t.Error("PingNotification shouldn't have created a notif")

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.112
+HOOK_VERSION       = 0.113
 SINKER_VERSION     = 0.10
 DECK_VERSION       = 0.28
 SPLICE_VERSION     = 0.20

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.112
+        image: gcr.io/k8s-prow/hook:0.113
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cmd/hook/server.go
+++ b/prow/cmd/hook/server.go
@@ -19,9 +19,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
@@ -99,6 +100,18 @@ func (s *Server) demuxEvent(eventType string, payload []byte) error {
 			return err
 		}
 		go s.handlePullRequestEvent(pr)
+	case "pull_request_review":
+		var re github.ReviewEvent
+		if err := json.Unmarshal(payload, &re); err != nil {
+			return err
+		}
+		go s.handleReviewEvent(re)
+	case "pull_request_review_comment":
+		var rce github.ReviewCommentEvent
+		if err := json.Unmarshal(payload, &rce); err != nil {
+			return err
+		}
+		go s.handleReviewCommentEvent(rce)
 	case "push":
 		var pe github.PushEvent
 		if err := json.Unmarshal(payload, &pe); err != nil {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -78,6 +78,7 @@ type PullRequest struct {
 	Head               PullRequestBranch `json:"head"`
 	Body               string            `json:"body"`
 	RequestedReviewers []User            `json:"requested_reviewers"`
+	Assignees          []User            `json:"assignees"`
 }
 
 // PullRequestBranch contains information about a particular branch in a PR.
@@ -209,4 +210,39 @@ type Commit struct {
 	Added    []string `json:"added"`
 	Removed  []string `json:"removed"`
 	Modified []string `json:"modified"`
+}
+
+// ReviewEvent is what GitHub sends us when a PR review is changed.
+type ReviewEvent struct {
+	Action      string `json:"action"`
+	PullRequest `json:"pull_request"`
+	Repo        `json:"repository"`
+	Review      `json:"review"`
+}
+
+// Review describes a Pull Request review.
+type Review struct {
+	ID      int `json:"id"`
+	User    `json:"user"`
+	Body    string `json:"body"`
+	State   string `json:"state"`
+	HTMLURL string `json:"html_url"`
+}
+
+// ReviewCommentEvent is what GitHub sends us when a PR review comment is changed.
+type ReviewCommentEvent struct {
+	Action      string `json:"action"`
+	PullRequest `json:"pull_request"`
+	Repo        `json:"repository"`
+	Comment     ReviewComment `json:"comment"`
+}
+
+// ReviewComment describes a Pull Request review.
+type ReviewComment struct {
+	ID       int `json:"id"`
+	ReviewID int `json:"pull_request_review_id"`
+	User     `json:"user"`
+	Body     string `json:"body"`
+	Path     string `json:"path"`
+	HTMLURL  string `json:"html_url"`
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -214,16 +214,16 @@ type Commit struct {
 
 // ReviewEvent is what GitHub sends us when a PR review is changed.
 type ReviewEvent struct {
-	Action      string `json:"action"`
-	PullRequest `json:"pull_request"`
-	Repo        `json:"repository"`
-	Review      `json:"review"`
+	Action      string      `json:"action"`
+	PullRequest PullRequest `json:"pull_request"`
+	Repo        Repo        `json:"repository"`
+	Review      Review      `json:"review"`
 }
 
 // Review describes a Pull Request review.
 type Review struct {
-	ID      int `json:"id"`
-	User    `json:"user"`
+	ID      int    `json:"id"`
+	User    User   `json:"user"`
 	Body    string `json:"body"`
 	State   string `json:"state"`
 	HTMLURL string `json:"html_url"`
@@ -231,17 +231,17 @@ type Review struct {
 
 // ReviewCommentEvent is what GitHub sends us when a PR review comment is changed.
 type ReviewCommentEvent struct {
-	Action      string `json:"action"`
-	PullRequest `json:"pull_request"`
-	Repo        `json:"repository"`
+	Action      string        `json:"action"`
+	PullRequest PullRequest   `json:"pull_request"`
+	Repo        Repo          `json:"repository"`
 	Comment     ReviewComment `json:"comment"`
 }
 
 // ReviewComment describes a Pull Request review.
 type ReviewComment struct {
-	ID       int `json:"id"`
-	ReviewID int `json:"pull_request_review_id"`
-	User     `json:"user"`
+	ID       int    `json:"id"`
+	ReviewID int    `json:"pull_request_review_id"`
+	User     User   `json:"user"`
 	Body     string `json:"body"`
 	Path     string `json:"path"`
 	HTMLURL  string `json:"html_url"`

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -66,7 +66,7 @@ type githubClient interface {
 	IsMember(org, user string) (bool, error)
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
-	GetLabels(owner, repo string) ([]github.Label, error)
+	GetRepoLabels(owner, repo string) ([]github.Label, error)
 	BotName() string
 }
 
@@ -155,7 +155,7 @@ func handle(gc githubClient, log *logrus.Entry, ae assignEvent, sc slackClient) 
 		return nil
 	}
 
-	labels, err := gc.GetLabels(ae.org, ae.repo)
+	labels, err := gc.GetRepoLabels(ae.org, ae.repo)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -17,6 +17,7 @@ limitations under the License.
 package lgtm
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/Sirupsen/logrus"
@@ -33,8 +34,23 @@ var (
 	lgtmCancelRe = regexp.MustCompile(`(?mi)^\/lgtm cancel\r?$`)
 )
 
+type event struct {
+	action        string
+	org           string
+	repo          string
+	number        int
+	prAuthor      string
+	commentAuthor string
+	body          string
+	assignees     []github.User
+	hasLabel      func(label string) (bool, error)
+	htmlurl       string
+}
+
 func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
+	plugins.RegisterReviewEventHandler(pluginName, handleReview)
+	plugins.RegisterReviewCommentEventHandler(pluginName, handleReviewComment)
 }
 
 type githubClient interface {
@@ -43,28 +59,101 @@ type githubClient interface {
 	AssignIssue(owner, repo string, number int, assignees []string) error
 	CreateComment(owner, repo string, number int, comment string) error
 	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+// prLabelChecker returns a function that lazily checks if a label is applied to a pr.
+func prLabelChecker(gc githubClient, log *logrus.Entry, org, repo string, num int) func(string) (bool, error) {
+	return func(label string) (bool, error) {
+		labels, err := gc.GetIssueLabels(org, repo, num)
+		if err != nil {
+			return false, err
+		}
+		for _, candidate := range labels {
+			if candidate.Name == label {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
 }
 
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
-	return handle(pc.GitHubClient, pc.Logger, ic)
-}
-
-func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
 	// Only consider open PRs.
-	if !ic.Issue.IsPullRequest() || ic.Issue.State != "open" || ic.Action != "created" {
+	if !ic.Issue.IsPullRequest() || ic.Issue.State != "open" {
 		return nil
 	}
 
-	org := ic.Repo.Owner.Login
-	repo := ic.Repo.Name
-	number := ic.Issue.Number
+	e := &event{
+		action:        ic.Action,
+		org:           ic.Repo.Owner.Login,
+		repo:          ic.Repo.Name,
+		number:        ic.Issue.Number,
+		prAuthor:      ic.Issue.User.Login,
+		commentAuthor: ic.Comment.User.Login,
+		body:          ic.Comment.Body,
+		assignees:     ic.Issue.Assignees,
+		hasLabel:      func(label string) (bool, error) { return ic.Issue.HasLabel(label), nil },
+		htmlurl:       ic.Comment.HTMLURL,
+	}
+	return handle(pc.GitHubClient, pc.Logger, e)
+}
+
+func handleReview(pc plugins.PluginClient, re github.ReviewEvent) error {
+	e := &event{
+		action:        re.Action,
+		org:           re.Repo.Owner.Login,
+		repo:          re.Repo.Name,
+		number:        re.PullRequest.Number,
+		prAuthor:      re.PullRequest.User.Login,
+		commentAuthor: re.Review.User.Login,
+		body:          re.Review.Body,
+		assignees:     re.PullRequest.Assignees,
+		hasLabel: prLabelChecker(
+			pc.GitHubClient,
+			pc.Logger,
+			re.Repo.Owner.Login,
+			re.Repo.Name,
+			re.PullRequest.Number,
+		),
+		htmlurl: re.Review.HTMLURL,
+	}
+	return handle(pc.GitHubClient, pc.Logger, e)
+}
+
+func handleReviewComment(pc plugins.PluginClient, rce github.ReviewCommentEvent) error {
+	e := &event{
+		action:        rce.Action,
+		org:           rce.Repo.Owner.Login,
+		repo:          rce.Repo.Name,
+		number:        rce.PullRequest.Number,
+		prAuthor:      rce.PullRequest.User.Login,
+		commentAuthor: rce.Comment.User.Login,
+		body:          rce.Comment.Body,
+		assignees:     rce.PullRequest.Assignees,
+		hasLabel: prLabelChecker(
+			pc.GitHubClient,
+			pc.Logger,
+			rce.Repo.Owner.Login,
+			rce.Repo.Name,
+			rce.PullRequest.Number,
+		),
+		htmlurl: rce.Comment.HTMLURL,
+	}
+	return handle(pc.GitHubClient, pc.Logger, e)
+}
+
+func handle(gc githubClient, log *logrus.Entry, e *event) error {
+	if e.action != "created" && e.action != "submitted" {
+		return nil
+	}
 
 	// If we create an "/lgtm" comment, add lgtm if necessary.
 	// If we create a "/lgtm cancel" comment, remove lgtm if necessary.
 	wantLGTM := false
-	if lgtmRe.MatchString(ic.Comment.Body) {
+	if lgtmRe.MatchString(e.body) {
 		wantLGTM = true
-	} else if lgtmCancelRe.MatchString(ic.Comment.Body) {
+	} else if lgtmCancelRe.MatchString(e.body) {
 		wantLGTM = false
 	} else {
 		return nil
@@ -72,38 +161,46 @@ func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) err
 
 	// Allow authors to cancel LGTM. Do not allow authors to LGTM, and do not
 	// accept commands from any other user.
-	commentAuthor := ic.Comment.User.Login
-	isAssignee := ic.Issue.IsAssignee(commentAuthor)
-	isAuthor := ic.Issue.IsAuthor(commentAuthor)
+	isAssignee := false
+	for _, user := range e.assignees {
+		if user.Login == e.commentAuthor {
+			isAssignee = true
+			break
+		}
+	}
+	isAuthor := e.commentAuthor == e.prAuthor
 	if isAuthor && wantLGTM {
 		resp := "you cannot LGTM your own PR"
 		log.Infof("Commenting with \"%s\".", resp)
-		return gc.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
+		return gc.CreateComment(e.org, e.repo, e.number, plugins.FormatResponseRaw(e.body, e.htmlurl, e.commentAuthor, resp))
 	} else if !isAuthor && !isAssignee {
-		log.Infof("Assigning %s/%s#%d to %s", org, repo, number, commentAuthor)
-		if err := gc.AssignIssue(org, repo, number, []string{commentAuthor}); err != nil {
+		log.Infof("Assigning %s/%s#%d to %s", e.org, e.repo, e.number, e.commentAuthor)
+		if err := gc.AssignIssue(e.org, e.repo, e.number, []string{e.commentAuthor}); err != nil {
 			msg := "assigning you to the PR failed"
-			if ok, merr := gc.IsMember(org, commentAuthor); merr == nil && !ok {
+			if ok, merr := gc.IsMember(e.org, e.commentAuthor); merr == nil && !ok {
 				msg = "only kubernetes org members may be assigned issues"
 			} else if merr != nil {
-				log.WithError(merr).Errorf("Failed IsMember(%s, %s)", org, commentAuthor)
+				log.WithError(merr).Errorf("Failed IsMember(%s, %s)", e.org, e.commentAuthor)
 			} else {
-				log.WithError(err).Errorf("Failed AssignIssue(%s, %s, %d, %s)", org, repo, number, commentAuthor)
+				log.WithError(err).Errorf("Failed AssignIssue(%s, %s, %d, %s)", e.org, e.repo, e.number, e.commentAuthor)
 			}
 			resp := "changing LGTM is restricted to assignees, and " + msg
 			log.Infof("Reply to assign via /lgtm request with comment: \"%s\"", resp)
-			return gc.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
+			return gc.CreateComment(e.org, e.repo, e.number, plugins.FormatResponseRaw(e.body, e.htmlurl, e.commentAuthor, resp))
 		}
 	}
 
 	// Only add the label if it doesn't have it, and vice versa.
-	hasLGTM := ic.Issue.HasLabel(lgtmLabel)
+	hasLGTM, err := e.hasLabel(lgtmLabel)
+	if err != nil {
+		return fmt.Errorf("failed to get the labels on %s/%s#%d: %v", e.org, e.repo, e.number, err)
+	}
 	if hasLGTM && !wantLGTM {
 		log.Info("Removing LGTM label.")
-		return gc.RemoveLabel(org, repo, number, lgtmLabel)
+		return gc.RemoveLabel(e.org, e.repo, e.number, lgtmLabel)
 	} else if !hasLGTM && wantLGTM {
 		log.Info("Adding LGTM label.")
-		return gc.AddLabel(org, repo, number, lgtmLabel)
+		return gc.AddLabel(e.org, e.repo, e.number, lgtmLabel)
 	}
 	return nil
 }

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -148,31 +148,30 @@ func TestLGTMComment(t *testing.T) {
 		fc := &fakegithub.FakeClient{
 			IssueComments: make(map[int][]github.IssueComment),
 		}
-		ice := github.IssueCommentEvent{
-			Action: tc.action,
-			Comment: github.IssueComment{
-				Body: tc.body,
-				User: github.User{Login: tc.commenter},
-			},
-			Issue: github.Issue{
-				User:        github.User{Login: "a"},
-				Number:      5,
-				State:       "open",
-				PullRequest: &struct{}{},
-				Assignees:   []github.User{{Login: "a"}, {Login: "r1"}, {Login: "r2"}},
-			},
+		e := &event{
+			action:        tc.action,
+			body:          tc.body,
+			commentAuthor: tc.commenter,
+			prAuthor:      "a",
+			number:        5,
+			assignees:     []github.User{{Login: "a"}, {Login: "r1"}, {Login: "r2"}},
+			org:           "org",
+			repo:          "repo",
+			htmlurl:       "<url>",
 		}
 		if tc.hasLGTM {
-			ice.Issue.Labels = []github.Label{{Name: lgtmLabel}}
+			e.hasLabel = func(label string) (bool, error) { return label == lgtmLabel, nil }
+		} else {
+			e.hasLabel = func(label string) (bool, error) { return false, nil }
 		}
-		if err := handle(fc, logrus.WithField("plugin", pluginName), ice); err != nil {
+		if err := handle(fc, logrus.WithField("plugin", pluginName), e); err != nil {
 			t.Errorf("For case %s, didn't expect error from lgtmComment: %v", tc.name, err)
 			continue
 		}
 		if tc.shouldAssign {
 			found := false
 			for _, a := range fc.AssigneesAdded {
-				if a == fmt.Sprintf("/#%d:%s", 5, tc.commenter) {
+				if a == fmt.Sprintf("%s/%s#%d:%s", e.org, e.repo, 5, tc.commenter) {
 					found = true
 					break
 				}
@@ -204,6 +203,76 @@ func TestLGTMComment(t *testing.T) {
 			t.Errorf("For case %s, should have commented.", tc.name)
 		} else if !tc.shouldComment && len(fc.IssueComments[5]) != 0 {
 			t.Errorf("For case %s, should not have commented.", tc.name)
+		}
+	}
+}
+
+func TestPRLabelChecker(t *testing.T) {
+	testCases := []struct {
+		name       string
+		labels     []string
+		check      string
+		shouldPass bool
+	}{
+		{
+			name:       "no labels",
+			labels:     []string{},
+			check:      "good-pr",
+			shouldPass: false,
+		},
+		{
+			name:       "no labels, check empty",
+			labels:     []string{},
+			check:      "",
+			shouldPass: false,
+		},
+		{
+			name:       "some labels, check empty",
+			labels:     []string{"some-label", "lgtm"},
+			check:      "",
+			shouldPass: false,
+		},
+		{
+			name:       "some labels, does not have check",
+			labels:     []string{"some-label", "definitely-not-lgtm"},
+			check:      "good-pr",
+			shouldPass: false,
+		},
+		{
+			name:       "has label last",
+			labels:     []string{"some-label", "definitely-not-lgtm", "good-pr"},
+			check:      "good-pr",
+			shouldPass: true,
+		},
+		{
+			name:       "has label first",
+			labels:     []string{"good-pr", "some-label", "definitely-not-lgtm"},
+			check:      "good-pr",
+			shouldPass: true,
+		},
+	}
+	for _, test := range testCases {
+		fc := &fakegithub.FakeClient{}
+		for _, label := range test.labels {
+			fc.AddLabel("k8s", "kuber", 42, label)
+		}
+		res, err := prLabelChecker(fc, nil, "k8s", "kuber", 42)(test.check)
+		if err != nil {
+			t.Errorf("Unexpected error from prLabelChecker on test '%s': %v.", test.name, err)
+			continue
+		}
+		if res != test.shouldPass {
+			var not string
+			if !test.shouldPass {
+				not = "not "
+			}
+			t.Errorf(
+				"Error on test '%s': %q should %sbe recognized as a label on #42 which has labels %q.",
+				test.name,
+				test.check,
+				not,
+				test.labels,
+			)
 		}
 	}
 }


### PR DESCRIPTION
The first commit adds prow plugin support for `pull_request_review` and `pull_request_review_comment` webhook events.
The second commit updates the LGTM plugin to process these events so that the `/lgtm` command can be used from a review body or a review comment.

/cc @spxtr @fejta 