### PR TITLE
Make Gubernator redirect to optionless testgrid tabs.

### DIFF
--- a/gubernator/testgrid.py
+++ b/gubernator/testgrid.py
@@ -33,6 +33,7 @@ CONFIG_PROTO_SCHEMA = {
             'name': 'dashboard_tab',
             1: 'name',
             2: 'test_group_name',
+            6: 'base_options',
             7: {},
             8: {2: {}},
             9: {},
@@ -104,14 +105,17 @@ def path_to_query(path):
     options = {}
     for dashboard in get_config().get('dashboards', []):
         dashboard_name = dashboard['name'][0]
-        for tab in dashboard['dashboard_tab']:
+        tabs = dashboard['dashboard_tab']
+        for tab in tabs:
+            if 'base_options' in tab:
+                continue
             if group in tab['test_group_name']:
                 query = '%s#%s' % (dashboard_name, tab['name'][0])
-                options[dashboard_name] = query
+                options[dashboard_name] = (-len(tabs), query)
     if 'k8s' in options:
-        return options['k8s']
+        return options['k8s'][1]
     elif len(options) > 1:
         logging.warning('ambiguous testgrid options: %s', options)
     elif len(options) == 0:
         return ''
-    return options.values()[0]
+    return sorted(options.values())[0][1]

--- a/gubernator/testgrid_test.py
+++ b/gubernator/testgrid_test.py
@@ -60,6 +60,7 @@ class TestTestgrid(unittest.TestCase):
                 {'query': ['gce-serial'], 'name': ['gce-serial']},
                 {'query': ['gce-soak'], 'name': ['gce-soak']},
                 {'query': ['gce-soak-1.3'], 'name': ['gce-soak-1.3']},
+                {'query': ['gke'], 'name': ['gke']},
                 {'query': ['unusedgroup'], 'name': ['unused']},
             ],
             'dashboards': [
@@ -82,6 +83,21 @@ class TestTestgrid(unittest.TestCase):
                     'dashboard_tab': [
                         {'test_group_name': ['gce-soak-1.3'], 'name': ['soak']},
                     ]
+                },
+                {
+                    'name': ['gke'],
+                    'dashboard_tab': [
+                       {'test_group_name': ['gke'], 'name': ['gke']}
+                    ]
+                },
+                {
+                    'name': ['sig-storage'],
+                    'dashboard_tab': [
+                       {'test_group_name': ['gke'], 'name': ['gke'],
+                         'base_options': ['include-filter-by-regex=Storage']},
+                       {'test_group_name': ['gce-serial'], 'name': ['gce-serial'],
+                         'base_options': ['include-filter-by-regex=Storage']}
+                    ]
                 }
             ]
         }
@@ -93,6 +109,7 @@ class TestTestgrid(unittest.TestCase):
         expect('gce-soak-1.3', 'gce#soak-1.3')
         expect('unusedgroup', '')
         expect('notarealpath', '')
+        expect('gke', 'gke#gke')
 
 
 class TestTestgridGCS(main_test.TestBase):


### PR DESCRIPTION
This means GKE won't be directed to a sig-storage gke tab with a regex filter.