### PR TITLE
Use an external cluster for builds if requested.

### DIFF
--- a/prow/cmd/deck/jobs.go
+++ b/prow/cmd/deck/jobs.go
@@ -61,6 +61,7 @@ type Job struct {
 
 type JobAgent struct {
 	kc      *kube.Client
+	pkc     *kube.Client
 	jc      *jenkins.Client
 	jobs    []Job
 	jobsMap map[string]Job // pod name -> Job
@@ -96,7 +97,7 @@ func (ja *JobAgent) GetLog(name string) ([]byte, error) {
 	}
 	if job.Agent == "" || job.Agent == "kubernetes" {
 		// running on Kubernetes
-		return ja.kc.Namespace(kube.TestPodNamespace).GetLog(name)
+		return ja.pkc.GetLog(name)
 	} else if ja.jc != nil && job.Agent == "jenkins" {
 		// running on Jenkins
 		m := jobNameRE.FindStringSubmatch(name)

--- a/prow/kube/BUILD
+++ b/prow/kube/BUILD
@@ -26,6 +26,7 @@ go_library(
         "types.go",
     ],
     tags = ["automanaged"],
+    deps = ["//vendor:github.com/ghodss/yaml"],
 )
 
 filegroup(

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -28,6 +28,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/ghodss/yaml"
 )
 
 const (
@@ -202,15 +204,15 @@ func NewClientInCluster(namespace string) (*Client, error) {
 // master endpoint.
 type Cluster struct {
 	// The IP address of the cluster's master endpoint.
-	Endpoint string `json:"endpoint"`
+	Endpoint string `yaml:"endpoint"`
 	// Base64-encoded public cert used by clients to authenticate to the
 	// cluster endpoint.
-	ClientCertificate string `json:"clientCertificate"`
+	ClientCertificate string `yaml:"clientCertificate"`
 	// Base64-encoded private key used by clients..
-	ClientKey string `json:"clientKey"`
+	ClientKey string `yaml:"clientKey"`
 	// Base64-encoded public certificate that is the root of trust for the
 	// cluster.
-	ClusterCACertificate string `json:"clusterCaCertificate"`
+	ClusterCACertificate string `yaml:"clusterCaCertificate"`
 }
 
 // NewClientFromFile reads a Cluster object at clusterPath and returns an
@@ -221,7 +223,7 @@ func NewClientFromFile(clusterPath, namespace string) (*Client, error) {
 		return nil, err
 	}
 	var c Cluster
-	if err := json.Unmarshal(data, &c); err != nil {
+	if err := yaml.Unmarshal(data, &c); err != nil {
 		return nil, err
 	}
 	return NewClient(&c, namespace)

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -58,10 +58,10 @@ type Controller struct {
 	totURL   string
 }
 
-func NewController(kc *kube.Client, jc *jenkins.Client, crierURL, totURL string) *Controller {
+func NewController(kc, pkc *kube.Client, jc *jenkins.Client, crierURL, totURL string) *Controller {
 	return &Controller{
 		kc:       kc,
-		pkc:      kc.Namespace(kube.TestPodNamespace),
+		pkc:      pkc,
 		jc:       jc,
 		crierURL: crierURL,
 		totURL:   totURL,


### PR DESCRIPTION
This adds a `--build-cluster` flag to `cmd/deck` and `cmd/plank` that points to a file that contains credentials to talk to the build cluster. I already separated the clients to make it easy to run them in their own namespace, so this change is simple to make.