### PR TITLE
Prepare to migrate -v --dump out of e2e-runner.sh

### DIFF
--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -268,3 +268,31 @@ func joinUrl(urlPath, path string) (string, error) {
 	u.Path = filepath.Join(u.Path, path)
 	return u.String(), nil
 }
+
+// Chdir() to dir and return a function to cd back to Getwd()
+func pushd(dir string) (func() error, error) {
+	old, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to os.Getwd(): %v", err)
+	}
+	if err = os.Chdir(dir); err != nil {
+		return nil, err
+	}
+	return func() error {
+		return os.Chdir(old)
+	}, nil
+}
+
+// Push env=value and return a function that resets env
+func pushEnv(env, value string) (func() error, error) {
+	prev, present := os.LookupEnv(env)
+	if err := os.Setenv(env, value); err != nil {
+		return nil, fmt.Errorf("could not set %s: %v", env, err)
+	}
+	return func() error {
+		if present {
+			return os.Setenv(env, prev)
+		}
+		return os.Unsetenv(env)
+	}, nil
+}


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/2829

`$WORKSPACE/_artifacts` - created by `scenarios/kubernetes_e2e.py`
`CLOUDSDK_CONFIG` - set by `jenkins/bootstrap.py`

`KUBE_GCS_RELEASE_BUCKET` - usage migrated to `--extract`
`KUBE_GCS_DEV_RELEASE_BUCKET` - usage migrated to `--extract`

`trap` now autoset based on `--dump` flag
`E2E_REPORT_DIR` - will not get auto-set by `kubetest` before running `ginkgo-e2e.sh` (needs new image before removing, until then also auto-set based on --dump.

Adding a `KUBETEST_MANUAL_DUMP` toggle to disable auto-adding `-v -dump` flags automatically (needs a new image, after which we can migrate to `kubernetes_e2e.py`)

Minor refactoring of kubetest to add `pushd` and `pushEnv` methods which allow us to push and then defer a pop to revert back to previous state.

/assign @krzyzacy 

