### PR TITLE
Improve instructions on how to update the cluster for prow plugin

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -52,10 +52,11 @@ number.
 ## How to update the cluster
 
 Any modifications to Go code will require redeploying the affected binaries.
-Fortunately, this should result in no downtime for the system. Bump the
-relevant version number in the makefile as well as in the `cluster` manifest,
-then run the image and deployment make targets. For instance, if you bumped
-the hook version, run `make hook-image && make hook-deployment`.
+Fortunately, this should result in no downtime for the system. [Bump](https://github.com/kubernetes/test-infra/commit/cf1ac2f67142e91cb36978691e1718c007a3377a) the relevant version 
+number in the makefile as well as in the `cluster` manifest,
+then run the image and deployment make targets on a branch which has the 
+changes. For instance, if you bumped the hook version, run 
+`make hook-image && make hook-deployment`.
 
 **Please ensure that your git tree is up to date before updating anything.**
 


### PR DESCRIPTION
(1) added an example link for bumping the image
(2) stated that `make` has to be carried out on a branch which has the changes

Addressing https://github.com/kubernetes/test-infra/issues/3142