### PR TITLE
mungegithub: publish k8s.io/metrics

### DIFF
--- a/mungegithub/mungers/publish_scripts/initialize_repos.sh
+++ b/mungegithub/mungers/publish_scripts/initialize_repos.sh
@@ -32,7 +32,7 @@ pushd kubernetes
     ./hack/godep-restore.sh
 popd
 
-for repo in "apimachinery" "client-go" "apiserver" "kube-aggregator" "sample-apiserver" "apiextensions-apiserver" "api"
+for repo in "apimachinery" "client-go" "apiserver" "kube-aggregator" "sample-apiserver" "apiextensions-apiserver" "api" "metrics"
 do
     git clone "https://github.com/${ORG}/${repo}"
 done

--- a/mungegithub/mungers/publish_scripts/publish_metrics.sh
+++ b/mungegithub/mungers/publish_scripts/publish_metrics.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script publishes the latest changes in the ${src_branch} of
+# k8s.io/kubernetes/staging/src/apiextensions_apiserver to the ${dst_branch} of
+# k8s.io/apiextensions_apiserver.
+#
+# ${kubernetes_remote} is the remote url of k8s.io/kubernetes that will be used
+# in .git/config in the local checkout of apiextensions_apiserver. We usually
+# set it to the local checkout of k8s.io/kubernetes to avoid multiple
+# checkouts.This not only reduces the run time, but also ensures all published
+# repos are generated from the same revision of k8s.io/kubernetes.
+#
+# The script assumes that the working directory is
+# $GOPATH/src/k8s.io/metrics.
+#
+# The script is expected to be run by
+# k8s.io/test-infra/mungegithub/mungers/publisher.go
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ ! $# -eq 4 ]; then
+    echo "usage: $0 src_branch dst_branch dependent_k8s_repos kubernetes_remote"
+    exit 1
+fi
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
+"${SCRIPT_DIR}"/publish_template.sh "metrics" "${1}" "${2}" "${3}" "${4}" "false"

--- a/mungegithub/mungers/publisher.go
+++ b/mungegithub/mungers/publisher.go
@@ -163,8 +163,8 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/apiserver"},
 				dst: coordinate{repo: "apiserver", branch: "release-1.7", dir: "./"},
 				deps: []coordinate{
-					coordinate{repo: "apimachinery", branch: "release-1.7"},
-					coordinate{repo: "client-go", branch: "release-4.0"},
+					{repo: "apimachinery", branch: "release-1.7"},
+					{repo: "client-go", branch: "release-4.0"},
 				},
 			},
 		},
@@ -199,9 +199,9 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/kube-aggregator"},
 				dst: coordinate{repo: "kube-aggregator", branch: "release-1.7", dir: "./"},
 				deps: []coordinate{
-					coordinate{repo: "apimachinery", branch: "release-1.7"},
-					coordinate{repo: "client-go", branch: "release-4.0"},
-					coordinate{repo: "apiserver", branch: "release-1.7"},
+					{repo: "apimachinery", branch: "release-1.7"},
+					{repo: "client-go", branch: "release-4.0"},
+					{repo: "apiserver", branch: "release-1.7"},
 				},
 			},
 		},
@@ -236,9 +236,9 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/sample-apiserver"},
 				dst: coordinate{repo: "sample-apiserver", branch: "release-1.7", dir: "./"},
 				deps: []coordinate{
-					coordinate{repo: "apimachinery", branch: "release-1.7"},
-					coordinate{repo: "client-go", branch: "release-4.0"},
-					coordinate{repo: "apiserver", branch: "release-1.7"},
+					{repo: "apimachinery", branch: "release-1.7"},
+					{repo: "client-go", branch: "release-4.0"},
+					{repo: "apiserver", branch: "release-1.7"},
 				},
 			},
 		},
@@ -263,9 +263,9 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/apiextensions-apiserver"},
 				dst: coordinate{repo: "apiextensions-apiserver", branch: "release-1.7", dir: "./"},
 				deps: []coordinate{
-					coordinate{repo: "apimachinery", branch: "release-1.7"},
-					coordinate{repo: "client-go", branch: "release-4.0"},
-					coordinate{repo: "apiserver", branch: "release-1.7"},
+					{repo: "apimachinery", branch: "release-1.7"},
+					{repo: "client-go", branch: "release-4.0"},
+					{repo: "apiserver", branch: "release-1.7"},
 				},
 			},
 		},
@@ -286,8 +286,34 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 		},
 		publishScript: "/publish_scripts/publish_api.sh",
 	}
+
+	metrics := repoRules{
+		dstRepo: "metrics",
+		srcToDst: []branchRule{
+			{
+				// rule for the metrics master branch
+				src: coordinate{repo: config.Project, branch: "master", dir: "staging/src/k8s.io/metrics"},
+				dst: coordinate{repo: "metrics", branch: "master", dir: "./"},
+				deps: []coordinate{
+					{repo: "apimachinery", branch: "master"},
+					{repo: "client-go", branch: "master"},
+				},
+			},
+			{
+				// rule for the sample-apiserver 1.7 branch
+				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/metrics"},
+				dst: coordinate{repo: "metrics", branch: "release-1.7", dir: "./"},
+				deps: []coordinate{
+					{repo: "apimachinery", branch: "release-1.7"},
+					{repo: "client-go", branch: "release-4.0"},
+				},
+			},
+		},
+		publishScript: "/publish_scripts/publish_metrics.sh",
+	}
+
 	// NOTE: Order of the repos is sensitive!!! A dependent repo needs to be published first, so that other repos can vendor its latest revision.
-	p.reposRules = []repoRules{apimachinery, api, clientGo, apiserver, kubeAggregator, sampleAPIServer, apiExtensionsAPIServer}
+	p.reposRules = []repoRules{apimachinery, api, clientGo, apiserver, kubeAggregator, sampleAPIServer, apiExtensionsAPIServer, metrics}
 	glog.Infof("publisher munger rules: %#v\n", p.reposRules)
 	p.features = features
 	p.githubConfig = config

--- a/mungegithub/mungers/publisher.go
+++ b/mungegithub/mungers/publisher.go
@@ -158,6 +158,15 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 					{repo: "client-go", branch: "release-3.0"},
 				},
 			},
+			{
+				// rule for the apiserver 1.7 branch
+				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/apiserver"},
+				dst: coordinate{repo: "apiserver", branch: "release-1.7", dir: "./"},
+				deps: []coordinate{
+					coordinate{repo: "apimachinery", branch: "release-1.7"},
+					coordinate{repo: "client-go", branch: "release-4.0"},
+				},
+			},
 		},
 		publishScript: "/publish_scripts/publish_apiserver.sh",
 	}
@@ -183,6 +192,16 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 					{repo: "apimachinery", branch: "release-1.6"},
 					{repo: "client-go", branch: "release-3.0"},
 					{repo: "apiserver", branch: "release-1.6"},
+				},
+			},
+			{
+				// rule for the kube-aggregator 1.7 branch
+				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/kube-aggregator"},
+				dst: coordinate{repo: "kube-aggregator", branch: "release-1.7", dir: "./"},
+				deps: []coordinate{
+					coordinate{repo: "apimachinery", branch: "release-1.7"},
+					coordinate{repo: "client-go", branch: "release-4.0"},
+					coordinate{repo: "apiserver", branch: "release-1.7"},
 				},
 			},
 		},
@@ -212,6 +231,16 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 					{repo: "apiserver", branch: "release-1.6"},
 				},
 			},
+			{
+				// rule for the sample-apiserver 1.7 branch
+				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/sample-apiserver"},
+				dst: coordinate{repo: "sample-apiserver", branch: "release-1.7", dir: "./"},
+				deps: []coordinate{
+					coordinate{repo: "apimachinery", branch: "release-1.7"},
+					coordinate{repo: "client-go", branch: "release-4.0"},
+					coordinate{repo: "apiserver", branch: "release-1.7"},
+				},
+			},
 		},
 		publishScript: "/publish_scripts/publish_sample_apiserver.sh",
 	}
@@ -227,6 +256,16 @@ func (p *PublisherMunger) Initialize(config *github.Config, features *features.F
 					{repo: "apimachinery", branch: "master"},
 					{repo: "client-go", branch: "master"},
 					{repo: "apiserver", branch: "master"},
+				},
+			},
+			{
+				// rule for the sample-apiserver 1.7 branch
+				src: coordinate{repo: config.Project, branch: "release-1.7", dir: "staging/src/k8s.io/apiextensions-apiserver"},
+				dst: coordinate{repo: "apiextensions-apiserver", branch: "release-1.7", dir: "./"},
+				deps: []coordinate{
+					coordinate{repo: "apimachinery", branch: "release-1.7"},
+					coordinate{repo: "client-go", branch: "release-4.0"},
+					coordinate{repo: "apiserver", branch: "release-1.7"},
 				},
 			},
 		},


### PR DESCRIPTION
k8s.io/metrics is vendored manually, but should be published as all other staging repos. Otherwise, vendoring kube becomes hard.

Warning: have no setup to test this myself.