### PR TITLE
PR authors can now do `/approve no-issue` or `/lgtm no-issue`.

### DIFF
--- a/mungegithub/mungers/approvers/owners.go
+++ b/mungegithub/mungers/approvers/owners.go
@@ -309,6 +309,9 @@ func (ap *Approvers) AddApprover(login, reference string, noIssue bool) {
 
 // AddSAuthorSelfApprover adds the author self approval
 func (ap *Approvers) AddAuthorSelfApprover(login, reference string) {
+	if ap.shouldNotOverrideApproval(login, false) {
+		return
+	}
 	ap.approvers[login] = Approval{
 		Login:     login,
 		How:       "Author self-approved",


### PR DESCRIPTION
Previously the 'no-issue' argument wasn't accepted even if the author was a valid approver
for the changed files. This occurred because we overwrote the approval struct for the
author after processing comments, erasing any no-issue argument seen from the author.
fixes #3228 

/cc @rmmh 