### PR TITLE
Ignore local GOPATH when copy over env vars to scenario

### DIFF
--- a/scenarios/kubernetes_kops_aws.py
+++ b/scenarios/kubernetes_kops_aws.py
@@ -230,6 +230,7 @@ def main(args):
     # TODO(krzyzacy) change this to a whitelist
     docker_env_ignore = [
       'GOOGLE_APPLICATION_CREDENTIALS',
+      'GOPATH',
       'GOROOT',
       'HOME',
       'PATH',


### PR DESCRIPTION
[e2e scenario](https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_e2e.py#L234) already ignored that.

`make: *** /var/lib/jenkins/workspace/pull-kubernetes-e2e-kops-aws-scenario/go/src/k8s.io/kubernetes: No such file or directory.  Stop.`
Getting closer.

/assign @fejta @zmerlynn 