### PR TITLE
prow: plank need not depend on jenkins

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       = 0.31
 SPLICE_VERSION     = 0.21
 TOT_VERSION        = 0.3
 HOROLOGIUM_VERSION = 0.3
-PLANK_VERSION      = 0.25
+PLANK_VERSION      = 0.26
 
 # These are the usual GKE variables.
 PROJECT ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.25
+        image: gcr.io/k8s-prow/plank:0.26
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -65,13 +65,17 @@ func main() {
 		}
 	}
 
-	jenkinsSecretRaw, err := ioutil.ReadFile(*jenkinsTokenFile)
-	if err != nil {
-		logrus.WithError(err).Fatalf("Could not read token file.")
-	}
-	jenkinsToken := string(bytes.TrimSpace(jenkinsSecretRaw))
+	var jc *jenkins.Client
 
-	jc := jenkins.NewClient(*jenkinsURL, *jenkinsUserName, jenkinsToken)
+	if *jenkinsTokenFile != "" {
+		jenkinsSecretRaw, err := ioutil.ReadFile(*jenkinsTokenFile)
+		if err != nil {
+			logrus.WithError(err).Fatalf("Could not read token file.")
+		}
+		jenkinsToken := string(bytes.TrimSpace(jenkinsSecretRaw))
+
+		jc = jenkins.NewClient(*jenkinsURL, *jenkinsUserName, jenkinsToken)
+	}
 
 	oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
 	if err != nil {

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -168,6 +168,10 @@ func (c *Controller) terminateDupes(pjs []kube.ProwJob) error {
 }
 
 func (c *Controller) syncJenkinsJob(pj kube.ProwJob) error {
+	if c.jc == nil {
+		return fmt.Errorf("jenkins client nil, not syncing job %s", pj.Metadata.Name)
+	}
+
 	var jerr error
 	if pj.Complete() {
 		return nil


### PR DESCRIPTION
Changes discussed in https://github.com/kubernetes/test-infra/issues/3221. 

Looks like deck already has this [treatment](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/deck/main.go#L67).