### PR TITLE
disable podpreset tests in 1-6-1-7 upgrade test

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master.env
@@ -5,5 +5,7 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-g1-4-up-mas
 
+#disabling PodPreset tests because it is Alpha feature and is disabled by default.
+GINKGO_TEST_ARGS=--ginkgo.skip=PodPreset
 
 SKEW_KUBECTL=y


### PR DESCRIPTION
Disabling PodPreset tests from 1-6-1-7 upgrade test because its an Alpha feature and Alpha features are disabled by default.