### PR TITLE
deck: serve on non-privileged port

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -17,7 +17,7 @@ all: build test
 
 HOOK_VERSION       = 0.115
 SINKER_VERSION     = 0.10
-DECK_VERSION       = 0.31
+DECK_VERSION       = 0.32
 SPLICE_VERSION     = 0.22
 TOT_VERSION        = 0.3
 HOROLOGIUM_VERSION = 0.3

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,10 +33,10 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.31
+        image: gcr.io/k8s-prow/deck:0.32
         ports:
           - name: http
-            containerPort: 80
+            containerPort: 8080
         args:
         - --jenkins-url=$(JENKINS_URL)
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -86,7 +86,7 @@ func main() {
 	http.Handle("/log", gziphandler.GzipHandler(handleLog(ja)))
 	http.Handle("/rerun", gziphandler.GzipHandler(handleRerun(kc)))
 
-	logrus.WithError(http.ListenAndServe(":http", nil)).Fatal("ListenAndServe returned.")
+	logrus.WithError(http.ListenAndServe(":8080", nil)).Fatal("ListenAndServe returned.")
 }
 
 func handleData(ja *JobAgent) http.HandlerFunc {


### PR DESCRIPTION
Port 80 is a privileged port and in locked-down environments
CAP_NET_BIND_SERVICE is required in order to hold a privileged
port. Instead of adding the capability in the container spec,
use a non-privileged port for deck.

Openshift clusters are locked down by default (the default service
account is running in a restricted PodSecurityPolicy profile where
most capabilities are dropped).
```
$ oc logs -f deck-3975025701-kg28c
{"error":"listen tcp :80: bind: permission denied","level":"fatal","msg":"ListenAndServe returned.","time":"2017-06-30T15:20:22Z"}
```
@spxtr @rmmh @fejta using a non-privileged port fixes the issue. If you guys don't like the change I can make the port configurable.

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>