### PR TITLE
Don't require @ for the /assign or /cc commands.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.118
+HOOK_VERSION       = 0.119
 SINKER_VERSION     = 0.10
 DECK_VERSION       = 0.32
 SPLICE_VERSION     = 0.22

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.118
+        image: gcr.io/k8s-prow/hook:0.119
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -30,8 +30,8 @@ import (
 const pluginName = "assign"
 
 var (
-	assignRe = regexp.MustCompile(`(?mi)^/(un)?assign(( @[-\w]+?)*)\s*$`)
-	ccRe     = regexp.MustCompile(`(?mi)^/(un)?cc(( +@[-\w]+?)*)\s*$`)
+	assignRe = regexp.MustCompile(`(?mi)^/(un)?assign(( @?[-\w]+?)*)\s*$`)
+	ccRe     = regexp.MustCompile(`(?mi)^/(un)?cc(( +@?[-\w]+?)*)\s*$`)
 )
 
 func init() {

--- a/prow/plugins/assign/assign_test.go
+++ b/prow/plugins/assign/assign_test.go
@@ -189,6 +189,13 @@ func TestAssignAndReview(t *testing.T) {
 			assigned:  []string{"fejta"},
 		},
 		{
+			name:      "no @ works too",
+			action:    "created",
+			body:      "/assign fejta",
+			commenter: "rando",
+			assigned:  []string{"fejta"},
+		},
+		{
 			name:       "multi commands",
 			action:     "created",
 			body:       "/assign @fejta\n/unassign @spxtr",
@@ -210,10 +217,10 @@ func TestAssignAndReview(t *testing.T) {
 			body:      "/assign @Invalid$User",
 		},
 		{
-			name:      "require @",
+			name:      "bad login, no @",
 			action:    "created",
 			commenter: "rando",
-			body:      "/assign no at symbol",
+			body:      "/assign Invalid$User",
 		},
 		{
 			name:      "assign friends",
@@ -286,6 +293,13 @@ func TestAssignAndReview(t *testing.T) {
 			requested: []string{"cjwagner"},
 		},
 		{
+			name:      "no @ works too",
+			action:    "created",
+			body:      "/cc cjwagner ",
+			commenter: "rando",
+			requested: []string{"cjwagner"},
+		},
+		{
 			name:        "multi commands",
 			action:      "created",
 			body:        "/cc @cjwagner\n/uncc @spxtr",
@@ -307,10 +321,10 @@ func TestAssignAndReview(t *testing.T) {
 			body:      "/cc @Invalid$User",
 		},
 		{
-			name:      "require @",
+			name:      "bad login",
 			action:    "created",
 			commenter: "rando",
-			body:      "/cc no at symbol",
+			body:      "/cc Invalid$User",
 		},
 		{
 			name:      "request mulitple",


### PR DESCRIPTION
Causes user frustration: https://github.com/kubernetes/kubernetes/pull/48292#issuecomment-312349791

You'll get an email anyways when the issue is assigned to you, so there's no need to require a @ping.

Fixes #3285.