### PR TITLE
mungegithub: Re-munge every issue every morning

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -2463,6 +2463,11 @@ func (config *Config) ForEachIssueDo(fn MungeFunction) error {
 		config.since = time.Time{}
 	}
 
+	// It's a new day, let's restart from scratch.
+	if time.Now().Format("Jan 2 2006") != config.since.Format("Jan 2 2006") {
+		config.since = time.Time{}
+	}
+
 	since := time.Now()
 	for {
 		glog.V(4).Infof("Fetching page %d of issues", page)


### PR DESCRIPTION
First thing in the morning, let's remunge every issue. This is needed
because some issues are not "modified" but still need to be munged for
various reasons:

- They have become stale,
- They need to be rebased (a push doesn't trigger a re-munge).

Re-munge everything by resetting the since timestamp to 0.