### PR TITLE
Update kubekins-e2e base image in prow e2e image to non-buggy one

### DIFF
--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170707-9507f9e1
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170707-6440bde9
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /


### PR DESCRIPTION
Ref #3380 

Fixed the bug in kubekins-e2e and deleted the unhealthy images I created in the process from registry.
Hence updating prow with the latest one. I'll soon push the new prow image (and delete the previous one I created).

/cc @kubernetes/test-infra-maintainers  @gmarek @fejta 