### PR TITLE
Enable monitoring in enormous-cluster & prepare enormous-deploy for correctness tests

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
@@ -6,9 +6,6 @@ CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
 # XXX Not a unique project
 PROJECT=kubernetes-scale
 # Override GCE defaults.
-# Temporarily switch of Heapster, as this will not schedule anywhere.
-# TODO: Think of a solution to enable it.
-KUBE_ENABLE_CLUSTER_MONITORING=none
 # TODO: Move to us-central1-c once we have permission for it.
 KUBE_GCE_ZONE=us-east1-a
 # TODO: Increase it when we make cluster larger.

--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.env
@@ -6,12 +6,9 @@ CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
 # XXX Not a unique project
 PROJECT=kubernetes-scale
 # Override GCE defaults.
-# Temporarily switch of Heapster, as this will not schedule anywhere.
-# TODO: Think of a solution to enable it.
-KUBE_ENABLE_CLUSTER_MONITORING=none
 # TODO: Move to us-central1-c once we have permission for it.
 KUBE_GCE_ZONE=us-east1-a
-MASTER_SIZE=n1-standard-32
+MASTER_SIZE=n1-standard-16
 # Increase disk size to check if that helps for etcd latency.
 MASTER_DISK_SIZE=100GB
 NODE_SIZE=n1-standard-1
@@ -33,6 +30,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 ### job-env
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Empty\]
 CLUSTER_IP_RANGE=10.224.0.0/13
-NUM_NODES=2000
-ALLOWED_NOTREADY_NODES=20
+NUM_NODES=500
+ALLOWED_NOTREADY_NODES=5
 

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -817,7 +817,7 @@
       "--cluster=e2e-enormous-deploy",
       "--down=false",
       "--timeout=300m",
-      "--extract=ci/latest"
+      "--extract=ci/latest-1.6"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
This should fix e2e correctness tests failing due to heapster not being enabled.
Ref: run 13 of gce-enormous-cluster test.

/cc @gmarek 