### PR TITLE
Create e2e-kubeadm:0.5 based on kubekins-e2e:v20170605-ed5d94ed and kubectl v1.6.4

### DIFF
--- a/images/ci-kubernetes-e2e-kubeadm/Dockerfile
+++ b/images/ci-kubernetes-e2e-kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170327-d33e8685
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170605-ed5d94ed
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 
 ENV TERRAFORM_VERSION=0.7.2 \
     KUBERNETES_PROVIDER=kubernetes-anywhere \
-    KUBECTL_VERSION=1.6.0-beta.4 \
+    KUBECTL_VERSION=1.6.4 \
     PATH=/usr/local/bin:${PATH}
 
 # Add kubernetes-anywhere dependencies: jsonnet, terraform, kubectl

--- a/images/ci-kubernetes-e2e-kubeadm/Makefile
+++ b/images/ci-kubernetes-e2e-kubeadm/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.4
+VERSION = 0.5
 
 image:
 	docker build -t "gcr.io/k8s-testimages/e2e-kubeadm:$(VERSION)" .

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -89,7 +89,7 @@ presubmits:
     trigger: "@k8s-bot (pull-kubernetes-e2e-kubeadm-gce |kubeadm e2e )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -371,7 +371,7 @@ presubmits:
     trigger: "@k8s-bot (pull-security-kubernetes-e2e-kubeadm-gce |kubeadm e2e )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -780,7 +780,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -887,7 +887,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce-1-6
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1160,7 +1160,7 @@ periodics:
     - name: periodic-kubernetes-e2e-kubeadm-gce-1-6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.4
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
           args:
           - "--repo=k8s.io/kubernetes=release-1.6"
           - "--clean"


### PR DESCRIPTION
This doesn't actually fix the PR kubeadm job (see https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/45057/pull-kubernetes-e2e-kubeadm-gce/5102/?log#log where I tested this) but it at least makes it more consistent with the other jobs.

The remaining issue seems to be that `--extract=local` is the wrong setting for this job, but I don't know what setting is correct.

/assign @pipejakob 
/cc @fejta 