### PR TITLE
Add dashboard for sig-api-machinery to testgrid. See also: PR #48890.

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2790,12 +2790,38 @@ dashboards:
 
 - name: sig-api-machinery
   dashboard_tab:
-  - name: TODO
-    description: what does this tab do exactly
-    test_group_name: ci-kubernetes-e2e-gce-slow  # TODO(fejta): fix
-  notifications:
-  - summary: Please configure this skeleton dashboard and remove this notification
-    context_link: https://github.com/kubernetes/test-infra/tree/master/testgrid/config
+  - name: gce
+    test_group_name: ci-kubernetes-e2e-gce
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gce e2e tests for master branch'
+  - name: gke
+    test_group_name: ci-kubernetes-e2e-gke
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gke e2e tests for master branch'
+  - name: gce-flaky
+    test_group_name: ci-kubernetes-e2e-gce-flaky
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gce flaky e2e tests for master branch'
+  - name: gke-flaky
+    test_group_name: ci-kubernetes-e2e-gke-flaky
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gke flaky e2e tests for master branch'
+  - name: gce-slow
+    test_group_name: ci-kubernetes-e2e-gce-slow
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gce slow e2e tests for master branch'
+  - name: gke-slow
+    test_group_name: ci-kubernetes-e2e-gke-slow
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gke slow e2e tests for master branch'
+  - name: gce-serial
+    test_group_name: ci-kubernetes-e2e-gce-serial
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gce serial e2e tests for master branch'
+  - name: gke-serial
+    test_group_name: ci-kubernetes-e2e-gke-serial
+    base_options: 'include-filter-by-regex=sig-api-machinery'
+    description: 'apimachinery gke serial e2e tests for master branch'
 
 - name: sig-apps # TODO(crimsonfaith91): add upgrade tests when k8s v1.9 rolls out
   dashboard_tab:


### PR DESCRIPTION
Add a `sig-api-machinery` dashboard and populate it with a core set of tabs for gce and gke including tabs for flaky, slow and serial.

All apimachinery e2e tests added to the test/e2e/apimachinery directory that use `SIGDescribe` (instead of `framework.KubeDescribe`) will have `[sig-api-machinery]` prepended to their test names and will automatically be added to these tabs.

See PR #48890 for initial list of tests to be added to this dashboard.