### PR TITLE
Add a somewhat e2e test for hook.

### DIFF
--- a/prow/BUILD
+++ b/prow/BUILD
@@ -30,6 +30,7 @@ filegroup(
         "//prow/hook:all-srcs",
         "//prow/jenkins:all-srcs",
         "//prow/kube:all-srcs",
+        "//prow/phony:all-srcs",
         "//prow/plank:all-srcs",
         "//prow/plugins:all-srcs",
         "//prow/slack:all-srcs",

--- a/prow/BUILD
+++ b/prow/BUILD
@@ -27,6 +27,7 @@ filegroup(
         "//prow/cmd/tot:all-srcs",
         "//prow/config:all-srcs",
         "//prow/github:all-srcs",
+        "//prow/hook:all-srcs",
         "//prow/jenkins:all-srcs",
         "//prow/kube:all-srcs",
         "//prow/plank:all-srcs",

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -20,10 +20,7 @@ go_binary(
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "main_test.go",
-        "server_test.go",
-    ],
+    srcs = ["main_test.go"],
     data = [
         "//prow:configs",
     ],
@@ -34,15 +31,12 @@ go_test(
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "events.go",
-        "main.go",
-        "server.go",
-    ],
+    srcs = ["main.go"],
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/hook:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/assign:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/slack"
@@ -152,7 +153,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting plugins.")
 	}
 
-	server := &Server{
+	server := &hook.Server{
 		HMACSecret:  webhookSecret,
 		ConfigAgent: configAgent,
 		Plugins:     pluginAgent,

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "events.go",
+        "server.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -10,9 +10,18 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["server_test.go"],
+    srcs = [
+        "hook_test.go",
+        "server_test.go",
+    ],
     library = ":go_default_library",
     tags = ["automanaged"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/phony:go_default_library",
+        "//prow/plugins:go_default_library",
+    ],
 )
 
 go_library(

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package hook
 
 import (
 	"github.com/Sirupsen/logrus"

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hook
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/phony"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+var ice = github.IssueCommentEvent{
+	Action: "reopened",
+	Repo: github.Repo{
+		Owner: github.User{
+			Login: "foo",
+		},
+		Name:     "bar",
+		FullName: "foo/bar",
+	},
+}
+
+// TestHook sets up a hook.Server and then sends a fake webhook at it. It then
+// ensures that a fake plugin is called.
+func TestHook(t *testing.T) {
+	called := make(chan bool, 1)
+	secret := []byte("123abc")
+	payload, err := json.Marshal(&ice)
+	if err != nil {
+		t.Fatalf("Marshalling ICE: %v", err)
+	}
+	plugins.RegisterIssueHandler("baz", func(pc plugins.PluginClient, ie github.IssueEvent) error {
+		called <- true
+		return nil
+	})
+	pa := &plugins.PluginAgent{}
+	if err := pa.Set(map[string][]string{"foo/bar": []string{"baz"}}); err != nil {
+		t.Fatalf("Setting plugins: %v", err)
+	}
+	ca := &config.Agent{}
+	s := httptest.NewServer(&Server{
+		Plugins:     pa,
+		ConfigAgent: ca,
+		HMACSecret:  secret,
+	})
+	defer s.Close()
+	if err := phony.SendHook(s.URL, "issues", payload, secret); err != nil {
+		t.Fatalf("Error sending hook: %v", err)
+	}
+	select {
+	case <-called: // All good.
+	case <-time.After(time.Second):
+		t.Error("Plugin not called after one second.")
+	}
+}

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package hook
 
 import (
 	"encoding/json"

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package hook
 
 import (
 	"net/http"

--- a/prow/phony/BUILD
+++ b/prow/phony/BUILD
@@ -4,24 +4,14 @@ licenses(["notice"])
 
 load(
     "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
     "go_library",
-)
-
-go_binary(
-    name = "phony",
-    library = ":go_default_library",
-    tags = ["automanaged"],
 )
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = ["phony.go"],
     tags = ["automanaged"],
-    deps = [
-        "//prow/phony:go_default_library",
-        "//vendor:github.com/Sirupsen/logrus",
-    ],
+    deps = ["//prow/github:go_default_library"],
 )
 
 filegroup(

--- a/prow/phony/phony.go
+++ b/prow/phony/phony.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phony
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+// SendHook sends a GitHub event of type eventType to the provided address.
+func SendHook(address, eventType string, payload, hmac []byte) error {
+	req, err := http.NewRequest(http.MethodPost, address, bytes.NewBuffer(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-GitHub-Event", eventType)
+	req.Header.Set("X-Hub-Signature", github.PayloadSignature(payload, hmac))
+	req.Header.Set("content-type", "application/json")
+
+	c := &http.Client{}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	rb, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("response from hook has status %d and body %s", resp.StatusCode, string(bytes.TrimSpace(rb)))
+	}
+	return nil
+}


### PR DESCRIPTION
I didn't have any coverage for the webhook -> unmarshal -> call plugins path. Now I do. I call it a "somewhat e2e" test because it's exercising the full hook behavior, and I already have unit tests for most of the in-between pieces. It's still not a true e2e test.