### PR TITLE
use --keep-redundant-commits when cherry-pick

### DIFF
--- a/mungegithub/mungers/publish_scripts/util.sh
+++ b/mungegithub/mungers/publish_scripts/util.sh
@@ -97,8 +97,8 @@ sync_repo() {
         if [[ -z "${commitSHA}" ]]; then
             continue
         fi
-    	echo "working ${commitSHA}"
-    	git -c user.name="Kubernetes Publisher" -c user.email="k8s-publish-robot@users.noreply.github.com" cherry-pick ${commitSHA}
+        echo "working ${commitSHA}"
+        git -c user.name="Kubernetes Publisher" -c user.email="k8s-publish-robot@users.noreply.github.com" cherry-pick --keep-redundant-commits ${commitSHA}
     done <<< "${commits}"
     
     # track the k8s.io/kubernetes commit SHA so we can always determine which level of kube this repo matches


### PR DESCRIPTION
Fix #2847

Please note there will be an empty commit in k8s.io/apiserver due to https://github.com/kubernetes/test-infra/issues/2847#issuecomment-307955662. If a user tries to cherry-pick that commit, she will hit the same problem and will need to manually fix the cherry-pick. I don't know if it's alright.

The robot seems to work correctly for my repos: https://github.com/caesarxuchao/client-go