### PR TITLE
Add a git client to prow.

### DIFF
--- a/prow/BUILD
+++ b/prow/BUILD
@@ -26,6 +26,7 @@ filegroup(
         "//prow/cmd/splice:all-srcs",
         "//prow/cmd/tot:all-srcs",
         "//prow/config:all-srcs",
+        "//prow/git:all-srcs",
         "//prow/github:all-srcs",
         "//prow/hook:all-srcs",
         "//prow/jenkins:all-srcs",

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       = 0.119
+HOOK_VERSION       = 0.120
 SINKER_VERSION     = 0.10
 DECK_VERSION       = 0.32
 SPLICE_VERSION     = 0.22

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -30,10 +30,10 @@ spec:
       labels:
         app: hook
     spec:
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.119
+        image: gcr.io/k8s-prow/hook:0.120
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -35,6 +35,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/hook/Dockerfile
+++ b/prow/cmd/hook/Dockerfile
@@ -15,7 +15,7 @@
 FROM alpine:3.4
 MAINTAINER spxtr@google.com
 
-RUN apk add --no-cache ca-certificates && update-ca-certificates
+RUN apk add --no-cache git ca-certificates && update-ca-certificates
 
 COPY hook /hook
 ENTRYPOINT ["/hook"]

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/hook"
 	"k8s.io/test-infra/prow/kube"
@@ -136,6 +137,11 @@ func main() {
 		slackClient = slack.NewFakeClient()
 	}
 
+	gitClient, err := git.NewClient()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting git client.")
+	}
+
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(*configPath); err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
@@ -145,6 +151,7 @@ func main() {
 		PluginClient: plugins.PluginClient{
 			GitHubClient: githubClient,
 			KubeClient:   kubeClient,
+			GitClient:    gitClient,
 			SlackClient:  slackClient,
 			Logger:       logrus.NewEntry(logrus.StandardLogger()),
 		},

--- a/prow/git/BUILD
+++ b/prow/git/BUILD
@@ -1,0 +1,35 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["git_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["git.go"],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package git provides a client to plugins that can do git operations.
+package git
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+)
+
+const github = "https://github.com"
+
+// Client can clone repos. It keeps a local cache, so successive clones of the
+// same repo should be quick. Create with NewClient. Be sure to clean it up.
+type Client struct {
+	// dir is the location of the git cache.
+	dir string
+	// git is the path to the git binary.
+	git string
+	// base is the base path for git clone calls. For users it will be set to
+	// GitHub, but for tests set it to a directory with git repos.
+	base string
+
+	// The mutex protects repoLocks which protect individual repos. This is
+	// necessary because Clone calls for the same repo are racy. Rather than
+	// one lock for all repos, use a lock per repo.
+	// Lock with Client.lockRepo, unlock with Client.unlockRepo.
+	rlm       sync.Mutex
+	repoLocks map[string]*sync.Mutex
+}
+
+// Clean removes the local repo cache. The Client is unusable after calling.
+func (c *Client) Clean() error {
+	return os.RemoveAll(c.dir)
+}
+
+// NewClient returns a client that talks to GitHub. It will fail if git is not
+// in the PATH.
+func NewClient() (*Client, error) {
+	g, err := exec.LookPath("git")
+	if err != nil {
+		return nil, err
+	}
+	t, err := ioutil.TempDir("", "git")
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		dir:       t,
+		git:       g,
+		base:      github,
+		repoLocks: make(map[string]*sync.Mutex),
+	}, nil
+}
+
+func (c *Client) lockRepo(repo string) {
+	c.rlm.Lock()
+	if _, ok := c.repoLocks[repo]; !ok {
+		c.repoLocks[repo] = &sync.Mutex{}
+	}
+	m := c.repoLocks[repo]
+	c.rlm.Unlock()
+	m.Lock()
+}
+
+func (c *Client) unlockRepo(repo string) {
+	c.rlm.Lock()
+	defer c.rlm.Unlock()
+	c.repoLocks[repo].Unlock()
+}
+
+// Clone clones a repository. Pass the full repository name, such as
+// "kubernetes/test-infra" as the repo.
+// This function may take a long time if it is the first time cloning the repo.
+// In that case, it must do a full git mirror clone. For large repos, this can
+// take a while. Once that is done, it will do a git fetch instead of a clone,
+// which will usually take at most a few seconds.
+func (c *Client) Clone(repo string) (*Repo, error) {
+	c.lockRepo(repo)
+	defer c.unlockRepo(repo)
+
+	remote := filepath.Join(c.base, repo)
+	cache := filepath.Join(c.dir, repo) + ".git"
+	if _, err := os.Stat(cache); os.IsNotExist(err) {
+		// Cache miss, clone it now.
+		if err := os.Mkdir(filepath.Dir(cache), os.ModePerm); err != nil && !os.IsExist(err) {
+			return nil, err
+		}
+		if b, err := exec.Command(c.git, "clone", "--mirror", remote, cache).CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git cache clone error: %v. output: %s", err, string(b))
+		}
+	} else if err != nil {
+		return nil, err
+	} else {
+		// Cache hit. Do a git fetch to keep updated.
+		cmd := exec.Command(c.git, "fetch")
+		cmd.Dir = cache
+		if b, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("git fetch error: %v. output: %s", err, string(b))
+		}
+	}
+	t, err := ioutil.TempDir("", "git")
+	if err != nil {
+		return nil, err
+	}
+	if b, err := exec.Command(c.git, "clone", cache, t).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("git repo clone error: %v. output: %s", err, string(b))
+	}
+	return &Repo{
+		dir: t,
+		git: c.git,
+	}, nil
+}
+
+// Repo is a clone of a git repository. Create with Client.Clone, and don't
+// forget to clean it up after.
+type Repo struct {
+	// dir is the location of the git cache.
+	dir string
+	// git is the path to the git binary.
+	git string
+}
+
+// Clean deletes the repo. It is unusable after calling.
+func (r *Repo) Clean() error {
+	return os.RemoveAll(r.dir)
+}

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// runCmd runs cmd in dir with arg.
+func runCmd(cmd, dir string, arg ...string) error {
+	c := exec.Command(cmd, arg...)
+	c.Dir = dir
+	if b, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s %v: %v, %s", cmd, arg, err, string(b))
+	}
+	return nil
+}
+
+func TestClone(t *testing.T) {
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("Making client: %v", err)
+	}
+	defer func() {
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up old client: %v", err)
+		}
+	}()
+	// Make fake local repositories in a temp dir.
+	tmp, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatalf("Making tmpdir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmp); err != nil {
+			t.Errorf("Cleaning up tmp dir: %v", err)
+		}
+	}()
+	c.base = tmp
+	if err := makeFakeRepo(c.git, tmp, "foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	if err := makeFakeRepo(c.git, tmp, "foo", "baz"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+
+	// Fresh clone, will be a cache miss.
+	r1, err := c.Clone("foo/bar")
+	if err != nil {
+		t.Fatalf("Cloning the first time: %v", err)
+	}
+	defer func() {
+		if err := r1.Clean(); err != nil {
+			t.Errorf("Cleaning repo: %v", err)
+		}
+	}()
+
+	// Clone from the same org.
+	r2, err := c.Clone("foo/baz")
+	if err != nil {
+		t.Fatalf("Cloning another repo in the same org: %v", err)
+	}
+	defer func() {
+		if err := r2.Clean(); err != nil {
+			t.Errorf("Cleaning repo: %v", err)
+		}
+	}()
+
+	// Make sure it fetches when we clone again.
+	if err := addCommit(c.git, filepath.Join(tmp, "foo", "bar"), "second"); err != nil {
+		t.Fatalf("Adding second commit: %v", err)
+	}
+	r3, err := c.Clone("foo/bar")
+	if err != nil {
+		t.Fatalf("Cloning a second time: %v", err)
+	}
+	defer func() {
+		if err := r3.Clean(); err != nil {
+			t.Errorf("Cleaning repo: %v", err)
+		}
+	}()
+	log := exec.Command("git", "log", "--oneline")
+	log.Dir = r3.dir
+	if b, err := log.CombinedOutput(); err != nil {
+		t.Fatalf("git log: %v, %s", err, string(b))
+	} else {
+		t.Logf("git log output: %s", string(b))
+		if len(bytes.Split(bytes.TrimSpace(b), []byte("\n"))) != 2 {
+			t.Error("Wrong number of commits in git log output. Expected 2")
+		}
+	}
+}
+
+func makeFakeRepo(git, tmp, org, repo string) error {
+	rdir := filepath.Join(tmp, org, repo)
+	if err := os.MkdirAll(rdir, os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := runCmd(git, rdir, "init"); err != nil {
+		return err
+	}
+	if err := runCmd(git, rdir, "config", "user.email", "test@test.test"); err != nil {
+		return err
+	}
+	if err := runCmd(git, rdir, "config", "user.name", "test test"); err != nil {
+		return err
+	}
+	if err := addCommit(git, rdir, "initial"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addCommit(git, rdir, name string) error {
+	if err := ioutil.WriteFile(filepath.Join(rdir, name), []byte("wow!"), os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := runCmd(git, rdir, "add", name); err != nil {
+		return err
+	}
+	if err := runCmd(git, rdir, "commit", "-m", "wow"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -28,6 +28,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/slack:go_default_library",

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/slack"
@@ -64,15 +65,6 @@ func RegisterPullRequestHandler(name string, fn PullRequestHandler) {
 	pullRequestHandlers[name] = fn
 }
 
-// PluginClient may be used concurrently, so each entry must be thread-safe.
-type PluginClient struct {
-	GitHubClient *github.Client
-	KubeClient   *kube.Client
-	SlackClient  *slack.Client // This might be nil.
-	Config       *config.Config
-	Logger       *logrus.Entry
-}
-
 type StatusEventHandler func(PluginClient, github.StatusEvent) error
 
 func RegisterStatusEventHandler(name string, fn StatusEventHandler) {
@@ -99,6 +91,16 @@ type ReviewCommentEventHandler func(PluginClient, github.ReviewCommentEvent) err
 func RegisterReviewCommentEventHandler(name string, fn ReviewCommentEventHandler) {
 	allPlugins[name] = struct{}{}
 	reviewCommentEventHandlers[name] = fn
+}
+
+// PluginClient may be used concurrently, so each entry must be thread-safe.
+type PluginClient struct {
+	GitHubClient *github.Client
+	KubeClient   *kube.Client
+	GitClient    *git.Client
+	SlackClient  *slack.Client
+	Config       *config.Config
+	Logger       *logrus.Entry
 }
 
 type PluginAgent struct {


### PR DESCRIPTION
This will let us write plugins that would like a local git clone to mess
around with. It uses a cache so that multiple clones of the same repo
will be quick.

Note that this makes the hook image dependent on the git tool. This is a
shame, but it's unavoidable.

Right now the client only knows how to clone repos. In future work we
can add methods to the Repo struct that will let us do more interesting
things.

This is the first step towards #3092. In the next PR I will add a plugin that actually uses it.