### PR TITLE
Use UUIDs for pod names.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       ?= 0.38
 SPLICE_VERSION     ?= 0.24
 TOT_VERSION        ?= 0.3
 HOROLOGIUM_VERSION ?= 0.5
-PLANK_VERSION      ?= 0.28
+PLANK_VERSION      ?= 0.29
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.28
+        image: gcr.io/k8s-prow/plank:0.29
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/snowflake"
+	"github.com/satori/go.uuid"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
@@ -343,11 +344,7 @@ func (c *Controller) startPod(pj kube.ProwJob) (string, string, error) {
 	}
 	spec := pj.Spec.PodSpec
 	spec.RestartPolicy = "Never"
-	// Keep this synchronized with get_running_build_log in Gubernator!
-	podName := fmt.Sprintf("%s-%s", pj.Spec.Job, buildID)
-	if len(podName) > 60 {
-		podName = podName[len(podName)-60:]
-	}
+	podName := uuid.NewV1().String()
 
 	// Set environment variables in each container in the pod spec. We don't
 	// want to update the spec in place, since that will update the ProwJob


### PR DESCRIPTION
#3402 
Fixes an awkward bug where long job names being truncated leads to invalid pod names.