### PR TITLE
Remove federation from 1.6 blocking again.

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2034,9 +2034,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-serial-release-1-6
   - name: gci-gke-serial-1.6
     test_group_name: ci-kubernetes-e2e-gci-gke-serial-release-1-6
-  # Federation
-  - name: gce-federation-1.6
-    test_group_name: ci-kubernetes-e2e-gce-federation-release-1.6
   # Alpha
   - name: gce-alpha-features-1.6
     test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1-6


### PR DESCRIPTION
This was removed in #3009 and then mistakenly readded in 764baeabcd, presumably while resolving merge conflicts.

@krzyzacy @madhusudancs 