### PR TITLE
Fix configmap name when replace

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.117
+HOOK_VERSION       = 0.118
 SINKER_VERSION     = 0.10
 DECK_VERSION       = 0.31
 SPLICE_VERSION     = 0.22

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.117
+        image: gcr.io/k8s-prow/hook:0.118
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/plugins/update_config/update_config.go
+++ b/prow/plugins/update_config/update_config.go
@@ -57,6 +57,9 @@ func handleConfig(gc githubClient, kc kubeClient, org, repo, commit string) erro
 	}
 
 	c := kube.ConfigMap{
+		Metadata: kube.ObjectMeta{
+			Name: "config",
+		},
 		Data: map[string]string{
 			"config": string(content),
 		},
@@ -73,6 +76,9 @@ func handlePlugin(gc githubClient, kc kubeClient, org, repo, commit string) erro
 	}
 
 	c := kube.ConfigMap{
+		Metadata: kube.ObjectMeta{
+			Name: "plugins",
+		},
 		Data: map[string]string{
 			"plugins": string(content),
 		},

--- a/prow/plugins/update_config/update_config_test.go
+++ b/prow/plugins/update_config/update_config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package update_config
 
 import (
+	"fmt"
 	"github.com/Sirupsen/logrus"
 	"strings"
 	"testing"
@@ -31,6 +32,9 @@ type fakeKubeClient struct {
 }
 
 func (c *fakeKubeClient) ReplaceConfigMap(name string, config kube.ConfigMap) (kube.ConfigMap, error) {
+	if config.Metadata.Name != name {
+		return kube.ConfigMap{}, fmt.Errorf("name %s does not match configmap name %s", name, config.Metadata.Name)
+	}
 	c.maps[name] = config
 	return c.maps[name], nil
 }


### PR DESCRIPTION
`error:  "response has status "400 Bad Request" and body "{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the name of the object () does not match the name on the URL (config)","reason":"BadRequest","code":400}`

/assign @spxtr 