### PR TITLE
Run the builds in a separate cluster.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -17,15 +17,16 @@ all: build test
 
 HOOK_VERSION       = 0.109
 SINKER_VERSION     = 0.10
-DECK_VERSION       = 0.27
+DECK_VERSION       = 0.28
 SPLICE_VERSION     = 0.20
 TOT_VERSION        = 0.0
 CRIER_VERSION      = 0.7
 HOROLOGIUM_VERSION = 0.3
-PLANK_VERSION      = 0.17
+PLANK_VERSION      = 0.18
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow
+BUILD_PROJECT ?= k8s-prow-builds
 ZONE ?= us-central1-f
 CLUSTER ?= prow
 # Build and push specific variables.
@@ -40,6 +41,9 @@ update-plugins: get-cluster-credentials
 
 get-cluster-credentials:
 	gcloud container clusters get-credentials "$(CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
+
+get-build-cluster-credentials:
+	gcloud container clusters get-credentials "$(BUILD_CLUSTER)" --project="$(PROJECT)" --zone="$(ZONE)"
 
 build:
 	go install ./cmd/...

--- a/prow/README.md
+++ b/prow/README.md
@@ -104,7 +104,7 @@ set up a prow cluster on GKE.
 1. Create the cluster. I'm assuming that `PROJECT`, `CLUSTER`, and `ZONE` are
 set. I'm putting prow components on a node with the label `role=prow`, and I'm
 doing the actual tests on nodes with the label `role=build`, but this isn't a
-hard requirement.
+hard requirement. You can also choose to run the builds in a separate cluster.
 
  ```
  gcloud -q container --project "${PROJECT}" clusters create "${CLUSTER}" --zone "${ZONE}" --machine-type n1-standard-4 --num-nodes 4 --node-labels=role=prow --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.full_control","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management" --network "default" --enable-cloud-logging --enable-cloud-monitoring

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -35,12 +35,13 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.27
+        image: gcr.io/k8s-prow/deck:0.28
         ports:
           - name: http
             containerPort: 80
         args:
         - --jenkins-url=$(JENKINS_URL)
+        - --build-cluster=/etc/cluster/cluster
         env:
         - name: JENKINS_URL
           valueFrom:
@@ -51,8 +52,15 @@ spec:
         - mountPath: /etc/jenkins
           name: jenkins
           readOnly: true
+        - mountPath: /etc/cluster
+          name: cluster
+          readOnly: true
       volumes:
       - name: jenkins
         secret:
           defaultMode: 420
           secretName: jenkins-token
+      - name: cluster
+        secret:
+          defaultMode: 420
+          secretName: build-cluster

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -29,8 +29,13 @@ spec:
         role: prow
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.17
+        image: gcr.io/k8s-prow/plank:0.18
+        args:
+        - --build-cluster=/etc/cluster/cluster
         volumeMounts:
+        - mountPath: /etc/cluster
+          name: cluster
+          readOnly: true
         - mountPath: /etc/jenkins
           name: jenkins
           readOnly: true
@@ -39,3 +44,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: jenkins-token
+      - name: cluster
+        secret:
+          defaultMode: 420
+          secretName: build-cluster


### PR DESCRIPTION
I'm not sure how to properly note that this is optional. I think it might be a good time to move the `k8s-prow` YAML config out of `prow/cluster` and make the stuff in `prow/cluster` set up a generic default cluster? Not sure.