### PR TITLE
Add test-infra base image for golang builds

### DIFF
--- a/Dockerfile-golang
+++ b/Dockerfile-golang
@@ -1,0 +1,26 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.6
+
+ENV GOPATH=/go
+ENV PATH=$PATH:$GOPATH/bin
+
+COPY . /go/src/k8s.io/test-infra
+RUN apk update --no-cache && \
+   apk add --no-cache git go mercurial musl-dev && \
+   go get github.com/tools/godep
+
+WORKDIR /go/src/k8s.io/test-infra
+CMD [ "go", "version" ]


### PR DESCRIPTION
I want to gather feedback on building prow+munger so I am pushing a base image I have been playing around with to automate builds inside Openshift. It's not clear to me how you guys are handling builds with bazel but my hope is that bazel can make use of this image. I would love to see this kept to a minimum size.

@spxtr @fejta @rmmh 