### PR TITLE
Migrate jobs to use --test_args instead of GINKGO_TEST_ARGS and SKEW_KUBECTL

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -435,51 +435,51 @@ testSuites:
   alphafeatures:
     args:
     - --timeout=180m
+    - --test_args=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
     envs:
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
   autoscaling:
     args:
     - --timeout=300m
+    - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
     envs:
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
   default:
     args:
     - --timeout=50m
+    - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
     envs:
     - GINKGO_PARALLEL=y
     - GINKGO_PARALLEL_NODES=30
-    - GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
   flaky:
     args:
     - --timeout=300m
+    - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
     envs:
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
   ingress:
     args:
     - --timeout=300m
+    - --test_args=--test_args=--ginkgo.focus=\[Feature:Ingress\]
     envs:
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
   reboot:
     args:
     - --timeout=180m
+    - --test_args=--ginkgo.focus=\[Feature:Reboot\]
     envs:
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
   serial:
     args:
     - --timeout=500m
+    - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
     envs:
     - GINKGO_PARALLEL=n
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
   slow:
     args:
     - --timeout=150m
+    - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
     envs:
     - GINKGO_PARALLEL=y
     - GINKGO_PARALLEL_NODES=30
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
   updown:
     args:
     - --timeout=30m
+    - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
     envs:
     - GINKGO_PARALLEL=y
-    - GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2175,6 +2175,7 @@ class JobTest(unittest.TestCase):
                     ('FAIL_ON_GCP_RESOURCE_LEAK=', '--check-leaked-resources=true|false'),
                     ('FEDERATION_DOWN=', '--down=true|false'),
                     ('FEDERATION_UP=', '--up=true|false'),
+                    ('GINKGO_TEST_ARGS=', '--test_args=FOO'),
                     ('GINKGO_UPGRADE_TEST_ARGS=', '--upgrade_args=FOO'),
                     ('JENKINS_FEDERATION_PREFIX=', '--stage=gs://FOO'),
                     ('JENKINS_PUBLISHED_VERSION=', '--extract=V'),
@@ -2190,10 +2191,14 @@ class JobTest(unittest.TestCase):
                     ('JENKINS_USE_GCI_HEAD_IMAGE_FAMILY=', '--extract=gci/FAMILY'),
                     ('KUBEKINS_TIMEOUT=', '--timeout=XXm'),
                     ('PERF_TESTS=', '--perf'),
+                    ('SKEW_KUBECTL=', '--test_args=--kubectl-path=FOO'),
                     ('USE_KUBEMARK=', '--kubemark'),
                 ]
                 for env, fix in black:
-                    if 'JENKINS_PUBLISHED_VERSION' in env and 'kops' in job:
+                    if 'kops' in job and env in [
+                            'JENKINS_PUBLISHED_VERSION=',
+                            'GINKGO_TEST_ARGS=',
+                    ]:
                         continue  # TOOD(fejta): migrate kops jobs
                     if env in line:
                         self.fail('[%s]: Env %s: Convert %s to use %s in jobs/config.json' % (

--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -49,14 +49,4 @@ for arg in "${@}" "${e2e_go_args[@]}"; do
   fi
 done
 
-if [[ "${E2E_TEST:-}" == "true" ]]; then
-  e2e_go_args+=(--test)
-  if [[ "${SKEW_KUBECTL:-}" == 'y' ]]; then
-      GINKGO_TEST_ARGS="${GINKGO_TEST_ARGS:-} --kubectl-path=$(pwd)/kubernetes_skew/cluster/kubectl.sh"
-  fi
-  if [[ -n "${GINKGO_TEST_ARGS:-}" ]]; then
-    e2e_go_args+=(--test_args="${GINKGO_TEST_ARGS}")
-  fi
-fi
-
 kubetest "${e2e_go_args[@]}" "${@}"

--- a/jobs/ci-kubernetes-e2e-aws-release-1.5.env
+++ b/jobs/ci-kubernetes-e2e-aws-release-1.5.env
@@ -15,5 +15,4 @@ GINKGO_PARALLEL=y
 # expected empty
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|NodeProblemDetector
 

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env
@@ -1,5 +1,4 @@
 ### job-env
 KUBE_OS_DISTRIBUTION=gci
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-cos-docker-val-serial
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_OS_DISTRIBUTION=gci
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-cos-docker-val-slow
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-cos-docker-validation.env
+++ b/jobs/ci-kubernetes-e2e-cos-docker-validation.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_OS_DISTRIBUTION=gci
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-cos-docker-val
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-1-5-1-6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-5-1-6-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gce-cvm-1-5-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
@@ -7,4 +6,3 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-5-1-6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-5-1-6-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gce-gci-1-5-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
@@ -7,4 +6,3 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-5-1-6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-5-1-6-upgrade-cluster.env
@@ -8,4 +8,3 @@ PROJECT=k8s-gce-upg-1-5-1-6-up-clu
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-5-1-6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-5-1-6-upgrade-master.env
@@ -8,4 +8,3 @@ PROJECT=k8s-gce-upg-1-5-1-6-up-mas
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-5-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gce-cvm-1-6-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-5-downgrade-cluster.env
@@ -14,5 +14,4 @@ STORAGE_MEDIA_TYPE=application/json
 
 # Rather than downgrading and then running e2e tests, just downgrade.
 # etcd flags are specific to the 1.6 to 1.5 downgrade
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --gce-upgrade-script=/workspace/kubernetes_skew/cluster/gce/upgrade.sh --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1
 

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-5-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gce-gci-1-6-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew-serial.env
@@ -1,7 +1,5 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gce-cvm-1-6-m-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew.env
@@ -1,7 +1,5 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gce-cvm-1-6-mstr-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew-serial.env
@@ -1,7 +1,5 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gce-gci-1-6-m-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew.env
@@ -1,7 +1,5 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gce-gci-1-6-mstr-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster-new.env
@@ -4,6 +4,5 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-g1-4-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster.env
@@ -4,8 +4,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-g1-4-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master.env
@@ -4,8 +4,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=gce-up-c1-3-g1-4-up-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew-serial.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gce-cvm-m-1-6-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gce-cvm-mstr-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew-serial.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gce-gci-m-1-6-ctl-skw-srl
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gce-gci-mstr-1-6-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-4.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\]
 PROJECT=k8s-jkns-e2e-gce-alpha1-4
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
 PROJECT=k8s-e2e-gce-alpha1-5
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-6.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
 PROJECT=k8s-jkns-gce-alpha-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]|Initializers
 PROJECT=k8s-jkns-e2e-gce-serial-1-2
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gce-alpha-features.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gce-alpha
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(DynamicKubeletConfig|Audit)\]|Initializers
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-audit-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-audit-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
 KUBE_FEATURE_GATES=AdvancedAuditing=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Audit\]
 PROJECT=k8s-jkns-gci-gke-slow-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-audit.env
+++ b/jobs/ci-kubernetes-e2e-gce-audit.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-gke-1-4
 KUBE_FEATURE_GATES=AdvancedAuditing=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Audit\]
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.env
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling-migs.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 PROJECT=k8s-jnks-e2e-gce-autoscl-migs
 # Override GCE default for cluster size autoscaling purposes.
 KUBE_ENABLE_CLUSTER_AUTOSCALER=true

--- a/jobs/ci-kubernetes-e2e-gce-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-gce-autoscaling.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\]
 PROJECT=k8s-jnks-e2e-gce-autoscaling
 
 # Override GCE default for cluster size autoscaling purposes.

--- a/jobs/ci-kubernetes-e2e-gce-canary.env
+++ b/jobs/ci-kubernetes-e2e-gce-canary.env
@@ -1,5 +1,4 @@
 # Everything else is the same as the other job it is testing
-GINKGO_TEST_ARGS=--ginkgo.focus=Variable.Expansion
 
 # Test update gcloud code path
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/ci/staging
@@ -7,4 +6,3 @@ CLOUDSDK_BUCKET=gs://cloud-sdk-testing/ci/staging
 # Test --upgrade_args and --extract=E --extract=E
 KUBE_NODE_OS_DISTRIBUTION=debian
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-container-vm.env
+++ b/jobs/ci-kubernetes-e2e-gce-container-vm.env
@@ -1,6 +1,5 @@
 ### job-env
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jenkins-cvm
 KUBE_GCE_NODE_IMAGE=container-v1-3-v20160604

--- a/jobs/ci-kubernetes-e2e-gce-cosbeta-no-snat.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosbeta-no-snat.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:NoSNAT\]
 GINKGO_PARALLEL=n
 GINKGO_PARALLEL_NODES=1
 PROJECT=k8s-e2e-170223

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-default.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial.env
@@ -15,7 +15,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-default.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-serial.env
@@ -15,7 +15,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-slow.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-default.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial.env
@@ -15,7 +15,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-default.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial.env
@@ -17,7 +17,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-default.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial.env
@@ -17,7 +17,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-default.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial.env
@@ -17,7 +17,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-default.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial.env
@@ -17,7 +17,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-default.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial.env
@@ -17,7 +17,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow.env
@@ -18,7 +18,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=cos-image-validation

--- a/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-cluster.env
@@ -35,7 +35,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 ### job-env
 GINKGO_PARALLEL=y
 #GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=50
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=120m --system-pods-startup-timeout=5m --kube-api-content-type=application/vnd.kubernetes.protobuf
 CLUSTER_IP_RANGE=10.160.0.0/11
 NUM_NODES=5000
 ALLOWED_NOTREADY_NODES=50

--- a/jobs/ci-kubernetes-e2e-gce-enormous-deploy.env
+++ b/jobs/ci-kubernetes-e2e-gce-enormous-deploy.env
@@ -29,7 +29,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Empty\]
 CLUSTER_IP_RANGE=10.224.0.0/13
 NUM_NODES=500
 ALLOWED_NOTREADY_NODES=5

--- a/jobs/ci-kubernetes-e2e-gce-es-logging.env
+++ b/jobs/ci-kubernetes-e2e-gce-es-logging.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=kubernetes-es-logging
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Elasticsearch\]
 KUBE_LOGGING_DESTINATION=elasticsearch
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-etcd2-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd2-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-etcd2-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-etcd3-pr-validate.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3-pr-validate.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-gke-alpha-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-etcd3-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gce-etcd3-1-5
 TEST_ETCD_IMAGE=3.0.17

--- a/jobs/ci-kubernetes-e2e-gce-etcd3.env
+++ b/jobs/ci-kubernetes-e2e-gce-etcd3.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-etcd3
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-examples.env
+++ b/jobs/ci-kubernetes-e2e-gce-examples.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Example\]
 PROJECT=k8s-jkns-e2e-examples
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1-6.env
@@ -11,7 +11,6 @@ E2E_ZONES=us-central1-a us-central1-b us-central1-f
 FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
 
 FEDERATION_DNS_ZONE_NAME=release1-6.test-f8n.k8s.io.
 

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1-7.env
@@ -11,7 +11,6 @@ E2E_ZONES=us-central1-a us-central1-b us-central1-f
 FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
 
 FEDERATION_DNS_ZONE_NAME=release1-7.test-f8n.k8s.io.
 

--- a/jobs/ci-kubernetes-e2e-gce-federation-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-serial.env
@@ -15,7 +15,6 @@ FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 # it just uses golang's regexp library, which in turn uses
 # RE2 which doesn't support lookaheads. So we are living with
 # this for now.
-GINKGO_TEST_ARGS=--ginkgo.focus=(\[Feature:Federation\].*(\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]))
 
 # We don't have namespaces yet in federation apiserver, so we need to serialize
 GINKGO_PARALLEL=n

--- a/jobs/ci-kubernetes-e2e-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation.env
@@ -10,7 +10,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
 FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
 
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gce-flaky.env
+++ b/jobs/ci-kubernetes-e2e-gce-flaky.env
@@ -1,6 +1,5 @@
 ### job-env
 JENKINS_USE_GET_KUBE_SCRIPT=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gce-flaky
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-garbage.env
+++ b/jobs/ci-kubernetes-e2e-gce-garbage.env
@@ -1,6 +1,5 @@
 ### job-env
 # Start the gc in controller plane
 PROJECT=k8s-jenkins-garbagecollector
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:GarbageCollector\]
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd.env
@@ -10,6 +10,3 @@ STORAGE_MEDIA_TYPE=application/json
 
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-5-rb-etcd
-
-
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-1-5-upgrade-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-1-5-upgrade-etcd.env
@@ -10,6 +10,3 @@ STORAGE_MEDIA_TYPE=application/json
 
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-g1-5-up-etcd
-
-
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-master.env
@@ -2,7 +2,6 @@
 # The master branch will always use GCI images built from its
 # tip of tree, categorized in family `gci-canary`.
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-master
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env
@@ -1,7 +1,6 @@
 ### job-env
 # To qualify GCI milestone 56 for k8s release-1.4.
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-1-4
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-1-5
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env
@@ -1,5 +1,4 @@
 ### job-env
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-ci-serial
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env
@@ -1,6 +1,5 @@
 ### job-env
 # To qualify GCI milestone 56 for k8s release-1.4.
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=kubekins-gce-gci-ci-serial-1-4
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=kubekins-gce-gci-ci-serial-1-5
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env
@@ -1,6 +1,5 @@
 ### job-env
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-master-slow
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env
@@ -1,7 +1,6 @@
 ### job-env
 # To qualify GCI milestone 56 for k8s release-1.4.
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-slow-1-4
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-slow-1-5
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd.env
@@ -7,6 +7,3 @@ STORAGE_MEDIA_TYPE=application/json
 
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-glat-rb-etcd
-
-
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd.env
@@ -7,6 +7,3 @@ STORAGE_MEDIA_TYPE=application/json
 
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=gce-up-glat-up-etcd
-
-
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m58.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m58.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-m58
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m59.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m59.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-m59
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-m60.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-m60.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-m60
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-master.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-master
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m58.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m58.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-qa-serial-m58
 JENKINS_GCI_PATCH_K8S=n
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m59.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m59.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-qa-serial-m59
 JENKINS_GCI_PATCH_K8S=n
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m60.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m60.env
@@ -1,6 +1,5 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-qa-serial-m60
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-qa-serial-master
 JENKINS_GCI_PATCH_K8S=n
 

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m58.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m58.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-slow-m58
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m59.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m59.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-slow-m59
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m60.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m60.env
@@ -1,7 +1,6 @@
 # Use GCI builtin k8s version.
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-slow-m60
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.env
@@ -2,7 +2,6 @@
 
 ### job-env
 JENKINS_USE_GET_KUBE_SCRIPT=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-qa-slow-master
 JENKINS_GCI_PATCH_K8S=n

--- a/jobs/ci-kubernetes-e2e-gce-gpu.env
+++ b/jobs/ci-kubernetes-e2e-gce-gpu.env
@@ -1,7 +1,6 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gce-gpus
 KUBE_FEATURE_GATES=Accelerators=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:GPU\]
 KUBE_NODE_OS_DISTRIBUTION=gci
 KUBE_GCI_VERSION=cos-stable-59-9460-60-0
 NODE_ACCELERATORS=type=nvidia-tesla-k80,count=2

--- a/jobs/ci-kubernetes-e2e-gce-ha-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-ha-master.env
@@ -4,7 +4,6 @@ KUBE_GCE_ZONE=us-central1-f
 CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:HAMaster\]
 PROJECT=kubernetes-ha-master
 # TODO: Enable this when we've split 1.2 tests into another project.
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-ingress.env
+++ b/jobs/ci-kubernetes-e2e-gce-ingress.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=kubernetes-ingress
 # TODO: Enable this when we've split 1.2 tests into another project.
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env
@@ -1,7 +1,6 @@
 ### job-env
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-lat-cluster
 

--- a/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env
@@ -1,7 +1,6 @@
 ### job-env
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-lat-master
 

--- a/jobs/ci-kubernetes-e2e-gce-master-new-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-new-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=gce-cvm-upg-1-5-1-4-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=gce-gci-upg-1-5-1-4-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gce-multizone.env
+++ b/jobs/ci-kubernetes-e2e-gce-multizone.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gce-ubelite
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 MULTIZONE=true
 

--- a/jobs/ci-kubernetes-e2e-gce-new-master-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-new-master-cvm-kubectl-skew.env
@@ -1,7 +1,5 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=gce-cvm-upg-1-4-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=debian
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew.env
@@ -1,7 +1,5 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=gce-gci-upg-1-4-1-5-ctl-skew
 KUBE_NODE_OS_DISTRIBUTION=gci
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
@@ -4,4 +4,3 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-1-4-1-5-upg-clu
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-new-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-new-master-upgrade-master.env
@@ -4,4 +4,3 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gce-upg-1-4-1-5-upg-mas
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gce-proto.env
+++ b/jobs/ci-kubernetes-e2e-gce-proto.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kube-api-content-type=application/vnd.kubernetes.protobuf
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-protobuf
 # Store protobufs in database.

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gce-reboot-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-gce-reboot-1-5
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gce-reboot-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-reboot-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gce-reboot-1-3
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-reboot.env
+++ b/jobs/ci-kubernetes-e2e-gce-reboot.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-jkns-e2e-gce-ci-reboot
 

--- a/jobs/ci-kubernetes-e2e-gce-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gce-1-5
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-gce-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-1-3
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1-6.env
@@ -1,7 +1,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 # Use the 1.1 project for now, since it has quota.
 # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
 PROJECT=k8s-e2e-gce-scalability-1-1

--- a/jobs/ci-kubernetes-e2e-gce-scalability-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-scalability-release-1-7.env
@@ -1,7 +1,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 # Use the 1.1 project for now, since it has quota.
 # TODO: create a project k8s-e2e-gce-scalability-release and move this test there
 PROJECT=k8s-e2e-gce-scalability-1-1

--- a/jobs/ci-kubernetes-e2e-gce-scalability.env
+++ b/jobs/ci-kubernetes-e2e-gce-scalability.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 
 # Create a project k8s-jenkins-scalability-head and move this test there
 PROJECT=google.com:k8s-jenkins-scalability

--- a/jobs/ci-kubernetes-e2e-gce-sd-logging.env
+++ b/jobs/ci-kubernetes-e2e-gce-sd-logging.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-gce-sd-log
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StackdriverLogging\]
 KUBE_LOGGING_DESTINATION=gcp
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gce-serial-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-gce-serial-1-5
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gce-serial-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-serial-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gce-serial-1-3
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-serial.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=kubernetes-jkns-e2e-gce-serial
 KUBE_NODE_OS_DISTRIBUTION=debian
 

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-slow-1-4
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gce-slow-1-5
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-slow-1-6
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-slow-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gce-slow-1-3
 KUBE_NODE_OS_DISTRIBUTION=debian

--- a/jobs/ci-kubernetes-e2e-gce-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-slow.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 # Run outside US to improve test coverage (kubernetes/kubernetes#26361)
 KUBE_GCE_ZONE=europe-west1-c

--- a/jobs/ci-kubernetes-e2e-gce-stackdriver.env
+++ b/jobs/ci-kubernetes-e2e-gce-stackdriver.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StackdriverMonitoring\]
 PROJECT=k8s-jkns-e2e-gce-stackdriver
 
 KUBE_ENABLE_CLUSTER_MONITORING=stackdriver

--- a/jobs/ci-kubernetes-e2e-gce-statefulset.env
+++ b/jobs/ci-kubernetes-e2e-gce-statefulset.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StatefulSet\]
 PROJECT=kubernetes-petset
 
 # TODO: Enable once we've fixed #23032

--- a/jobs/ci-kubernetes-e2e-gce-taint-evict.env
+++ b/jobs/ci-kubernetes-e2e-gce-taint-evict.env
@@ -4,7 +4,6 @@ KUBE_GCE_ZONE=us-central1-f
 CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS=1
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:TaintEviction\]
 PROJECT=k8s-jkns-gce-taintevict
 # TODO: Enable this when we've split 1.2 tests into another project.
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial.env
@@ -15,7 +15,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial.env
@@ -15,7 +15,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-default.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial.env
@@ -15,7 +15,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow.env
@@ -16,7 +16,6 @@ KUBE_NODE_OS_DISTRIBUTION=ubuntu
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-dev-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-default.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-default.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow.env
+++ b/jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-os-gke-cloud-tests

--- a/jobs/ci-kubernetes-e2e-gce.env
+++ b/jobs/ci-kubernetes-e2e-gce.env
@@ -1,6 +1,5 @@
 ### job-env
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=k8s-jkns-e2e-gce

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
 PROJECT=k8s-jkns-e2e-gci-gce-alpha1-4
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
 PROJECT=k8s-e2e-gci-gce-alpha1-5
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6.env
@@ -1,6 +1,5 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
 PROJECT=k8s-jkns-gci-gce-alpha-1-6
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
 PROJECT=k8s-jkns-gci-gce-serial-1-2
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-alpha-features.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gci-gce-alpha
 KUBE_FEATURE_GATES=AllAlpha=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Audit\]
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-audit-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-audit-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
 KUBE_FEATURE_GATES=AdvancedAuditing=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Audit\]
 PROJECT=k8s-jkns-gke-reboot-1-4
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-audit.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-audit.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-gke-slow-1-4
 KUBE_FEATURE_GATES=AdvancedAuditing=true
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Audit\]
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 PROJECT=k8s-jkns-gci-autoscaling-migs
 # Override GCE default for cluster size autoscaling purposes.
 KUBE_ENABLE_CLUSTER_AUTOSCALER=true

--- a/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-autoscaling.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\]
 PROJECT=k8s-jkns-gci-autoscaling
 # Override GCE default for cluster size autoscaling purposes.
 ENABLE_CUSTOM_METRICS=true

--- a/jobs/ci-kubernetes-e2e-gci-gce-docker.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-docker.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 KUBE_OS_DISTRIBUTION=gci
 PROJECT=k8s-docker-validation-gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-es-logging.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-es-logging.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=kubernetes-gci-es-logging
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Elasticsearch\]
 KUBE_LOGGING_DESTINATION=elasticsearch
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-etcd3.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-etcd3.env
@@ -1,6 +1,5 @@
 ### job-env
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-etcd3
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-examples.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-examples.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Example\]
 PROJECT=k8s-jkns-e2e-gci-examples
 KUBE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-flaky.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-flaky.env
@@ -1,6 +1,5 @@
 ### job-env
 JENKINS_USE_GET_KUBE_SCRIPT=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gce-flaky
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-garbage.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-garbage.env
@@ -1,6 +1,5 @@
 ### job-env
 # Start the gc in controller plane
 PROJECT=k8s-jkns-gci-garbage
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:GarbageCollector\]
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-jkns-gci-gce-ingress1-4
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-gci-gce-ingress1-5
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-jkns-gci-gce-ingress-1-6
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-7.env
@@ -1,4 +1,3 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=kubernetes-gci-ingress-1-3
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-ingress.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ingress.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=kubernetes-gci-ingress
 # TODO: Enable this when we've split 1.2 tests into another project.
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-ip-alias.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-ip-alias.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 KUBE_OS_DISTRIBUTION=gci
 PROJECT=k8s-jenkins-gce-gci-ip-aliases

--- a/jobs/ci-kubernetes-e2e-gci-gce-proto.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-proto.env
@@ -1,6 +1,5 @@
 ### job-env
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kube-api-content-type=application/vnd.kubernetes.protobuf
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-gce-protobuf
 # Store protobufs in database.

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gci-gce-reboot-1-4
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-gci-gce-reboot-1-5
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gci-gce-reboot-1-6
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gci-gce-reboot-1-3
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-reboot.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-reboot.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 KUBE_NODE_OS_DISTRIBUTION=gci
 PROJECT=k8s-jkns-gci-gce-reboot
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-1-4
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-1-5
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-gci-gce-1-6
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-gce-1-3
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-6.env
@@ -2,7 +2,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 
 # Use the 1.4 project for now, since it has quota.
 # TODO: create a project k8s-e2e-gce-scalability-release and move this test there

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-7.env
@@ -2,7 +2,6 @@
 KUBE_GCE_ZONE=us-east1-b
 
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 
 # Use the 1.1 project for now, since it has quota.
 # TODO: create a project k8s-e2e-gce-scalability-release and move this test there

--- a/jobs/ci-kubernetes-e2e-gci-gce-scalability.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-scalability.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Performance\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json
 
 # Create a project k8s-jenkins-scalability-head and move this test there
 PROJECT=k8s-jenkins-gci-scalability

--- a/jobs/ci-kubernetes-e2e-gci-gce-sd-logging.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-sd-logging.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-gci-gce-sd-log
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StackdriverLogging\]
 KUBE_LOGGING_DESTINATION=gcp
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-ci-serial-1-4
 KUBE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=e2e-gce-gci-ci-serial-1-5
 KUBE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gce-serial-1-6
 KUBE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-7.env
@@ -1,4 +1,3 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gce-serial-1-3
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-serial.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-serial.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gce-gci-serial
 KUBE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-4.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-slow-1-4
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-slow-1-5
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-gce-slow-1-6
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-gce-slow-1-3
 KUBE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gce-slow.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-slow.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 # Run outside US to improve test coverage (kubernetes/kubernetes#26361)
 KUBE_GCE_ZONE=europe-west1-c

--- a/jobs/ci-kubernetes-e2e-gci-gce-statefulset.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-statefulset.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StatefulSet\]
 PROJECT=kubernetes-gci-petset
 
 # TODO: Enable once we've fixed #23032

--- a/jobs/ci-kubernetes-e2e-gci-gce.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce.env
@@ -1,6 +1,5 @@
 ### job-env
 # This list should match the list in kubernetes-pull-build-test-e2e-gce.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 KUBE_OS_DISTRIBUTION=gci
 PROJECT=k8s-jkns-e2e-gce-gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-alpha-features.env
@@ -1,7 +1,6 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gci-gke-alpha
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci
 

--- a/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-autoscaling.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 NUM_NODES=3
 PROJECT=k8s-e2e-gci-gke-autoscaling
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-flaky.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-flaky.env
@@ -1,7 +1,6 @@
 ### job-env
 JENKINS_USE_GET_KUBE_SCRIPT=y
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gci-gke-ci-flaky
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-gci-gke-ingress-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=k8s-jkns-gci-gke-ingress-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=kubernetes-gci-gke-ingress-1-3
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-ingress.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-ingress.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=kubernetes-gci-gke-ingress
 # TODO: Enable this when we've split 1.2 tests into another project.
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-multizone.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-multizone.env
@@ -1,7 +1,6 @@
 ### job-env
 ADDITIONAL_ZONES=us-central1-a,us-central1-b
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gci-gke-multizone
 ZONE=us-central1-f
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.env
@@ -2,7 +2,6 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-e2e-gci-gke-prod-parallel
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.env
@@ -2,7 +2,6 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-e2e-gci-gke-prod-smoke
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-prod.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-prod.env
@@ -5,4 +5,3 @@ PROJECT=k8s-jkns-e2e-gci-gke-prod
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci
 ZONE=us-central1-b
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-gci-gke-reboot-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gci-gke-reboot-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gci-gke-reboot-1-3
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-reboot.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-reboot.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-e2e-gci-gke-ci-reboot
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-gci-gke-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1-6.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gke-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-release-1-7.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gke-1-3
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-gci-gke-serial-1-5
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gke-serial-1-6
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gci-gke-serial-1-3
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-serial.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-serial.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=jenkins-gke-gci-e2e-serial
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gci-gke-slow-1-5
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-gke-slow-1-6
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gci-gke-slow-1-3
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-slow.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-slow.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-gke-gci-slow
 KUBE_GKE_IMAGE_TYPE=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.env
@@ -2,7 +2,6 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-e2e-gci-gke-staging-plel
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke-staging.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-staging.env
@@ -4,4 +4,3 @@ CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 PROJECT=k8s-jkns-e2e-gci-gke-staging
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gci-gke-updown.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke-updown.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 PROJECT=kubernetes-e2e-gci-gke-updown
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gci-gke.env
+++ b/jobs/ci-kubernetes-e2e-gci-gke.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gke-gci-ci
 KUBE_GKE_IMAGE_TYPE=gci
 KUBE_NODE_OS_DISTRIBUTION=gci

--- a/jobs/ci-kubernetes-e2e-gke-1-5-1-6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-5-1-6-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gke-cvm-1-5-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
@@ -8,4 +7,3 @@ ZONE=us-central1-c
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1-5-1-6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-5-1-6-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gke-gci-1-5-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
@@ -8,4 +7,3 @@ ZONE=us-central1-c
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1-6-1-5-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-6-1-5-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gke-cvm-1-6-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-1-6-1-5-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-6-1-5-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=k8s-gke-gci-1-6-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew-serial.env
@@ -1,8 +1,6 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gke-cvm-1-6-m-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew.env
@@ -1,8 +1,6 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gke-cvm-1-6-mstr-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew-serial.env
@@ -1,8 +1,6 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gke-gci-1-6-m-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew.env
@@ -1,8 +1,6 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gke-gci-1-6-mstr-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew-serial.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gke-cvm-m-1-6-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gke-cvm-mstr-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew-serial.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl.*\[Serial\]
 PROJECT=k8s-gke-gci-m-1-6-ctl-skw-srl
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]
 PROJECT=k8s-gke-gci-mstr-1-6-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-e2e-gke-alpha-1-5
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly)\]
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-6.env
@@ -1,6 +1,5 @@
 ### job-env
 PROJECT=k8s-jkns-gke-alpha-1-6
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-gke-alpha-features.env
@@ -1,7 +1,6 @@
 ### job-env
 PROJECT=k8s-jkns-e2e-gke-alpha
 GKE_CREATE_FLAGS=--enable-kubernetes-alpha
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
 # Use gcloud credentials for authentication
 CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=false
 

--- a/jobs/ci-kubernetes-e2e-gke-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-gke-autoscaling.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 NUM_NODES=3
 PROJECT=k8s-e2e-gke-autoscaling
 

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-cluster.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-master.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster-new.env
@@ -4,6 +4,5 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-clat-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster.env
@@ -5,8 +5,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-clat-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-master.env
@@ -5,8 +5,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-clat-up-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-cluster.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-master.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster-new.env
@@ -4,6 +4,5 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-glat-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster.env
@@ -5,8 +5,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-glat-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-master.env
@@ -5,8 +5,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=gke-up-c1-3-glat-up-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster-new.env
@@ -4,7 +4,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=kube-gke-upg-1-3-1-4-upg-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster.env
@@ -4,11 +4,9 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf::
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=kube-gke-upg-1-3-1-4-upg-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-master.env
@@ -4,11 +4,9 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=kube-gke-upg-1-3-1-4-upg-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster-new.env
@@ -4,7 +4,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-g1-4-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster.env
@@ -4,11 +4,9 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-g1-4-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-master.env
@@ -4,11 +4,9 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=container_vm
 PROJECT=gke-up-c1-3-g1-4-up-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-cluster.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-c1-4-c1-6-up-clu
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-master.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-c1-4-c1-6-up-mas
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-cluster.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-c1-4-g1-6-up-clu
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-master.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-c1-4-g1-6-up-mas
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-stable-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-stable-cvm-master-upgrade-master.env
@@ -6,4 +6,3 @@ KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=kube-gke-upg-1-1-1-2-upg-mas
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master.env
@@ -6,4 +6,3 @@ KUBE_GKE_IMAGE_TYPE=container_vm
 
 PROJECT=kube-gke-upg-1-2-1-3-upg-mas
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-flaky.env
+++ b/jobs/ci-kubernetes-e2e-gke-flaky.env
@@ -1,6 +1,5 @@
 ### job-env
 JENKINS_USE_GET_KUBE_SCRIPT=y
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gke-ci-flaky
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-cluster.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-master.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster-new.env
@@ -4,6 +4,5 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-clat-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster.env
@@ -5,8 +5,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-clat-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-master.env
@@ -5,8 +5,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-clat-up-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-cluster.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-master.env
@@ -11,4 +11,3 @@ ZONE=us-central1-a
 # Enable when testing upgrades from a version < 1.6 to a version >= 1.6
 ENABLE_LEGACY_ABAC=true
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster-new.env
@@ -4,6 +4,5 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-glat-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster.env
@@ -5,8 +5,6 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-glat-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-master.env
@@ -5,7 +5,5 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=gke-up-g1-3-glat-up-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster-new.env
@@ -4,7 +4,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-c1-4-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster.env
@@ -4,11 +4,9 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-c1-4-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-master.env
@@ -4,11 +4,9 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-c1-4-up-mas
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-5-downgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-5-downgrade-cluster.env
@@ -4,7 +4,6 @@ PROJECT=k8s-gke-dg-g1-6-g1-5-dwngr-clu
 
 
 # Rather than downgrading and then running e2e tests, just downgrade.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci
 
 ### version-env
 ZONE=us-central1-a

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster-new.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster-new.env
@@ -4,7 +4,6 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-g1-4-up-clu-n
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster.env
@@ -4,11 +4,9 @@
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 PROJECT=gke-up-g1-3-g1-4-up-clu
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 ### version-env
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-master.env
@@ -7,8 +7,6 @@ PROJECT=gke-up-g1-3-g1-4-up-mas
 
 ### version-env
 ZONE=us-central1-a
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-ci-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-ci-master.env
@@ -1,7 +1,6 @@
 ### job-env
 # Use Google credentials to authenticate to the cluster API server
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 # The master branch will always use GCI images built from its
 # tip of tree, categorized in family `gci-canary`.

--- a/jobs/ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-cluster.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-g1-4-c1-6-up-clu
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-master.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-g1-4-c1-6-up-mas
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-g1-4-g1-6-up-clu
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master.env
@@ -9,4 +9,3 @@ PROJECT=k8s-gke-upg-g1-4-g1-6-up-mas
 ZONE=us-central1-a
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-stable-cvm-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-stable-cvm-master-upgrade-master.env
@@ -5,5 +5,3 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=kube-gke-upg-1-1-1-3-upg-mas
-
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master.env
@@ -6,4 +6,3 @@ KUBE_GKE_IMAGE_TYPE=gci
 
 PROJECT=kube-gke-upg-1-2-1-4-upg-mas
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-gpu.env
+++ b/jobs/ci-kubernetes-e2e-gke-gpu.env
@@ -3,7 +3,6 @@ PROJECT=k8s-jkns-e2e-gke-gpus
 GKE_CREATE_FLAGS=--accelerator=type=nvidia-tesla-k80,count=2
 KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 KUBE_GKE_IMAGE_TYPE=gci
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:GPU\]
 GCLOUD=gcloud
 CMD_GROUP=alpha --quiet
 # GPUs are not available across all zones yet and need additional quota by

--- a/jobs/ci-kubernetes-e2e-gke-ingress.env
+++ b/jobs/ci-kubernetes-e2e-gke-ingress.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 PROJECT=kubernetes-gke-ingress
 # TODO: Enable this when we've split 1.2 tests into another project.
 

--- a/jobs/ci-kubernetes-e2e-gke-large-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-large-cluster.env
@@ -1,7 +1,6 @@
 ### job-env
 PROJECT=kubernetes-scale
 # TODO: Remove FAIL_ON_GCP_RESOURCE_LEAK when PROJECT changes back to gke-large-cluster-jenkins.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=120m --system-pods-startup-timeout=5m
 GINKGO_PARALLEL=y
 ZONE=us-east1-a
 NUM_NODES=1000

--- a/jobs/ci-kubernetes-e2e-gke-large-deploy.env
+++ b/jobs/ci-kubernetes-e2e-gke-large-deploy.env
@@ -1,7 +1,6 @@
 ### job-env
 PROJECT=kubernetes-scale
 # TODO: Remove FAIL_ON_GCP_RESOURCE_LEAK when PROJECT changes back to gke-large-cluster-jenkins.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Empty\] --allowed-not-ready-nodes=0 --node-schedulable-timeout=360m --system-pods-startup-timeout=60m
 
 ZONE=us-east1-a
 NUM_NODES=3

--- a/jobs/ci-kubernetes-e2e-gke-large-teardown.env
+++ b/jobs/ci-kubernetes-e2e-gke-large-teardown.env
@@ -1,7 +1,5 @@
 ### job-env
 PROJECT=kubernetes-scale
-# TODO: Remove FAIL_ON_GCP_RESOURCE_LEAK when PROJECT changes back to gke-large-cluster-jenkins.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Empty\]
 ZONE=us-east1-a
 NUM_NODES=5000
 # We were asked (by MIG team) to not create more than 5 MIGs per zone.

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env
@@ -1,7 +1,6 @@
 ### job-env
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gke-upg-lat-cluster
 

--- a/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
+++ b/jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env
@@ -1,7 +1,6 @@
 ### job-env
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest
 KUBE_NODE_OS_DISTRIBUTION=debian
 PROJECT=kube-gke-upg-lat-master
 

--- a/jobs/ci-kubernetes-e2e-gke-master-new-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-new-cvm-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=kube-gke-upg-1-5-1-4-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew.env
@@ -1,5 +1,4 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=gke-gci-upg-1-5-1-4-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c

--- a/jobs/ci-kubernetes-e2e-gke-multizone.env
+++ b/jobs/ci-kubernetes-e2e-gke-multizone.env
@@ -1,7 +1,6 @@
 ### job-env
 ADDITIONAL_ZONES=us-central1-a,us-central1-b
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gke-multizone
 ZONE=us-central1-f
 

--- a/jobs/ci-kubernetes-e2e-gke-new-master-cvm-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-new-master-cvm-kubectl-skew.env
@@ -1,8 +1,6 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=kube-gke-upg-1-4-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=container_vm
 ZONE=us-central1-c
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew.env
+++ b/jobs/ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew.env
@@ -1,8 +1,6 @@
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=Kubectl
 PROJECT=gke-gci-upg-1-4-1-5-ctl-skew
 KUBE_GKE_IMAGE_TYPE=gci
 ZONE=us-central1-c
 
 
-SKEW_KUBECTL=y

--- a/jobs/ci-kubernetes-e2e-gke-prod-parallel.env
+++ b/jobs/ci-kubernetes-e2e-gke-prod-parallel.env
@@ -2,7 +2,6 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-e2e-gke-prod-parallel
 ZONE=us-central1-b
 

--- a/jobs/ci-kubernetes-e2e-gke-prod-smoke.env
+++ b/jobs/ci-kubernetes-e2e-gke-prod-smoke.env
@@ -2,7 +2,6 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-e2e-gke-prod-smoke
 ZONE=us-east1-d
 

--- a/jobs/ci-kubernetes-e2e-gke-prod.env
+++ b/jobs/ci-kubernetes-e2e-gke-prod.env
@@ -3,4 +3,3 @@ CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://container.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 PROJECT=k8s-jkns-e2e-gke-prod
 ZONE=us-central1-b
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-gke-reboot-1-5
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gke-reboot-1-6
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-reboot-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gke-reboot-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-gke-reboot-1-3
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-reboot.env
+++ b/jobs/ci-kubernetes-e2e-gke-reboot.env
@@ -1,5 +1,4 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 PROJECT=k8s-jkns-e2e-gke-ci-reboot
 

--- a/jobs/ci-kubernetes-e2e-gke-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gke-release-1-5.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-gke-1-5
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gke-release-1-6.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gke-1-6
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gke-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gke-1-3
 ZONE=us-central1-a

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-gke-serial-1-5
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gke-serial-1-6
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-serial-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gke-serial-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-gke-serial-1-3
 ZONE=us-central1-a
 

--- a/jobs/ci-kubernetes-e2e-gke-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-serial.env
@@ -1,5 +1,4 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 PROJECT=jenkins-gke-e2e-serial
 

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1-5.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-gke-slow-1-5
 ZONE=us-central1-a

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1-6.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gke-slow-1-6
 ZONE=us-central1-a

--- a/jobs/ci-kubernetes-e2e-gke-slow-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gke-slow-release-1-7.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-gke-slow-1-3
 ZONE=us-central1-a

--- a/jobs/ci-kubernetes-e2e-gke-slow.env
+++ b/jobs/ci-kubernetes-e2e-gke-slow.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y
 PROJECT=k8s-jkns-e2e-gke-slow
 

--- a/jobs/ci-kubernetes-e2e-gke-stackdriver.env
+++ b/jobs/ci-kubernetes-e2e-gke-stackdriver.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:StackdriverMonitoring\]
 PROJECT=k8s-jkns-e2e-gke-stackdriver
 
 STACKDRIVER_API_ENDPOINT_OVERRIDE=https://test-monitoring.sandbox.googleapis.com/

--- a/jobs/ci-kubernetes-e2e-gke-staging-parallel.env
+++ b/jobs/ci-kubernetes-e2e-gke-staging-parallel.env
@@ -2,7 +2,6 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 JENKINS_USE_GET_KUBE_SCRIPT=y
 PROJECT=k8s-e2e-gke-staging-parallel
 

--- a/jobs/ci-kubernetes-e2e-gke-staging.env
+++ b/jobs/ci-kubernetes-e2e-gke-staging.env
@@ -2,4 +2,3 @@
 CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER=https://staging-container.sandbox.googleapis.com/
 CLOUDSDK_BUCKET=gs://cloud-sdk-testing/rc
 PROJECT=k8s-jkns-e2e-gke-staging
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The k8s version configurations.
 
 # The test suite configurations.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The k8s version configurations.
 
 # The test suite configurations.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default.env
@@ -21,7 +21,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The k8s version configurations.
 
 # The test suite configurations.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The k8s version configurations.
 
 # The test suite configurations.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot.env
@@ -19,7 +19,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The k8s version configurations.
 
 # The test suite configurations.
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 
 # The test suite configurations.
 GINKGO_PARALLEL=n
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow.env
@@ -21,7 +21,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 # The test suite configurations.
 GINKGO_PARALLEL=y
 GINKGO_PARALLEL_NODES=30
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown.env
@@ -20,7 +20,6 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 
 # The test suite configurations.
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 
 # The job configurations.
 PROJECT=ubuntu-image-validation

--- a/jobs/ci-kubernetes-e2e-gke-updown.env
+++ b/jobs/ci-kubernetes-e2e-gke-updown.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 PROJECT=kubernetes-e2e-gke-updown
 

--- a/jobs/ci-kubernetes-e2e-gke.env
+++ b/jobs/ci-kubernetes-e2e-gke.env
@@ -1,6 +1,5 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 PROJECT=k8s-jkns-e2e-gke-ci
 

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7.env
@@ -3,4 +3,3 @@
 PROJECT=k8s-kubeadm-1-6-on-1-7
 KUBERNETES_PROVIDER=kubernetes-anywhere
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env
@@ -3,7 +3,6 @@
 PROJECT=k8s-jkns-e2e-kubeadm-ci-1-6
 KUBERNETES_PROVIDER=kubernetes-anywhere
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
 
 # Resource leak detection is disabled because prow runs multiple instances of
 # this job in the same project concurrently, and resource leak detection will

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce-1-7.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce-1-7.env
@@ -3,7 +3,6 @@
 PROJECT=k8s-jkns-gci-gke-reboot-1-4
 KUBERNETES_PROVIDER=kubernetes-anywhere
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
 
 # Resource leak detection is disabled because prow runs multiple instances of
 # this job in the same project concurrently, and resource leak detection will

--- a/jobs/ci-kubernetes-e2e-kubeadm-gce.env
+++ b/jobs/ci-kubernetes-e2e-kubeadm-gce.env
@@ -3,7 +3,6 @@
 PROJECT=k8s-jkns-e2e-kubeadm-gce-ci
 KUBERNETES_PROVIDER=kubernetes-anywhere
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
 
 # Resource leak detection is disabled because prow runs multiple instances of
 # this job in the same project concurrently, and resource leak detection will

--- a/jobs/ci-kubernetes-e2e-prow-canary.env
+++ b/jobs/ci-kubernetes-e2e-prow-canary.env
@@ -1,4 +1,3 @@
 # Everything else is the same as the other job it is testing
-GINKGO_TEST_ARGS=--ginkgo.focus=Variable.Expansion
 # TODO(krzyzacy):Revert this after prow has ci credential
 PROJECT=k8s-jkns-e2e-prow-canary

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-alpha

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 NUM_NODES=3
 
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-flaky

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-ingres

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-reboot.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-reboot.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-reboot

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-serial.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-serial.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-serial

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-slow.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-slow.env
@@ -2,7 +2,6 @@
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-slow

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6-updown

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-1-6.env
@@ -2,7 +2,6 @@
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 
 PROJECT=k8s-jkns-gke-ubuntu-1-6

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-alpha-features.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-alpha-features.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
 
 PROJECT=k8s-jkns-gke-ubuntu-alpha
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-autoscaling.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 NUM_NODES=3
 
 PROJECT=k8s-jkns-gke-ubuntu-as

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-flaky.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-flaky.env
@@ -1,5 +1,4 @@
 ### job-env
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 
 PROJECT=k8s-jkns-gke-ubuntu-flaky
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-ingress.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-ingress.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 
 PROJECT=k8s-jkns-gke-ubuntu-ingress
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-reboot.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-reboot.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 
 PROJECT=k8s-jkns-gke-ubuntu-reboot
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-serial.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-serial.env
@@ -1,7 +1,6 @@
 ### job-env
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 PROJECT=k8s-jkns-gke-ubuntu-serial
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-slow.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-slow.env
@@ -2,7 +2,6 @@
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 PROJECT=k8s-jkns-gke-ubuntu-slow
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke-updown.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke-updown.env
@@ -1,6 +1,5 @@
 ### job-env
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 
 PROJECT=k8s-jkns-gke-ubuntu-updown
 

--- a/jobs/ci-kubernetes-e2e-ubuntu-gke.env
+++ b/jobs/ci-kubernetes-e2e-ubuntu-gke.env
@@ -2,7 +2,6 @@
 CLOUDSDK_CONTAINER_USE_CLIENT_CERTIFICATE=False
 
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 PROJECT=k8s-jkns-gke-ubuntu
 

--- a/jobs/ci-kubernetes-soak-cos-docker-validation-test.env
+++ b/jobs/ci-kubernetes-soak-cos-docker-validation-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=cos-docker-validation-soak

--- a/jobs/ci-kubernetes-soak-gce-1-7-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1-7-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak-1-3

--- a/jobs/ci-kubernetes-soak-gce-1.4-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.4-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak-1-4

--- a/jobs/ci-kubernetes-soak-gce-1.5-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.5-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-gce-soak-1-5

--- a/jobs/ci-kubernetes-soak-gce-1.6-test.env
+++ b/jobs/ci-kubernetes-soak-gce-1.6-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak-1-6

--- a/jobs/ci-kubernetes-soak-gce-2-test.env
+++ b/jobs/ci-kubernetes-soak-gce-2-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 HAIRPIN_MODE=hairpin-veth

--- a/jobs/ci-kubernetes-soak-gce-federation-test.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.env
@@ -22,6 +22,5 @@ FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 # accurate.
 FEDERATION_HOST_CLUSTER_ZONE=us-central1-f
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-soak-gce-gci-test.env
+++ b/jobs/ci-kubernetes-soak-gce-gci-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gce-gci-soak

--- a/jobs/ci-kubernetes-soak-gce-test.env
+++ b/jobs/ci-kubernetes-soak-gce-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gce-soak

--- a/jobs/ci-kubernetes-soak-gci-gce-1-7-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1-7-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gci-gce-soak-1-7

--- a/jobs/ci-kubernetes-soak-gci-gce-1.4-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.4-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gci-gce-soak-1-4

--- a/jobs/ci-kubernetes-soak-gci-gce-1.5-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.5-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-gci-gce-soak-1-5

--- a/jobs/ci-kubernetes-soak-gci-gce-1.6-test.env
+++ b/jobs/ci-kubernetes-soak-gci-gce-1.6-test.env
@@ -8,7 +8,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gci-gce-soak-1-6

--- a/jobs/ci-kubernetes-soak-gke-gci-test.env
+++ b/jobs/ci-kubernetes-soak-gke-gci-test.env
@@ -6,7 +6,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gke-gci-soak

--- a/jobs/ci-kubernetes-soak-gke-test.env
+++ b/jobs/ci-kubernetes-soak-gke-test.env
@@ -6,7 +6,6 @@ DOCKER_TEST_LOG_LEVEL=--log-level=warn
 # We should be testing the reliability of a long-running cluster. The
 # [Disruptive] tests kill/restart components or nodes in the cluster,
 # defeating the purpose of a soak cluster. (#15722)
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 ### job-env
 PROJECT=k8s-jkns-gke-soak

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -180,8 +180,7 @@
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -231,8 +230,7 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -281,8 +279,7 @@
       "--extract=ci/latest-1.5",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -856,8 +853,7 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=150m",
-      "--test_args=None"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -896,8 +892,7 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=500m",
-      "--test_args=None"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1773,8 +1768,7 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.env",
       "--timeout=150m",
       "--extract=gci/gci-canary",
-      "--check-leaked-resources",
-      "--test_args=None"
+      "--check-leaked-resources"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1858,8 +1852,7 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gpu-1-7.env",
       "--timeout=180m",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--test_args=None"
+      "--check-leaked-resources"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2034,8 +2027,7 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3629,8 +3621,7 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-pre-release.env",
       "--timeout=480m",
       "--extract=release/latest",
-      "--check-leaked-resources",
-      "--test_args=None"
+      "--check-leaked-resources"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3800,8 +3791,7 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-5.env",
       "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=None"
+      "--check-leaked-resources"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3930,8 +3920,7 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3945,8 +3934,7 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4263,8 +4251,7 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4367,8 +4354,7 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4575,8 +4561,7 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4627,8 +4612,7 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest--upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4727,8 +4711,7 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4831,8 +4814,7 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5069,8 +5051,7 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5121,8 +5102,7 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5155,8 +5135,7 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5341,8 +5320,7 @@
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5371,8 +5349,7 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-pre-release.env",
       "--timeout=480m",
       "--extract=release/latest",
-      "--check-leaked-resources",
-      "--test_args=None"
+      "--check-leaked-resources"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5687,8 +5664,7 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5702,8 +5678,7 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=None"
+      "--check-version-skew=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6749,8 +6724,7 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest-1.5",
-      "--mode=docker",
-      "--test_args=None"
+      "--mode=docker"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -107,7 +107,8 @@
       "--cluster=e2e-aws-1-5",
       "--timeout=120m",
       "--extract=ci/latest-1.5",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|NodeProblemDetector"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -120,7 +121,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-cos-docker-validation.env",
       "--timeout=50m",
       "--extract=gci/gci-next-canary",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -133,7 +135,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env",
       "--timeout=300m",
       "--extract=gci/gci-next-canary",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -146,7 +149,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env",
       "--timeout=150m",
       "--extract=gci/gci-next-canary",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -160,7 +164,8 @@
       "--publish=gs://kubernetes-release-dev/ci/latest-green.txt",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -175,7 +180,8 @@
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -190,7 +196,8 @@
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -206,7 +213,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -223,7 +231,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -239,7 +248,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -255,7 +265,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -270,7 +281,8 @@
       "--extract=ci/latest-1.5",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -286,7 +298,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -301,7 +314,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -316,7 +330,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -331,7 +346,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -346,7 +362,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -362,7 +379,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -379,7 +397,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -395,7 +414,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -411,7 +431,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -427,7 +448,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -443,7 +465,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -459,7 +482,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -472,7 +496,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(DynamicKubeletConfig|Audit)\\]|Initializers"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -485,7 +510,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-4.env",
       "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -498,7 +524,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-5.env",
       "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -511,7 +538,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-6.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -524,7 +552,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=180m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]|Initializers"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -537,7 +566,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-audit.env",
       "--timeout=180m",
       "--check-leaked-resources",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -550,7 +580,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-audit-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--timeout=180m"
+      "--timeout=180m",
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -563,7 +594,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-autoscaling.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -576,7 +608,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-autoscaling-migs.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -596,7 +629,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Variable.Expansion --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -609,7 +643,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-container-vm.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -624,7 +659,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-default.env",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -635,11 +671,11 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/image/cosbeta.env",
-      "--env-file=jobs/suite/serial.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-serial.env",
       "--extract=ci/latest-1.7",
       "--timeout=300m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -654,7 +690,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-slow.env",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -669,7 +706,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-default.env",
       "--extract=ci/latest-1.6",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -680,11 +718,11 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/image/cosbeta.env",
-      "--env-file=jobs/suite/serial.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-serial.env",
       "--extract=ci/latest-1.6",
       "--timeout=300m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -699,7 +737,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-slow.env",
       "--extract=ci/latest-1.6",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -714,7 +753,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-default.env",
       "--extract=ci/latest-1.5",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -725,11 +765,11 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/image/cosbeta.env",
-      "--env-file=jobs/suite/serial.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-serial.env",
       "--extract=ci/latest-1.5",
       "--timeout=300m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -744,7 +784,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-slow.env",
       "--extract=ci/latest-1.5",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -758,7 +799,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-no-snat.env",
       "--timeout=20m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:NoSNAT\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -774,7 +816,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -793,7 +836,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -812,7 +856,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -831,7 +876,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -850,7 +896,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -869,7 +916,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -888,7 +936,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest-1.7",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -907,7 +956,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest-1.7",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -926,7 +976,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest-1.7",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -943,7 +994,8 @@
       "--cluster=test-860e3c0e94",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -960,7 +1012,8 @@
       "--cluster=test-85dd292325",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -977,7 +1030,8 @@
       "--cluster=test-2448497393",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -994,7 +1048,8 @@
       "--cluster=test-f76fffef8e",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1011,7 +1066,8 @@
       "--cluster=test-b829ee97f8",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1028,7 +1084,8 @@
       "--cluster=test-0eae043a2d",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1045,7 +1102,8 @@
       "--cluster=test-63180d3429",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1062,7 +1120,8 @@
       "--cluster=test-ba4378bb1a",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1079,7 +1138,8 @@
       "--cluster=test-86260199f2",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1096,7 +1156,8 @@
       "--cluster=test-fa64f85611",
       "--check-leaked-resources",
       "--extract=ci/latest-1.6",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1113,7 +1174,8 @@
       "--cluster=test-f76dcc51ae",
       "--check-leaked-resources",
       "--extract=ci/latest-1.6",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1130,7 +1192,8 @@
       "--cluster=test-58d04d5cd7",
       "--check-leaked-resources",
       "--extract=ci/latest-1.6",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1147,7 +1210,8 @@
       "--cluster=test-28f4c52467",
       "--check-leaked-resources",
       "--extract=ci/latest-1.5",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1164,7 +1228,8 @@
       "--cluster=test-9f6a2cfa0f",
       "--check-leaked-resources",
       "--extract=ci/latest-1.5",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1181,7 +1246,8 @@
       "--cluster=test-3e0b31d18c",
       "--check-leaked-resources",
       "--extract=ci/latest-1.5",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1197,7 +1263,8 @@
       "--cluster=e2e-enormous-cluster",
       "--timeout=1400m",
       "--extract=ci/latest",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=120m --system-pods-startup-timeout=5m --kube-api-content-type=application/vnd.kubernetes.protobuf"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1211,7 +1278,8 @@
       "--down=false",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.focus=\\[Feature:Empty\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1239,7 +1307,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-es-logging.env",
       "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Elasticsearch\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1252,7 +1321,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd2-release-1-6.env",
       "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1265,7 +1335,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1279,7 +1350,8 @@
       "--timeout=50m",
       "--extract=ci/latest",
       "--cluster=pr-validation",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1292,7 +1364,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3-release-1-5.env",
       "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1305,7 +1378,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-examples.env",
       "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Example\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1319,7 +1393,8 @@
       "--federation",
       "--timeout=900m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1333,7 +1408,8 @@
       "--federation",
       "--timeout=900m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1347,7 +1423,8 @@
       "--extract=ci/latest-1.7",
       "--federation",
       "--timeout=900m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1361,7 +1438,8 @@
       "--federation",
       "--timeout=900m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=(\\[Feature:Federation\\].*(\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\]))"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1374,7 +1452,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-flaky.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1388,7 +1467,8 @@
       "--cluster=gc-feature",
       "--timeout=600m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:GarbageCollector\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1435,7 +1515,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-master.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1448,7 +1529,8 @@
       "--extract=ci/latest-1.4",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env",
       "--timeout=50m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1461,7 +1543,8 @@
       "--extract=ci/latest-1.5",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env",
       "--timeout=50m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1474,7 +1557,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1487,7 +1571,8 @@
       "--extract=ci/latest-1.4",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env",
       "--timeout=300m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1500,7 +1585,8 @@
       "--extract=ci/latest-1.5",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env",
       "--timeout=300m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1513,7 +1599,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1526,7 +1613,8 @@
       "--extract=ci/latest-1.4",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1539,7 +1627,8 @@
       "--extract=ci/latest-1.5",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1586,7 +1675,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-m58.env",
       "--timeout=50m",
       "--extract=gci/gci-58",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1599,7 +1689,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-m59.env",
       "--timeout=50m",
       "--extract=gci/gci-59",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1612,7 +1703,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-m60.env",
       "--timeout=50m",
       "--extract=gci/gci-60",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1625,7 +1717,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-master.env",
       "--timeout=50m",
       "--extract=gci/gci-canary",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1638,7 +1731,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m58.env",
       "--timeout=300m",
       "--extract=gci/gci-58",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1651,7 +1745,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m59.env",
       "--timeout=300m",
       "--extract=gci/gci-59",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1664,7 +1759,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m60.env",
       "--timeout=300m",
       "--extract=gci/gci-60",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1677,7 +1773,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.env",
       "--timeout=150m",
       "--extract=gci/gci-canary",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1690,7 +1787,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m58.env",
       "--timeout=150m",
       "--extract=gci/gci-58",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1703,7 +1801,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m59.env",
       "--timeout=150m",
       "--extract=gci/gci-59",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1716,7 +1815,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m60.env",
       "--timeout=150m",
       "--extract=gci/gci-60",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1729,7 +1829,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.env",
       "--timeout=150m",
       "--extract=gci/gci-canary",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1742,7 +1843,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gpu.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:GPU\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1756,7 +1858,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-gpu-1-7.env",
       "--timeout=180m",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1768,7 +1871,8 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-ha-master.env",
       "--timeout=220m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:HAMaster\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1780,7 +1884,8 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-ingress.env",
       "--timeout=90m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1796,7 +1901,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1812,7 +1918,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1828,7 +1935,8 @@
       "--skew",
       "--extract=ci/latest",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1844,7 +1952,8 @@
       "--skew",
       "--extract=ci/latest",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1858,7 +1967,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-multizone.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1873,7 +1983,8 @@
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1888,7 +1999,8 @@
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1904,7 +2016,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1921,7 +2034,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1937,7 +2051,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1950,7 +2065,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-proto.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kube-api-content-type=application/vnd.kubernetes.protobuf"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1963,7 +2079,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1977,7 +2094,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-4.env",
       "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1990,7 +2108,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-5.env",
       "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2004,7 +2123,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-6.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2018,7 +2138,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=180m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2031,7 +2152,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-4.env",
       "--timeout=50m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2044,7 +2166,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-5.env",
       "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2057,7 +2180,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-6.env",
       "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2070,7 +2194,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2083,7 +2208,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-scalability.env",
       "--cluster=e2e-scalability",
       "--timeout=120m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2097,7 +2223,8 @@
       "--cluster=e2e-scalability-1-6",
       "--timeout=120m",
       "--extract=ci/latest-1.6",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2111,7 +2238,8 @@
       "--extract=ci/latest-1.7",
       "--cluster=e2e-scalability-1-7",
       "--timeout=120m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2124,7 +2252,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-sd-logging.env",
       "--timeout=1320m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2137,7 +2266,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial.env",
       "--timeout=500m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2150,7 +2280,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-4.env",
       "--timeout=300m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2163,7 +2294,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-5.env",
       "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2176,7 +2308,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-6.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2189,7 +2322,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2202,7 +2336,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2215,7 +2350,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-4.env",
       "--timeout=150m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2228,7 +2364,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-5.env",
       "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2241,7 +2378,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-6.env",
       "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2254,7 +2392,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-7.env",
       "--timeout=150m",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2267,7 +2406,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gce-stackdriver.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverMonitoring\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2279,7 +2419,8 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-statefulset.env",
       "--timeout=50m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:StatefulSet\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2291,7 +2432,8 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-taint-evict.env",
       "--timeout=50m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:TaintEviction\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2365,7 +2507,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2384,7 +2527,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2403,7 +2547,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2422,7 +2567,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2441,7 +2587,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2460,7 +2607,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2479,7 +2627,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest-1.7",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2498,7 +2647,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest-1.7",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2517,7 +2667,8 @@
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest-1.7",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2534,7 +2685,8 @@
       "--cluster=test-2e79fbd2ec",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2551,7 +2703,8 @@
       "--cluster=test-c858633e76",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2568,7 +2721,8 @@
       "--cluster=test-70b21a36b2",
       "--check-leaked-resources",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2585,7 +2739,8 @@
       "--cluster=test-b9bc64dba5",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2602,7 +2757,8 @@
       "--cluster=test-4c9af8b031",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2619,7 +2775,8 @@
       "--cluster=test-7214dd78b9",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2636,7 +2793,8 @@
       "--cluster=test-2245e27031",
       "--check-leaked-resources",
       "--extract=ci/latest-1.6",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2653,7 +2811,8 @@
       "--cluster=test-9dcf8231c6",
       "--check-leaked-resources",
       "--extract=ci/latest-1.6",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2670,7 +2829,8 @@
       "--cluster=test-e5822f389c",
       "--check-leaked-resources",
       "--extract=ci/latest-1.6",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2686,7 +2846,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2699,7 +2860,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2712,7 +2874,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4.env",
       "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2725,7 +2888,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5.env",
       "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2738,7 +2902,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2751,7 +2916,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=180m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2764,7 +2930,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-audit.env",
       "--timeout=180m",
       "--check-leaked-resources",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2777,7 +2944,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-audit-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--timeout=180m"
+      "--timeout=180m",
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2790,7 +2958,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-autoscaling.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2803,7 +2972,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2816,7 +2986,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-docker.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2829,7 +3000,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-es-logging.env",
       "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Elasticsearch\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2842,7 +3014,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-etcd3.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2855,7 +3028,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-examples.env",
       "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Example\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2868,7 +3042,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-flaky.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2882,7 +3057,8 @@
       "--cluster=gc-feature",
       "--timeout=600m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:GarbageCollector\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2894,7 +3070,8 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress.env",
       "--timeout=90m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2907,7 +3084,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-4.env",
       "--timeout=90m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2920,7 +3098,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-5.env",
       "--timeout=90m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2933,7 +3112,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-6.env",
       "--timeout=90m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2946,7 +3126,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=90m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2959,7 +3140,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ip-alias.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2972,7 +3154,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-proto.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kube-api-content-type=application/vnd.kubernetes.protobuf"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2986,7 +3169,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2999,7 +3183,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-4.env",
       "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3012,7 +3197,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-5.env",
       "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3025,7 +3211,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-6.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3038,7 +3225,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=180m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3051,7 +3239,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-4.env",
       "--timeout=50m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3064,7 +3253,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-5.env",
       "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3077,7 +3267,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-6.env",
       "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3090,7 +3281,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3103,7 +3295,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability.env",
       "--cluster=e2e-scalability",
       "--timeout=120m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3116,7 +3309,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-6.env",
       "--cluster=e2e-scalability-1-6",
       "--timeout=120m",
-      "--extract=ci/latest-1.6"
+      "--extract=ci/latest-1.6",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3129,7 +3323,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--cluster=e2e-scalability-1-7",
-      "--timeout=120m"
+      "--timeout=120m",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3142,7 +3337,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-sd-logging.env",
       "--timeout=1320m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3155,7 +3351,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial.env",
       "--timeout=500m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3168,7 +3365,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-4.env",
       "--timeout=300m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3181,7 +3379,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-5.env",
       "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3194,7 +3393,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-6.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3207,7 +3407,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3220,7 +3421,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3233,7 +3435,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-4.env",
       "--timeout=150m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3246,7 +3449,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-5.env",
       "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3259,7 +3463,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-6.env",
       "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3272,7 +3477,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3284,7 +3490,8 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-statefulset.env",
       "--timeout=90m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:StatefulSet\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3297,7 +3504,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3310,7 +3518,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-alpha-features.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3323,7 +3532,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-autoscaling.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3336,7 +3546,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-flaky.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3348,7 +3559,8 @@
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress.env",
       "--timeout=300m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3361,7 +3573,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-5.env",
       "--timeout=90m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3374,7 +3587,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-6.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3387,7 +3601,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=300m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3400,7 +3615,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-multizone.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3413,7 +3629,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-pre-release.env",
       "--timeout=480m",
       "--extract=release/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3427,7 +3644,8 @@
       "--timeout=600m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3441,7 +3659,8 @@
       "--timeout=80m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3455,7 +3674,8 @@
       "--timeout=80m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3468,7 +3688,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3481,7 +3702,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-5.env",
       "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3494,7 +3716,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-6.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3507,7 +3730,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=180m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3520,7 +3744,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1-5.env",
       "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3533,7 +3758,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1-6.env",
       "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3546,7 +3772,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3559,7 +3786,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3572,7 +3800,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-5.env",
       "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3585,7 +3814,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-6.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3598,7 +3828,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3611,7 +3842,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3624,7 +3856,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-5.env",
       "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3637,7 +3870,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-6.env",
       "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3650,7 +3884,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3664,7 +3899,8 @@
       "--timeout=600m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3678,7 +3914,8 @@
       "--timeout=80m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3693,7 +3930,8 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3707,7 +3945,8 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3720,7 +3959,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-updown.env",
       "--timeout=30m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3733,7 +3973,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3748,7 +3989,8 @@
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3763,7 +4005,8 @@
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3779,7 +4022,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3795,7 +4039,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3810,7 +4055,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3825,7 +4071,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3840,7 +4087,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3855,7 +4103,8 @@
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3871,7 +4120,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3887,7 +4137,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3903,7 +4154,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3919,7 +4171,8 @@
       "--skew",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3932,7 +4185,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3946,7 +4200,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-5.env",
       "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3959,7 +4214,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-6.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3972,7 +4228,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-autoscaling.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3988,7 +4245,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4005,7 +4263,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4021,7 +4280,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4037,7 +4297,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4054,7 +4315,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4070,7 +4332,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4086,7 +4349,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4103,7 +4367,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4119,7 +4384,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4135,7 +4401,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4152,7 +4419,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4168,7 +4436,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4184,7 +4453,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4201,7 +4471,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4217,7 +4488,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4233,7 +4505,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4250,7 +4523,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4266,7 +4540,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4282,7 +4557,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4299,7 +4575,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4315,7 +4592,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4331,7 +4609,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4348,7 +4627,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest--upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4364,7 +4644,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4380,7 +4661,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4396,7 +4678,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4409,7 +4692,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-flaky.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4425,7 +4709,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4442,7 +4727,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4458,7 +4744,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4474,7 +4761,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4491,7 +4779,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4507,7 +4796,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4523,7 +4813,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4540,7 +4831,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4556,7 +4848,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4572,7 +4865,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4589,7 +4883,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4605,7 +4900,8 @@
       "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4621,7 +4917,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4638,7 +4935,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4654,7 +4952,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4669,7 +4968,8 @@
       "--extract=ci/latest-1.5",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterDowngrade\\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4685,7 +4985,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4702,7 +5003,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4718,7 +5020,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4731,7 +5034,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-ci-master.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4747,7 +5051,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4764,7 +5069,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4780,7 +5086,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4796,7 +5103,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4813,7 +5121,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4829,7 +5138,8 @@
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4845,7 +5155,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4861,7 +5172,8 @@
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4874,7 +5186,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-gpu.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:GPU\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4886,7 +5199,8 @@
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-ingress.env",
       "--timeout=90m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4899,7 +5213,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-large-cluster.env",
       "--cluster=gke-large-cluster",
       "--timeout=600m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=120m --system-pods-startup-timeout=5m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4913,7 +5228,8 @@
       "--cluster=gke-large-deploy",
       "--down=false",
       "--timeout=1200m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --allowed-not-ready-nodes=0 --node-schedulable-timeout=360m --system-pods-startup-timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4944,7 +5260,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4960,7 +5277,8 @@
       "--skew",
       "--extract=ci/latest-1.6",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4976,7 +5294,8 @@
       "--skew",
       "--extract=ci/latest",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4992,7 +5311,8 @@
       "--skew",
       "--extract=ci/latest",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5005,7 +5325,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-multizone.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5020,7 +5341,8 @@
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5035,7 +5357,8 @@
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../kubernetes_skew/cluster/kubectl.sh"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5048,7 +5371,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-pre-release.env",
       "--timeout=480m",
       "--extract=release/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5062,7 +5386,8 @@
       "--timeout=600m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5076,7 +5401,8 @@
       "--timeout=80m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5090,7 +5416,8 @@
       "--timeout=80m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5103,7 +5430,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5116,7 +5444,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1-5.env",
       "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5129,7 +5458,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1-6.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5142,7 +5472,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=180m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5155,7 +5486,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1-5.env",
       "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5169,7 +5501,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1-6.env",
       "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5182,7 +5515,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5195,7 +5529,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5208,7 +5543,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1-5.env",
       "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5221,7 +5557,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1-6.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5234,7 +5571,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5247,7 +5585,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5260,7 +5599,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1-5.env",
       "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5273,7 +5613,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1-6.env",
       "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5286,7 +5627,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5299,7 +5641,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-stackdriver.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverMonitoring\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5313,7 +5656,8 @@
       "--timeout=600m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5327,7 +5671,8 @@
       "--timeout=80m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5342,7 +5687,8 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5356,7 +5702,8 @@
       "--timeout=480m",
       "--extract=gke",
       "--check-leaked-resources",
-      "--check-version-skew=false"
+      "--check-version-skew=false",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5370,7 +5717,8 @@
       "--cluster=test-761f0eadc1",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=180m"
+      "--timeout=180m",
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5387,7 +5735,8 @@
       "--cluster=test-4b6146a96f",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=300m"
+      "--timeout=300m",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5404,7 +5753,8 @@
       "--cluster=test-f08378c6bb",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=50m"
+      "--timeout=50m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5421,7 +5771,8 @@
       "--cluster=test-7b1edb0409",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=300m"
+      "--timeout=300m",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5438,7 +5789,8 @@
       "--cluster=test-73afed9487",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=300m"
+      "--timeout=300m",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5455,7 +5807,8 @@
       "--cluster=test-139569f31c",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=180m"
+      "--timeout=180m",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5472,7 +5825,8 @@
       "--cluster=test-aac0a04ffb",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5489,7 +5843,8 @@
       "--cluster=test-3e74ad8150",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5506,7 +5861,8 @@
       "--cluster=test-7f37c1d417",
       "--check-leaked-resources",
       "--extract=ci/latest-1.7",
-      "--timeout=30m"
+      "--timeout=30m",
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5523,7 +5879,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-updown.env",
       "--timeout=30m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5657,7 +6014,8 @@
       "--kubernetes-anywhere-kubernetes-version=latest",
       "--deployment=kubernetes-anywhere",
       "--timeout=300m",
-      "--extract=ci/latest"
+      "--extract=ci/latest",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5673,7 +6031,8 @@
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
       "--deployment=kubernetes-anywhere",
       "--timeout=300m",
-      "--extract=ci/latest-1.6"
+      "--extract=ci/latest-1.6",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5689,7 +6048,8 @@
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
       "--deployment=kubernetes-anywhere",
       "--timeout=300m",
-      "--extract=ci/latest-1.6"
+      "--extract=ci/latest-1.6",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5705,7 +6065,8 @@
       "--kubernetes-anywhere-kubernetes-version=latest-1.7",
       "--deployment=kubernetes-anywhere",
       "--timeout=300m",
-      "--extract=ci/latest-1.7"
+      "--extract=ci/latest-1.7",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5721,7 +6082,8 @@
       "--tag=latest",
       "--timeout=40m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=Variable.Expansion"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5734,7 +6096,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5747,7 +6110,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5760,7 +6124,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5773,7 +6138,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5786,7 +6152,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5799,7 +6166,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5812,7 +6180,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5825,7 +6194,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5838,7 +6208,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5851,7 +6222,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=30m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5864,7 +6236,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5877,7 +6250,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5890,7 +6264,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5903,7 +6278,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5916,7 +6292,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5929,7 +6306,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5942,7 +6320,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5955,7 +6334,8 @@
       "--env-file=jobs/platform/gke.env",
       "--timeout=30m",
       "--extract=ci/latest",
-      "--check-leaked-resources"
+      "--check-leaked-resources",
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6270,7 +6650,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=gci/gci-next-canary",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6302,7 +6683,8 @@
       "--up=false",
       "--down=false",
       "--timeout=600m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6334,7 +6716,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest-1.4",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6366,7 +6749,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest-1.5",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=None"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6398,7 +6782,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest-1.6",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6430,7 +6815,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6482,7 +6868,8 @@
       "--down=false",
       "--timeout=90m",
       "--extract=ci/latest",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6515,7 +6902,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6532,7 +6920,8 @@
       "--timeout=600m",
       "--extract=ci/latest",
       "--check-version-skew=false",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6564,7 +6953,8 @@
       "--up=false",
       "--down=false",
       "--timeout=600m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6596,7 +6986,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest-1.4",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6628,7 +7019,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest-1.5",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6660,7 +7052,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest-1.6",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6710,7 +7103,8 @@
       "--timeout=600m",
       "--extract=ci/latest",
       "--check-version-skew=false",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6726,7 +7120,8 @@
       "--down=false",
       "--timeout=600m",
       "--extract=ci/latest",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6904,7 +7299,8 @@
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
       "--deployment=kubernetes-anywhere",
       "--timeout=300m",
-      "--extract=ci/latest-1.6"
+      "--extract=ci/latest-1.6",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6920,7 +7316,8 @@
       "--kubernetes-anywhere-kubernetes-version=latest-1.7",
       "--deployment=kubernetes-anywhere",
       "--timeout=300m",
-      "--extract=ci/latest-1.7"
+      "--extract=ci/latest-1.7",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6973,7 +7370,8 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce",
       "--cluster=",
       "--timeout=55m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6989,7 +7387,8 @@
       "--build=bazel",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-bazel",
       "--cluster=",
-      "--timeout=55m"
+      "--timeout=55m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7006,7 +7405,8 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary",
       "--cluster=",
       "--timeout=55m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7023,7 +7423,8 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-etcd3",
       "--cluster=",
       "--timeout=65m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7040,7 +7441,8 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gci",
       "--cluster=",
       "--timeout=55m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7058,7 +7460,8 @@
       "--stage-suffix=pull-gke",
       "--cluster=",
       "--timeout=55m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7076,7 +7479,8 @@
       "--stage-suffix=pull-gke-gci",
       "--cluster=",
       "--timeout=55m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7092,7 +7496,8 @@
       "--kubeadm=pull",
       "--kubernetes-anywhere-kubernetes-version=latest",
       "--deployment=kubernetes-anywhere",
-      "--timeout=55m"
+      "--timeout=55m",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7113,7 +7518,8 @@
       "--deployment=none",
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
       "--timeout=90m",
-      "--mode=docker"
+      "--mode=docker",
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7134,7 +7540,8 @@
       "--federation",
       "--deployment=none",
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy-canary",
-      "--timeout=90m"
+      "--timeout=90m",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/jobs/move_extract.py
+++ b/jobs/move_extract.py
@@ -33,62 +33,96 @@ def sort():
     with open(test_infra('jobs/config.json'), 'r+') as fp:
         configs = json.loads(fp.read())
     regexp = re.compile('|'.join([
-        r'E2E_OPT=(--check_version_skew=false|true)'
+        r'^GINKGO_TEST_ARGS=(.*)$|^SKEW_KUBECTL=(y)$'
     ]))
     problems = []
     for job, values in configs.items():
+        if values.get('scenario') != 'kubernetes_e2e':
+            continue
         if 'args' not in values:
             continue
-        new_args = []
-        found = False
-        for arg in values['args']:
-            if arg == '--check-leaked-resources=true':
-                found = True
-                new_args.append('--check-leaked-resources')
-            elif arg == '--check-leaked-resources=false':
-                found = True
-            elif arg == '--check_version_skew=false':
-                found = True
-                new_args.append('--check-version-skew=false')
-            else:
-                new_args.append(arg)
-        if not found:
+        args = values['args']
+        new_args = [a for a in args if a != '--test_args=None']
+        if new_args != args:
+            args = new_args
+            values['args'] = args
+        if any('None' in a for a in args):
+            problems.append('Bad flag with None: %s' % job)
             continue
-        if found and values.get('scenario') != 'kubernetes_e2e':
-            problems.append('Weird %s' % job)
+        if any(a.startswith('--test_args=') for a in args):
             continue
-        values['args'] = new_args
-        if values:
-            continue
-        # old stuff
         with open(test_infra('jobs/%s.env' % job)) as fp:
             env = fp.read()
+        tests = None
+        skew = False
         lines = []
-        skew = None
         for line in env.split('\n'):
             mat = regexp.search(line)
             if not mat:
                 lines.append(line)
                 continue
-            args = mat.group(1)
-            if args:
-                if skew:
+            group, now_skew = mat.groups()
+            if group:
+                if tests:
                     problems.append('Duplicate %s' % job)
                     break
-                skew = args
+                tests = group
                 continue
+            if now_skew:
+                if skew:
+                    problems.append('Duplicate skew %s' % job)
+                skew = now_skew
         else:
-            if not skew:
+            new_args = []
+            stop = False
+            for arg in args:
+                these = None
+                add = True
+                if (
+                        arg == '--env-file=jobs/pull-kubernetes-federation-e2e-gce.env'
+                        and not job == 'pull-kubernetes-federation-e2e-gce'):
+                    these = r'--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'  # pylint: disable=line-too-long
+                elif (
+                        arg == '--env-file=jobs/pull-kubernetes-e2e.env'
+                        and not job.startswith('pull-kubernetes-federation-e2e-gce')):
+                    these = r'--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'  # pylint: disable=line-too-long
+                elif arg == '--env-file=jobs/suite/slow.env':
+                    these = r'--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'  # pylint: disable=line-too-long
+                elif arg == '--env-file=jobs/suite/serial.env':
+                    these = r'--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]'  # pylint: disable=line-too-long
+                    add = False
+                elif arg == '--env-file=jobs/suite/default.env':
+                    these = r'--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'  # pylint: disable=line-too-long
+                if add:
+                    new_args.append(arg)
+                if not these:
+                    continue
+                if tests:
+                    problems.append('Duplicate end %s' % job)
+                    stop = True
+                    break
+                tests = these
+            if stop:
                 continue
-            for arg in values['args']:
-                if not arg.startswith('--check_version_skew'):
-                    continue
-                if arg != skew:
-                    problems.append('Mismatch in %s: %s != %s' % (job, arg, skew))
-                    continue
-                break
-            else:
-                values['args'].append(skew)
+            args = new_args
+
+            testing = '--test=false' not in args
+
+            if not testing:
+                if skew:
+                    problems.append('Cannot skew kubectl without tests %s' % job)
+                if tests:
+                    problems.append('Cannot --test_args when --test=false %s' % job)
+                continue
+            if skew:
+                path = '--kubectl-path=../kubernetes_skew/cluster/kubectl.sh'
+                if tests:
+                    tests = '%s %s' % (tests, path)
+                else:
+                    tests = path
+            if tests:
+                args.append('--test_args=%s' % tests)
+            values['args'] = args
             with open(test_infra('jobs/%s.env' % job), 'w') as fp:
                 fp.write('\n'.join(lines))
     with open(test_infra('jobs/config.json'), 'w') as fp:

--- a/jobs/periodic-kubernetes-e2e-kubeadm-gce-1-6.env
+++ b/jobs/periodic-kubernetes-e2e-kubeadm-gce-1-6.env
@@ -3,7 +3,6 @@
 PROJECT=k8s-jkns-e2e-kubeadm-per-1-6
 KUBERNETES_PROVIDER=kubernetes-anywhere
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
 
 # Resource leak detection is disabled because prow runs multiple instances of
 # this job in the same project concurrently, and resource leak detection will

--- a/jobs/periodic-kubernetes-e2e-kubeadm-gce-1-7.env
+++ b/jobs/periodic-kubernetes-e2e-kubeadm-gce-1-7.env
@@ -3,7 +3,6 @@
 PROJECT=k8s-jkns-gci-gke-serial-1-4
 KUBERNETES_PROVIDER=kubernetes-anywhere
 
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\]
 
 # Resource leak detection is disabled because prow runs multiple instances of
 # this job in the same project concurrently, and resource leak detection will

--- a/jobs/pull-kubernetes-e2e-kubeadm-gce.env
+++ b/jobs/pull-kubernetes-e2e-kubeadm-gce.env
@@ -4,7 +4,6 @@ PROJECT=k8s-jkns-pr-kubeadm
 KUBERNETES_PROVIDER=kubernetes-anywhere
 
 GINKGO_PARALLEL=y
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]
 
 # Resource leak detection is disabled because prow runs multiple instances of
 # this job in the same project concurrently, and resource leak detection will

--- a/jobs/pull-kubernetes-e2e.env
+++ b/jobs/pull-kubernetes-e2e.env
@@ -5,8 +5,6 @@ GINKGO_TOLERATE_FLAKES=y
 KUBE_GCS_UPDATE_LATEST=n
 
 GINKGO_PARALLEL=y
-# This list should match the list in kubernetes-e2e-gce.
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # NUM_NODES and GINKGO_PARALLEL_NODES should match kubernetes-e2e-gce.
 NUM_NODES=4

--- a/jobs/pull-kubernetes-federation-e2e-gce.env
+++ b/jobs/pull-kubernetes-federation-e2e-gce.env
@@ -5,7 +5,6 @@ FEDERATION=true
 USE_KUBEFED=true
 PROJECT=k8s-jkns-pr-bldr-e2e-gce-fdrtn
 KUBE_REGISTRY=gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Federation\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[NoCluster\]
 
 # Recycle control plane.
 # We only recycle federation control plane in each run, we don't

--- a/jobs/suite/default.env
+++ b/jobs/suite/default.env
@@ -1,2 +1,1 @@
-GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y

--- a/jobs/suite/serial.env
+++ b/jobs/suite/serial.env
@@ -1,1 +1,0 @@
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]

--- a/jobs/suite/slow.env
+++ b/jobs/suite/slow.env
@@ -1,2 +1,1 @@
-GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 GINKGO_PARALLEL=y

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -399,10 +399,13 @@ def main(args):
             raise ValueError(k8s)
         mode.add_k8s(os.path.dirname(k8s), 'kubernetes', 'release')
 
+    # TODO(fejta): move these out of this file
     if args.up == 'true':
         runner_args.append('--up')
     if args.down == 'true':
         runner_args.append('--down')
+    if args.test == 'true':
+        runner_args.append('--test')
 
     cluster = cluster_name(args.cluster, os.getenv('BUILD_NUMBER', 0))
     # TODO(fejta): remove this add_environment after pushing new kubetest image
@@ -430,7 +433,6 @@ def main(args):
       # Use default component update behavior
       'CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false',
       # E2E
-      'E2E_TEST=%s' % args.test,
       'E2E_NAME=%s' % cluster,
       # AWS
       'KUBE_AWS_INSTANCE_PREFIX=%s' % cluster,


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/2829
/assign @yguo0905 @krzyzacy 

Also fixed etcd upgrade and gke-large jobs that try to set `--test_args` when `--test=false`