### PR TITLE
Support job level overrides + set --check-leaked-resources=false for tests using shared projects

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -45,166 +45,232 @@ jobs:
   # +------------+----------+----------+------------+------------+------------+
   ci-kubernetes-e2e-gce-cosdev-k8sdev-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sdev-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sdev-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sbeta-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sstable1-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sdev-default:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sdev-slow:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sdev-serial:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sbeta-default:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sbeta-slow:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sbeta-serial:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sstable1-default:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sstable1-slow:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
 # ci-kubernetes-e2e-gce-cosbeta-k8sstable1-serial:
 #   interval: 2h
+#   args:
+#   - --check-leaked-resources=false # disabled since it uses shared project.
 #   envs:
 #   - PROJECT=cos-image-validation
 #   sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sdev-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sbeta-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable1-default:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable2-default:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable3-default:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=cos-image-validation
     sigOwners: ['sig-node']
@@ -224,91 +290,127 @@ jobs:
   # +---------------+----------+----------+------------+------------+------------+
   ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-dev-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial:
     interval: 2h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-default:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
   ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial:
     interval: 6h
+    args:
+    - --check-leaked-resources=false # disabled since it uses shared project.
     envs:
     - PROJECT=ubuntu-os-gke-cloud-tests # Canonical owned project.
     sigOwners: ['sig-node']
@@ -361,6 +463,9 @@ jobs:
 common:
   args:
   - --cluster=test-${job_name_hash}
+  envs:
+  # If PROJECT is not specified in 'job', use this as the default one.
+  - PROJECT=k8s-test-${job_name_hash}
 
 cloudProviders:
   gce:

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2281,10 +2281,6 @@ class JobTest(unittest.TestCase):
                             and '--check-leaked-resources' in args
                             and 'generated' not in config[job].get('tags', [])):
                         self.fail('Only GCP jobs can --check-leaked-resources, not %s' % job)
-                    if (
-                            '--check-leaked-resources' not in args
-                            and 'generated' in config[job].get('tags', [])):
-                        self.fail('Generated job %s must have --check-leaked-resources=yes' % job)
                     if '--mode=local' in args:
                         self.fail('--mode=local is default now, drop that for %s' % job)
 

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -808,12 +808,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-default.env",
       "--cluster=test-349504ad4b",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -828,12 +828,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial.env",
       "--cluster=test-ce1e942232",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -848,12 +848,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow.env",
       "--cluster=test-7c91d4db34",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -868,12 +868,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-default.env",
       "--cluster=test-cd3f14e5ae",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -888,12 +888,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-serial.env",
       "--cluster=test-16f7a6f1b2",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -908,12 +908,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-slow.env",
       "--cluster=test-018ded2eb1",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -928,12 +928,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-default.env",
       "--cluster=test-26653b91cd",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -948,12 +948,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial.env",
       "--cluster=test-12c21e8bb2",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -968,12 +968,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow.env",
       "--cluster=test-603851a011",
-      "--check-leaked-resources",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -988,10 +988,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-default.env",
       "--cluster=test-860e3c0e94",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1006,10 +1006,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial.env",
       "--cluster=test-85dd292325",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1024,10 +1024,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow.env",
       "--cluster=test-2448497393",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1042,10 +1042,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-default.env",
       "--cluster=test-f76fffef8e",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1060,10 +1060,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial.env",
       "--cluster=test-b829ee97f8",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1078,10 +1078,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow.env",
       "--cluster=test-0eae043a2d",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1096,10 +1096,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-default.env",
       "--cluster=test-63180d3429",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1114,10 +1114,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial.env",
       "--cluster=test-ba4378bb1a",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1132,10 +1132,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow.env",
       "--cluster=test-86260199f2",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1150,10 +1150,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-default.env",
       "--cluster=test-fa64f85611",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.6",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1168,10 +1168,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial.env",
       "--cluster=test-f76dcc51ae",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.6",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1186,10 +1186,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow.env",
       "--cluster=test-58d04d5cd7",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.6",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1204,10 +1204,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-default.env",
       "--cluster=test-28f4c52467",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.5",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1222,10 +1222,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial.env",
       "--cluster=test-9f6a2cfa0f",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.5",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1240,10 +1240,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow.env",
       "--cluster=test-3e0b31d18c",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.5",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2497,12 +2497,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default.env",
       "--cluster=test-4f454c8522",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2517,12 +2517,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial.env",
       "--cluster=test-bdd5648636",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2537,12 +2537,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow.env",
       "--cluster=test-b5d96c1598",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2557,12 +2557,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default.env",
       "--cluster=test-b3fd097a64",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2577,12 +2577,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial.env",
       "--cluster=test-52428544e5",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2597,12 +2597,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow.env",
       "--cluster=test-5d6257d272",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2617,12 +2617,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-default.env",
       "--cluster=test-f99af785cf",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2637,12 +2637,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial.env",
       "--cluster=test-7dcacf28c9",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2657,12 +2657,12 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow.env",
       "--cluster=test-5978e38009",
-      "--check-leaked-resources",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2677,10 +2677,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env",
       "--cluster=test-2e79fbd2ec",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2695,10 +2695,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env",
       "--cluster=test-c858633e76",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2713,10 +2713,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env",
       "--cluster=test-70b21a36b2",
-      "--check-leaked-resources",
       "--extract=ci/latest",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2731,10 +2731,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env",
       "--cluster=test-b9bc64dba5",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.7",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2749,10 +2749,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env",
       "--cluster=test-4c9af8b031",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.7",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2767,10 +2767,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env",
       "--cluster=test-7214dd78b9",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.7",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2785,10 +2785,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-default.env",
       "--cluster=test-2245e27031",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.6",
       "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2803,10 +2803,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial.env",
       "--cluster=test-9dcf8231c6",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.6",
       "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2821,10 +2821,10 @@
     "args": [
       "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow.env",
       "--cluster=test-e5822f389c",
-      "--check-leaked-resources",
       "--extract=ci/latest-1.6",
       "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]",
+      "--check-leaked-resources=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
It turned out that the `--check-leaked-resources` does not work well with tests in shared test projects.

/assign @krzyzacy 