### PR TITLE
Correct the --extract arg for gci-ci-* job configs

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-master.env
@@ -1,7 +1,3 @@
 ### job-env
-# The master branch will always use GCI images built from its
-# tip of tree, categorized in family `gci-canary`.
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-master
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env
@@ -1,6 +1,3 @@
 ### job-env
-# To qualify GCI milestone 56 for k8s release-1.4.
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-1-4
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env
@@ -1,5 +1,3 @@
 ### job-env
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-1-5
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env
@@ -1,4 +1,2 @@
 ### job-env
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
 PROJECT=e2e-gce-gci-ci-serial
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env
@@ -1,5 +1,2 @@
 ### job-env
-# To qualify GCI milestone 56 for k8s release-1.4.
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 PROJECT=kubekins-gce-gci-ci-serial-1-4
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env
@@ -1,4 +1,2 @@
 ### job-env
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 PROJECT=kubekins-gce-gci-ci-serial-1-5
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env
@@ -1,5 +1,3 @@
 ### job-env
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary
 GINKGO_PARALLEL=y
 PROJECT=e2e-gce-gci-ci-master-slow
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env
@@ -1,6 +1,3 @@
 ### job-env
-# To qualify GCI milestone 56 for k8s release-1.4.
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-slow-1-4
-

--- a/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env
@@ -1,5 +1,3 @@
 ### job-env
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-56
 GINKGO_PARALLEL=y
 PROJECT=kubekins-gce-gci-ci-slow-1-5
-

--- a/jobs/ci-kubernetes-e2e-gci-gce-docker.env
+++ b/jobs/ci-kubernetes-e2e-gci-gce-docker.env
@@ -2,5 +2,3 @@
 GINKGO_PARALLEL=y
 KUBE_OS_DISTRIBUTION=gci
 PROJECT=k8s-docker-validation-gci
-JENKINS_GCI_HEAD_IMAGE_FAMILY=gci-canary-test
-

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1508,7 +1508,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-master.env",
       "--timeout=50m",
-      "--extract=ci/latest",
+      "--extract=gci/gci-canary/latest",
       "--check-leaked-resources",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
@@ -1520,7 +1520,7 @@
   "ci-kubernetes-e2e-gce-gci-ci-release-1-4": {
     "args": [
       "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.4",
+      "--extract=gci/gci-56/latest-1.4",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env",
       "--timeout=50m",
       "--check-leaked-resources",
@@ -1534,7 +1534,7 @@
   "ci-kubernetes-e2e-gce-gci-ci-release-1-5": {
     "args": [
       "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.5",
+      "--extract=gci/gci-56/latest-1.5",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env",
       "--timeout=50m",
       "--check-leaked-resources",
@@ -1550,7 +1550,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env",
       "--timeout=300m",
-      "--extract=ci/latest",
+      "--extract=gci/gci-canary/latest",
       "--check-leaked-resources",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
@@ -1562,7 +1562,7 @@
   "ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4": {
     "args": [
       "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.4",
+      "--extract=gci/gci-56/latest-1.4",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env",
       "--timeout=300m",
       "--check-leaked-resources",
@@ -1576,7 +1576,7 @@
   "ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5": {
     "args": [
       "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.5",
+      "--extract=gci/gci-56/latest-1.5",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env",
       "--timeout=300m",
       "--check-leaked-resources",
@@ -1592,7 +1592,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env",
       "--timeout=150m",
-      "--extract=ci/latest",
+      "--extract=gci/gci-canary/latest",
       "--check-leaked-resources",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
@@ -1604,7 +1604,7 @@
   "ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4": {
     "args": [
       "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.4",
+      "--extract=gci/gci-56/latest-1.4",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env",
       "--timeout=150m",
       "--check-leaked-resources",
@@ -1618,7 +1618,7 @@
   "ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5": {
     "args": [
       "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.5",
+      "--extract=gci/gci-56/latest-1.5",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env",
       "--timeout=150m",
       "--check-leaked-resources",
@@ -2976,7 +2976,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-docker.env",
       "--timeout=50m",
-      "--extract=ci/latest",
+      "--extract=gci/gci-canary-test/latest",
       "--check-leaked-resources",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],


### PR DESCRIPTION
These jobs test a daily build of GCI with a particular branch head of
k8s. According extract.go, the correct setting should be
`--extract=gci/<gci-image-family>/<k8s-ci-version>`.

Also, remove uses of the  env var JENKINS_GCI_HEAD_IMAGE_FAMILY that is
now obsolete. The only remaining use of it is in
`jobs/ci-kubernetes-e2e-gke-gci-ci-master.env`. I am not sure what that
job is used for so I'm not touching it.

Ref: #3313 cc/ @zmerlynn @fejta @kubernetes/goog-image 