### PR TITLE
Use bazel-built pylint

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -346,7 +346,7 @@ class CheckoutTest(unittest.TestCase):
                 bootstrap.checkout(third_time_charm, REPO, None, PULL)
         self.assertEquals(expected_attempts, self.tries)
 
-    def test_pull(self):
+    def test_pull_ref(self):
         """checkout fetches the right ref for a pull."""
         fake = FakeSubprocess()
         with Stub(os, 'chdir', Pass):
@@ -459,7 +459,7 @@ class ParseReposTest(unittest.TestCase):
             bootstrap.parse_repos(
                 FakeArgs(repo=['foo=this:abcd'], branch='', pull='')))
 
-    def test_pull(self):
+    def test_parse_repos(self):
         """--repo=foo=111,222 works"""
         self.assertEquals(
             {'foo': ('', '111,222')},

--- a/jenkins/test_history/gen_html.py
+++ b/jenkins/test_history/gen_html.py
@@ -28,7 +28,8 @@ import re
 import sys
 import time
 
-import jinja2
+# TODO(fejta): add jinja2 to bazel dependencies
+import jinja2  # pylint: disable=import-error
 import yaml
 
 
@@ -56,12 +57,11 @@ JINJA_ENV = jinja2.Environment(
 def failure_class(passed, failed):
     if failed == 0:
         return ''
-    elif passed == 0:
+    if passed == 0:
         return 'job-broken'
-    elif passed / 10 < failed:
+    if passed / 10 < failed:
         return 'job-troubled'
-    else:
-        return 'job-flaky'
+    return 'job-flaky'
 
 JINJA_ENV.globals['failure_class'] = failure_class
 

--- a/jenkins/test_history/gen_json.py
+++ b/jenkins/test_history/gen_json.py
@@ -70,8 +70,7 @@ class GCSClient(object):
                 resp.raise_for_status()
                 if as_json:
                     return resp.json()
-                else:
-                    return resp.content
+                return resp.content
             except requests.exceptions.RequestException:
                 logging.exception('request failed %s', url)
             time.sleep(random.random() * min(60, 2 ** retry))

--- a/jenkins/test_history/gen_json_test.py
+++ b/jenkins/test_history/gen_json_test.py
@@ -87,10 +87,10 @@ class MockedClient(gen_json.GCSClient):
     </testsuite>
     '''}
 
-    def get(self, path, **_kwargs):
+    def get(self, path, **_kwargs):  # pylint: disable=arguments-differ
         return self.gets.get(path)
 
-    def ls(self, path, **_kwargs):
+    def ls(self, path, **_kwargs):  # pylint: disable=arguments-differ
         return self.lists[path]
 
 

--- a/queue_health/poll/poller.py
+++ b/queue_health/poll/poller.py
@@ -123,4 +123,4 @@ if __name__ == '__main__':
     PP = pprint.PrettyPrinter(stream=sys.stderr)
     PP.pprint(sys.argv)
 
-    poll_forever(*sys.argv[1:])
+    poll_forever(*sys.argv[1:])  # pylint: disable=no-value-for-parameter

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -346,7 +346,7 @@ def main(args):
         sudo = args.docker_in_docker or args.build is not None
         mode = DockerMode(container, workspace, sudo, args.tag, args.mount_paths)
     elif args.mode == 'local':
-        mode = LocalMode(workspace) #pylint:disable=redefined-variable-type
+        mode = LocalMode(workspace)  # pylint: disable=bad-option-value
     else:
         raise ValueError(args.mode)
 

--- a/verify/verify-pylint.sh
+++ b/verify/verify-pylint.sh
@@ -22,4 +22,4 @@ pylint="$(dirname $0)/pylint_bin"
 
 
 shopt -s extglob globstar
-pylint !(gubernator|kettle|external|mungegithub|bazel-*)/**/*.py
+${pylint} !(gubernator|kettle|external|mungegithub|bazel-*)/**/*.py


### PR DESCRIPTION
`pylint` != `${pylint}`
/assign @rmmh @krzyzacy 

Fix pylint errors highlighted by newer pylint version