### PR TITLE
--gcp-zone should set KUBE_GCE_ZONE when --provider=gce

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -442,6 +442,13 @@ func installGcloud(tarball string, location string) error {
 }
 
 func migrateGcpEnvAndOptions(o *options) error {
+	var z string
+	switch o.provider {
+	case "gke":
+		z = "ZONE"
+	default:
+		z = "KUBE_GCE_ZONE"
+	}
 	return migrateOptions([]migratedOption{
 		{
 			env:    "PROJECT",
@@ -449,7 +456,7 @@ func migrateGcpEnvAndOptions(o *options) error {
 			name:   "--gcp-project",
 		},
 		{
-			env:    "ZONE",
+			env:    z,
 			option: &o.gcpZone,
 			name:   "--gcp-zone",
 		},
@@ -471,7 +478,6 @@ func prepareGcp(o *options) error {
 	if err := migrateGcpEnvAndOptions(o); err != nil {
 		return err
 	}
-
 	if o.gcpProject == "" {
 		var resType string
 		if o.provider == "gce" {


### PR DESCRIPTION
/assign @krzyzacy @shyamjvs 

Added unit test for this scenario

ref https://github.com/kubernetes/test-infra/issues/3375

After merging will build and push a new kubetest image with this change, and then revert back to using --gcp-zone