### PR TITLE
Use separate projects for Ubuntu GKE tests

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -315,47 +315,47 @@ jobs:
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-761f0eadc1
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-4b6146a96f
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-f08378c6bb
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-7b1edb0409
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-73afed9487
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-139569f31c
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-aac0a04ffb
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-3e74ad8150
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown:
     interval: 2h
     envs:
-    - PROJECT=ubuntu-image-validation
+    - PROJECT=k8s-test-7f37c1d417
     sigOwners: ['sig-node']
 
 common:

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures.env
@@ -22,4 +22,4 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-761f0eadc1

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling.env
@@ -22,4 +22,4 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-4b6146a96f

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default.env
@@ -24,4 +24,4 @@ GINKGO_PARALLEL_NODES=30
 GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-f08378c6bb

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky.env
@@ -22,4 +22,4 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-7b1edb0409

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress.env
@@ -22,4 +22,4 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Ingress\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-73afed9487

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot.env
@@ -22,4 +22,4 @@ KUBE_GKE_ENABLE_KUBERNETES_ALPHA=true
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Feature:Reboot\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-139569f31c

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial.env
@@ -23,4 +23,4 @@ GINKGO_PARALLEL=n
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-aac0a04ffb

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow.env
@@ -24,4 +24,4 @@ GINKGO_PARALLEL_NODES=30
 GINKGO_TEST_ARGS=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-3e74ad8150

--- a/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown.env
+++ b/jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown.env
@@ -23,4 +23,4 @@ GINKGO_PARALLEL=y
 GINKGO_TEST_ARGS=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
 
 # The job configurations.
-PROJECT=ubuntu-image-validation
+PROJECT=k8s-test-7f37c1d417

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1603,23 +1603,23 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-slow
   - name: ubuntu-gke-1.6-updown
     test_group_name: ci-kubernetes-e2e-ubuntu-gke-1-6-updown
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures
+  - name: gke-ubuntustable1-k8sstable1-alphafeatures
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling
+  - name: gke-ubuntustable1-k8sstable1-autoscaling
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default
+  - name: gke-ubuntustable1-k8sstable1-default
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky
+  - name: gke-ubuntustable1-k8sstable1-flaky
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress
+  - name: gke-ubuntustable1-k8sstable1-ingress
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot
+  - name: gke-ubuntustable1-k8sstable1-reboot
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial
+  - name: gke-ubuntustable1-k8sstable1-serial
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow
+  - name: gke-ubuntustable1-k8sstable1-slow
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow
-  - name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown
+  - name: gke-ubuntustable1-k8sstable1-updown
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown
 
 - name: google-gke-staging


### PR DESCRIPTION
The Ubuntu k8s-1.7 tests on GKE are broken because the cluster cannot be brought up. I think this is because they are sharing the same project `ubuntu-image-validation`, which may cause network conflicts. At this moment, I will just change the tests to use individual projects for now. Will investigate the issue later.

