### PR TITLE
enable reiteration of a sig mention when corresponding sig label exists

### DIFF
--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -128,13 +128,10 @@ func getLabelsFromREMatches(matches [][]string) (labels []string) {
 }
 
 func (ae assignEvent) getRepeats(sigMatches [][]string, existingLabels map[string]string) (toRepeat []string) {
-
 	toRepeat = []string{}
 	for _, sigMatch := range sigMatches {
 		sigLabel := strings.ToLower("sig" + "/" + strings.TrimSpace(sigMatch[1]))
-		if ae.issue.HasLabel(sigLabel) {
-			continue
-		}
+
 		if _, ok := existingLabels[sigLabel]; ok {
 			toRepeat = append(toRepeat, sigMatch[0])
 		}


### PR DESCRIPTION
Addressing #2956 

A sig mention is not reiterated if corresponding sig label exists.

For instance, an issue already has `sig/testing` label. When a non-org member types `@kubernetes/sig-testing-misc`, the sig mention is not reiterated.

This PR resolves this by removing the codes that skip choosing a sig group when the sig label exists.