### PR TITLE
Fixes test cluster name

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -6,19 +6,19 @@ jobs:
     envs:
     - PROJECT=ubuntu-image-validation
     args:
-    - --cluster=${job_name_hash}
+    - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow:
     envs:
     - PROJECT=ubuntu-image-validation
     args:
-    - --cluster=${job_name_hash}
+    - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial:
     envs:
     - PROJECT=ubuntu-image-validation
     args:
-    - --cluster=${job_name_hash}
+    - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
 
 common:

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2055,7 +2055,7 @@
       "--check-leaked-resources=true",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--cluster=dcb74cd42a"
+      "--cluster=test-dcb74cd42a"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2073,7 +2073,7 @@
       "--check-leaked-resources=true",
       "--extract=ci/latest-1.7",
       "--timeout=300m",
-      "--cluster=0ac5dfddd1"
+      "--cluster=test-0ac5dfddd1"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2091,7 +2091,7 @@
       "--check-leaked-resources=true",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--cluster=d17516cf20"
+      "--cluster=test-d17516cf20"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
`ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial` failed to run because of the invalid cluster name.

```
I0616 14:07:33.962] Creating new network: 0ac5dfddd1
W0616 14:07:34.438] ERROR: (gcloud.compute.networks.create) Could not fetch resource:
W0616 14:07:34.439]  - Invalid value for field 'resource.name': '0ac5dfddd1'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'
```

This PR just fixes the issue but we will need to validate the name in the config validation tests.

/assign @krzyzacy 