### PR TITLE
Refresh the list of ProwJobs after we abort duplicates.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       = 0.30
 SPLICE_VERSION     = 0.20
 TOT_VERSION        = 0.1
 HOROLOGIUM_VERSION = 0.3
-PLANK_VERSION      = 0.22
+PLANK_VERSION      = 0.23
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.22
+        image: gcr.io/k8s-prow/plank:0.23
         args:
         - --build-cluster=/etc/cluster/cluster
         - --dry-run=false


### PR DESCRIPTION
Otherwise we'll get an error due to conflict. It won't break anyone,
but it's ugly and noisy.