### PR TITLE
Do not allow same dashboard in multiple groups

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2807,11 +2807,6 @@ dashboards:
 #
 
 dashboard_groups:
-- name: 1.7-upgrade-all
-  dashboard_names:
-  - 1.5-1.7-upgrade
-  - 1.6-1.7-upgrade
-
 - name: gke-all
   dashboard_names:
   - google-gke

--- a/testgrid/config/config_test.go
+++ b/testgrid/config/config_test.go
@@ -147,6 +147,7 @@ func TestConfig(t *testing.T) {
 
 	// No dup of dashboard groups, and no dup dashboard in a dashboard group
 	groups := make(map[string]bool)
+	tabs := make(map[string]string)
 
 	for idx, dashboardGroup := range config.DashboardGroups {
 		// All dashboard must have a name
@@ -155,23 +156,21 @@ func TestConfig(t *testing.T) {
 		}
 
 		// All dashboardgroup must not have duplicated names
-		if groups[dashboardGroup.Name] {
+		if _, ok := groups[dashboardGroup.Name]; ok {
 			t.Errorf("Duplicated dashboard: %v", dashboardGroup.Name)
 		} else {
 			groups[dashboardGroup.Name] = true
 		}
 
-		tabs := make(map[string]bool)
-
 		for _, dashboard := range dashboardGroup.DashboardNames {
 			// All dashboard must not have duplicated names
-			if tabs[dashboard] {
-				t.Errorf("Duplicated dashboard: %v", dashboardGroup.Name)
+			if exist, ok := tabs[dashboard]; ok {
+				t.Errorf("Duplicated dashboard %v in dashboard group %v and %v", dashboard, exist, dashboardGroup.Name)
 			} else {
-				tabs[dashboard] = true
+				tabs[dashboard] = dashboardGroup.Name
 			}
 
-			if ok, _ := dashboardmap[dashboard]; !ok {
+			if _, ok := dashboardmap[dashboard]; !ok {
 				t.Errorf("Dashboard %v needs to be defined before adding to a dashboard group!", dashboard)
 			}
 		}


### PR DESCRIPTION
That's not supported, update tests.

I created 1.7-upgrade-all for testing purpose, that's fine to remove, plus those two are still within the same group.

/assign @roberthbailey @michelle192837 