### PR TITLE
Remove nodeSelector from prow components.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -22,7 +22,7 @@ SPLICE_VERSION     = 0.20
 TOT_VERSION        = 0.1
 CRIER_VERSION      = 0.7
 HOROLOGIUM_VERSION = 0.3
-PLANK_VERSION      = 0.18
+PLANK_VERSION      = 0.19
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/README.md
+++ b/prow/README.md
@@ -115,13 +115,11 @@ Prow should run anywhere that Kubernetes runs. Here are the steps required to
 set up a prow cluster on GKE.
 
 1. Create the cluster. I'm assuming that `PROJECT`, `CLUSTER`, and `ZONE` are
-set. I'm putting prow components on a node with the label `role=prow`, and I'm
-doing the actual tests on nodes with the label `role=build`, but this isn't a
-hard requirement. You can also choose to run the builds in a separate cluster.
+set. You can also choose to run the builds in a separate cluster.
 
  ```
- gcloud -q container --project "${PROJECT}" clusters create "${CLUSTER}" --zone "${ZONE}" --machine-type n1-standard-4 --num-nodes 4 --node-labels=role=prow --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.full_control","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management" --network "default" --enable-cloud-logging --enable-cloud-monitoring
- gcloud -q container node-pools create build-pool --project "${PROJECT}" --cluster "${CLUSTER}" --zone "${ZONE}" --machine-type n1-standard-8 --num-nodes 4 --local-ssd-count=1 --node-labels=role=build
+ gcloud -q container --project "${PROJECT}" clusters create "${CLUSTER}" --zone "${ZONE}" --machine-type n1-standard-4 --num-nodes 4 --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.full_control","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management" --network "default" --enable-cloud-logging --enable-cloud-monitoring
+ gcloud -q container node-pools create build-pool --project "${PROJECT}" --cluster "${CLUSTER}" --zone "${ZONE}" --machine-type n1-standard-8 --num-nodes 4 --local-ssd-count=1
  ```
 
 2. Create the secrets that allow prow to talk to GitHub. The `hmac-token` is

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -25,8 +25,6 @@ spec:
       labels:
         app: crier
     spec:
-      nodeSelector:
-        role: prow
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -30,8 +30,6 @@ spec:
       labels:
         app: deck
     spec:
-      nodeSelector:
-        role: prow
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -30,8 +30,6 @@ spec:
       labels:
         app: hook
     spec:
-      nodeSelector:
-        role: prow
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -25,8 +25,6 @@ spec:
       labels:
         app: horologium
     spec:
-      nodeSelector:
-        role: prow
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -25,11 +25,9 @@ spec:
       labels:
         app: plank
     spec:
-      nodeSelector:
-        role: prow
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.18
+        image: gcr.io/k8s-prow/plank:0.19
         args:
         - --build-cluster=/etc/cluster/cluster
         volumeMounts:

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         app: sinker
     spec:
-      nodeSelector:
-        role: prow
       containers:
       - name: sinker
         image: gcr.io/k8s-prow/sinker:0.10

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         app: splice
     spec:
-      nodeSelector:
-        role: prow
       containers:
       - name: splice
         image: gcr.io/k8s-prow/splice:0.20

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -54,8 +54,6 @@ spec:
       labels:
         app: tot
     spec:
-      nodeSelector:
-        role: prow
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -331,9 +331,6 @@ func (c *Controller) startPod(pj kube.ProwJob) (string, string, error) {
 	}
 	spec := pj.Spec.PodSpec
 	spec.RestartPolicy = "Never"
-	spec.NodeSelector = map[string]string{
-		"role": "build",
-	}
 	// Keep this synchronized with get_running_build_log in Gubernator!
 	podName := fmt.Sprintf("%s-%s", pj.Spec.Job, buildID)
 	if len(podName) > 60 {


### PR DESCRIPTION
Previously I used role=prow and role=build, but this was a bad decision
and a poor replacement for careful resource handling.

@spiffxp ref https://github.com/kubernetes/test-infra/issues/3073#issuecomment-308854352