### PR TITLE
Runs Ubuntu k8s 1.7 tests on Canonical owned project

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -22,19 +22,19 @@ jobs:
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default:
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow:
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial:
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default.env
@@ -21,4 +21,4 @@ GINKGO_PARALLEL_NODES=30
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial.env
@@ -20,4 +20,4 @@ GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow.env
@@ -21,4 +21,4 @@ GINKGO_PARALLEL_NODES=30
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=ubuntu-os-gke-cloud-tests


### PR DESCRIPTION
Follow https://github.com/kubernetes/test-infra/pull/3091.

The tests running against the master and the 1.6 k8s branches on Canonical owned project are fine over the weekend, so let's move the 1.7 tests.

Once this PR is merged, we will run the following 9 cluster e2e tests on this project:

```
ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default
ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial
ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow
ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default
ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial
ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow
ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default
ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial
ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow
```
The next step would be to move the node e2e tests.

@kubernetes/ubuntu-image
/assign @krzyzacy