### PR TITLE
Sync -release-blocking dashboards with kubernetes/release/lib/releaselib.sh

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1995,6 +1995,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-reboot-release-1-6
   - name: gce-1.6
     test_group_name: ci-kubernetes-e2e-gce-release-1-6
+  - name: federation-build-1.6
+    test_group_name: ci-kubernetes-federation-build-1.6
   - name: gce-scalability-1.6
     test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
   - name: gce-serial-1.6
@@ -2054,167 +2056,70 @@ dashboards:
   - name: periodic-kubeadm-gce-1.6
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-6
 
-# Matches the list on https://github.com/kubernetes/test-infra/issues/2029
+# These are the release *blocking* tests.  These provide a valid binary signal
+# to gate releases (alpha, beta, official).
+# This list is used by kubernetes/release/lib/releaselib.sh to provide go/nogo
+# signal for releases.
+# The first test/suite in the list is the primary suite for release purposes
 - name: release-1.6-blocking
   dashboard_tab:
-  # Build/Verify
   - name: build-1.6
     test_group_name: ci-kubernetes-build-1.6
-  - name: verify-1.6
-    test_group_name: ci-kubernetes-verify-release-1.6
-  - name: test-go-1.6
-    test_group_name: ci-kubernetes-test-go-release-1.6
-  - name: federation-build-1.6
-    test_group_name: ci-kubernetes-federation-build-1.6
-  # E2E
   - name: gce-1.6
     test_group_name: ci-kubernetes-e2e-gce-release-1-6
-  - name: gci-gce-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gce-release-1-6
-  - name: gke-1.6
-    test_group_name: ci-kubernetes-e2e-gke-release-1-6
-  - name: gci-gke-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gke-release-1-6
-  - name: kubeadm-gce-1.6
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6
-  # AWS
-  - name: kops-aws-1.6
-    test_group_name: ci-kubernetes-e2e-kops-aws-release-1.6
-  # Slow
-  - name: gce-slow-1.6
-    test_group_name: ci-kubernetes-e2e-gce-slow-release-1-6
-  - name: gci-gce-slow-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow-release-1-6
-  - name: gke-slow-1.6
-    test_group_name: ci-kubernetes-e2e-gke-slow-release-1-6
-  - name: gci-gke-slow-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gke-slow-release-1-6
-  # Serial
   - name: gce-serial-1.6
     test_group_name: ci-kubernetes-e2e-gce-serial-release-1-6
-  - name: gci-gce-serial-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial-release-1-6
-  - name: gke-serial-1.6
-    test_group_name: ci-kubernetes-e2e-gke-serial-release-1-6
-  - name: gci-gke-serial-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gke-serial-release-1-6
-  # Alpha
-  - name: gce-alpha-features-1.6
-    test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1-6
-  - name: gci-gce-alpha-features-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6
-  # Scalability
-  - name: gce-scalability-1.6
-    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
-  - name: gci-gce-scalability-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gce-scalability-release-1.6
-  # Ingress
-  - name: gci-gce-ingress-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-release-1-6
-  - name: gci-gke-ingress-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gke-ingress-release-1-6
-  # Reboot
+  - name: gce-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gce-slow-release-1-6
   - name: gce-reboot-1.6
     test_group_name: ci-kubernetes-e2e-gce-reboot-release-1-6
-  - name: gci-gce-reboot-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gce-reboot-release-1-6
-  - name: gke-reboot-1.6
-    test_group_name: ci-kubernetes-e2e-gke-reboot-release-1-6
-  - name: gci-gke-reboot-1.6
-    test_group_name: ci-kubernetes-e2e-gci-gke-reboot-release-1-6
-  # Soak
-  - name: ci-kubernetes-soak-gce-1.6-deploy
-    test_group_name: ci-kubernetes-soak-gce-1.6-deploy
-  - name: ci-kubernetes-soak-gce-1.6-test
-    test_group_name: ci-kubernetes-soak-gce-1.6-test
-  - name: ci-kubernetes-soak-gci-gce-1.6-deploy
-    test_group_name: ci-kubernetes-soak-gci-gce-1.6-deploy
-  - name: ci-kubernetes-soak-gci-gce-1.6-test
-    test_group_name: ci-kubernetes-soak-gci-gce-1.6-test
-  # Node
+  - name: gce-scalability-1.6
+    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1.6
+  - name: test-go-1.6
+    test_group_name: ci-kubernetes-test-go-release-1.6
+  - name: verify-1.6
+    test_group_name: ci-kubernetes-verify-release-1.6
   - name: kubelet-1.6
     test_group_name: ci-kubernetes-node-kubelet-1.6
-  - name: kubelet-non-cri-1.6
-    test_group_name: ci-kubernetes-node-kubelet-non-cri-1.6
+  - name: gke-serial-1.6
+    test_group_name: ci-kubernetes-e2e-gke-serial-release-1-6
+  - name: gke-1.6
+    test_group_name: ci-kubernetes-e2e-gke-release-1-6
+  - name: gke-slow-1.6
+    test_group_name: ci-kubernetes-e2e-gke-slow-release-1-6
 
+# These are the master *blocking* tests.  These provide a valid binary signal
+# to gate releases (alpha, beta, official).
+# This list is used by kubernetes/release/lib/releaselib.sh to provide go/nogo
+# signal for releases.
+# The first test/suite in the list is the primary suite for release purposes
 # Blocking tests for the next release
 - name: release-master-blocking
   dashboard_tab:
-  # Build/Verify
   - name: build
     test_group_name: ci-kubernetes-build
+  - name: gce
+    test_group_name: ci-kubernetes-e2e-gce
+  - name: gce-serial
+    test_group_name: ci-kubernetes-e2e-gce-serial
+  - name: gce-slow
+    test_group_name: ci-kubernetes-e2e-gce-slow
+  - name: gce-reboot
+    test_group_name: ci-kubernetes-e2e-gce-reboot
+  - name: gce-scalability
+    test_group_name: ci-kubernetes-e2e-gce-scalability
   - name: test-go
     test_group_name: ci-kubernetes-test-go
-  - name: verify-master
+  - name: verify
     test_group_name: ci-kubernetes-verify-master
   - name: kubelet
     test_group_name: ci-kubernetes-node-kubelet
-  - name: federation-build
-    test_group_name: ci-kubernetes-federation-build
-  - name: gce
-    test_group_name: ci-kubernetes-e2e-gce
-  - name: gce-etcd3
-    test_group_name: ci-kubernetes-e2e-gce-etcd3
-  - name: gci-gce
-    test_group_name: ci-kubernetes-e2e-gci-gce
   - name: gke
     test_group_name: ci-kubernetes-e2e-gke
-  - name: gci-gke
-    test_group_name: ci-kubernetes-e2e-gci-gke
-  - name: aws
-    test_group_name: ci-kubernetes-e2e-kops-aws
-  - name: gce-gpu
-    test_group_name: ci-kubernetes-e2e-gce-gpu
-  - name: gce-slow
-    test_group_name: ci-kubernetes-e2e-gce-slow
-  - name: gci-gce-slow
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow
   - name: gke-slow
     test_group_name: ci-kubernetes-e2e-gke-slow
-  - name: gci-gke-slow
-    test_group_name: ci-kubernetes-e2e-gci-gke-slow
-  - name: gce-serial
-    test_group_name: ci-kubernetes-e2e-gce-serial
-  - name: gci-gce-serial
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial
-  - name: gke-serial
-    test_group_name: ci-kubernetes-e2e-gke-serial
-  - name: gci-gke-serial
-    test_group_name: ci-kubernetes-e2e-gci-gke-serial
   - name: gce-federation
     test_group_name: ci-kubernetes-e2e-gce-federation
-  - name: gce-alpha-features
-    test_group_name: ci-kubernetes-e2e-gce-alpha-features
-  - name: gci-gce-alpha-features
-    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
-  - name: gce-audit
-    test_group_name: ci-kubernetes-e2e-gce-audit
-  - name: gci-gce-audit
-    test_group_name: ci-kubernetes-e2e-gci-gce-audit
-  - name: gce-scalability
-    test_group_name: ci-kubernetes-e2e-gce-scalability
-  - name: gci-gce-scalability
-    test_group_name: ci-kubernetes-e2e-gci-gce-scalability
-  - name: gci-gce-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-  - name: gci-gke-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gke-ingress
-  - name: gce-reboot
-    test_group_name: ci-kubernetes-e2e-gce-reboot
-  - name: gci-gce-reboot
-    test_group_name: ci-kubernetes-e2e-gci-gce-reboot
-  - name: gke-reboot
-    test_group_name: ci-kubernetes-e2e-gke-reboot
-  - name: gci-gke-reboot
-    test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-  - name: soak-gce-deploy
-    test_group_name: ci-kubernetes-soak-gce-deploy
-  - name: soak-gce-test
-    test_group_name: ci-kubernetes-soak-gce-test
-  - name: soak-gce-gci-deploy
-    test_group_name: ci-kubernetes-soak-gce-gci-deploy
-  - name: soak-gce-gci-test
-    test_group_name: ci-kubernetes-soak-gce-gci-test
 
 - name: release-1.6-upgrade-skew
   dashboard_tab:
@@ -2750,82 +2655,76 @@ dashboards:
   - name: periodic-bazel-test-1.7
     test_group_name: periodic-kubernetes-bazel-test-1-7
 
+# These are the release *blocking* tests.  These provide a valid binary signal
+# to gate releases (alpha, beta, official).
+# This list is used by kubernetes/release/lib/releaselib.sh to provide go/nogo
+# signal for releases.
+# The first test/suite in the list is the primary suite for release purposes
 - name: release-1.7-blocking
   dashboard_tab:
   - name: build-1.7
     test_group_name: ci-kubernetes-build-1.7
+  - name: gce-release-1-7
+    test_group_name: ci-kubernetes-e2e-gce-release-1-7
+  - name: gce-serial-release-1-7
+    test_group_name: ci-kubernetes-e2e-gce-serial-release-1-7
+  - name: gce-slow-release-1-7
+    test_group_name: ci-kubernetes-e2e-gce-slow-release-1-7
+  - name: gce-reboot-release-1-7
+    test_group_name: ci-kubernetes-e2e-gce-reboot-release-1-7
+  - name: gce-scalability-release-1-7
+    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1-7
   - name: test-go-1.7
     test_group_name: ci-kubernetes-test-go-release-1.7
   - name: verify-1.7
     test_group_name: ci-kubernetes-verify-release-1.7
+  - name: gce-kubeadm-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: kubelet-1.7
     test_group_name: ci-kubernetes-node-kubelet-1.7
-  - name: federation-build-1.7
-    test_group_name: ci-kubernetes-federation-build-1.7
-  - name: gce-release-1-7
-    test_group_name: ci-kubernetes-e2e-gce-release-1-7
-  - name: gci-gce-release-1-7
-    test_group_name: ci-kubernetes-e2e-gci-gce-release-1-7
-  - name: gke-release-1-7
-    test_group_name: ci-kubernetes-e2e-gke-release-1-7
-  - name: gci-gke-release-1-7
-    test_group_name: ci-kubernetes-e2e-gci-gke-release-1-7
   - name: aws-release-1-7
     test_group_name: ci-kubernetes-e2e-kops-aws-release-1-7
-  - name: gce-slow-release-1-7
-    test_group_name: ci-kubernetes-e2e-gce-slow-release-1-7
-  - name: gci-gce-slow-release-1-7
-    test_group_name: ci-kubernetes-e2e-gci-gce-slow-release-1-7
-  - name: gke-slow-release-1-7
-    test_group_name: ci-kubernetes-e2e-gke-slow-release-1-7
-  - name: gci-gke-slow-release-1-7
-    test_group_name: ci-kubernetes-e2e-gci-gke-slow-release-1-7
-  - name: gce-serial-release-1-7
-    test_group_name: ci-kubernetes-e2e-gce-serial-release-1-7
-  - name: gci-gce-serial-release-1-7
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial-release-1-7
   - name: gke-serial-release-1-7
     test_group_name: ci-kubernetes-e2e-gke-serial-release-1-7
-  - name: gci-gke-serial-release-1-7
-    test_group_name: ci-kubernetes-e2e-gci-gke-serial-release-1-7
-  - name: gce-federation-release-1-7
-    test_group_name: ci-kubernetes-e2e-gce-federation-release-1-7
+  - name: gke-release-1-7
+    test_group_name: ci-kubernetes-e2e-gke-release-1-7
   - name: gce-alpha-features-release-1-7
     test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1-7
+  - name: gke-slow-release-1-7
+    test_group_name: ci-kubernetes-e2e-gke-slow-release-1-7
+  - name: gce-federation-release-1-7
+    test_group_name: ci-kubernetes-e2e-gce-federation-release-1-7
+  - name: gci-gce-release-1-7
+    test_group_name: ci-kubernetes-e2e-gci-gce-release-1-7
+  - name: gci-gce-slow-release-1-7
+    test_group_name: ci-kubernetes-e2e-gci-gce-slow-release-1-7
+  - name: gci-gke-slow-release-1-7
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow-release-1-7
+  - name: gci-gce-serial-release-1-7
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial-release-1-7
+  - name: gci-gke-serial-release-1-7
+    test_group_name: ci-kubernetes-e2e-gci-gke-serial-release-1-7
   - name: gci-gce-alpha-features-release-1-7
     test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1-7
-  - name: gce-audit-release-1-7
-    test_group_name: ci-kubernetes-e2e-gce-audit-release-1-7
-  - name: gci-gce-audit-release-1-7
-    test_group_name: ci-kubernetes-e2e-gci-gce-audit-release-1-7
-  - name: gce-scalability-release-1-7
-    test_group_name: ci-kubernetes-e2e-gce-scalability-release-1-7
   - name: gci-gce-scalability-release-1-7
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-release-1-7
   - name: gci-gce-ingress-release-1-7
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress-release-1-7
   - name: gci-gke-ingress-release-1-7
     test_group_name: ci-kubernetes-e2e-gci-gke-ingress-release-1-7
-  - name: gce-reboot-release-1-7
-    test_group_name: ci-kubernetes-e2e-gce-reboot-release-1-7
   - name: gci-gce-reboot-release-1-7
     test_group_name: ci-kubernetes-e2e-gci-gce-reboot-release-1-7
   - name: gke-reboot-release-1-7
     test_group_name: ci-kubernetes-e2e-gke-reboot-release-1-7
   - name: gci-gke-reboot-release-1-7
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot-release-1-7
-  - name: soak-gce-1-7-deploy
-    test_group_name: ci-kubernetes-soak-gce-1-7-deploy
-  - name: soak-gce-1-7-test
-    test_group_name: ci-kubernetes-soak-gce-1-7-test
   - name: soak-gci-gce-1-7-deploy
     test_group_name: ci-kubernetes-soak-gci-gce-1-7-deploy
   - name: soak-gci-gce-1-7-test
     test_group_name: ci-kubernetes-soak-gci-gce-1-7-test
   - name: gce-gpu-1-7
     test_group_name: ci-kubernetes-e2e-gce-gpu-1-7
-  - name: gce-kubeadm-1.7
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
+
 
 - name: cos-image-validation
   dashboard_tab:


### PR DESCRIPTION
This is the first step in [centralizing test suite](https://github.com/kubernetes/release/issues/340) definitions.  

~~This splits the current release blocking lists into hard (binary signal) and soft (human ack required) and provides a place for [releaselib.sh](https://github.com/kubernetes/release/blob/master/lib/releaselib.sh#L104) to consume the list of suites rather than hardcoding them leading to them inevitably drifting out of sync.~~

~~The "-hard" lists in this PR are a best guess based on a union of the "-soft" lists and what's currently in [releaselib.sh](https://github.com/kubernetes/release/blob/master/lib/releaselib.sh#L104).~~

~~I do not expect this is the final list.  Release managers, please chime in here.  This is to help you with a simple 'gate' to provide release signal.  Ideally we'd have everything in one list vs hard/soft.  We'll get there, but in the meantime you'll use both lists to get a reasonable 'hard' signal and a human ack by checking the soft list in conjunction.~~

This simply syncs up the "blocking" suites with what is currently in [releaselib.sh](https://github.com/kubernetes/release/blob/master/lib/releaselib.sh#L104).

Fixes https://github.com/kubernetes/release/pull/340

cc @kubernetes/kubernetes-release-managers @dclaar @javier-b-perez