### PR TITLE
Creates Ubuntu image validation tests running on Canonical owned project

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -2,6 +2,24 @@
 # dimension.
 jobs:
   # Ubuntu image validation.
+  ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default:
+    envs:
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
+    args:
+    - --cluster=test-${job_name_hash}
+    sigOwners: ['sig-node']
+  ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow:
+    envs:
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
+    args:
+    - --cluster=test-${job_name_hash}
+    sigOwners: ['sig-node']
+  ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial:
+    envs:
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
+    args:
+    - --cluster=test-${job_name_hash}
+    sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default:
     envs:
     - PROJECT=ubuntu-image-validation
@@ -17,6 +35,24 @@ jobs:
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial:
     envs:
     - PROJECT=ubuntu-image-validation
+    args:
+    - --cluster=test-${job_name_hash}
+    sigOwners: ['sig-node']
+  ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default:
+    envs:
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
+    args:
+    - --cluster=test-${job_name_hash}
+    sigOwners: ['sig-node']
+  ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow:
+    envs:
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
+    args:
+    - --cluster=test-${job_name_hash}
+    sigOwners: ['sig-node']
+  ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial:
+    envs:
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1997,9 +1997,15 @@ class JobTest(unittest.TestCase):
         # pylint: disable=line-too-long
         allowed_list = {
             # The ubuntu image validation jobs intentionally share projects.
+            'ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env': 'ci-kubernetes-e2e-gce-ubuntu*',
+            'ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env': 'ci-kubernetes-e2e-gce-ubuntu*',
+            'ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env': 'ci-kubernetes-e2e-gce-ubuntu*',
             'ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default.env': 'ci-kubernetes-e2e-gce-ubuntu*',
             'ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial.env': 'ci-kubernetes-e2e-gce-ubuntu*',
             'ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow.env': 'ci-kubernetes-e2e-gce-ubuntu*',
+            'ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env': 'ci-kubernetes-e2e-gce-ubuntu*',
+            'ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env': 'ci-kubernetes-e2e-gce-ubuntu*',
+            'ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env': 'ci-kubernetes-e2e-gce-ubuntu*',
             # The 1.5 and 1.6 scalability jobs intentionally share projects.
             'ci-kubernetes-e2e-gce-scalability-release-1-7.env': 'ci-kubernetes-e2e-gce-scalability-release-*',
             'ci-kubernetes-e2e-gce-scalability-release-1.6.env': 'ci-kubernetes-e2e-gce-scalability-release-*',

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env
@@ -1,0 +1,24 @@
+# AUTO-GENERATED - DO NOT EDIT.
+
+# The common configurations.
+
+# The cloud provider configurations.
+KUBERNETES_PROVIDER=gce
+E2E_MIN_STARTUP_PODS=8
+KUBE_GCE_ZONE=us-central1-f
+CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
+
+# The image configurations.
+KUBE_NODE_OS_DISTRIBUTION=ubuntu
+KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud
+KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1
+
+# The k8s version configurations.
+
+# The test suite configurations.
+GINKGO_PARALLEL=y
+GINKGO_PARALLEL_NODES=30
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+
+# The job configurations.
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env
@@ -1,0 +1,23 @@
+# AUTO-GENERATED - DO NOT EDIT.
+
+# The common configurations.
+
+# The cloud provider configurations.
+KUBERNETES_PROVIDER=gce
+E2E_MIN_STARTUP_PODS=8
+KUBE_GCE_ZONE=us-central1-f
+CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
+
+# The image configurations.
+KUBE_NODE_OS_DISTRIBUTION=ubuntu
+KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud
+KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1
+
+# The k8s version configurations.
+
+# The test suite configurations.
+GINKGO_PARALLEL=n
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+
+# The job configurations.
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env
@@ -1,0 +1,24 @@
+# AUTO-GENERATED - DO NOT EDIT.
+
+# The common configurations.
+
+# The cloud provider configurations.
+KUBERNETES_PROVIDER=gce
+E2E_MIN_STARTUP_PODS=8
+KUBE_GCE_ZONE=us-central1-f
+CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
+
+# The image configurations.
+KUBE_NODE_OS_DISTRIBUTION=ubuntu
+KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud
+KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1
+
+# The k8s version configurations.
+
+# The test suite configurations.
+GINKGO_PARALLEL=y
+GINKGO_PARALLEL_NODES=30
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+
+# The job configurations.
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env
@@ -1,0 +1,24 @@
+# AUTO-GENERATED - DO NOT EDIT.
+
+# The common configurations.
+
+# The cloud provider configurations.
+KUBERNETES_PROVIDER=gce
+E2E_MIN_STARTUP_PODS=8
+KUBE_GCE_ZONE=us-central1-f
+CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
+
+# The image configurations.
+KUBE_NODE_OS_DISTRIBUTION=ubuntu
+KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud
+KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1
+
+# The k8s version configurations.
+
+# The test suite configurations.
+GINKGO_PARALLEL=y
+GINKGO_PARALLEL_NODES=30
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+
+# The job configurations.
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env
@@ -1,0 +1,23 @@
+# AUTO-GENERATED - DO NOT EDIT.
+
+# The common configurations.
+
+# The cloud provider configurations.
+KUBERNETES_PROVIDER=gce
+E2E_MIN_STARTUP_PODS=8
+KUBE_GCE_ZONE=us-central1-f
+CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
+
+# The image configurations.
+KUBE_NODE_OS_DISTRIBUTION=ubuntu
+KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud
+KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1
+
+# The k8s version configurations.
+
+# The test suite configurations.
+GINKGO_PARALLEL=n
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
+
+# The job configurations.
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env
@@ -1,0 +1,24 @@
+# AUTO-GENERATED - DO NOT EDIT.
+
+# The common configurations.
+
+# The cloud provider configurations.
+KUBERNETES_PROVIDER=gce
+E2E_MIN_STARTUP_PODS=8
+KUBE_GCE_ZONE=us-central1-f
+CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
+
+# The image configurations.
+KUBE_NODE_OS_DISTRIBUTION=ubuntu
+KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud
+KUBE_GCE_NODE_IMAGE=ubuntu-gke-1604-xenial-v20170420-1
+
+# The k8s version configurations.
+
+# The test suite configurations.
+GINKGO_PARALLEL=y
+GINKGO_PARALLEL_NODES=30
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+
+# The job configurations.
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2101,6 +2101,114 @@
       "generated"
     ]
   },
+  "ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default": {
+    "_comment": "AUTO-GENERATED - DO NOT EDIT.",
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env",
+      "--mode=local",
+      "--check-leaked-resources=true",
+      "--extract=ci/latest",
+      "--timeout=50m",
+      "--cluster=test-2e79fbd2ec"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ],
+    "tags": [
+      "generated"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial": {
+    "_comment": "AUTO-GENERATED - DO NOT EDIT.",
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env",
+      "--mode=local",
+      "--check-leaked-resources=true",
+      "--extract=ci/latest",
+      "--timeout=300m",
+      "--cluster=test-c858633e76"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ],
+    "tags": [
+      "generated"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow": {
+    "_comment": "AUTO-GENERATED - DO NOT EDIT.",
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env",
+      "--mode=local",
+      "--check-leaked-resources=true",
+      "--extract=ci/latest",
+      "--timeout=150m",
+      "--cluster=test-70b21a36b2"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ],
+    "tags": [
+      "generated"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default": {
+    "_comment": "AUTO-GENERATED - DO NOT EDIT.",
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env",
+      "--mode=local",
+      "--check-leaked-resources=true",
+      "--extract=ci/latest-1.6",
+      "--timeout=50m",
+      "--cluster=test-b9bc64dba5"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ],
+    "tags": [
+      "generated"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial": {
+    "_comment": "AUTO-GENERATED - DO NOT EDIT.",
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env",
+      "--mode=local",
+      "--check-leaked-resources=true",
+      "--extract=ci/latest-1.6",
+      "--timeout=300m",
+      "--cluster=test-4c9af8b031"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ],
+    "tags": [
+      "generated"
+    ]
+  },
+  "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow": {
+    "_comment": "AUTO-GENERATED - DO NOT EDIT.",
+    "args": [
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env",
+      "--mode=local",
+      "--check-leaked-resources=true",
+      "--extract=ci/latest-1.6",
+      "--timeout=150m",
+      "--cluster=test-7214dd78b9"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ],
+    "tags": [
+      "generated"
+    ]
+  },
   "ci-kubernetes-e2e-gci-gce": {
     "args": [
       "--env-file=jobs/platform/gce.env",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7679,6 +7679,104 @@ periodics:
         secretName: ssh-key-secret
 
 - interval: 2h
+  name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial
+  spec:
+    containers:
+    - args:
+      - --timeout=420
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow
+  spec:
+    containers:
+    - args:
+      - --timeout=170
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+- interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default
   spec:
     containers:
@@ -7746,6 +7844,105 @@ periodics:
 
 - interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow
+  spec:
+    containers:
+    - args:
+      - --timeout=170
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial
+  spec:
+    containers:
+    - args:
+      - --timeout=420
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow
   spec:
     containers:
     - args:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -804,12 +804,24 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntu-1-6-serial
 - name: ci-kubernetes-e2e-gce-ubuntu-1-6-slow
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntu-1-6-slow
+- name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default
+- name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial
+- name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow
 - name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default
 - name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial
 - name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow
+- name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default
+- name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial
+- name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow
 # Ubuntu cluster e2e tests on GKE (contact: @kubernetes/ubuntu-image on github)
 - name: ci-kubernetes-e2e-ubuntu-gke
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gke
@@ -1089,12 +1101,24 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-ubuntu-1-6-serial
   - name: gce-ubuntu-1.6-slow
     test_group_name: ci-kubernetes-e2e-gce-ubuntu-1-6-slow
+  - name: gce-ubuntustable1-k8sdev-default
+    test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default
+  - name: gce-ubuntustable1-k8sdev-serial
+    test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial
+  - name: gce-ubuntustable1-k8sdev-slow
+    test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow
   - name: gce-ubuntustable1-k8sbeta-default
     test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default
   - name: gce-ubuntustable1-k8sbeta-serial
     test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial
   - name: gce-ubuntustable1-k8sbeta-slow
     test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow
+  - name: gce-ubuntustable1-k8sstable1-default
+    test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default
+  - name: gce-ubuntustable1-k8sstable1-serial
+    test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial
+  - name: gce-ubuntustable1-k8sstable1-slow
+    test_group_name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow
   - name: cdk-gce-node
     test_group_name: canonical-kubernetes-e2e-gce
 


### PR DESCRIPTION
The following e2e tests are currently running in Google owned projects.

`ci-kubernetes-e2e-gce-ubuntu`
`ci-kubernetes-e2e-gce-ubuntu-serial`
`ci-kubernetes-e2e-gce-ubuntu-slow`
`ci-kubernetes-e2e-gce-ubuntu-1-6`
`ci-kubernetes-e2e-gce-ubuntu-1-6-serial`
`ci-kubernetes-e2e-gce-ubuntu-1-6-slow`

This PR duplicates the tests (using the standardized name) and runs them on Canonical owned project `ubuntu-os-gke-cloud-tests`.

Tests against master branch:
`ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default`
`ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial`
`ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow`

Tests against 1.6 branch:
`ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default`
`ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial`
`ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow`

Once the new tests are running fine consistently, I will remove the old test jobs. I will migrate the tests against 1.7 branch later.

@kubernetes/ubuntu-image 
/assign @dchen1107 
/assign @krzyzacy 