### PR TITLE
Add GPU tests to the release-master-blocking dashboard.

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2097,6 +2097,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gke
   - name: aws
     test_group_name: ci-kubernetes-e2e-kops-aws
+  - name: gce-gpu
+    test_group_name: ci-kubernetes-e2e-gce-gpu
   - name: gce-slow
     test_group_name: ci-kubernetes-e2e-gce-slow
   - name: gci-gce-slow


### PR DESCRIPTION
Their counterparts are already in the release-1.7-blocking dashboard.

This is related to kubernetes/kubernetes#47192.