### PR TITLE
Add flag -metadata-sources, listing files to be merged into metadata.json

### DIFF
--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -52,7 +52,7 @@ go_test(
     srcs = [
         "anywhere_test.go",
         "extract_test.go",
-        "outputs_test.go",
+        "main_test.go",
         "util_test.go",
     ],
     library = ":go_default_library",

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -52,6 +52,7 @@ go_test(
     srcs = [
         "anywhere_test.go",
         "extract_test.go",
+        "outputs_test.go",
         "util_test.go",
     ],
     library = ":go_default_library",

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -233,7 +233,7 @@ func complete(o *options) error {
 	}
 
 	if o.dump != "" {
-		defer writeMetadata(o)
+		defer writeMetadata(o.dump, o.metadataSources)
 		defer writeXML(o.dump, time.Now())
 	}
 	if err := prepare(o); err != nil {
@@ -378,12 +378,11 @@ func maybeMergeJSON(meta map[string]string, path string) {
 }
 
 // Write metadata.json, including version and env arg data.
-func writeMetadata(o *options) error {
-	path := o.dump
+func writeMetadata(path, metadataSources string) error {
 	m := make(map[string]string)
 
 	// Look for any sources of metadata and load 'em
-	for _, f := range strings.Split(o.metadataSources, ",") {
+	for _, f := range strings.Split(metadataSources, ",") {
 		maybeMergeJSON(m, filepath.Join(path, f))
 	}
 

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -72,6 +72,7 @@ type options struct {
 	kubemark            bool
 	kubemarkMasterSize  string
 	kubemarkNodes       string // TODO(fejta): switch to int after migration
+	metadataSources     string
 	multipleFederations bool
 	perfTests           bool
 	provider            string
@@ -107,6 +108,7 @@ func defineFlags() *options {
 	flag.BoolVar(&o.perfTests, "perf-tests", false, "If true, run tests from perf-tests repo.")
 	flag.StringVar(&o.provider, "provider", "", "Kubernetes provider such as gce, gke, aws, etc")
 	flag.StringVar(&o.publish, "publish", "", "Publish version to the specified gs:// path on success")
+	flag.StringVar(&o.metadataSources, "metadata-sources", "images.json", "Comma-seperated list of files inside ./artifacts to merge into metadata.json")
 	flag.StringVar(&o.stage.dockerRegistry, "registry", "", "Push images to the specified docker registry (e.g. gcr.io/a-test-project)")
 	flag.StringVar(&o.save, "save", "", "Save credentials to gs:// path on --up if set (or load from there if not --up)")
 	flag.BoolVar(&o.skew, "skew", false, "If true, run tests in another version at ../kubernetes/hack/e2e.go")
@@ -231,7 +233,7 @@ func complete(o *options) error {
 	}
 
 	if o.dump != "" {
-		defer writeMetadata(o.dump)
+		defer writeMetadata(o)
 		defer writeXML(o.dump, time.Now())
 	}
 	if err := prepare(o); err != nil {
@@ -368,9 +370,23 @@ func findVersion() string {
 	return "unknown" // Sad trombone
 }
 
+// maybeMergeMetadata will add new keyvals into the map; quietly eats errors.
+func maybeMergeJSON(meta map[string]string, path string) {
+	if data, err := ioutil.ReadFile(path); err == nil {
+		json.Unmarshal(data, &meta)
+	}
+}
+
 // Write metadata.json, including version and env arg data.
-func writeMetadata(path string) error {
+func writeMetadata(o *options) error {
+	path := o.dump
 	m := make(map[string]string)
+
+	// Look for any sources of metadata and load 'em
+	for _, f := range strings.Split(o.metadataSources, ",") {
+		maybeMergeJSON(m, filepath.Join(path, f))
+	}
+
 	ver := findVersion()
 	m["version"] = ver // TODO(fejta): retire
 	m["job-version"] = ver

--- a/kubetest/main_test.go
+++ b/kubetest/main_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -39,7 +55,7 @@ func TestWriteMetadata(t *testing.T) {
 	writeTmpMetadataSource := func(filePath string, md mdata) {
 		outputBytes, _ := json.MarshalIndent(md, "", "  ")
 		if err := ioutil.WriteFile(filePath, outputBytes, 0644); err != nil {
-			t.Fatal("write to %q: %v", filePath, err)
+			t.Fatalf("write to %q: %v", filePath, err)
 		}
 	}
 
@@ -58,7 +74,7 @@ func TestWriteMetadata(t *testing.T) {
 		}
 
 		if err := ioutil.WriteFile(filepath.Join(topDir, "version"), []byte(tc.version+"\n"), 0644); err != nil {
-			t.Fatal("write %q/version: %v", topDir, err)
+			t.Fatalf("write %q/version: %v", topDir, err)
 		}
 		sourceNames := []string{}
 		for filename, metadata := range tc.sources {

--- a/kubetest/outputs_test.go
+++ b/kubetest/outputs_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteMetadata(t *testing.T) {
+	type mdata map[string]string
+	cases := []struct {
+		sources map[string]mdata
+		key     string
+		version string
+	}{
+		{
+			sources: nil,
+			key:     "version",
+			version: "v1.8.0-alpha.2.251+ba2bdb1aead615",
+		},
+		{
+			sources: map[string]mdata{"images.json": mdata{"imgkey": "imgval"}},
+			key:     "imgkey",
+			version: "v1.8.0-alpha.2.251+ba2bdb1aead615",
+		},
+		{
+			sources: map[string]mdata{
+				"images.json": mdata{"imgkey": "imgval"},
+				"foo.json":    mdata{"fookey": "fooval"},
+			},
+			key:     "fookey",
+			version: "v1.8.0-alpha.2.251+ba2bdb1aead615",
+		},
+	}
+
+	writeTmpMetadataSource := func(filePath string, md mdata) {
+		outputBytes, _ := json.MarshalIndent(md, "", "  ")
+		if err := ioutil.WriteFile(filePath, outputBytes, 0644); err != nil {
+			t.Fatal("write to %q: %v", filePath, err)
+		}
+	}
+
+	for _, tc := range cases {
+		topDir, err := ioutil.TempDir("", "TestWriteMetadata")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer os.RemoveAll(topDir) // Stack up all the cleanups
+
+		dumpDir := filepath.Join(topDir, "artifacts")
+		if err := os.Mkdir(dumpDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ioutil.WriteFile(filepath.Join(topDir, "version"), []byte(tc.version+"\n"), 0644); err != nil {
+			t.Fatal("write %q/version: %v", topDir, err)
+		}
+		sourceNames := []string{}
+		for filename, metadata := range tc.sources {
+			sourceNames = append(sourceNames, filename)
+			writeTmpMetadataSource(filepath.Join(dumpDir, filename), metadata)
+		}
+
+		// Now we've set things up, call the function
+		//
+		os.Chdir(topDir) // version file is read from "."
+		writeMetadata(dumpDir, strings.Join(sourceNames, ","))
+
+		// Load up the output
+		metadata := map[string]string{}
+		maybeMergeJSON(metadata, filepath.Join(dumpDir, "metadata.json"))
+
+		if _, exists := metadata[tc.key]; !exists {
+			t.Errorf("Expcected metadata key %q, but read in map %#v\n", tc.key, metadata)
+		}
+	}
+}


### PR DESCRIPTION
Just before writing the `metadata.json` file, read some other JSON files from the same dir and inline their contents into the final output of `metadata.json`.

The flag's value consists of comma-separated filenames that are relative to the directory specified in `-dump`.

The flag has a non-empty default (`"images.json"`) to ensure that this file is loaded wherever possible, on all test jobs. Any failures on loading are silently swallowed, so this is safe to do.

@fejta, not entirely sure how to test this in practice, but local unit tests pass ...

/assign @fejta 
/cc @yguo0905 @krzyzacy 