### PR TITLE
Fix janitor list instance-groups

### DIFF
--- a/jenkins/janitor.py
+++ b/jenkins/janitor.py
@@ -70,7 +70,7 @@ def collect(project, age, resource, filt):
         cmd.append(resource.group)
     cmd.extend([
         'list',
-        '--format=json(name,creationTimestamp.date(tz=UTC),zone,region,MANAGED)',
+        '--format=json(name,creationTimestamp.date(tz=UTC),zone,region,isManaged)',
         '--filter=%s' % filt,
         '--project=%s' % project])
     print '%r' % cmd


### PR DESCRIPTION
It's a change introduced by gcloud between 158.0.0 and 159.0.0, which cause all `list instance-groups` to fail.
```
gcloud compute -q instance-groups list --project=k8s-gce-upg-1-5-1-6-up-mas --format='json(name,creationTimestamp.date(tz=UTC),zone,region,isManaged)'
[
  {
    "creationTimestamp": "2017-06-19T17:35:42",
    "isManaged": "Yes",
    "name": "bootstrap-e2e-minion-group",
    "zone": "us-central1-f"
  },
  {
    "creationTimestamp": "2017-06-19T17:42:14",
    "isManaged": "No",
    "name": "k8s-ig--cb4f955a95accdd9",
    "zone": "us-central1-f"
  }
]
```