### PR TITLE
Supports Prow configuration auto-generation

### DIFF
--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -4,6 +4,17 @@ py_binary(
     deps = ["@requests//:requests"],
 )
 
+py_binary(
+    name = "generate_tests",
+    srcs = ["generate_tests.py"],
+    data = [
+        "test_config.yaml",
+        "//jobs",
+        "//prow:configs",
+    ],
+    deps = ["@ruamel_yaml//ruamel/yaml:ruamel.yaml"],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -1,110 +1,157 @@
+# This file defines the list of tests whose definition and Prow configurations
+# that can be generated automatically.
+#
+# The name of the test job in this file must satisfy a predefined format, which
+# consists of several dimensions, such as cloud provider, OS image name,
+# Kubernetes version and test suites. The definition of each dimension is
+# provided separately from the job defintion. A tool can automatically generate
+# the test defintion and Prow configuration from the test name by pulling the
+# configs of each dimension in the test name and assembling them together.
+#
+# E.g., for test "ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial", its
+# configuration will be generated from the configs of cloud provider "gce", the
+# image "ubuntustable1", the Kubernetes version "k8sdev" and the test suite
+# "serial".
+
+# To generate the test definitions and Prow configurations from this file:
+#
+#   bazel run //experiment:generate_tests -- \
+#     --yaml-config-path=experiment/test_config.yaml \
+#     --json-config-path=jobs/config.json \
+#     --prow-config-path=prow/config.yaml && bazel run //jobs:config_sort
+
+
 # The envs and args defined in "jobs" override the ones defined in each
 # dimension.
 jobs:
+  # Cluster E2E Tests
+  #
+  # Cluster E2E test name starts with "ci-kubernetes-e2e-" and must satisfy the
+  # following format:
+  #   ci-kubernetes-e2e-<cloudProvider>-<image>-<k8sVersion>-<testSuite>
+
   # Ubuntu image validation.
   ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-alphafeatures:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-autoscaling:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-default:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-flaky:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-ingress:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-reboot:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-serial:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-slow:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
     - --cluster=test-${job_name_hash}
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-updown:
+    interval: 2h
     envs:
     - PROJECT=ubuntu-image-validation
     args:
@@ -118,7 +165,7 @@ common:
 cloudProviders:
   gce:
     args:
-    - --check-leaked-resources=true
+    - --check-leaked-resources
     envs:
     - KUBERNETES_PROVIDER=gce
     - E2E_MIN_STARTUP_PODS=8
@@ -126,7 +173,7 @@ cloudProviders:
     - CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
   gke:
     args:
-    - --check-leaked-resources=true
+    - --check-leaked-resources
     envs:
     - KUBERNETES_PROVIDER=gke
     - E2E_MIN_STARTUP_PODS=8
@@ -192,7 +239,7 @@ testSuites:
     - GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
   serial:
     args:
-    - --timeout=300m
+    - --timeout=500m
     envs:
     - GINKGO_PARALLEL=n
     - GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2216,7 +2216,7 @@
       "--mode=local",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--timeout=500m",
       "--cluster=test-0ac5dfddd1"
     ],
     "scenario": "kubernetes_e2e",
@@ -2270,7 +2270,7 @@
       "--mode=local",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=300m",
+      "--timeout=500m",
       "--cluster=test-c858633e76"
     ],
     "scenario": "kubernetes_e2e",
@@ -2324,7 +2324,7 @@
       "--mode=local",
       "--check-leaked-resources",
       "--extract=ci/latest-1.6",
-      "--timeout=300m",
+      "--timeout=500m",
       "--cluster=test-4c9af8b031"
     ],
     "scenario": "kubernetes_e2e",
@@ -5300,7 +5300,7 @@
       "--mode=local",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--timeout=500m",
       "--cluster=test-ea2434d90d"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5438,13 +5438,15 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-default
   spec:
     containers:
     - args:
-      - --timeout=70
       - --bare
+      - --timeout=70
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5470,14 +5472,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-serial
   spec:
     containers:
     - args:
-      - --timeout=420
       - --bare
+      - --timeout=520
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5503,14 +5506,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sbeta-slow
   spec:
     containers:
     - args:
-      - --timeout=170
       - --bare
+      - --timeout=170
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5536,14 +5540,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default
   spec:
     containers:
     - args:
-      - --timeout=70
       - --bare
+      - --timeout=70
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5569,14 +5574,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial
   spec:
     containers:
     - args:
-      - --timeout=420
       - --bare
+      - --timeout=520
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5602,14 +5608,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow
   spec:
     containers:
     - args:
-      - --timeout=170
       - --bare
+      - --timeout=170
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5635,13 +5642,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default
   spec:
     containers:
     - args:
-      - --timeout=70
       - --bare
+      - --timeout=70
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5667,14 +5676,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial
   spec:
     containers:
     - args:
-      - --timeout=420
       - --bare
+      - --timeout=520
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5700,14 +5710,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow
   spec:
     containers:
     - args:
-      - --timeout=170
       - --bare
+      - --timeout=170
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -5733,7 +5744,6 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce
   spec:
@@ -10567,13 +10577,15 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-alphafeatures
   spec:
     containers:
     - args:
-      - --timeout=200
       - --bare
+      - --timeout=200
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10599,14 +10611,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-autoscaling
   spec:
     containers:
     - args:
-      - --timeout=320
       - --bare
+      - --timeout=320
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10632,14 +10645,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-default
   spec:
     containers:
     - args:
-      - --timeout=70
       - --bare
+      - --timeout=70
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10665,14 +10679,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-flaky
   spec:
     containers:
     - args:
-      - --timeout=320
       - --bare
+      - --timeout=320
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10698,14 +10713,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-ingress
   spec:
     containers:
     - args:
-      - --timeout=320
       - --bare
+      - --timeout=320
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10732,13 +10748,15 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-reboot
   spec:
     containers:
     - args:
-      - --timeout=200
       - --bare
+      - --timeout=200
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10764,14 +10782,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-serial
   spec:
     containers:
     - args:
-      - --timeout=320
       - --bare
+      - --timeout=520
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10797,14 +10816,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-slow
   spec:
     containers:
     - args:
-      - --timeout=170
       - --bare
+      - --timeout=170
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10830,14 +10850,15 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
-- interval: 2h
+- tags:
+  - generated   # AUTO-GENERATED; DO NOT EDIT!
+  interval: 2h
   name: ci-kubernetes-e2e-gke-ubuntustable1-k8sbeta-updown
   spec:
     containers:
     - args:
-      - --timeout=50
       - --bare
+      - --timeout=50
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -10863,7 +10884,6 @@ periodics:
       secret:
         defaultMode: 256
         secretName: ssh-key-secret
-
 - name: ci-kubernetes-e2e-prow-canary
   interval: 24h
   spec:

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -66,6 +66,7 @@ type Periodic struct {
 	Name     string        `json:"name"`
 	Spec     *kube.PodSpec `json:"spec,omitempty"`
 	Interval string        `json:"interval"`
+	Tags     []string      `json:"tags,omitempty"`
 
 	RunAfterSuccess []Periodic `json:"run_after_success"`
 


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/2894

This PR enhances `experiment/generate_tests.py` to auto-generate Prow configurations based on test job names. This tool is useful for creating/modifying a large number of test jobs for new image or new k8s releases. It would provide a single place to configure what a test job will run, when it will run and where to see the run result (testgrid config auto generation to be done).

We might want a `config_sort.py` thing for Prow configuration too so that it would make the diff more meaningful. For this PR, it's easier to review commit by commit.

@fejta 
/assign @krzyzacy 