### PR TITLE
Add a etcd3-pr-validate job, and make gce-etcd3 to master blocking dashboard

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-etcd3-pr-validate.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3-pr-validate.env
@@ -1,0 +1,17 @@
+### job-env
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_PARALLEL=y
+PROJECT=k8s-jkns-e2e-gke-alpha-1-4
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+# Envs should match pull-kubernetes-e2e-gce-etcd3.
+NUM_NODES=4
+GINKGO_PARALLEL_NODES=30
+E2E_MIN_STARTUP_PODS=1
+
+# Flake detection. Individual tests get a second chance to pass.
+GINKGO_TOLERATE_FLAKES=y
+KUBE_GCS_UPDATE_LATEST=n
+
+# Disable ENABLE_CACHE_MUTATION_DETECTOR to see if it causes slow down
+# ENABLE_CACHE_MUTATION_DETECTOR=true

--- a/jobs/ci-kubernetes-e2e-gce-etcd3.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3.env
@@ -3,4 +3,3 @@ GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Fe
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-etcd3
 KUBE_NODE_OS_DISTRIBUTION=debian
-

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -820,6 +820,21 @@
       "UNKNOWN"
     ]
   },
+  "ci-kubernetes-e2e-gce-etcd3-pr-validate": {
+    "args": [
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3-pr-validate.env",
+      "--timeout=50m",
+      "--extract=ci/latest",
+      "--mode=local",
+      "--cluster=pr-validation",
+      "--check-leaked-resources=true"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-release"
+    ]
+  },
   "ci-kubernetes-e2e-gce-etcd3-release-1-5": {
     "args": [
       "--env-file=jobs/platform/gce.env",

--- a/jobs/validOwners.json
+++ b/jobs/validOwners.json
@@ -25,5 +25,6 @@
    "sig-storage",
    "sig-testing",
    "sig-ui",
-   "sig-windows"
+   "sig-windows",
+   "sig-release"
 ]

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7644,3 +7644,36 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
+
+- interval: 30m
+  name: ci-kubernetes-e2e-gce-etcd3-pr-validate
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -143,6 +143,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-sd-logging
 - name: ci-kubernetes-e2e-gce-etcd3
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd3
+- name: ci-kubernetes-e2e-gce-etcd3-pr-validate
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd3-pr-validate
 - name: ci-kubernetes-e2e-gce-etcd3-release-1-5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd3-release-1-5
 - name: ci-kubernetes-e2e-gci-gce-etcd3
@@ -1193,6 +1195,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-sd-logging
   - name: gce-etcd3
     test_group_name: ci-kubernetes-e2e-gce-etcd3
+  - name: gce-etcd3-pr-validate
+    test_group_name: ci-kubernetes-e2e-gce-etcd3-pr-validate
   - name: gce-etcd3-1.5
     test_group_name: ci-kubernetes-e2e-gce-etcd3-release-1-5
   - name: gci-gce-etcd3
@@ -2089,6 +2093,8 @@ dashboards:
     test_group_name: ci-kubernetes-federation-build
   - name: gce
     test_group_name: ci-kubernetes-e2e-gce
+  - name: gce-etcd3
+    test_group_name: ci-kubernetes-e2e-gce-etcd3
   - name: gci-gce
     test_group_name: ci-kubernetes-e2e-gci-gce
   - name: gke


### PR DESCRIPTION
Makes two suite have matching env so that we can have signal when the ci- version start to fail.

Currently have `ENABLE_CACHE_MUTATION_DETECTOR` disabled, to compare if it causes any significant slow down.

xref https://github.com/kubernetes/kubernetes/issues/47446