### PR TITLE
Set PROJECT which is used by list-resources.sh

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -480,6 +480,11 @@ func prepareGcp(o *options) error {
 			return fmt.Errorf("fail to set project %s : err %v", p, err)
 		}
 
+		// TODO(krzyzacy):Remove this when we retire migrateGcpEnvAndOptions
+		if err := os.Setenv("PROJECT", p); err != nil {
+			return fmt.Errorf("fail to set env var PROJECT %s : err %v", p, err)
+		}
+
 		go func(c *client.Client, proj string) {
 			for range time.Tick(time.Minute * 5) {
 				if err := c.UpdateOne(p, "busy"); err != nil {


### PR DESCRIPTION
almost - https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-prow-canary/16661/?log#log apparently there are still places `PROJECT` is used.

got `./cluster/gce/list-resources.sh: line 67: PROJECT: unbound variable`

/assign @fejta 