### PR TITLE
bump timeout on no-snat test job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -727,7 +727,7 @@
       "--env-file=jobs/platform/gce.env", 
       "--env-file=jobs/image/cosbeta.env", 
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-no-snat.env", 
-      "--timeout=10m", 
+      "--timeout=15m", 
       "--mode=local", 
       "--extract=ci/latest", 
       "--check-leaked-resources=true"


### PR DESCRIPTION
It looks like the job is getting killed during teardown due to timeout at 10m. Hopefully this will fix.

Example error:
```
W0614 17:31:55.834] 2017/06/14 17:31:55 util.go:155: Interrupt testing after 10m0s timeout. Will terminate in another 15m
W0614 17:31:55.834] 
W0614 17:31:55.834] 
W0614 17:31:55.835] Command killed by keyboard interrupt
W0614 17:31:55.835] 
```
from: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosbeta-no-snat/3/build-log.txt