### PR TITLE
Bump no-snat test timeout again

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -790,7 +790,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/image/cosbeta.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-no-snat.env",
-      "--timeout=15m",
+      "--timeout=20m",
       "--mode=local",
       "--extract=ci/latest",
       "--check-leaked-resources=true"


### PR DESCRIPTION
The last timeout bump (https://github.com/kubernetes/test-infra/pull/3072) mostly worked, but there is still an occasional flake due to timeout (e.g. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosbeta-no-snat/8). This should hopefully widen the window enough.