### PR TITLE
Rename StaleComment to StaleIssueComment.

### DIFF
--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -55,7 +55,7 @@ type BlockPath struct {
 func init() {
 	b := &BlockPath{}
 	RegisterMungerOrDie(b)
-	RegisterStaleComments(b)
+	RegisterStaleIssueComments(b)
 }
 
 // Name is the name usable in --pr-mungers
@@ -144,7 +144,7 @@ func (b *BlockPath) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (b *BlockPath) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (b *BlockPath) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -158,7 +158,7 @@ func (b *BlockPath) isStaleComment(obj *github.MungeObject, comment *githubapi.I
 	return stale
 }
 
-// StaleComments returns a slice of stale comments
-func (b *BlockPath) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, b.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (b *BlockPath) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, b.isStaleIssueComment)
 }

--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -43,7 +43,7 @@ type LabelUnapprovedPicks struct{}
 func init() {
 	l := LabelUnapprovedPicks{}
 	RegisterMungerOrDie(l)
-	RegisterStaleComments(l)
+	RegisterStaleIssueComments(l)
 }
 
 // Name is the name usable in --pr-mungers
@@ -87,7 +87,7 @@ func (LabelUnapprovedPicks) Munge(obj *github.MungeObject) {
 	obj.WriteComment(labelUnapprovedBody)
 }
 
-func (LabelUnapprovedPicks) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (LabelUnapprovedPicks) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -101,7 +101,7 @@ func (LabelUnapprovedPicks) isStaleComment(obj *github.MungeObject, comment *git
 	return stale
 }
 
-// StaleComments returns a list of stale comments
-func (l LabelUnapprovedPicks) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, l.isStaleComment)
+// StaleIssueComments returns a list of stale issue comments.
+func (l LabelUnapprovedPicks) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, l.isStaleIssueComment)
 }

--- a/mungegithub/mungers/cherrypick-must-have-milestone.go
+++ b/mungegithub/mungers/cherrypick-must-have-milestone.go
@@ -42,7 +42,7 @@ type PickMustHaveMilestone struct{}
 func init() {
 	p := PickMustHaveMilestone{}
 	RegisterMungerOrDie(p)
-	RegisterStaleComments(p)
+	RegisterStaleIssueComments(p)
 }
 
 // Name is the name usable in --pr-mungers
@@ -83,7 +83,7 @@ func (PickMustHaveMilestone) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (PickMustHaveMilestone) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (PickMustHaveMilestone) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -101,7 +101,7 @@ func (PickMustHaveMilestone) isStaleComment(obj *github.MungeObject, comment *gi
 	return stale
 }
 
-// StaleComments returns a slice of stale comments
-func (p PickMustHaveMilestone) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, p.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (p PickMustHaveMilestone) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, p.isStaleIssueComment)
 }

--- a/mungegithub/mungers/close-stale.go
+++ b/mungegithub/mungers/close-stale.go
@@ -61,7 +61,7 @@ type CloseStale struct{}
 func init() {
 	s := CloseStale{}
 	RegisterMungerOrDie(s)
-	RegisterStaleComments(s)
+	RegisterStaleIssueComments(s)
 }
 
 // Name is the name usable in --pr-mungers
@@ -338,7 +338,7 @@ func (CloseStale) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (CloseStale) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (CloseStale) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -350,7 +350,7 @@ func (CloseStale) isStaleComment(obj *github.MungeObject, comment *githubapi.Iss
 	return true
 }
 
-// StaleComments returns a slice of stale comments
-func (s CloseStale) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, s.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (s CloseStale) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, s.isStaleIssueComment)
 }

--- a/mungegithub/mungers/comment-deleter-jenkins.go
+++ b/mungegithub/mungers/comment-deleter-jenkins.go
@@ -51,15 +51,15 @@ type CommentDeleterJenkins struct{}
 
 func init() {
 	c := CommentDeleterJenkins{}
-	RegisterStaleComments(c)
+	RegisterStaleIssueComments(c)
 }
 
 func isJenkinsTestComment(body string) bool {
 	return updatedCommentRegexp.MatchString(body) || commentRegexp.MatchString(body)
 }
 
-// StaleComments returns a slice of comments which are stale
-func (CommentDeleterJenkins) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+// StaleIssueComments returns a slice of stale issue comments.
+func (CommentDeleterJenkins) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
 	out := []*githubapi.IssueComment{}
 	var last *githubapi.IssueComment
 

--- a/mungegithub/mungers/comment-deleter-jenkins_test.go
+++ b/mungegithub/mungers/comment-deleter-jenkins_test.go
@@ -106,7 +106,7 @@ func comment(id int, body string) *githubapi.IssueComment {
 	return github_test.Comment(id, jenkinsBotName, time.Now(), passComment)
 }
 
-func TestJenkinsStaleComments(t *testing.T) {
+func TestJenkinsStaleIssueComments(t *testing.T) {
 	c := CommentDeleterJenkins{}
 
 	tests := []struct {
@@ -144,7 +144,7 @@ func TestJenkinsStaleComments(t *testing.T) {
 		},
 	}
 	for testNum, test := range tests {
-		out := c.StaleComments(nil, test.comments)
+		out := c.StaleIssueComments(nil, test.comments)
 		if len(out) != len(test.expected) {
 			t.Errorf("%d:%s: len(expected):%d, len(out):%d", testNum, test.name, len(test.expected), len(out))
 		}

--- a/mungegithub/mungers/comment-deleter.go
+++ b/mungegithub/mungers/comment-deleter.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	_        = glog.Infof
-	deleters = []StaleComment{}
+	deleters = []StaleIssueComment{}
 )
 
 // CommentDeleter looks for comments which are no longer useful
@@ -42,15 +42,15 @@ func init() {
 	RegisterMungerOrDie(CommentDeleter{})
 }
 
-// StaleComment is an interface for a munger which writes comments which might go stale
-// and which should be cleaned up
-type StaleComment interface {
-	StaleComments(*github.MungeObject, []*githubapi.IssueComment) []*githubapi.IssueComment
+// StaleIssueComment is an interface for a munger which writes issue comments which might go stale
+// and which should be cleaned up.
+type StaleIssueComment interface {
+	StaleIssueComments(*github.MungeObject, []*githubapi.IssueComment) []*githubapi.IssueComment
 }
 
-// RegisterStaleComments is the method for a munger to register that it creates comment
-// which might go stale and need to be cleaned up
-func RegisterStaleComments(s StaleComment) {
+// RegisterStaleIssueComments is the method for a munger to register that it creates issue comments
+// which might go stale and need to be cleaned up.
+func RegisterStaleIssueComments(s StaleIssueComment) {
 	deleters = append(deleters, s)
 }
 
@@ -102,7 +102,7 @@ func (CommentDeleter) Munge(obj *github.MungeObject) {
 		validComments = append(validComments, comment)
 	}
 	for _, d := range deleters {
-		stale := d.StaleComments(obj, validComments)
+		stale := d.StaleIssueComments(obj, validComments)
 		for _, comment := range stale {
 			obj.DeleteComment(comment)
 		}

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -44,7 +44,7 @@ type LGTMAfterCommitMunger struct{}
 func init() {
 	l := LGTMAfterCommitMunger{}
 	RegisterMungerOrDie(l)
-	RegisterStaleComments(l)
+	RegisterStaleIssueComments(l)
 }
 
 // Name is the name usable in --pr-mungers
@@ -92,7 +92,7 @@ func (LGTMAfterCommitMunger) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (LGTMAfterCommitMunger) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (LGTMAfterCommitMunger) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -113,7 +113,7 @@ func (LGTMAfterCommitMunger) isStaleComment(obj *github.MungeObject, comment *gi
 	return stale
 }
 
-// StaleComments returns a list of comments which are stale
-func (l LGTMAfterCommitMunger) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, l.isStaleComment)
+// StaleIssueComments returns a list of stale issue comments.
+func (l LGTMAfterCommitMunger) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, l.isStaleIssueComment)
 }

--- a/mungegithub/mungers/nag-flake-issues.go
+++ b/mungegithub/mungers/nag-flake-issues.go
@@ -53,7 +53,7 @@ var _ Munger = &NagFlakeIssues{}
 func init() {
 	n := &NagFlakeIssues{}
 	RegisterMungerOrDie(n)
-	RegisterStaleComments(n)
+	RegisterStaleIssueComments(n)
 }
 
 // Name is the name usable in --pr-mungers
@@ -128,8 +128,8 @@ func (NagFlakeIssues) Munge(obj *mgh.MungeObject) {
 	}
 }
 
-// StaleComments returns a slice of stale comments
-func (NagFlakeIssues) StaleComments(obj *mgh.MungeObject, issueComments []*github.IssueComment) []*github.IssueComment {
+// StaleIssueComments returns a slice of stale issue comments.
+func (NagFlakeIssues) StaleIssueComments(obj *mgh.MungeObject, issueComments []*github.IssueComment) []*github.IssueComment {
 	comments := c.FromIssueComments(issueComments)
 	// Remove all pings written before the last human actor comment
 	filtered := c.FilterComments(comments, c.And([]c.Matcher{

--- a/mungegithub/mungers/needs_rebase.go
+++ b/mungegithub/mungers/needs_rebase.go
@@ -45,7 +45,7 @@ const (
 func init() {
 	n := NeedsRebaseMunger{}
 	RegisterMungerOrDie(n)
-	RegisterStaleComments(n)
+	RegisterStaleIssueComments(n)
 }
 
 // Name is the name usable in --pr-mungers
@@ -89,7 +89,7 @@ func (NeedsRebaseMunger) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (NeedsRebaseMunger) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (NeedsRebaseMunger) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -103,7 +103,7 @@ func (NeedsRebaseMunger) isStaleComment(obj *github.MungeObject, comment *github
 	return stale
 }
 
-// StaleComments returns a slice of comments which are stale
-func (n NeedsRebaseMunger) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, n.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (n NeedsRebaseMunger) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, n.isStaleIssueComment)
 }

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -63,7 +63,7 @@ type ReleaseNoteLabel struct {
 func init() {
 	r := &ReleaseNoteLabel{}
 	RegisterMungerOrDie(r)
-	RegisterStaleComments(r)
+	RegisterStaleIssueComments(r)
 }
 
 // Name is the name usable in --pr-mungers
@@ -202,7 +202,7 @@ func releaseNoteAlreadyAdded(obj *github.MungeObject) bool {
 		obj.HasLabel(releaseNoteNone)
 }
 
-func (r *ReleaseNoteLabel) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (r *ReleaseNoteLabel) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -220,7 +220,7 @@ func (r *ReleaseNoteLabel) isStaleComment(obj *github.MungeObject, comment *gith
 	return stale
 }
 
-// StaleComments returns a slice of stale comments
-func (r *ReleaseNoteLabel) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, r.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (r *ReleaseNoteLabel) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, r.isStaleIssueComment)
 }

--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -53,7 +53,7 @@ type SizeMunger struct {
 func init() {
 	s := &SizeMunger{}
 	RegisterMungerOrDie(s)
-	RegisterStaleComments(s)
+	RegisterStaleIssueComments(s)
 }
 
 // Name is the name usable in --pr-mungers
@@ -266,7 +266,7 @@ func calculateSize(adds, dels int) string {
 	return sizeXXL
 }
 
-func (s *SizeMunger) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (s *SizeMunger) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -277,7 +277,7 @@ func (s *SizeMunger) isStaleComment(obj *github.MungeObject, comment *githubapi.
 	return stale
 }
 
-// StaleComments returns a slice of stale comments
-func (s *SizeMunger) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, s.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (s *SizeMunger) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, s.isStaleIssueComment)
 }

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -47,7 +47,7 @@ type StaleGreenCI struct {
 func init() {
 	s := &StaleGreenCI{}
 	RegisterMungerOrDie(s)
-	RegisterStaleComments(s)
+	RegisterStaleIssueComments(s)
 }
 
 // Name is the name usable in --pr-mungers
@@ -115,7 +115,7 @@ func (s *StaleGreenCI) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (s *StaleGreenCI) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (s *StaleGreenCI) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -129,9 +129,9 @@ func (s *StaleGreenCI) isStaleComment(obj *github.MungeObject, comment *githubap
 	return stale
 }
 
-// StaleComments returns a slice of stale comments
-func (s *StaleGreenCI) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, s.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (s *StaleGreenCI) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, s.isStaleIssueComment)
 }
 
 func commentBeforeLastCI(obj *github.MungeObject, comment *githubapi.IssueComment, requiredContexts []string) bool {

--- a/mungegithub/mungers/stale-pending-ci.go
+++ b/mungegithub/mungers/stale-pending-ci.go
@@ -56,7 +56,7 @@ type StalePendingCI struct {
 func init() {
 	s := &StalePendingCI{}
 	RegisterMungerOrDie(s)
-	RegisterStaleComments(s)
+	RegisterStaleIssueComments(s)
 }
 
 // Name is the name usable in --pr-mungers
@@ -110,7 +110,7 @@ func (s *StalePendingCI) Munge(obj *github.MungeObject) {
 	}
 }
 
-func (s *StalePendingCI) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (s *StalePendingCI) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -124,10 +124,10 @@ func (s *StalePendingCI) isStaleComment(obj *github.MungeObject, comment *github
 	return stale
 }
 
-// StaleComments returns a slice of stale comments
-func (s *StalePendingCI) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+// StaleIssueComments returns a slice of stale issue comments.
+func (s *StalePendingCI) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
 	if s.features == nil {
 		return nil // munger not initialized, cannot clean stale comments
 	}
-	return forEachCommentTest(obj, comments, s.isStaleComment)
+	return forEachCommentTest(obj, comments, s.isStaleIssueComment)
 }

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -283,7 +283,7 @@ func init() {
 		githubE2EQueue: map[int]*github.MungeObject{},
 	}
 	RegisterMungerOrDie(sq)
-	RegisterStaleComments(sq)
+	RegisterStaleIssueComments(sq)
 }
 
 // Name is the name usable in --pr-mungers
@@ -1578,7 +1578,7 @@ func (sq *SubmitQueue) serveHealthSVG(res http.ResponseWriter, req *http.Request
 	res.Write(sq.getHealthSVG())
 }
 
-func (sq *SubmitQueue) isStaleComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
+func (sq *SubmitQueue) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
 	if !mergeBotComment(comment) {
 		return false
 	}
@@ -1592,7 +1592,7 @@ func (sq *SubmitQueue) isStaleComment(obj *github.MungeObject, comment *githubap
 	return stale
 }
 
-// StaleComments returns a slice of stale comments
-func (sq *SubmitQueue) StaleComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
-	return forEachCommentTest(obj, comments, sq.isStaleComment)
+// StaleIssueComments returns a slice of stale issue comments.
+func (sq *SubmitQueue) StaleIssueComments(obj *github.MungeObject, comments []*githubapi.IssueComment) []*githubapi.IssueComment {
+	return forEachCommentTest(obj, comments, sq.isStaleIssueComment)
 }


### PR DESCRIPTION
As requested in #2970 

This change is good for clarity since mungegithub now uses comments
from multiple sources besides issue comments (e.g. review comments and
bodies). This distinguishes issue comments from other comment sources and from
generic Comment structs that represent a comment from an arbitrary source.

/cc @spiffxp 