### PR TITLE
Add 'unbound variable' to gubernator default_words

### DIFF
--- a/gubernator/regex.py
+++ b/gubernator/regex.py
@@ -25,7 +25,7 @@ def wordRE(word):
 # HACK: match ANSI colored lines by allowing preceding "m",
 # as in"\x1b[0;31mFAILED\x1b[0m"
 
-default_words = ["build timed out", "error", "fail", "failed", "fatal", "undefined"]
+default_words = ["build timed out", "error", "fail", "failed", "fatal", "undefined", "unbound variable"]
 
 error_re = re.compile(
     r'(?:\b|(?<=m))(%s)\b' % '|'.join(default_words), re.IGNORECASE)

--- a/gubernator/regex_test.py
+++ b/gubernator/regex_test.py
@@ -45,6 +45,7 @@ class RegexTest(unittest.TestCase):
             ('FAIL k8s.io/kubernetes/pkg/client/record', True),
             ('undefined: someVariable', True),
             ('\x1b[0;31mFAILED\x1b[0m', True),  # color codes
+            ('unbound variable', True),
         ]:
             self.assertEqual(bool(regex.error_re.search(text)), matches,
                 'error_re.search(%r) should be %r' % (text, matches))


### PR DESCRIPTION
I've seen this show up in shell scripts several times, most recently here:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/48555/pull-kubernetes-e2e-gce-etcd3/39197/build-log.txt
`W0707 03:55:18.406] /workspace/e2e-runner.sh: line 52: e2e_go_args[@]: unbound variable`

It would be nice to see this immediately in gubernator's summary of the build log.