### PR TITLE
Make logging in splice and tot consistent with the rest.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -18,8 +18,8 @@ all: build test
 HOOK_VERSION       ?= 0.130
 SINKER_VERSION     ?= 0.14
 DECK_VERSION       ?= 0.39
-SPLICE_VERSION     ?= 0.25
-TOT_VERSION        ?= 0.4
+SPLICE_VERSION     ?= 0.26
+TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.6
 PLANK_VERSION      ?= 0.30
 

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,13 +13,11 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.25
+        image: gcr.io/k8s-prow/splice:0.26
         volumeMounts:
         - name: config
           mountPath: /etc/config
           readOnly: true
-        args:
-        - -log-json
       volumes:
       - name: config
         configMap:

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -57,10 +57,9 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:0.4
+        image: gcr.io/k8s-prow/tot:0.5
         imagePullPolicy: Always
         args:
-        - -log-json
         - -storage=/store/tot.json
         - -fallback
         ports:

--- a/prow/cmd/splice/main.go
+++ b/prow/cmd/splice/main.go
@@ -39,7 +39,6 @@ var (
 	remoteURL      = flag.String("remote-url", "https://github.com/kubernetes/kubernetes", "Remote Git URL")
 	orgName        = flag.String("org", "kubernetes", "Org name")
 	repoName       = flag.String("repo", "kubernetes", "Repo name")
-	logJSON        = flag.Bool("log-json", false, "output log in JSON format")
 	configPath     = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
 	maxBatchSize   = flag.Int("batch-size", 5, "Maximum batch size")
 )
@@ -50,7 +49,7 @@ func call(binary string, args ...string) (string, error) {
 	for _, arg := range args {
 		cmdout += arg + " "
 	}
-	log.Debug(cmdout)
+	log.Info(cmdout)
 
 	cmd := exec.Command(binary, args...)
 	output, err := cmd.CombinedOutput()
@@ -111,7 +110,7 @@ func makeSplicer() (*splicer, error) {
 		s.cleanup()
 		return nil, err
 	}
-	log.Debug("splicer created in", dir)
+	log.Infof("Splicer created in %s.", dir)
 	return s, nil
 }
 
@@ -125,7 +124,7 @@ func (s *splicer) gitCall(args ...string) error {
 	fullArgs := append([]string{"-C", s.dir}, args...)
 	output, err := call("git", fullArgs...)
 	if len(output) > 0 {
-		log.Debug(output)
+		log.Info(output)
 	}
 	return err
 }
@@ -262,10 +261,7 @@ func neededPresubmits(presubmits []config.Presubmit, currentJobs []kube.ProwJob,
 
 func main() {
 	flag.Parse()
-	if *logJSON {
-		log.SetFormatter(&log.JSONFormatter{})
-	}
-	log.SetLevel(log.DebugLevel)
+	log.SetFormatter(&log.JSONFormatter{})
 
 	splicer, err := makeSplicer()
 	if err != nil {

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -35,7 +35,6 @@ import (
 
 var (
 	port        = flag.Int("port", 8888, "port to listen on")
-	logJSON     = flag.Bool("log-json", false, "output log in JSON format")
 	storagePath = flag.String("storage", "tot.json", "where to store the results")
 
 	// TODO(rmmh): remove this once we have no jobs running on Jenkins
@@ -120,24 +119,24 @@ func (s *store) handle(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "GET":
 		n := s.vend(b)
-		log.Infof("vending %s number %d to %s", b, n, r.RemoteAddr)
+		log.Infof("Vending %s number %d to %s.", b, n, r.RemoteAddr)
 		fmt.Fprintf(w, "%d", n)
 	case "HEAD":
 		n := s.peek(b)
-		log.Infof("peeking %s number %d to %s", b, n, r.RemoteAddr)
+		log.Infof("Peeking %s number %d to %s.", b, n, r.RemoteAddr)
 		fmt.Fprintf(w, "%d", n)
 	case "POST":
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.WithError(err).Error("unable to read body")
+			log.WithError(err).Error("Unable to read body.")
 			return
 		}
 		n, err := strconv.Atoi(string(body))
 		if err != nil {
-			log.WithError(err).Error("unable to parse number")
+			log.WithError(err).Error("Unable to parse number.")
 			return
 		}
-		log.Infof("setting %s to %d from %s", b, n, r.RemoteAddr)
+		log.Infof("Setting %s to %d from %s.", b, n, r.RemoteAddr)
 		s.set(b, n)
 	}
 }
@@ -164,7 +163,7 @@ func (f fallbackHandler) get(b string) int {
 				}
 			}
 		} else {
-			log.WithError(err).Errorf("Failed to GET %s", url)
+			log.WithError(err).Errorf("Failed to GET %s.", url)
 		}
 		time.Sleep(2 * time.Second)
 	}
@@ -180,10 +179,7 @@ func (f fallbackHandler) get(b string) int {
 func main() {
 	flag.Parse()
 
-	if *logJSON {
-		log.SetFormatter(&log.JSONFormatter{})
-	}
-	log.SetLevel(log.DebugLevel)
+	log.SetFormatter(&log.JSONFormatter{})
 
 	s, err := newStore(*storagePath)
 	if err != nil {


### PR DESCRIPTION
Ref #3530. This makes them use JSON logging and standardizes some logging strings. `cmd/hook` does not use JSON logging only if you specify `--local`, otherwise it does.