### PR TITLE
Increase kubelet verbosity for gce-enormous correctness test

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
@@ -18,6 +18,8 @@ NODE_DISK_SIZE=50GB
 KUBE_DELETE_NETWORK=true
 # Reduce logs verbosity
 TEST_CLUSTER_LOG_LEVEL=--v=1
+# Temporarily increase verbosity for kubelet debugging (#48359).
+KUBELET_TEST_LOG_LEVEL=--v-2
 # Switch off image puller to workaround #32191.
 PREPULL_E2E_IMAGES=false
 MAX_INSTANCES_PER_MIG=1000


### PR DESCRIPTION
/cc @gmarek @wojtek-t 

This will most likely crash jenkins with logs at the end, but we can fix that (like before) by manually deleting some node logs.