### PR TITLE
Make kettle skip successful repeated tests.

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -107,7 +107,10 @@ def path_to_job_and_number(path):
 def row_for_build(path, started, finished, results):
     tests = []
     for result in results:
-        tests.extend(parse_junit(result))
+        for test in parse_junit(result):
+            if '#' in test['name'] and not test.get('failed'):
+                continue  # skip successful repeated tests
+            tests.append(test)
     build = {
         'path': path,
         'test': tests,

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -65,13 +65,15 @@ class MakeJsonTest(unittest.TestCase):
                result='FAILURE', job='J', number=123, finished=15,
                metadata=[{'key': 'pull', 'value': 'asdf'}, {'key': 'repo', 'value': 'ignored'}])
         expect(path, None, None, [
-            '''<testsuite>
-            <testcase name="t1" time="1.0"><failure>stacktrace</failure></testcase>
-            <testcase name="t2" time="2.0"></testcase>
-            </testsuite>'''],
-            job='J', number=123,
-            tests_run=2, tests_failed=1,
-            test=[{'name': 't1', 'time': 1.0, 'failed': True, 'failure_text': 'stacktrace'}, {'name': 't2', 'time': 2.0}])
+                '''<testsuite>
+                    <testcase name="t1" time="1.0"><failure>stacktrace</failure></testcase>
+                    <testcase name="t2" time="2.0"></testcase>
+                    <testcase name="t2#1" time="2.0"></testcase>
+                   </testsuite>'''],
+               job='J', number=123,
+               tests_run=2, tests_failed=1,
+               test=[{'name': 't1', 'time': 1.0, 'failed': True, 'failure_text': 'stacktrace'},
+                     {'name': 't2', 'time': 2.0}])
 
     def test_main(self):
         now = time.time()


### PR DESCRIPTION
TBR. The kettle pipeline is getting wedged by the unit tests with 1000s of duplicate runs.

Ref kubernetes/kubernetes#46731