### PR TITLE
Change machine type to single-core for k8s-anywhere e2es.

### DIFF
--- a/images/ci-kubernetes-e2e-kubeadm/Makefile
+++ b/images/ci-kubernetes-e2e-kubeadm/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.5
+VERSION = 0.6
 
 image:
 	docker build -t "gcr.io/k8s-testimages/e2e-kubeadm:$(VERSION)" .

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -42,7 +42,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase1.cloud_provider="gce"
 
 .phase1.gce.os_image="ubuntu-1604-xenial-v20160420c"
-.phase1.gce.instance_type="n1-standard-2"
+.phase1.gce.instance_type="n1-standard-1"
 .phase1.gce.project="{{.Project}}"
 .phase1.gce.region="us-central1"
 .phase1.gce.zone="us-central1-b"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -89,7 +89,7 @@ presubmits:
     trigger: "@k8s-bot (pull-kubernetes-e2e-kubeadm-gce |kubeadm e2e )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.6
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -370,7 +370,7 @@ presubmits:
     trigger: "@k8s-bot (pull-security-kubernetes-e2e-kubeadm-gce |kubeadm e2e )?test this"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:0.6
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -778,7 +778,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.6
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -885,7 +885,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce-1-6
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.6
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -992,7 +992,7 @@ postsubmits:
       - name: ci-kubernetes-e2e-kubeadm-gce-1-7
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:0.6
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1265,7 +1265,7 @@ periodics:
     - name: periodic-kubernetes-e2e-kubeadm-gce-1-6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.6
           args:
           - "--repo=k8s.io/kubernetes=release-1.6"
           - "--clean"
@@ -1375,7 +1375,7 @@ periodics:
     - name: periodic-kubernetes-e2e-kubeadm-gce-1-7
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:0.6
           args:
           - "--repo=k8s.io/kubernetes=release-1.7"
           - "--clean"


### PR DESCRIPTION
There's no need for these hosts to be dual-core. All of the kubeadm e2es pass in about the same amount of time with single-core VMs.

This should help our quota problems in the CI project.