### PR TITLE
Only chmod when dir exists

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -306,6 +306,8 @@ class DockerMode(object):
         try:
             check(*cmd)
         finally:  # Ensure docker files are readable by bootstrap
+            if not os.path.isdir(self.local_artifacts):  # May not exist
+                pass
             try:
                 check('sudo', 'chmod', '-R', 'o+r', self.local_artifacts)
             except subprocess.CalledProcessError:  # fails outside CI


### PR DESCRIPTION
Works when there are artifacts: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/batch/pull-kubernetes-e2e-gce-etcd3/39391/

Non-fatal (but still distracting) error when there are no artifacts: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/batch/pull-kubernetes-e2e-gce-etcd3/39388/?log#log

/assign @krzyzacy @rmmh 