### PR TITLE
velodrome/config: Remove dependency on envsubst(1)

### DIFF
--- a/velodrome/BUILD
+++ b/velodrome/BUILD
@@ -9,7 +9,6 @@ sh_test(
         ":config.py",
         ":configs",
     ],
-    tags = ["manual"],
 )
 
 filegroup(

--- a/velodrome/config.py
+++ b/velodrome/config.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os
-import subprocess
+import string
 import sys
 
 import yaml
@@ -111,13 +111,8 @@ def print_deployments(components, env):
 
 
 def print_deployment(deployment, env):
-    p = subprocess.Popen(["envsubst", " ".join(["$" + key for key in env])],
-                         stdin=subprocess.PIPE,
-                         env=env)
-    p.communicate(deployment)
+    print string.Template(deployment).safe_substitute(**env),
     print '---'
-    sys.stdout.flush()
-
 
 if __name__ == '__main__':
     main()

--- a/velodrome/test_config.sh
+++ b/velodrome/test_config.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2017 The Kubernetes Authors.
 #


### PR DESCRIPTION
Use `string.Template` instead which does the same thing, and is
equivalently safe. The output has been compared before/after and is
exactly the same.