### PR TITLE
Use --repo={repo-name}={branch} instead of --branch={branch} in bootstrap-ci-commit jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -6,10 +6,9 @@
         # TODO(fejta): consider a stable tag instead of master
         git clone https://github.com/kubernetes/test-infra -b master
         './test-infra/jenkins/bootstrap.py' \
-            --branch='{branch}' \
             --job='{job-name}' \
             --json \
-            --repo='{repo-name}' \
+            --repo='{repo-name}={branch}' \
             --repo='k8s.io/release' \
             --root="${{GOPATH}}/src" \
             --service-account="${{GOOGLE_APPLICATION_CREDENTIALS}}" \


### PR DESCRIPTION
Reverts #3211. Arg.
```
+ ./test-infra/jenkins/bootstrap.py --branch=master --job=ci-kubernetes-build --json --repo=k8s.io/kubernetes --repo=k8s.io/release --root=/var/lib/jenkins/workspace/ci-kubernetes-build/go/src '--service-account=/var/lib/jenkins/workspace/ci-kubernetes-build@tmp/secretFiles/36bf0a68-2d80-4b16-ac69-f1fc059deb9a/Kubernetes Jenkins Builds-2152c16d13db.json' --timeout=30 --upload=gs://kubernetes-jenkins/logs
Traceback (most recent call last):
  File "./test-infra/jenkins/bootstrap.py", line 965, in <module>
    bootstrap(ARGS)
  File "./test-infra/jenkins/bootstrap.py", line 842, in bootstrap
    repos = parse_repos(args)
  File "./test-infra/jenkins/bootstrap.py", line 813, in parse_repos
    raise ValueError('Multi --repo does not support --branch, use --repo=R=branch')
ValueError: Multi --repo does not support --branch, use --repo=R=branch
```