### PR TITLE
skip some bad 1-5 to 1-7 cluster upgrade tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster.env
@@ -6,5 +6,9 @@ KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-clat-up-clu
 
+# Skip Deamon set should run and stop complex daemon with node affinity; see kubernetes/kubernetes#47765
+# Skip [SchedulerPredicates]; kubernetes/kubernetes#47767
+# Skip [SchedulerPriorities]; kubernetes/kubernetes#47769
+GINKGO_TEST_ARGS=--ginkgo.skip="Daemon\ set\ \[Serial\]\ should\ run\ and\ stop\ complex\ \daemon\ with\ node\ affinity|\[SchedulerPredicates\]|\[SchedulerPriorities\]"
 
 SKEW_KUBECTL=y


### PR DESCRIPTION
Disabling some tests in the [1.5 to 1.7 upgrade suite](https://k8s-testgrid.appspot.com/1.5-1.7-upgrade#gke-cvm-1-5-cvm-1-7-upgrade-master&sort-by-failures=)

Reasons for disabling the tests are recorded in the following associated issues:

* Daemon set [Serial] should run and stop complex daemon with node affinity
  kubernetes/kubernetes#47765

* SchedulerPredicates - swarm of test failures
  kubernetes/kubernetes#47767

* SchedulerPriorities - swarm of 1.5 to 1.7 upgrade failures
  kubernetes/kubernetes#47769

