### PR TITLE
Refactor code to eliminate duplicate githubClient interfaces.

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/jenkins"
 	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/plugins"
 )
 
 const (
@@ -50,20 +51,11 @@ type jenkinsClient interface {
 	Status(job, id string) (*jenkins.Status, error)
 }
 
-type githubClient interface {
-	BotName() string
-	CreateStatus(org, repo, ref string, s github.Status) error
-	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
-	CreateComment(org, repo string, number int, comment string) error
-	DeleteComment(org, repo string, ID int) error
-	EditComment(org, repo string, ID int, comment string) error
-}
-
 type Controller struct {
 	kc     kubeClient
 	pkc    kubeClient
 	jc     jenkinsClient
-	ghc    githubClient
+	ghc    plugins.GithubClient
 	totURL string
 
 	reports []kube.ProwJob

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -22,6 +22,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "gitplugin.go",
         "plugins.go",
         "respond.go",
     ],
@@ -30,7 +31,6 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
-        "//prow/slack:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
         "//vendor:github.com/ghodss/yaml",
     ],

--- a/prow/plugins/assign/BUILD
+++ b/prow/plugins/assign/BUILD
@@ -14,7 +14,7 @@ go_test(
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
-        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
     ],
 )

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -40,16 +40,6 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
-type githubClient interface {
-	AssignIssue(owner, repo string, number int, logins []string) error
-	UnassignIssue(owner, repo string, number int, logins []string) error
-
-	RequestReview(org, repo string, number int, logins []string) error
-	UnrequestReview(org, repo string, number int, logins []string) error
-
-	CreateComment(owner, repo string, number int, comment string) error
-}
-
 type event struct {
 	action string
 	body   string
@@ -199,7 +189,7 @@ type handler struct {
 	// as the first subgroup and the arguments to the command as the second subgroup.
 	regexp *regexp.Regexp
 	// gc is the githubClient to use for creating response comments in the event of a failure.
-	gc githubClient
+	gc plugins.GithubClient
 
 	// log is a logrus.Entry used to record actions the handler takes.
 	log *logrus.Entry
@@ -207,7 +197,7 @@ type handler struct {
 	userType string
 }
 
-func newAssignHandler(e *event, gc githubClient, log *logrus.Entry) *handler {
+func newAssignHandler(e *event, gc plugins.GithubClient, log *logrus.Entry) *handler {
 	addFailureResponse := func(mu github.MissingUsers) string {
 		return fmt.Sprintf("GitHub didn't allow me to assign the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) can be assigned", strings.Join(mu.Users, ", "), e.org, e.org)
 	}
@@ -224,7 +214,7 @@ func newAssignHandler(e *event, gc githubClient, log *logrus.Entry) *handler {
 	}
 }
 
-func newReviewHandler(e *event, gc githubClient, log *logrus.Entry) *handler {
+func newReviewHandler(e *event, gc plugins.GithubClient, log *logrus.Entry) *handler {
 	addFailureResponse := func(mu github.MissingUsers) string {
 		return fmt.Sprintf("GitHub didn't allow me to request PR reviews from the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) can review this PR, and authors cannot review their own PRs", strings.Join(mu.Users, ", "), e.org, e.repo)
 	}

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -58,14 +58,6 @@ func init() {
 	plugins.RegisterStatusEventHandler(pluginName, handleStatusEvent)
 }
 
-type gitHubClient interface {
-	CreateComment(owner, repo string, number int, comment string) error
-	AddLabel(owner, repo string, number int, label string) error
-	RemoveLabel(owner, repo string, number int, label string) error
-	GetPullRequest(owner, repo string, number int) (*github.PullRequest, error)
-	FindIssues(query string) ([]github.Issue, error)
-}
-
 func handleStatusEvent(pc plugins.PluginClient, se github.StatusEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, se)
 }
@@ -75,7 +67,7 @@ func handleStatusEvent(pc plugins.PluginClient, se github.StatusEvent) error {
 // 3. For each issue that matches, check that the PR's HEAD commit hash against the commit hash for which the status
 //    was received. This is because we only care about the status associated with the last (latest) commit in a PR.
 // 4. Set the corresponding CLA label if needed.
-func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
+func handle(gc plugins.GithubClient, log *logrus.Entry, se github.StatusEvent) error {
 	if se.State == "" || se.Context == "" {
 		return fmt.Errorf("invalid status event delivered with empty state/context")
 	}

--- a/prow/plugins/close/BUILD
+++ b/prow/plugins/close/BUILD
@@ -15,6 +15,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
     ],
 )

--- a/prow/plugins/close/close.go
+++ b/prow/plugins/close/close.go
@@ -33,16 +33,11 @@ func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
 }
 
-type githubClient interface {
-	CreateComment(owner, repo string, number int, comment string) error
-	CloseIssue(owner, repo string, number int) error
-}
-
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, ic)
 }
 
-func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
+func handle(gc plugins.GithubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
 	// Only consider open issues and new comments.
 	if ic.Issue.State != "open" || ic.Issue.IsPullRequest() || ic.Action != "created" {
 		return nil

--- a/prow/plugins/close/close_test.go
+++ b/prow/plugins/close/close_test.go
@@ -22,22 +22,8 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
 )
-
-type fakeClient struct {
-	commented bool
-	closed    bool
-}
-
-func (c *fakeClient) CreateComment(owner, repo string, number int, comment string) error {
-	c.commented = true
-	return nil
-}
-
-func (c *fakeClient) CloseIssue(owner, repo string, number int) error {
-	c.closed = true
-	return nil
-}
 
 func TestCloseComment(t *testing.T) {
 	// "a" is the author, "r1", and "r2" are reviewers.
@@ -106,7 +92,7 @@ func TestCloseComment(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		fc := &fakeClient{}
+		fc := &fakegithub.FakeClient{}
 		ice := github.IssueCommentEvent{
 			Action: tc.action,
 			Comment: github.IssueComment{
@@ -124,14 +110,14 @@ func TestCloseComment(t *testing.T) {
 			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
 			continue
 		}
-		if tc.shouldClose && !fc.closed {
+		if tc.shouldClose && !fc.Closed {
 			t.Errorf("For case %s, should have closed but didn't.", tc.name)
-		} else if !tc.shouldClose && fc.closed {
+		} else if !tc.shouldClose && fc.Closed {
 			t.Errorf("For case %s, should not have closed but did.", tc.name)
 		}
-		if tc.shouldComment && !fc.commented {
+		if tc.shouldComment && !fc.Commented {
 			t.Errorf("For case %s, should have commented but didn't.", tc.name)
-		} else if !tc.shouldComment && fc.commented {
+		} else if !tc.shouldComment && fc.Commented {
 			t.Errorf("For case %s, should not have commented but did.", tc.name)
 		}
 	}

--- a/prow/plugins/gitplugin.go
+++ b/prow/plugins/gitplugin.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"k8s.io/test-infra/prow/github"
+)
+
+type GithubClient interface {
+	// Git Use and Bot management.
+	IsMember(org, user string) (bool, error)
+	BotName() string
+
+	// Git Issue Comments.
+	CreateComment(owner, repo string, number int, comment string) error
+	CreateCommentReaction(org, repo string, ID int, reaction string) error
+	DeleteComment(org, repo string, ID int) error
+	EditComment(org, repo string, ID int, comment string) error
+
+	// Git Issue Labels.
+	AddLabel(owner, repo string, number int, label string) error
+	GetRepoLabels(owner, repo string) ([]github.Label, error)
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	RemoveLabel(owner, repo string, number int, label string) error
+
+	// Git Issue Management.
+	AssignIssue(org, repo string, number int, logins []string) error
+	CreateIssueReaction(org, repo string, ID int, reaction string) error
+	CloseIssue(org, repo string, number int) error
+	FindIssues(query string) ([]github.Issue, error)
+	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+	ReopenIssue(org, repo string, number int) error
+	UnassignIssue(org, repo string, number int, logins []string) error
+
+	// Git PRs.
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	GetPullRequestChanges(pr github.PullRequest) ([]github.PullRequestChange, error)
+
+	//Git Reviews.
+	RequestReview(org, repo string, number int, logins []string) error
+	UnrequestReview(org, repo string, number int, logins []string) error
+
+	// Git Issue or Commit Status.
+	CreateStatus(org, repo, ref string, s github.Status) error
+	GetRef(org, repo, ref string) (string, error)
+	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
+}

--- a/prow/plugins/heart/heart.go
+++ b/prow/plugins/heart/heart.go
@@ -47,12 +47,6 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
-type githubClient interface {
-	CreateCommentReaction(org, repo string, ID int, reaction string) error
-	CreateIssueReaction(org, repo string, ID int, reaction string) error
-	GetPullRequestChanges(pr github.PullRequest) ([]github.PullRequestChange, error)
-}
-
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
 	return handleIC(pc.GitHubClient, pc.Logger, ic)
 }
@@ -61,7 +55,7 @@ func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) err
 	return handlePR(pc.GitHubClient, pc.Logger, pre)
 }
 
-func handleIC(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
+func handleIC(gc plugins.GithubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
 	// Only consider new comments on PRs.
 	if !ic.Issue.IsPullRequest() || ic.Action != "created" {
 		return nil
@@ -83,7 +77,7 @@ func handleIC(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) e
 		reactions[rand.Intn(len(reactions))])
 }
 
-func handlePR(gc githubClient, log *logrus.Entry, pre github.PullRequestEvent) error {
+func handlePR(gc plugins.GithubClient, log *logrus.Entry, pre github.PullRequestEvent) error {
 	// Only consider newly opened PRs
 	if pre.Action != "opened" {
 		return nil

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -61,19 +61,6 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
 }
 
-type githubClient interface {
-	CreateComment(owner, repo string, number int, comment string) error
-	IsMember(org, user string) (bool, error)
-	AddLabel(owner, repo string, number int, label string) error
-	RemoveLabel(owner, repo string, number int, label string) error
-	GetRepoLabels(owner, repo string) ([]github.Label, error)
-	BotName() string
-}
-
-type slackClient interface {
-	WriteMessage(msg string, channel string) error
-}
-
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
 	ae := assignEvent{
 		action:  ic.Action,
@@ -142,7 +129,7 @@ func (ae assignEvent) getRepeats(sigMatches [][]string, existingLabels map[strin
 	return
 }
 
-func handle(gc githubClient, log *logrus.Entry, ae assignEvent, sc slackClient) error {
+func handle(gc plugins.GithubClient, log *logrus.Entry, ae assignEvent, sc plugins.SlackClient) error {
 	// only parse newly created comments/issues/PRs and if non bot author
 	if ae.login == gc.BotName() || !(ae.action == "created" || ae.action == "opened") {
 		return nil

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -53,17 +53,8 @@ func init() {
 	plugins.RegisterReviewCommentEventHandler(pluginName, handleReviewComment)
 }
 
-type githubClient interface {
-	IsMember(owner, login string) (bool, error)
-	AddLabel(owner, repo string, number int, label string) error
-	AssignIssue(owner, repo string, number int, assignees []string) error
-	CreateComment(owner, repo string, number int, comment string) error
-	RemoveLabel(owner, repo string, number int, label string) error
-	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
-}
-
 // prLabelChecker returns a function that lazily checks if a label is applied to a pr.
-func prLabelChecker(gc githubClient, log *logrus.Entry, org, repo string, num int) func(string) (bool, error) {
+func prLabelChecker(gc plugins.GithubClient, log *logrus.Entry, org, repo string, num int) func(string) (bool, error) {
 	return func(label string) (bool, error) {
 		labels, err := gc.GetIssueLabels(org, repo, num)
 		if err != nil {
@@ -143,7 +134,7 @@ func handleReviewComment(pc plugins.PluginClient, rce github.ReviewCommentEvent)
 	return handle(pc.GitHubClient, pc.Logger, e)
 }
 
-func handle(gc githubClient, log *logrus.Entry, e *event) error {
+func handle(gc plugins.GithubClient, log *logrus.Entry, e *event) error {
 	if e.action != "created" && e.action != "submitted" {
 		return nil
 	}

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
-	"k8s.io/test-infra/prow/slack"
 )
 
 var (
@@ -64,11 +63,15 @@ func RegisterPullRequestHandler(name string, fn PullRequestHandler) {
 	pullRequestHandlers[name] = fn
 }
 
+type SlackClient interface {
+	WriteMessage(msg string, channel string) error
+}
+
 // PluginClient may be used concurrently, so each entry must be thread-safe.
 type PluginClient struct {
-	GitHubClient *github.Client
+	GitHubClient GithubClient
 	KubeClient   *kube.Client
-	SlackClient  *slack.Client // This might be nil.
+	SlackClient  SlackClient // This might be nil.
 	Config       *config.Config
 	Logger       *logrus.Entry
 }

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -51,18 +51,11 @@ func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
 }
 
-type githubClient interface {
-	IsMember(org, user string) (bool, error)
-	CreateComment(owner, repo string, number int, comment string) error
-	AddLabel(owner, repo string, number int, label string) error
-	RemoveLabel(owner, repo string, number int, label string) error
-}
-
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, ic)
 }
 
-func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
+func handle(gc plugins.GithubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
 	// Only consider PRs and new comments.
 	if !ic.Issue.IsPullRequest() || ic.Action != "created" {
 		return nil

--- a/prow/plugins/reopen/BUILD
+++ b/prow/plugins/reopen/BUILD
@@ -15,6 +15,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
     ],
 )

--- a/prow/plugins/reopen/reopen.go
+++ b/prow/plugins/reopen/reopen.go
@@ -33,16 +33,11 @@ func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
 }
 
-type githubClient interface {
-	CreateComment(owner, repo string, number int, comment string) error
-	ReopenIssue(owner, repo string, number int) error
-}
-
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
 	return handle(pc.GitHubClient, pc.Logger, ic)
 }
 
-func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
+func handle(gc plugins.GithubClient, log *logrus.Entry, ic github.IssueCommentEvent) error {
 	// Only consider closed issues and new comments.
 	if ic.Issue.State != "closed" || ic.Issue.IsPullRequest() || ic.Action != "created" {
 		return nil

--- a/prow/plugins/reopen/reopen_test.go
+++ b/prow/plugins/reopen/reopen_test.go
@@ -22,22 +22,8 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
 )
-
-type fakeClient struct {
-	commented bool
-	open      bool
-}
-
-func (c *fakeClient) CreateComment(owner, repo string, number int, comment string) error {
-	c.commented = true
-	return nil
-}
-
-func (c *fakeClient) ReopenIssue(owner, repo string, number int) error {
-	c.open = true
-	return nil
-}
 
 func TestOpenComment(t *testing.T) {
 	// "a" is the author, "r1", and "r2" are reviewers.
@@ -106,7 +92,7 @@ func TestOpenComment(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		fc := &fakeClient{}
+		fc := &fakegithub.FakeClient{}
 		ice := github.IssueCommentEvent{
 			Action: tc.action,
 			Comment: github.IssueComment{
@@ -124,14 +110,14 @@ func TestOpenComment(t *testing.T) {
 			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
 			continue
 		}
-		if tc.shouldReopen && !fc.open {
+		if tc.shouldReopen && !fc.Open {
 			t.Errorf("For case %s, should have reopened but didn't.", tc.name)
-		} else if !tc.shouldReopen && fc.open {
+		} else if !tc.shouldReopen && fc.Open {
 			t.Errorf("For case %s, should not have reopened but did.", tc.name)
 		}
-		if tc.shouldComment && !fc.commented {
+		if tc.shouldComment && !fc.Commented {
 			t.Errorf("For case %s, should have commented but didn't.", tc.name)
-		} else if !tc.shouldComment && fc.commented {
+		} else if !tc.shouldComment && fc.Commented {
 			t.Errorf("For case %s, should not have commented but did.", tc.name)
 		}
 	}

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -73,7 +73,7 @@ func handlePR(c client, pr github.PullRequestEvent) error {
 	return nil
 }
 
-func askToJoin(ghc githubClient, pr github.PullRequest) error {
+func askToJoin(ghc plugins.GithubClient, pr github.PullRequest) error {
 	commentTemplate := `Hi @%s. Thanks for your PR.
 
 I'm waiting for a [%s](https://github.com/orgs/%s/people) member to verify that this patch is reasonable to test. If it is, they should reply with ` + "`/ok-to-test`" + ` on its own line. Until that is done, I will not automatically test new commits in this PR, but the usual testing commands by org members will still work. Regular contributors should join the org to skip this step.
@@ -100,7 +100,7 @@ I understand the commands that are listed [here](https://github.com/kubernetes/t
 // trustedPullRequest returns whether or not the given PR should be tested.
 // It first checks if the author is in the org, then looks for "ok to test
 // comments by org members.
-func trustedPullRequest(ghc githubClient, pr github.PullRequest) (bool, error) {
+func trustedPullRequest(ghc plugins.GithubClient, pr github.PullRequest) (bool, error) {
 	author := pr.User.Login
 	// First check if the author is a member of the org.
 	orgMember, err := ghc.IsMember(trustedOrg, author)

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -37,26 +37,13 @@ func init() {
 	plugins.RegisterPushEventHandler(pluginName, handlePush)
 }
 
-type githubClient interface {
-	AddLabel(org, repo string, number int, label string) error
-	BotName() string
-	IsMember(org, user string) (bool, error)
-	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
-	GetRef(org, repo, ref string) (string, error)
-	CreateComment(owner, repo string, number int, comment string) error
-	ListIssueComments(owner, repo string, issue int) ([]github.IssueComment, error)
-	CreateStatus(owner, repo, ref string, status github.Status) error
-	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
-	GetPullRequestChanges(github.PullRequest) ([]github.PullRequestChange, error)
-	RemoveLabel(org, repo string, number int, label string) error
-}
-
 type kubeClient interface {
 	CreateProwJob(kube.ProwJob) (kube.ProwJob, error)
 }
 
 type client struct {
-	GitHubClient githubClient
+	GitHubClient plugins.GithubClient
+	SlackClient  plugins.SlackClient
 	KubeClient   kubeClient
 	Config       *config.Config
 	Logger       *logrus.Entry
@@ -65,6 +52,7 @@ type client struct {
 func getClient(pc plugins.PluginClient) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
+		SlackClient:  pc.SlackClient,
 		Config:       pc.Config,
 		KubeClient:   pc.KubeClient,
 		Logger:       pc.Logger,

--- a/prow/plugins/yuks/yuks.go
+++ b/prow/plugins/yuks/yuks.go
@@ -43,10 +43,6 @@ func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
 }
 
-type githubClient interface {
-	CreateComment(owner, repo string, number int, comment string) error
-}
-
 type joker interface {
 	readJoke() (string, error)
 }
@@ -84,7 +80,7 @@ func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) er
 	return handle(pc.GitHubClient, pc.Logger, ic, jokeUrl)
 }
 
-func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent, j joker) error {
+func handle(gc plugins.GithubClient, log *logrus.Entry, ic github.IssueCommentEvent, j joker) error {
 	// Only consider new comments.
 	if ic.Action != "created" {
 		return nil


### PR DESCRIPTION
This PR will refactor githubClient interface into one single file and eliminates redeclaration of the interface in individual files. Also pluginClient is change to make this globally accessible. 

My thought is that the code will be better readable for future enhancements. Your comments are appreciated.