### PR TITLE
Include fractional seconds when sorting github events.

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -192,7 +192,7 @@ def do_get_latest(payload, user):
     if '#' not in text:
         return None
     _text, _start, latest = text.rsplit('#', 2)
-    return int(latest)
+    return float(latest)
 
 
 def do_ltrim(s, needle):

--- a/gubernator/github/models.py
+++ b/gubernator/github/models.py
@@ -57,7 +57,7 @@ class GithubWebhookRaw(ndb.Model):
     body = ndb.TextProperty(compressed=True)
 
     def to_tuple(self):
-        return (self.event, shrink(json.loads(self.body)), int(self.timestamp.strftime('%s')))
+        return (self.event, shrink(json.loads(self.body)), float(self.timestamp.strftime('%s.%f')))
 
 
 def from_iso8601(t):


### PR DESCRIPTION
Otherwise, multiple events in the same second could be reordered with
bad results (unassign 1.2, assign 1.3) => (assign 1, unassign 1).