### PR TITLE
Add step name to interrupt/terminate messages

### DIFF
--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -149,10 +149,10 @@ func finishRunning(cmd *exec.Cmd) error {
 			terminate.Reset(time.Duration(0)) // Kill subsequent processes immediately.
 			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 			cmd.Process.Kill()
-			return fmt.Errorf("Terminate testing after 15m after %s timeout during %s", timeout, stepName)
+			return fmt.Errorf("Terminate after 15m after %s timeout during %s", timeout, stepName)
 		case <-interrupt.C:
 			interrupted = true
-			log.Printf("Interrupt testing after %s timeout. Will terminate in another 15m", timeout)
+			log.Printf("Interrupt after %s timeout during %s. Will terminate in another 15m", timeout, stepName)
 			terminate.Reset(15 * time.Minute)
 			if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGINT); err != nil {
 				log.Printf("Failed to interrupt %v. Will terminate immediately: %v", stepName, err)


### PR DESCRIPTION
Digging through logs when an e2e run failed after the tests passed, but the cluster-down step failed, the "Interrupt testing after 55m0s timeout. Will terminate in another 15m" message was confusing:

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/46796/pull-kubernetes-e2e-gce-etcd3/35620/?log#log

```
...
I0612 19:43:25.306] SUCCESS! -- 302 Passed | 0 Failed | 0 Pending | 345 Skipped 
I0612 19:43:25.306] 
I0612 19:43:25.306] Ginkgo ran 1 suite in 30m13.309131901s
I0612 19:43:25.306] Test Suite Passed
I0612 19:43:25.345] Shutting down test cluster in background.
W0612 19:43:25.445] 2017/06/12 19:43:25 util.go:131: Step './hack/ginkgo-e2e.sh --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]' finished in 30m14.033223284s
W0612 19:43:25.446] 2017/06/12 19:43:25 util.go:129: Running: ./hack/e2e-internal/e2e-down.sh
W0612 19:43:25.446] Project: k8s-jkns-pr-gce-etcd3
W0612 19:43:25.446] Zone: us-central1-f
W0612 19:43:42.502] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-minion-e2e-35620-http-alt].
W0612 19:43:48.141] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-minion-e2e-35620-nodeports].
I0612 19:43:48.242] Bringing down cluster using provider: gce
W0612 19:43:48.903] Project: k8s-jkns-pr-gce-etcd3
W0612 19:43:48.903] Zone: us-central1-f
W0612 19:43:50.444] INSTANCE_GROUPS=e2e-35620-minion-group
W0612 19:43:50.444] NODE_NAMES=e2e-35620-minion-group-g1fs e2e-35620-minion-group-hgth e2e-35620-minion-group-nf80 e2e-35620-minion-group-t035
I0612 19:43:50.544] Bringing down cluster
W0612 19:45:21.132] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/zones/us-central1-f/instanceGroupManagers/e2e-35620-minion-group].
W0612 19:45:26.307] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/instanceTemplates/e2e-35620-minion-template].
I0612 19:45:31.678] Removing etcd replica, name: e2e-35620-master, port: 2379, result: 0
I0612 19:45:32.700] Removing etcd replica, name: e2e-35620-master, port: 4002, result: 0
W0612 19:45:38.851] Updated [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/zones/us-central1-f/instances/e2e-35620-master].
W0612 19:46:31.586] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/zones/us-central1-f/instances/e2e-35620-master].
W0612 19:46:45.015] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-master-https].
W0612 19:46:56.596] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-minion-all].
W0612 19:47:01.061] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-master-etcd].
W0612 19:47:09.331] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/regions/us-central1/addresses/e2e-35620-master-ip].
I0612 19:47:10.783] Deleting routes e2e-35620-9b64dbd7-4fdd-11e7-bdf5-42010a800002
W0612 19:47:32.438] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/routes/e2e-35620-9b64dbd7-4fdd-11e7-bdf5-42010a800002].
W0612 19:47:50.348] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-default-internal-master].
W0612 19:47:55.958] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-default-internal-node].
W0612 19:47:56.605] Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-pr-gce-etcd3/global/firewalls/e2e-35620-default-ssh].
W0612 19:48:21.244] 2017/06/12 19:48:21 util.go:155: Interrupt testing after 55m0s timeout. Will terminate in another 15m
W0612 19:48:21.244] 
W0612 19:48:21.244] 
W0612 19:48:21.245] Command killed by keyboard interrupt
W0612 19:48:21.245] 
W0612 19:48:21.250] 2017/06/12 19:48:21 util.go:131: Step './hack/e2e-internal/e2e-down.sh' finished in 4m55.94037748s
```

this tweaks the message to not assume the step being run is testing, and includes the stepName in the message