### PR TITLE
:dog: Only keep ProwJobs for 2 days, not a week.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -16,7 +16,7 @@ all: build test
 
 
 HOOK_VERSION       = 0.121
-SINKER_VERSION     = 0.11
+SINKER_VERSION     = 0.12
 DECK_VERSION       = 0.33
 SPLICE_VERSION     = 0.23
 TOT_VERSION        = 0.3

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.11
+        image: gcr.io/k8s-prow/sinker:0.12
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	period        = time.Hour
-	maxProwJobAge = 7 * 24 * time.Hour
+	maxProwJobAge = 2 * 24 * time.Hour
 	maxPodAge     = 12 * time.Hour
 )
 


### PR DESCRIPTION
One week is a lot of data. It makes etcd slow down. We don't really
need a week, I was just messing around and seeing what would happen.
Two days is plenty.

We made about 43000 ProwJobs in the last week!