### PR TITLE
No more manual deletion of gce-enormous-cluster

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
@@ -17,6 +17,8 @@ MASTER_SIZE=n1-standard-64
 MASTER_DISK_SIZE=200GB
 NODE_SIZE=n1-standard-1
 NODE_DISK_SIZE=50GB
+# Make cluster down delete VPC network.
+KUBE_DELETE_NETWORK=true
 # Reduce logs verbosity
 TEST_CLUSTER_LOG_LEVEL=--v=1
 # Switch off image puller to workaround #32191.

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -804,7 +804,6 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-enormous-cluster.env",
       "--cluster=e2e-enormous-cluster",
-      "--down=false",
       "--timeout=1400m",
       "--extract=ci/latest",
       "--check-leaked-resources=false"


### PR DESCRIPTION
I've deleted the cluster manually for run 10 a while ago. Doing it 5 hours ago (when the test finished) would've saved > $1000.
Also it's an inconvenience to do it each time.

cc @kubernetes/sig-scalability-misc 