### PR TITLE
Increase Stackdriver Logging suites timeout to facilitate soak tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -403,9 +403,9 @@
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-sd-logging:
         job-name: ci-kubernetes-e2e-gce-sd-logging
-        jenkins-timeout: 300
-        timeout: 200
-        frequency: 'H/5 * * * *' # At least every 30m
+        jenkins-timeout: 1440
+        timeout: 1340
+        frequency: '0 0 * * *' # Daily at 09:00 CET
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gce-statefulset:
         job-name: ci-kubernetes-e2e-gce-statefulset
@@ -435,9 +435,9 @@
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gci-gce-sd-logging:
         job-name: ci-kubernetes-e2e-gci-gce-sd-logging
-        jenkins-timeout: 300
-        timeout: 200
-        frequency: 'H/5 * * * *' # At least every 30m
+        jenkins-timeout: 1440
+        timeout: 1340
+        frequency: '0 0 * * *' # Daily at 09:00 CET
         trigger-job: 'ci-kubernetes-build'
     - kubernetes-e2e-gci-gce-statefulset:
         job-name: ci-kubernetes-e2e-gci-gce-statefulset

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1811,13 +1811,13 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-sd-logging.env",
-      "--timeout=180m",
+      "--timeout=1320m",
       "--extract=ci/latest",
       "--check-leaked-resources=true"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-instrumentation"
     ]
   },
   "ci-kubernetes-e2e-gce-serial": {
@@ -2763,13 +2763,13 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-sd-logging.env",
-      "--timeout=180m",
+      "--timeout=1320m",
       "--extract=ci/latest",
       "--check-leaked-resources=true"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-instrumentation"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-serial": {


### PR DESCRIPTION
1440m = 21.5h test + 30m buffer for ginkgo + 2h buffer for jenkins

/cc @piosz 