### PR TITLE
Make cla requirement optional in the submit queue

### DIFF
--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -200,6 +200,7 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 	admin.Mux = admin.NewConcurrentMux()
 	sq := new(SubmitQueue)
 	sq.GateApproved = true
+	sq.GateCLA = true
 	sq.RequiredStatusContexts = []string{notRequiredReTestContext1, notRequiredReTestContext2}
 	sq.RequiredRetestContexts = []string{requiredReTestContext1, requiredReTestContext2}
 	sq.BlockingJobNames = []string{"foo"}

--- a/mungegithub/submit-queue/deployment.yaml
+++ b/mungegithub/submit-queue/deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --context-url=$(CONTEXT_URL)
         - --use-reviewers=$(APPROVAL_ACTIVATED)
         - --gate-approved=$(APPROVAL_ACTIVATED)
+        - --gate-cla=$(CLA_ACTIVATED)
         - --github-key=$(GITHUB_KEY)
         - --triage-window=$(TRIAGE_WINDOW)
         - --triage-count=$(TRIAGE_COUNT)
@@ -266,6 +267,11 @@ spec:
               configMapKeyRef:
                 name: @@-sq-config
                 key: approval-activated
+          - name: CLA_ACTIVATED
+            valueFrom:
+              configMapKeyRef:
+                name: @@-sq-config
+                key: cla-activated
           - name: GITHUB_KEY
             valueFrom:
               secretKeyRef:

--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -55,5 +55,5 @@ data:
   triage.count: "0"
   flakyjob.count: "0"
 
-  # Temporary gate approval process
   approval-activated: "true"
+  cla-activated: "true"

--- a/mungegithub/submit-queue/deployment/docs/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/docs/configmap.yaml
@@ -57,3 +57,4 @@ data:
 
   # Temporary gate approval process
   approval-activated: "false"
+  cla-activated: "true"

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -136,5 +136,5 @@ data:
   issue-categorizer.triager-url: "http://issue-triager-service:5000"
   alias.alias-file: "/gitrepos/kubernetes/OWNERS_ALIASES"
 
-  # Temporary gate approval process
   approval-activated: "true"
+  cla-activated: "true"

--- a/mungegithub/submit-queue/deployment/test-infra/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/test-infra/configmap.yaml
@@ -56,3 +56,4 @@ data:
 
   # Temporary gate approval process
   approval-activated: "false"
+  cla-activated: "true"


### PR DESCRIPTION
I opted for a flag instead of pulling all the plugin config. I think gating both cla and approvals should be enough for the simplest usage of the submit queue.

Currently running with this patch on Openshift - all PRs in my poc repo are updated, eg. https://github.com/origin-prow/origin/pull/9

Fixes https://github.com/kubernetes/test-infra/issues/3156

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>