### PR TITLE
Bump node machine-type & max-requests-inflight for gce-enormous-cluster

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
@@ -15,7 +15,7 @@ KUBE_GCE_ZONE=us-east1-a
 MASTER_SIZE=n1-standard-64
 # Increase disk size to check if that helps for etcd latency.
 MASTER_DISK_SIZE=200GB
-NODE_SIZE=g1-small
+NODE_SIZE=n1-standard-1
 NODE_DISK_SIZE=50GB
 # Reduce logs verbosity
 TEST_CLUSTER_LOG_LEVEL=--v=1
@@ -26,6 +26,8 @@ MAX_INSTANCES_PER_MIG=1000
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+# Increase allowed threshold for requests inflight
+TEST_CLUSTER_MAX_REQUESTS_INFLIGHT=--max-requests-inflight=2000 --max-mutating-requests-inflight=1000
 # =========================================
 # Configuration we are targetting in 1.6
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/47865

/cc @gmarek 