### PR TITLE
Fix deck version.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -17,7 +17,7 @@ all: build test
 
 HOOK_VERSION       = 0.122
 SINKER_VERSION     = 0.13
-DECK_VERSION       = 0.35
+DECK_VERSION       = 0.37
 SPLICE_VERSION     = 0.24
 TOT_VERSION        = 0.3
 HOROLOGIUM_VERSION = 0.5

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.34
+        image: gcr.io/k8s-prow/deck:0.37
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
Somehow in a merge conflict I didn't bump it right. Then I reverted
because it was broken, but that was caused by a different issue.

It was caused by #3492. @rmmh already deployed.