### PR TITLE
When loading metadata.json, also load images.json

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -385,17 +385,21 @@ def append_result(gsutil, path, build, version, passed):
             logging.warning('Failed to append to %s#%s', path, gen)
         errors += 1
 
-
-def metadata(repos, artifacts, call):
-    """Return metadata associated for the build, including inside artifacts."""
-    path = os.path.join(artifacts or '', 'metadata.json')
-    meta = None
+def mergeMetadata(meta,dir,file):
+    path = os.path.join(dir or '', file)
     if os.path.isfile(path):
         try:
             with open(path) as fp:
-                meta = json.loads(fp.read())
+                meta.update(json.loads(fp.read()))
         except (IOError, ValueError):
             pass
+
+def metadata(repos, artifacts, call):
+    """Return metadata associated for the build, including inside artifacts."""
+    meta = dict()
+    files = ['metadata.json', 'images.json']
+    for f in files:
+      mergeMetadata(meta, artifacts or '', f)
 
     if not meta or not isinstance(meta, dict):
         meta = {}


### PR DESCRIPTION
The OS images used in the test run are important test metadata, so the new images.json file that contains them should be loaded alongside the regular metadata.json file, and then displayed in the summary for test results.

/assign @michelle192837 

Michelle, I'm guesing (hoping :) you know about this layer - will this PR Do The Right Thing ?

Here is a sample of the new images.json file: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosdev-k8sdev-slow/121/artifacts/images.json

I'm hoping this PR will make those two fields will show up in the grid at the top of https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosdev-k8sdev-slow/121
