### PR TITLE
New e2e job to test Kubernetes 1.6 using kubeadm 1.7.

### DIFF
--- a/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7.env
@@ -1,0 +1,6 @@
+### job-env
+
+PROJECT=k8s-kubeadm-1-6-on-1-7
+KUBERNETES_PROVIDER=kubernetes-anywhere
+
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5322,6 +5322,24 @@
       "sig-cluster-lifecycle"
     ]
   },
+  "ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7": {
+    "args": [
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7.env",
+      "--kubeadm=ci",
+      "--kubernetes-anywhere-kubernetes-version=latest-1.6",
+      "--deployment=kubernetes-anywhere",
+      "--mode=local",
+      "--timeout=300m",
+      "--extract=ci/latest-1.6",
+      "--check-leaked-resources=false"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
   "ci-kubernetes-e2e-kubeadm-gce-1-7": {
     "args": [
       "--cluster=",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1029,6 +1029,47 @@ postsubmits:
           - name: cache-ssd
             hostPath:
               path: /mnt/disks/ssd0
+      - name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
+        spec:
+          containers:
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170616-3665d891
+            args:
+            - "--branch=$(PULL_REFS)"
+            - "--clean"
+            - "--git-cache=/root/.cache/git"
+            - "--json"
+            - "--timeout=320"
+            - "--upload=gs://kubernetes-jenkins/logs"
+            env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/service-account/service-account.json
+            - name:  JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-private
+            - name:  JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-public
+            volumeMounts:
+            - name: service
+              mountPath: /etc/service-account
+              readOnly: true
+            - name: ssh
+              mountPath: /etc/ssh-key-secret
+              readOnly: true
+            - name: cache-ssd
+              mountPath: /root/.cache
+            ports:
+            - containerPort: 9999
+              hostPort: 9999 
+          volumes:
+          - name: service
+            secret:
+              secretName: service-account
+          - name: ssh
+            secret:
+              secretName: ssh-key-secret
+              defaultMode: 0400
+          - name: cache-ssd
+            hostPath:
+              path: /mnt/disks/ssd0
 
   kubernetes/test-infra:
   - name: ci-test-infra-bazel

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -902,6 +902,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-6   
 - name: ci-kubernetes-e2e-kubeadm-gce-1-7   
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-7
+- name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
 # upgrade CI tests
 - name: ci-kubernetes-e2e-gce-latest-upgrade-cluster
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-latest-upgrade-cluster
@@ -1885,6 +1887,8 @@ dashboards:
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-6
   - name: kubeadm-gce-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
+  - name: kubeadm-gce-1.6-on-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: periodic-kubeadm-gce-1.7
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-7
   - name: kubeadm-gce
@@ -2699,6 +2703,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-gpu-1-7
   - name: ci-gce-kubeadm-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
+  - name: ci-gce-kubeadm-1.6-on-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: ci-bazel-build-1.7
     test_group_name: ci-kubernetes-bazel-build-1-7
   - name: ci-bazel-test-1.7
@@ -2735,6 +2741,8 @@ dashboards:
     test_group_name: ci-kubernetes-verify-release-1.7
   - name: gce-kubeadm-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
+  - name: gce-kubeadm-1.6-on-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: kubelet-1.7
     test_group_name: ci-kubernetes-node-kubelet-1.7
   - name: aws-release-1-7
@@ -2779,7 +2787,6 @@ dashboards:
     test_group_name: ci-kubernetes-soak-gci-gce-1-7-test
   - name: gce-gpu-1-7
     test_group_name: ci-kubernetes-e2e-gce-gpu-1-7
-
 
 - name: cos-image-validation
   dashboard_tab:


### PR DESCRIPTION
Since kubeadm 1.7 supports installing the 1.6 control plane, create an e2e job to exercise it.

Fixes https://github.com/kubernetes/kubeadm/issues/301.

Adds the job to these testgrid tabs:
  - google-gce
  - release-1.7-all
  - release-1.7-blocking