### PR TITLE
Bump timeout for ci-kubernetes-cross-build to 120m

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -82,7 +82,7 @@
         giturl: 'https://github.com/kubernetes/kubernetes'
         job-name: ci-kubernetes-cross-build
         repo-name: k8s.io/kubernetes
-        timeout: 100
+        timeout: 120
 
     - kubernetes-build-1.4:
         branch: release-1.4


### PR DESCRIPTION
After starting to build the hyperkube image in the `ci-kubernetes-cross-build` job, we've been regularly just touching the 100m timeout (http://k8s-testgrid.appspot.com/misc#cross-build&width=20&graph-metrics=test-duration-minutes).

Giving us another 20m should be fine; things should also hopefully speedup after https://github.com/kubernetes/kubernetes/pull/48365.