### PR TITLE
Hack to fix wrongly adding '--test' flag

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -413,6 +413,8 @@ def main(args):
         runner_args.append('--down')
     if args.test == 'true':
         runner_args.append('--test')
+    else:
+        mode.add_environment('E2E_TEST=false')
 
     cluster = cluster_name(args.cluster, os.getenv('BUILD_NUMBER', 0))
     runner_args.extend(args.kubetest_args)


### PR DESCRIPTION
@kubernetes/test-infra-maintainers @fejta This is to temporarily fix the issue. Feel free to revert this once you solve the bug of adding '--test' arg in [this line](https://github.com/kubernetes/test-infra/blob/2f9420cdfdf22226ce88a4ef96e027e31fc2fc2e/jenkins/e2e-image/e2e-runner.sh#L51) even though '--test' wasn't passed to the container from kubernetes_e2e.py just because the container image was built with env var E2E_TEST set to true by default (ref: https://github.com/kubernetes/test-infra/blob/2f9420cdfdf22226ce88a4ef96e027e31fc2fc2e/jenkins/e2e-image/Dockerfile#L36).

/cc @wojtek-t @gmarek 