### PR TITLE
Port kubernetes/hack/jenkins/build.sh to kubernetes_build scenario

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -10,6 +10,7 @@
             --job='{job-name}' \
             --json \
             --repo='{repo-name}' \
+            --repo='k8s.io/release' \
             --root="${{GOPATH}}/src" \
             --service-account="${{GOOGLE_APPLICATION_CREDENTIALS}}" \
             --timeout='{timeout}' \


### PR DESCRIPTION
Part of #3207.

Using `kubetest` directly is still tricky, since we need to get the `kubetest` binary from somewhere.
We have a `kubetest` binary in the `kubekins-e2e` image, but if we're going to use `kubekins-e2e`, we probably need to use the `kubernetes_e2e` scenario, and that is long and terrifying and I'm not sure we want to add more logic to it.

As such, I'm making small steps and getting rid of the `hack/jenkins/build.sh` script as a first step, which also unblocks us from making progress on #1400. Fixing #1400 will allow us to remove the `--federation` flow, which should make this scenario even more trivial and easier to reason about, setting up a path to remove it entirely.

As written I'm just making the switch away from `hack/jenkins/build.sh`. If that seems too risky, I guess I can flag-gate it on a few builds first? WDYT?

The non-kubernetes builds (kops, debian-unstable) should be unaffected by this change, I hope.

/assign @fejta @krzyzacy 
cc @luxas @mikedanese @zmerlynn @justinsb 