### PR TITLE
prow: introduce max concurrency for jobs

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       ?= 0.39
 SPLICE_VERSION     ?= 0.26
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.6
-PLANK_VERSION      ?= 0.30
+PLANK_VERSION      ?= 0.31
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.30
+        image: gcr.io/k8s-prow/plank:0.31
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -39,6 +39,8 @@ type Presubmit struct {
 	RerunCommand string `json:"rerun_command"`
 	// Whether or not to skip commenting and setting status on GitHub.
 	SkipReport bool `json:"skip_report"`
+	// Maximum number of this job running concurrently, 0 implies no limit.
+	MaxConcurrency int `json:"max_concurrency"`
 	// Kubernetes pod spec.
 	Spec *kube.PodSpec `json:"spec,omitempty"`
 	// Run these jobs after successfully running this one.
@@ -55,6 +57,8 @@ type Presubmit struct {
 type Postsubmit struct {
 	Name string        `json:"name"`
 	Spec *kube.PodSpec `json:"spec,omitempty"`
+	// Maximum number of this job running concurrently, 0 implies no limit.
+	MaxConcurrency int `json:"max_concurrency"`
 
 	Brancher
 

--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -61,9 +61,10 @@ type ProwJobSpec struct {
 	Job   string       `json:"job,omitempty"`
 	Refs  Refs         `json:"refs,omitempty"`
 
-	Report       bool   `json:"report,omitempty"`
-	Context      string `json:"context,omitempty"`
-	RerunCommand string `json:"rerun_command,omitempty"`
+	Report         bool   `json:"report,omitempty"`
+	Context        string `json:"context,omitempty"`
+	RerunCommand   string `json:"rerun_command,omitempty"`
+	MaxConcurrency int    `json:"max_concurrency,omitempty"`
 
 	PodSpec PodSpec `json:"pod_spec,omitempty"`
 

--- a/prow/plank/BUILD
+++ b/prow/plank/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//prow/jenkins:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/plugins:go_default_library",
+        "//vendor:github.com/Sirupsen/logrus",
         "//vendor:github.com/bwmarrin/snowflake",
         "//vendor:github.com/satori/go.uuid",
     ],

--- a/prow/plank/plank.go
+++ b/prow/plank/plank.go
@@ -19,7 +19,7 @@ package plank
 import (
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/kube"
@@ -48,9 +48,10 @@ func PresubmitSpec(p config.Presubmit, refs kube.Refs) kube.ProwJobSpec {
 		Job:  p.Name,
 		Refs: refs,
 
-		Report:       !p.SkipReport,
-		Context:      p.Context,
-		RerunCommand: p.RerunCommand,
+		Report:         !p.SkipReport,
+		Context:        p.Context,
+		RerunCommand:   p.RerunCommand,
+		MaxConcurrency: p.MaxConcurrency,
 	}
 	if p.Spec == nil {
 		pjs.Agent = kube.JenkinsAgent
@@ -67,9 +68,10 @@ func PresubmitSpec(p config.Presubmit, refs kube.Refs) kube.ProwJobSpec {
 // PostsubmitSpec initializes a ProwJobSpec for a given postsubmit job.
 func PostsubmitSpec(p config.Postsubmit, refs kube.Refs) kube.ProwJobSpec {
 	pjs := kube.ProwJobSpec{
-		Type: kube.PostsubmitJob,
-		Job:  p.Name,
-		Refs: refs,
+		Type:           kube.PostsubmitJob,
+		Job:            p.Name,
+		Refs:           refs,
+		MaxConcurrency: p.MaxConcurrency,
 	}
 	if p.Spec == nil {
 		pjs.Agent = kube.JenkinsAgent


### PR DESCRIPTION
This is a first pass at implementing the ability to specify the maximum number of concurrent instances for a job in Prow. 

Relevant issue: https://github.com/kubernetes/test-infra/issues/3209

I had to make a few decisions which I am curious for feedback on:
- In order to continue to only pass through syncing jobs once, this implementation will, in the case where there is a job `myjob` finished and a job `myjob` triggered, not start `myjob` on that sync. There are ways to work around this by making larger changes to the `Sync` function.
- Added the logic for maximum concurrency to both `syncJenkinsJob` and `syncKubernetesJob`, since the logic for starting the pods is in there. I think this may be necessary, but since it's duplicated it would be cool if it didn't have to be both places.