### PR TITLE
Extend timeout on release 1.7 serial jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1935,7 +1935,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--timeout=500m",
       "--mode=local",
       "--check-leaked-resources=true"
     ],
@@ -2887,7 +2887,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--timeout=500m",
       "--mode=local",
       "--check-leaked-resources=true"
     ],
@@ -3297,7 +3297,7 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-7.env",
       "--mode=local",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--timeout=500m",
       "--check-leaked-resources=true"
     ],
     "scenario": "kubernetes_e2e",
@@ -5024,7 +5024,7 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1-7.env",
       "--mode=local",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--timeout=500m",
       "--check-leaked-resources=true"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5784,7 +5784,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=320
+      - --timeout=500
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -5817,7 +5817,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=320
+      - --timeout=500
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -5850,7 +5850,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=320
+      - --timeout=500
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -5883,7 +5883,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=320
+      - --timeout=500
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5784,7 +5784,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=500
+      - --timeout=520
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -5817,7 +5817,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=500
+      - --timeout=520
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -5850,7 +5850,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=500
+      - --timeout=520
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -5883,7 +5883,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=500
+      - --timeout=520
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
There are currently frequent timeouts on the serial jobs for the release-1.7 branch. This PR changes job timeouts to match the durations for master branch jobs.