### PR TITLE
creating kops build queue - adding config map

### DIFF
--- a/mungegithub/submit-queue/deployment/kops/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kops/configmap.yaml
@@ -1,0 +1,27 @@
+# basic config options.
+http-cache-dir: /cache/httpcache
+organization: kubernetes
+project: kops
+pr-mungers: lgtm-after-commit,submit-queue,needs-rebase
+state: open
+token-file: /etc/secret-volume/token
+period: 30s
+repo-dir: /gitrepos
+github-key-file: /etc/hook-secret-volume/secret
+
+# status contexts options.
+required-contexts: "continuous-integration/travis-ci/pr"
+required-retest-contexts: "pull-kops-e2e-kubernetes-aws"
+protected-branches-extra-contexts: ""
+
+# submit-queue options.
+protected-branches: "master"
+nonblocking-jenkins-jobs: ""
+do-not-merge-milestones: ""
+admin-port: 9999
+context-url: https://kops.submit-queue.k8s.io
+
+# munger specific options.
+# label-file: "/gitrepos/kops/labels.yaml"
+
+gate-cla: true


### PR DESCRIPTION
One thing I do not understand is 

```yaml
nonblocking-jenkins-jobs: "pull-kops-e2e-kubernetes-aws"
```
Our e2e should block merging ... does this configure that?

Fixes: https://github.com/kubernetes/test-infra/issues/3534

/assign @cjwagner