### PR TITLE
Fix ginkgo flags for gke staging/prod jobs

### DIFF
--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.env
@@ -5,4 +5,4 @@ PROJECT=k8s-jkns-e2e-gci-gke-prod
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci
 ZONE=us-central1-b
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.env
@@ -4,4 +4,4 @@ CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 PROJECT=k8s-jkns-e2e-gci-gke-staging
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gke-prod.env
+++ b/jobs/ci-kubernetes-e2e-gke-prod.env
@@ -3,4 +3,4 @@ CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 PROJECT=k8s-jkns-e2e-gke-prod
 ZONE=us-central1-b
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gke-staging.env
+++ b/jobs/ci-kubernetes-e2e-gke-staging.env
@@ -2,4 +2,4 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 PROJECT=k8s-jkns-e2e-gke-staging
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]


### PR DESCRIPTION
missed the `|` between slow/serial, and we should also skip Flaky and Feature by default

changed from https://github.com/kubernetes/test-infra/pull/3128

/assign @jlowdermilk @ixdy 