### PR TITLE
Change back extract startegy of pull-kubernetes-federation-e2e-gce to…

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5295,7 +5295,7 @@
       "--deployment=none", 
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy", 
       "--timeout=90m", 
-      "--extract=ci/latest"
+      "--extract=local"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [
@@ -5318,7 +5318,7 @@
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy-canary", 
       "--mode=local", 
       "--timeout=90m", 
-      "--extract=ci/latest"
+      "--extract=local"
     ], 
     "scenario": "kubernetes_e2e", 
     "sigOwners": [


### PR DESCRIPTION
… local

Ref: https://github.com/kubernetes/kubernetes/issues/47032

pull-kubernetes-federation-e2e-gce job needs to run with extract strategy of `local`. it was changed to `ci/latest` from `local` which is causing the issue. This PR in test-infra introduced the issue. kubernetes/test-infra#2959

/assign @fejta 
/cc @madhusudancs @krzyzacy 