### PR TITLE
Enable `/lgtm` on the kube-aws repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -36,6 +36,9 @@ kubernetes-incubator:
 - cla
 - assign
 
+kubernetes-incubator/kube-aws:
+- lgtm
+
 kubernetes-security/kubernetes:
 - trigger
 


### PR DESCRIPTION
Hi, thanks for maintaining test-infra :smile:

I'm the primary maintainer of [kube-aws](https://github.com/kubernetes-incubator/kube-aws) and I'd like to enable the `/lgtm` command on PRs in our repo as per discussed in 
https://github.com/kubernetes-incubator/kube-aws/issues/717#issuecomment-312316733.

Would any of maintainers review this?

As this is my first time working with test-infra, I'm not even sure if this is a correct way to enable the command.
Any comment, advice, etc would be appreciated.
Thanks!
