### PR TITLE
Update kubekins-e2e-prow to v20170706-cdc96348

### DIFF
--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170707-6440bde9
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170630-78041cc6
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/images/e2e-prow/Makefile
+++ b/images/e2e-prow/Makefile
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+IMG = gcr.io/k8s-testimages/kubekins-e2e-prow
 TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
+all: image
+
 image:
-	docker build -t "gcr.io/k8s-testimages/kubekins-e2e-prow:$(TAG)" .
+	docker build -t "$(IMG):$(TAG)" .
+	docker tag "$(IMG):$(TAG)" "$(IMG):latest"
+	@echo Built $(IMG):$(TAG) and tagged with :latest
 
 push: image
-	gcloud docker -- push "gcr.io/k8s-testimages/kubekins-e2e-prow:$(TAG)"
+	gcloud docker -- push "$(IMG):$(TAG)"
+	gcloud docker -- push "$(IMG):latest"
+	@echo Pushed $(IMG) with :latest and :$(TAG) tags
 
 .PHONY: image push

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -132,7 +132,7 @@ presubmits:
         # Make Bazel use shared cache for its root
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170601-727dd8f5
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -269,7 +269,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -401,7 +401,7 @@ presubmits:
         # Make Bazel use shared cache for its root
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170601-727dd8f5
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -538,7 +538,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1127,7 +1127,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1160,7 +1160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1193,7 +1193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1226,7 +1226,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1258,7 +1258,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1291,7 +1291,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1324,7 +1324,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1357,7 +1357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1390,7 +1390,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1423,7 +1423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1456,7 +1456,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1489,7 +1489,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1522,7 +1522,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1555,7 +1555,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1588,7 +1588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1621,7 +1621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1654,7 +1654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1687,7 +1687,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1720,7 +1720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1753,7 +1753,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1786,7 +1786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1819,7 +1819,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1852,7 +1852,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1885,7 +1885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1917,7 +1917,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1950,7 +1950,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1983,7 +1983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2016,7 +2016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2049,7 +2049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2082,7 +2082,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2115,7 +2115,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2147,7 +2147,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2179,7 +2179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2211,7 +2211,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2243,7 +2243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2276,7 +2276,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2309,7 +2309,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2342,7 +2342,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2375,7 +2375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2408,7 +2408,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2441,7 +2441,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2474,7 +2474,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2507,7 +2507,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2540,7 +2540,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2575,7 +2575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2609,7 +2609,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2643,7 +2643,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2677,7 +2677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2711,7 +2711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2745,7 +2745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2779,7 +2779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2813,7 +2813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2847,7 +2847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2881,7 +2881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2916,7 +2916,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2950,7 +2950,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2984,7 +2984,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3018,7 +3018,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3052,7 +3052,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3086,7 +3086,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3120,7 +3120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3154,7 +3154,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3188,7 +3188,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3222,7 +3222,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3256,7 +3256,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3290,7 +3290,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3324,7 +3324,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3358,7 +3358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3390,7 +3390,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3422,7 +3422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3455,7 +3455,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3487,7 +3487,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3520,7 +3520,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3553,7 +3553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3585,7 +3585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3617,7 +3617,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3649,7 +3649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3682,7 +3682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3714,7 +3714,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3746,7 +3746,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3779,7 +3779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3812,7 +3812,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3845,7 +3845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3878,7 +3878,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3911,7 +3911,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3944,7 +3944,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3977,7 +3977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4010,7 +4010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4043,7 +4043,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4076,7 +4076,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4109,7 +4109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4142,7 +4142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4175,7 +4175,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4208,7 +4208,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4241,7 +4241,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4274,7 +4274,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4307,7 +4307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4340,7 +4340,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4373,7 +4373,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4406,7 +4406,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4439,7 +4439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4472,7 +4472,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4505,7 +4505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4538,7 +4538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4571,7 +4571,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4604,7 +4604,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4637,7 +4637,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4670,7 +4670,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4702,7 +4702,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4734,7 +4734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4767,7 +4767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4800,7 +4800,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4833,7 +4833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4866,7 +4866,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4898,7 +4898,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4931,7 +4931,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4964,7 +4964,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4997,7 +4997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5030,7 +5030,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5063,7 +5063,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5095,7 +5095,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5127,7 +5127,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5160,7 +5160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5193,7 +5193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5226,7 +5226,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5259,7 +5259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5292,7 +5292,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5325,7 +5325,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5358,7 +5358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5391,7 +5391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5423,7 +5423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5455,7 +5455,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5487,7 +5487,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5520,7 +5520,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5553,7 +5553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5586,7 +5586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5619,7 +5619,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5651,7 +5651,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5684,7 +5684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5717,7 +5717,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5750,7 +5750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5783,7 +5783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5815,7 +5815,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5847,7 +5847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5881,7 +5881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5915,7 +5915,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5949,7 +5949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5983,7 +5983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6017,7 +6017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6051,7 +6051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6085,7 +6085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6119,7 +6119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6153,7 +6153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6187,7 +6187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6221,7 +6221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6255,7 +6255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6289,7 +6289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6323,7 +6323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6357,7 +6357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6391,7 +6391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6425,7 +6425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6459,7 +6459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6491,7 +6491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6523,7 +6523,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6555,7 +6555,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6588,7 +6588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6621,7 +6621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6654,7 +6654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6687,7 +6687,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6720,7 +6720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6753,7 +6753,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6785,7 +6785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6817,7 +6817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6849,7 +6849,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6881,7 +6881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6913,7 +6913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6945,7 +6945,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6977,7 +6977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7009,7 +7009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7041,7 +7041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7074,7 +7074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7107,7 +7107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7140,7 +7140,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7173,7 +7173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7205,7 +7205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7237,7 +7237,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7269,7 +7269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7302,7 +7302,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7335,7 +7335,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7368,7 +7368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7401,7 +7401,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7434,7 +7434,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7467,7 +7467,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7500,7 +7500,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7533,7 +7533,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7565,7 +7565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7597,7 +7597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7629,7 +7629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7662,7 +7662,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7695,7 +7695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7728,7 +7728,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7761,7 +7761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7793,7 +7793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7826,7 +7826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7859,7 +7859,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7892,7 +7892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7925,7 +7925,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7957,7 +7957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7989,7 +7989,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8021,7 +8021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8053,7 +8053,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8085,7 +8085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8117,7 +8117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8150,7 +8150,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8183,7 +8183,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8216,7 +8216,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8248,7 +8248,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8280,7 +8280,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8312,7 +8312,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8344,7 +8344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8377,7 +8377,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8409,7 +8409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8442,7 +8442,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8475,7 +8475,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8508,7 +8508,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8541,7 +8541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8574,7 +8574,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8607,7 +8607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8639,7 +8639,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8672,7 +8672,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8705,7 +8705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8738,7 +8738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8770,7 +8770,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8803,7 +8803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8836,7 +8836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8869,7 +8869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8901,7 +8901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8933,7 +8933,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8965,7 +8965,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8997,7 +8997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9029,7 +9029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9061,7 +9061,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9094,7 +9094,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9127,7 +9127,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9160,7 +9160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9193,7 +9193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9226,7 +9226,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9259,7 +9259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9292,7 +9292,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9325,7 +9325,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9358,7 +9358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9391,7 +9391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9424,7 +9424,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9457,7 +9457,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9489,7 +9489,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9522,7 +9522,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9555,7 +9555,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9587,7 +9587,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9620,7 +9620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9653,7 +9653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9686,7 +9686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9719,7 +9719,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9752,7 +9752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9785,7 +9785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9818,7 +9818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9851,7 +9851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9884,7 +9884,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9917,7 +9917,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9950,7 +9950,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9983,7 +9983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10016,7 +10016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10049,7 +10049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10082,7 +10082,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10115,7 +10115,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10148,7 +10148,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10181,7 +10181,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10214,7 +10214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10247,7 +10247,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10280,7 +10280,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10313,7 +10313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10346,7 +10346,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10379,7 +10379,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10412,7 +10412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10445,7 +10445,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10477,7 +10477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10510,7 +10510,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10543,7 +10543,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10576,7 +10576,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10609,7 +10609,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10642,7 +10642,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10675,7 +10675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10708,7 +10708,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10741,7 +10741,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10774,7 +10774,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10807,7 +10807,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10840,7 +10840,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10873,7 +10873,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10906,7 +10906,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10939,7 +10939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10972,7 +10972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11005,7 +11005,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11038,7 +11038,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11071,7 +11071,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11104,7 +11104,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11138,7 +11138,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11171,7 +11171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11204,7 +11204,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11237,7 +11237,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11270,7 +11270,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11303,7 +11303,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11336,7 +11336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11369,7 +11369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11402,7 +11402,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11435,7 +11435,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11467,7 +11467,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11500,7 +11500,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11533,7 +11533,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11566,7 +11566,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11599,7 +11599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11631,7 +11631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11664,7 +11664,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11697,7 +11697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11729,7 +11729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11761,7 +11761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11793,7 +11793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11825,7 +11825,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11857,7 +11857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11890,7 +11890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11923,7 +11923,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11956,7 +11956,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11989,7 +11989,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12022,7 +12022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12055,7 +12055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12087,7 +12087,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12120,7 +12120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12153,7 +12153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12186,7 +12186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12218,7 +12218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12251,7 +12251,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12284,7 +12284,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12317,7 +12317,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12349,7 +12349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12381,7 +12381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12413,7 +12413,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12445,7 +12445,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12480,7 +12480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12514,7 +12514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12548,7 +12548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12582,7 +12582,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12616,7 +12616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12650,7 +12650,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12684,7 +12684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12718,7 +12718,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12752,7 +12752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12784,7 +12784,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12804,7 +12804,7 @@ periodics:
   interval: 24h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       args:
       - --bare
       - --timeout=60
@@ -12847,7 +12847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12880,7 +12880,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12913,7 +12913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12946,7 +12946,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12979,7 +12979,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13012,7 +13012,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13045,7 +13045,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13078,7 +13078,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13111,7 +13111,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13143,7 +13143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13176,7 +13176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13209,7 +13209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13242,7 +13242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13275,7 +13275,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13308,7 +13308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13341,7 +13341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13374,7 +13374,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13407,7 +13407,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13440,7 +13440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13461,7 +13461,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -13496,7 +13496,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170515-c7116fb4
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170706-cdc96348
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"


### PR DESCRIPTION
ref #2829 

* Derive from `kubekins-e2e:v20170630-78041cc6`
* Also change `make push` to also tag and push a `:latest` version of the image.
* Update all prow jobs to `kubekins-e2e-prow:v20170630-78041cc6`
  * `v20170606-e69a3df0` - nearly all jobs use this
  * `v20170601-727dd8f5` - crossbuild uses this
  * `v20170515-c7116fb4` - federation uses this

/assign @madhusudancs @rmmh 

