### PR TITLE
Use testing helper in TestSubmitQueue

### DIFF
--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -37,13 +37,7 @@ import (
 	fake_e2e "k8s.io/test-infra/mungegithub/mungers/e2e/fake"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"
 
-	"github.com/golang/glog"
 	"github.com/google/go-github/github"
-)
-
-var (
-	_ = fmt.Printf
-	_ = glog.Errorf
 )
 
 func stringPtr(val string) *string { return &val }
@@ -979,7 +973,7 @@ func TestSubmitQueue(t *testing.T) {
 	}
 	for testNum := range tests {
 		test := &tests[testNum]
-		fmt.Printf("---------Starting test %v (%v)---------------------\n", testNum, test.name)
+		t.Logf("---------Starting test %v (%v)---------------------", testNum, test.name)
 		issueNum := testNum + 1
 		issueNumStr := strconv.Itoa(issueNum)
 


### PR DESCRIPTION
The structure of an error is much cleaner by using the built-in
framework for printing. Compare https://pastebin.com/YW4jfDne with
https://pastebin.com/namKe9pg.

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>