### PR TITLE
Add 'interrupt testing' as a gubernator error

### DIFF
--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -25,7 +25,15 @@ def wordRE(word):
 # HACK: match ANSI colored lines by allowing preceding "m",
 # as in"\x1b[0;31mFAILED\x1b[0m"
 
-default_words = ["build timed out", "error", "fail", "failed", "fatal", "undefined"]
+default_words = [
+    "build timed out",
+    "error",
+    "fail",
+    "failed",
+    "fatal",
+    "undefined",
+    "interrupt testing"
+    ]
 
 error_re = re.compile(
     r'(?:\b|(?<=m))(%s)\b' % '|'.join(default_words), re.IGNORECASE)


### PR DESCRIPTION
it's hard to spot the actual timeout, add a highlight might help debugging in the future.

sample log: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-prod/2742?log#log