### PR TITLE
Disable fluentd in gce-enormous-cluster test

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
@@ -19,6 +19,8 @@ NODE_SIZE=n1-standard-1
 NODE_DISK_SIZE=50GB
 # Make cluster down delete VPC network.
 KUBE_DELETE_NETWORK=true
+# Disable fluentd to prevent OOM-kills on nodes and qps resulting from it (#47865).
+KUBE_ENABLE_NODE_LOGGING=false
 # Reduce logs verbosity
 TEST_CLUSTER_LOG_LEVEL=--v=1
 # Switch off image puller to workaround #32191.


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/47865

/cc @gmarek 