### PR TITLE
Remove old-docs from blocked path

### DIFF
--- a/mungegithub/block-path.yaml
+++ b/mungegithub/block-path.yaml
@@ -1,24 +1,8 @@
 blockRegexp:
-  - ^docs/admin
-  - ^docs/design
-  - ^docs/devel
-  - ^docs/getting-started-guides
-  - ^docs/proposals
+  - ^docs/man
   - ^docs/user-guide
+  - ^docs/yaml
 doNotBlockRegexp:
-  - ^docs/admin/federation-apiserver.md$
-  - ^docs/admin/federation-controller-manager.md$
-  - ^docs/admin/high-availability/.*\.(yaml)$
-  - ^docs/admin/kube-apiserver.md$
-  - ^docs/admin/kube-controller-manager.md$
-  - ^docs/admin/kube-proxy.md$
-  - ^docs/admin/kube-scheduler.md$
-  - ^docs/admin/kubefed.md$
-  - ^docs/admin/kubefed_init.md$
-  - ^docs/admin/kubefed_join.md$
-  - ^docs/admin/kubefed_options.md$
-  - ^docs/admin/kubefed_unjoin.md$
-  - ^docs/admin/kubefed_version.md$
-  - ^docs/admin/kubelet.md$
-  - ^docs/man/man1/kubectl.*\.1$
+  - ^docs/man/man1/.*\.1$
   - ^docs/user-guide/kubectl/kubectl.*\.md$
+  - ^docs/yaml/kubectl/kubectl_.*\.yaml$


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/pull/46813, we're removing a bunch of the static content from docs/ in k/k. This adjusts the paths of the old-docs munger to limit the amount of things that aren't allowed to be auto merged.