### PR TITLE
Update cos image used by GPU e2e tests on GCE.

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-gpu.env
+++ b/jobs/ci-kubernetes-e2e-gce-gpu.env
@@ -3,7 +3,7 @@ PROJECT=k8s-jkns-e2e-gce-gpus
 KUBE_FEATURE_GATES=Accelerators=true
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:GPU\]
 KUBE_NODE_OS_DISTRIBUTION=gci
+KUBE_GCI_VERSION=cos-stable-59-9460-60-0
 NODE_ACCELERATORS=type=nvidia-tesla-k80,count=2
 # GPUs are not available across all zones yet.
 KUBE_GCE_ZONE=us-west1-b
-


### PR DESCRIPTION
This is required by the updated installer added in https://github.com/kubernetes/kubernetes/pull/47467

Please merge only after the kubernetes PR is merged.