### PR TITLE
Pass unrecognized kubernetes_e2e flags to kubetest

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2203,6 +2203,7 @@ class JobTest(unittest.TestCase):
                                 )
                 if config[job]['scenario'] == 'kubernetes_e2e':
                     args = config[job]['args']
+                    self.assertNotIn('--charts-tests', args)  # Use --charts
                     self.assertTrue(
                         any('--check-leaked-resources' in a for a in args),
                         '--check-leaked-resources=true|false unset in %s' % job)

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -78,7 +78,7 @@
       "--env-file=jobs/ci-kubernetes-charts-gce.env",
       "--test=false",
       "--mount-paths=$GOPATH/src/k8s.io/charts:/src/k8s.io/charts",
-      "--charts-tests",
+      "--charts",
       "--timeout=180m",
       "--extract=ci/latest",
       "--check-leaked-resources=true"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -217,7 +217,7 @@ class DockerMode(object):
             '-v', '%s/_artifacts:/workspace/_artifacts' % workspace,
             '-v', '/etc/localtime:/etc/localtime:ro',
         ]
-        for path in mount_paths:
+        for path in mount_paths or []:
             self.cmd.extend(['-v', path])
 
         if sudo:
@@ -379,43 +379,11 @@ def main(args):
         if not os.path.basename(k8s) == 'kubernetes':
             raise ValueError(k8s)
         mode.add_k8s(os.path.dirname(k8s), 'kubernetes', 'release')
-    if args.stage:
-        runner_args.append('--stage=%s' % args.stage)
-    if args.stage_suffix:
-        runner_args.append('--stage-suffix=%s' % args.stage_suffix)
-    if args.multiple_federations:
-        runner_args.append('--multiple-federations')
-    if args.perf_tests:
-        runner_args.append('--perf-tests')
-    if args.charts_tests:
-        runner_args.append('--charts')
-    if args.kubemark:
-        runner_args.append('--kubemark')
-    if args.up == 'true':
-        runner_args.append('--up')
-    if args.down == 'true':
-        runner_args.append('--down')
-    if args.federation:
-        runner_args.append('--federation')
-    if args.deployment:
-        runner_args.append('--deployment=%s' % args.deployment)
-    if args.save:
-        runner_args.append('--save=%s' % args.save)
-    if args.publish:
-        runner_args.append('--publish=%s' % args.publish)
-    if args.timeout:
-        runner_args.append('--timeout=%s' % args.timeout)
-    if args.skew:
-        runner_args.append('--skew')
-    if args.upgrade_args:
-        runner_args.append('--upgrade_args=%s' % args.upgrade_args)
 
-    for ext in args.extract or []:
-        runner_args.append('--extract=%s' % ext)
     cluster = cluster_name(args.cluster, os.getenv('BUILD_NUMBER', 0))
     # TODO(fejta): remove this add_environment after pushing new kubetest image
     mode.add_environment('FAIL_ON_GCP_RESOURCE_LEAK=false')
-    runner_args.append('--check-leaked-resources=%s' % args.check_leaked_resources)
+    runner_args.extend(args.kubetest_args)
 
 
     if args.kubeadm:
@@ -487,63 +455,36 @@ def create_parser():
         help='Path to service-account.json')
     parser.add_argument(
         '--mount-paths',
-        default=[],
-        nargs='*',
+        action='append',
         help='Paths that should be mounted within the docker container in the form local:remote')
-    parser.add_argument('--publish', help='Upload binaries to gs://path if set')
     parser.add_argument(
         '--build', nargs='?', default=None, const='',
         help='Build kubernetes binaries if set, optionally specifying strategy')
     parser.add_argument(
-        '--stage', help='Stage binaries to gs:// path if set')
-    parser.add_argument(
-        '--stage-suffix', help='Append suffix to staged version if set')
-    parser.add_argument(
-        '--charts-tests', action='store_true', help='If the test is a charts test job')
-    parser.add_argument(
-        '--extract', action="append", help='Pass --extract flag(s) to kubetest')
-    parser.add_argument(
         '--cluster', default='bootstrap-e2e', help='Name of the cluster')
-    parser.add_argument(
-        '--deployment', default='bash', choices=['none', 'bash', 'kops', 'kubernetes-anywhere'])
     parser.add_argument(
         '--docker-in-docker', action='store_true', help='Enable run docker within docker')
     parser.add_argument(
-        '--down', default='true', help='If we need to tear down the e2e cluster')
-    parser.add_argument(
-        '--federation', action='store_true', help='If kubetest will have --federation flag')
-    parser.add_argument(
         '--kubeadm', choices=['ci', 'periodic', 'pull'])
-    parser.add_argument(
-        '--kubemark', action='store_true', help='If the test uses kubemark')
-    parser.add_argument(
-        '--perf-tests', action='store_true', help='If the test need to run k8s/perf-test e2e test')
-    parser.add_argument(
-        '--save', default=None,
-        help='Save credentials to gs:// path on --up if set (or load from there if not --up)')
-    parser.add_argument(
-        '--skew', action='store_true',
-        help='If we need to run skew tests, pass --skew to kubetest.')
     parser.add_argument(
         '--tag', default='v20170605-ed5d94ed', help='Use a specific kubekins-e2e tag if set')
     parser.add_argument(
         '--test', default='true', help='If we need to run any actual test within kubetest')
     parser.add_argument(
-        '--up', default='true', help='If we need to bring up a e2e cluster')
-    parser.add_argument(
-        '--timeout', help='Terminate testing after this golang duration (eg --timeout=100m).')
-    parser.add_argument(
-        '--multiple-federations', action='store_true',
-        help='Run federation control planes in parallel')
-    parser.add_argument(
-        '--check-leaked-resources',
-        nargs='?', default='false', const='true',
-        help='Send --check-leaked-resources to kubetest')
-    parser.add_argument(
-        '--upgrade_args', help='Send --upgrade_args to kubetest')
-    # TODO(fejta): allow sending arbitrary args to kubetest, remove flags that
-    # otherwise do nothing aside from pass value to kubetest
+        '--kubetest_args',
+        action='append',
+        default=[],
+        help='Send unrecognized args directly to kubetest')
     return parser
 
+
+def parse_args(args=None):
+    """Return args, adding unrecognized args to kubetest_args."""
+    parser = create_parser()
+    args, extra = parser.parse_known_args(args)
+    args.kubetest_args += extra
+    return args
+
+
 if __name__ == '__main__':
-    main(create_parser().parse_args())
+    main(parse_args())

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -112,7 +112,6 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
     envs = {}
 
     def setUp(self):
-        self.parser = kubernetes_e2e.create_parser()
         self.boiler = [
             Stub(kubernetes_e2e, 'check', self.fake_check),
             Stub(shutil, 'copy', fake_pass),
@@ -146,7 +145,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_local(self):
         """Make sure local mode is fine overall."""
-        args = self.parser.parse_args(['--mode=local'])
+        args = kubernetes_e2e.parse_args(['--mode=local'])
         self.assertEqual(args.mode, 'local')
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
@@ -157,15 +156,15 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_check_leaks_docker(self):
         """Ensure we also set FAIL_ON_GCP_RESOURCE_LEAK when mode=docker."""
-        args = self.parser.parse_args(['--mode=docker', '--check-leaked-resources'])
+        args = kubernetes_e2e.parse_args(['--mode=docker', '--check-leaked-resources'])
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
-            self.assertIn('--check-leaked-resources=true', self.callstack[-1])
+            self.assertIn('--check-leaked-resources', self.callstack[-1])
             self.assertIn('-e FAIL_ON_GCP_RESOURCE_LEAK=false', self.callstack[-1])
 
     def test_check_leaks_false_docker(self):
         """Ensure we also set FAIL_ON_GCP_RESOURCE_LEAK when mode=docker."""
-        args = self.parser.parse_args(['--mode=docker', '--check-leaked-resources=false'])
+        args = kubernetes_e2e.parse_args(['--mode=docker', '--check-leaked-resources=false'])
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
             self.assertIn('--check-leaked-resources=false', self.callstack[-1])
@@ -173,7 +172,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_check_leaks(self):
         """Ensure --check-leaked-resources=true sends flag to kubetest."""
-        args = self.parser.parse_args(['--check-leaked-resources=true', '--mode=local'])
+        args = kubernetes_e2e.parse_args(['--check-leaked-resources=true', '--mode=local'])
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
             self.assertIn('--check-leaked-resources=true', self.callstack[-1])
@@ -181,7 +180,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_check_leaks_false(self):
         """Ensure --check-leaked-resources=true sends flag to kubetest."""
-        args = self.parser.parse_args(['--check-leaked-resources=false', '--mode=local'])
+        args = kubernetes_e2e.parse_args(['--check-leaked-resources=false', '--mode=local'])
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
             self.assertIn('--check-leaked-resources=false', self.callstack[-1])
@@ -189,54 +188,55 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_check_leaks_default(self):
         """Ensure --check-leaked-resources=true sends flag to kubetest."""
-        args = self.parser.parse_args(['--check-leaked-resources', '--mode=local'])
+        args = kubernetes_e2e.parse_args(['--check-leaked-resources', '--mode=local'])
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
-            self.assertIn('--check-leaked-resources=true', self.callstack[-1])
+            self.assertIn('--check-leaked-resources', self.callstack[-1])
             self.assertEquals('false', self.envs.get('FAIL_ON_GCP_RESOURCE_LEAK'))
 
     def test_check_leaks_unset(self):
         """Ensure --check-leaked-resources=true sends flag to kubetest."""
-        args = self.parser.parse_args(['--mode=local'])
+        args = kubernetes_e2e.parse_args(['--mode=local'])
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
-            self.assertIn('--check-leaked-resources=false', self.callstack[-1])
+            self.assertNotIn('--check-leaked-resources', self.callstack[-1])
             self.assertEquals('false', self.envs.get('FAIL_ON_GCP_RESOURCE_LEAK'))
 
-    def test_extract_multiple(self):
-        """Ensure multiple --extract flags are accepted."""
-        args = self.parser.parse_args(['--extract=a', '--extract=b'])
-        self.assertEquals(['a', 'b'], args.extract)
-
-    def test_upgrade_args(self):
-        """Ensure upgrade_args flags are passed to kubetest."""
-        args = self.parser.parse_args(['--upgrade_args=foo bar'])
+    def test_migrated_kubetest_args(self):
+        migrated = [
+            '--stage=a-stage',
+            '--stage-suffix=panda',
+            '--random-flag', 'random-value',
+            '--multiple-federations',
+            'arg1', 'arg2',
+            '--federation',
+            '--kubemark',
+            '--extract=this',
+            '--extract=that',
+            '--perf-tests',
+            '--deployment=yay',
+            '--save=somewhere',
+            '--skew',
+            '--publish=location',
+            '--timeout=42m',
+            '--upgrade_args=ginkgo',
+            '--up=true',
+            '--down=false',
+            '--check-leaked-resources=true',
+            '--charts',
+        ]
+        args = kubernetes_e2e.parse_args(['--mode=docker'] + migrated + ['--test=false'])
+        self.assertEquals(migrated, args.kubetest_args)
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             kubernetes_e2e.main(args)
-            self.assertIn('--upgrade_args=foo bar', self.callstack[-1])
-
-    def test_extract_args(self):
-        """Ensure extract flags are passed to kubetest."""
-        args = self.parser.parse_args(['--extract=foo', '--extract=bar'])
-        with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
-            kubernetes_e2e.main(args)
-            self.assertIn('--extract=foo', self.callstack[-1])
-            self.assertIn('--extract=bar', self.callstack[-1])
-
-    def test_updown(self):
-        """Make sure local mode is fine overall."""
-        args = self.parser.parse_args(['--mode=local', '--up=false'])
-        self.assertEqual(args.mode, 'local')
-        with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
-            kubernetes_e2e.main(args)
-
         lastcall = self.callstack[-1]
-        self.assertNotIn('--up', lastcall)
-        self.assertIn('--down', lastcall)
+        for arg in migrated:
+            self.assertIn(arg, lastcall)
+
 
     def test_kubeadm_ci(self):
         """Make sure kubeadm ci mode is fine overall."""
-        args = self.parser.parse_args(['--mode=local', '--kubeadm=ci'])
+        args = kubernetes_e2e.parse_args(['--mode=local', '--kubeadm=ci'])
         self.assertEqual(args.mode, 'local')
         self.assertEqual(args.kubeadm, 'ci')
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
@@ -278,7 +278,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_kubeadm_periodic(self):
         """Make sure kubeadm periodic mode is fine overall."""
-        args = self.parser.parse_args(['--mode=local', '--kubeadm=periodic'])
+        args = kubernetes_e2e.parse_args(['--mode=local', '--kubeadm=periodic'])
         self.assertEqual(args.mode, 'local')
         self.assertEqual(args.kubeadm, 'periodic')
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
@@ -297,7 +297,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_kubeadm_periodic_v1_6(self):
         """Make sure kubeadm periodic mode has correct version on v1.6"""
-        args = self.parser.parse_args(['--mode=local', '--kubeadm=periodic'])
+        args = kubernetes_e2e.parse_args(['--mode=local', '--kubeadm=periodic'])
         self.assertEqual(args.mode, 'local')
         self.assertEqual(args.kubeadm, 'periodic')
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
@@ -316,7 +316,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_kubeadm_pull(self):
         """Make sure kubeadm pull mode is fine overall."""
-        args = self.parser.parse_args(['--mode=local', '--kubeadm=pull'])
+        args = kubernetes_e2e.parse_args(['--mode=local', '--kubeadm=pull'])
         self.assertEqual(args.mode, 'local')
         self.assertEqual(args.kubeadm, 'pull')
         fake_env = {'PULL_NUMBER': 1234, 'PULL_REFS': 'master:abcd'}
@@ -331,13 +331,13 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
     def test_kubeadm_invalid(self):
         """Make sure kubeadm invalid mode exits unsuccessfully."""
         with self.assertRaises(SystemExit) as sysexit:
-            self.parser.parse_args(['--mode=local', '--kubeadm=deploy'])
+            kubernetes_e2e.parse_args(['--mode=local', '--kubeadm=deploy'])
 
         self.assertEqual(sysexit.exception.code, 2)
 
     def test_docker(self):
         """Make sure docker mode is fine overall."""
-        args = self.parser.parse_args()
+        args = kubernetes_e2e.parse_args()
         self.assertEqual(args.mode, 'docker')
         with Stub(kubernetes_e2e, 'check_env', fake_bomb):
             kubernetes_e2e.main(args)
@@ -348,7 +348,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_default_tag(self):
         """Ensure the default tag exists on gcr.io."""
-        args = self.parser.parse_args()
+        args = kubernetes_e2e.parse_args()
         match = re.match('gcr.io/([^:]+):(.+)', kubernetes_e2e.kubekins(args.tag))
         self.assertIsNotNone(match)
         url = 'https://gcr.io/v2/%s/manifests/%s' % (match.group(1),


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/2829

`kubernetes_e2e.py --random-new-flag` will automatically result in calling `kubetest --random-new-flag` without having to modify `kubernetes_e2e.py`

Some flags such as `--build` are still processed by the scenario (to determine whether to mount the release repo, for example) so we parse them directly.

Added unit test to validate that all migrated flags still show up in the resulting commands.

/assign @pipejakob @krzyzacy 

