### PR TITLE
Fix test definition and regenerate tests

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -53,7 +53,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170606-e69a3df0
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170707-54693f85
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -436,12 +436,10 @@ testSuites:
     args:
     - --timeout=180m
     - --test_args=--ginkgo.focus=\[Feature:DynamicKubeletConfig\]
-    envs:
   autoscaling:
     args:
     - --timeout=300m
     - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\]
-    envs:
   default:
     args:
     - --timeout=50m
@@ -453,17 +451,14 @@ testSuites:
     args:
     - --timeout=300m
     - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\]
-    envs:
   ingress:
     args:
     - --timeout=300m
-    - --test_args=--test_args=--ginkgo.focus=\[Feature:Ingress\]
-    envs:
+    - --test_args=--ginkgo.focus=\[Feature:Ingress\]
   reboot:
     args:
     - --timeout=180m
     - --test_args=--ginkgo.focus=\[Feature:Reboot\]
-    envs:
   serial:
     args:
     - --timeout=500m

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -852,7 +852,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=150m"
+      "--timeout=150m",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -891,7 +892,8 @@
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
-      "--timeout=500m"
+      "--timeout=500m",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
- Remove the extra `--test_args=` in the ingress test suite definition.
- Regenerate tests to fix the missing test suite definition.

/assign @krzyzacy 