### PR TITLE
Kubetest should expect explicit flags rather than reading env

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -79,7 +79,7 @@ type kubernetesAnywhere struct {
 	Cluster           string
 }
 
-func NewKubernetesAnywhere() (*kubernetesAnywhere, error) {
+func NewKubernetesAnywhere(project string) (*kubernetesAnywhere, error) {
 	if *kubernetesAnywherePath == "" {
 		return nil, fmt.Errorf("--kubernetes-anywhere-path is required")
 	}
@@ -88,9 +88,8 @@ func NewKubernetesAnywhere() (*kubernetesAnywhere, error) {
 		return nil, fmt.Errorf("--kubernetes-anywhere-cluster is required")
 	}
 
-	project, ok := os.LookupEnv("PROJECT")
-	if !ok {
-		return nil, fmt.Errorf("The PROJECT environment variable is required to be set for kubernetes-anywhere")
+	if project == "" {
+		return nil, fmt.Errorf("--provider=kubernetes-anywhere requires --gcp-project")
 	}
 
 	// Set KUBERNETES_CONFORMANCE_TEST so the auth info is picked up

--- a/kubetest/anywhere_test.go
+++ b/kubetest/anywhere_test.go
@@ -24,10 +24,6 @@ import (
 )
 
 func TestNewKubernetesAnywhere(t *testing.T) {
-	if err := os.Setenv("PROJECT", "test-project"); err != nil {
-		t.Fatalf("couldn't set PROJECT environment: %v", err)
-	}
-
 	cases := []struct {
 		name              string
 		phase2            string
@@ -83,7 +79,7 @@ func TestNewKubernetesAnywhere(t *testing.T) {
 		*kubernetesAnywhereKubeadmVersion = tc.kubeadmVersion
 		*kubernetesAnywhereKubernetesVersion = tc.kubernetesVersion
 
-		_, err = NewKubernetesAnywhere()
+		_, err = NewKubernetesAnywhere("fake-project")
 		if err != nil {
 			t.Errorf("NewKubernetesAnywhere(%s) failed: %v", tc.name, err)
 			continue

--- a/kubetest/stage.go
+++ b/kubetest/stage.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -61,7 +60,7 @@ func (s *stageStrategy) Enabled() bool {
 
 // Stage the release build to GCS.
 // Essentially release/push-build.sh --bucket=B --ci? --gcs-suffix=S --federation? --noupdatelatest
-func (s *stageStrategy) Stage() error {
+func (s *stageStrategy) Stage(fed bool) error {
 	name := k8s("release", "push-build.sh")
 	b := s.bucket
 	if strings.HasPrefix(b, "gs://") {
@@ -85,7 +84,7 @@ func (s *stageStrategy) Stage() error {
 	if len(s.dockerRegistry) > 0 {
 		args = append(args, fmt.Sprintf("--docker-registry=%s", s.dockerRegistry))
 	}
-	if os.Getenv("FEDERATION") == "true" {
+	if fed {
 		args = append(args, "--federation")
 	}
 


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/3375

Adding the following kubetest flags:
* `--provider  # KUBERNETES_PROVIDER`
* `--gcp-project  # PROJECT`
* `--gcp-zone  # ZONE`
* `--gcp-cloud-sdk  # CLOUDSDK_BUCKET`
* `--gcp-service-account  # GOOGLE_APPLICATION_CREDENTIALS`
* `--kops-priority-path  # PRIORITY_PATH` (this logic is only used by kops)
* `--kubemark-nodes  # KUBEMARK_NUM_NODES`
* `--kubemark-master-size  # KUBEMARK_MASER_SIZE`

/assign @krzyzacy @pipejakob @wojtek-t @madhusudancs 

Also impacts:
* federation - `FEDERATION=true` duplicates `--federation`
* kops - now asks users to use flags instead of `KOPS_STATE_STORE`, `AWS_SSH_KEY`
* kubemark - `KUBEMARK_TEST_ARGS=foo` duplicates `--test_args=FOO`


Will migrate usage in `jobs/*.env` to these flags once I push a kubekins image with these changes.