### PR TITLE
pull_kubernetes_bazel image: Add gettext-base

### DIFF
--- a/images/pull_kubernetes_bazel/Dockerfile
+++ b/images/pull_kubernetes_bazel/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
     bash-completion \
     git \
     wget \
+    gettext-base \
     python \
     python-pip && \
     apt-get clean

--- a/images/pull_kubernetes_bazel/Makefile
+++ b/images/pull_kubernetes_bazel/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.12
+VERSION = 0.13
 
 image:
 	docker build -t "gcr.io/k8s-testimages/bazelbuild:$(VERSION)" .

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -72,7 +72,7 @@ presubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999  
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -115,7 +115,7 @@ presubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999   
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -354,7 +354,7 @@ presubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999   
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -397,7 +397,7 @@ presubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999  
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -616,7 +616,7 @@ presubmits:
     trigger: "@k8s-bot (pull-test-infra-bazel |bazel )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.12
+      - image: gcr.io/k8s-testimages/bazelbuild:0.13
         args:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--git-cache=/root/.cache/git"
@@ -700,7 +700,7 @@ presubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999  
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -737,7 +737,7 @@ postsubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999  
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -768,7 +768,7 @@ postsubmits:
             mountPath: /root/.cache
           ports:
           - containerPort: 9999
-            hostPort: 9999  
+            hostPort: 9999
         volumes:
         - name: service
           secret:
@@ -806,7 +806,7 @@ postsubmits:
               mountPath: /root/.cache
             ports:
             - containerPort: 9999
-              hostPort: 9999 
+              hostPort: 9999
           volumes:
           - name: service
             secret:
@@ -844,7 +844,7 @@ postsubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999  
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -875,7 +875,7 @@ postsubmits:
             mountPath: /root/.cache
           ports:
           - containerPort: 9999
-            hostPort: 9999  
+            hostPort: 9999
         volumes:
         - name: service
           secret:
@@ -913,7 +913,7 @@ postsubmits:
               mountPath: /root/.cache
             ports:
             - containerPort: 9999
-              hostPort: 9999 
+              hostPort: 9999
           volumes:
           - name: service
             secret:
@@ -932,7 +932,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.12
+      - image: gcr.io/k8s-testimages/bazelbuild:0.13
         args:
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--git-cache=/root/.cache/git"
@@ -951,7 +951,7 @@ postsubmits:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999  
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -1004,7 +1004,7 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.12
+    - image: gcr.io/k8s-testimages/bazelbuild:0.13
       args:
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--git-cache=/root/.cache/git"
@@ -1025,7 +1025,7 @@ periodics:
         mountPath: /root/.cache
       ports:
       - containerPort: 9999
-        hostPort: 9999  
+        hostPort: 9999
     volumes:
     - name: service
       secret:
@@ -1140,7 +1140,7 @@ periodics:
           mountPath: /root/.cache
         ports:
         - containerPort: 9999
-          hostPort: 9999  
+          hostPort: 9999
       volumes:
       - name: service
         secret:
@@ -1178,7 +1178,7 @@ periodics:
             mountPath: /root/.cache
           ports:
           - containerPort: 9999
-            hostPort: 9999  
+            hostPort: 9999
         volumes:
         - name: service
           secret:


### PR DESCRIPTION
So that we can have envsubst, used by //velodrome:test_config.