### PR TITLE
Bump the concurrent syncs of the namespace controller

### DIFF
--- a/jobs/pull-kubernetes-e2e-gce-etcd3.env
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.env
@@ -5,3 +5,8 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 ENABLE_CACHE_MUTATION_DETECTOR=true
 
 PROJECT=k8s-jkns-pr-gce-etcd3
+
+# Increase the concurrent syncs for the namespace controller.
+# See https://github.com/kubernetes/kubernetes/issues/47135 for the detailed
+# explanation.
+CONTROLLER_MANAGER_TEST_ARGS=--concurrent-namespace-syncs=10


### PR DESCRIPTION
This bumps the concurrent syncs of the namespace controller for the
pull-kubernetes-e2e-gce-etcd3 job to help alleviate the slow namespace
deletion issue.

This is to address https://github.com/kubernetes/kubernetes/issues/47135