### PR TITLE
Make mungers handle a reloading config.

### DIFF
--- a/mungegithub/BUILD
+++ b/mungegithub/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/spf13/cobra",
         "//vendor:k8s.io/kubernetes/pkg/util/flag",
+        "//vendor:k8s.io/kubernetes/pkg/util/sets",
     ],
 )
 

--- a/mungegithub/features/aliases_test.go
+++ b/mungegithub/features/aliases_test.go
@@ -74,14 +74,12 @@ func TestExpandAliases(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		a := Aliases{
-			aliasReader: &aliasTest{},
-			IsEnabled:   true,
-		}
+		a := Aliases{aliasFile: "dummy.file"}
 
 		if err := a.Initialize(&github_util.Config{}); err != nil {
 			t.Fatalf("%v", err)
 		}
+		a.aliasReader = &aliasTest{}
 
 		if err := a.EachLoop(); err != nil {
 			t.Fatalf("%v", err)

--- a/mungegithub/features/branch-protection.go
+++ b/mungegithub/features/branch-protection.go
@@ -17,6 +17,7 @@ limitations under the License.
 package features
 
 import (
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"
 	"k8s.io/test-infra/mungegithub/options"
@@ -63,8 +64,9 @@ func (bp *BranchProtection) EachLoop() error {
 	return nil
 }
 
-// RegisterOptions registers options used by the BranchProtection feature.
-func (bp *BranchProtection) RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options for this feature; returns any that require a restart when changed.
+func (bp *BranchProtection) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterStringSlice(&bp.branches, "protected-branches", []string{}, "branches to be marked 'protected'.  required-contexts, required-retest-contexts, and protected-branches-extra-contexts will be marked as required for non-admins")
 	opts.RegisterStringSlice(&bp.extraContexts, "protected-branches-extra-contexts", []string{}, "Contexts which will be marked as required in the Github UI but which the bot itself does not require")
+	return nil
 }

--- a/mungegithub/mungeopts/BUILD
+++ b/mungegithub/mungeopts/BUILD
@@ -11,7 +11,10 @@ go_library(
     name = "go_default_library",
     srcs = ["mungeopts.go"],
     tags = ["automanaged"],
-    deps = ["//mungegithub/options:go_default_library"],
+    deps = [
+        "//mungegithub/options:go_default_library",
+        "//vendor:k8s.io/kubernetes/pkg/util/sets",
+    ],
 )
 
 filegroup(

--- a/mungegithub/mungeopts/mungeopts.go
+++ b/mungegithub/mungeopts/mungeopts.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package mungeopts
 
-import "k8s.io/test-infra/mungegithub/options"
+import (
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/test-infra/mungegithub/options"
+)
 
 var (
 	// Server holds the values of options used by mungers that serve web services.
@@ -46,7 +49,9 @@ var (
 	}
 )
 
-func RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options that may be used by any munger, feature, or report. It returns
+// any options that require a restart when changed.
+func RegisterOptions(opts *options.Options) sets.String {
 	// Options for mungers that run web servers.
 	opts.RegisterString(&Server.Address, "address", ":8080", "The address to listen on for HTTP Status")
 	opts.RegisterString(&Server.WWWRoot, "www", "www", "Path to static web files to serve from the webserver")
@@ -61,4 +66,5 @@ func RegisterOptions(opts *options.Options) {
 	opts.RegisterStringSlice(&RequiredContexts.Retest, "required-retest-contexts", []string{}, "Comma separate list of statuses which will be retested and which must come back green after the `retest-body` comment is posted to a PR")
 	opts.RegisterStringSlice(&RequiredContexts.Merge, "required-contexts", []string{}, "Comma separate list of status contexts required for a PR to be considered ok to merge")
 
+	return sets.NewString("address", "www")
 }

--- a/mungegithub/mungers/BUILD
+++ b/mungegithub/mungers/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//mungegithub/mungers/e2e/fake:go_default_library",
         "//mungegithub/mungers/mungerutil:go_default_library",
         "//mungegithub/mungers/testowner:go_default_library",
+        "//mungegithub/options:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/google/go-github/github",
         "//vendor:k8s.io/contrib/test-utils/utils",

--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -23,6 +23,7 @@ import (
 
 	githubapi "github.com/google/go-github/github"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/approvers"
@@ -68,8 +69,8 @@ func (h *ApprovalHandler) Initialize(config *github.Config, features *features.F
 // EachLoop is called at the start of every munge loop
 func (*ApprovalHandler) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (*ApprovalHandler) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (*ApprovalHandler) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Returns associated issue, or 0 if it can't find any.
 // This is really simple, and could be improved later.

--- a/mungegithub/mungers/assign-fixes.go
+++ b/mungegithub/mungers/assign-fixes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mungers
 
 import (
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -53,9 +54,10 @@ func (a *AssignFixesMunger) Initialize(config *github.Config, features *features
 // EachLoop is called at the start of every munge loop
 func (a *AssignFixesMunger) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (a *AssignFixesMunger) RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (a *AssignFixesMunger) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterBool(&a.assignFixesReassign, "fixes-issue-reassign", false, "Assign fixes Issues even if they're already assigned")
+	return nil
 }
 
 // Munge is the workhorse the will actually make updates to the PR

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -69,10 +69,11 @@ func (b *BlunderbussMunger) Initialize(config *github.Config, features *features
 // EachLoop is called at the start of every munge loop
 func (b *BlunderbussMunger) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (b *BlunderbussMunger) RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (b *BlunderbussMunger) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterBool(&b.blunderbussReassign, "blunderbuss-reassign", false, "Assign PRs even if they're already assigned; use with -dry-run to judge changes to the assignment algorithm")
 	opts.RegisterInt(&b.numAssignees, "blunderbuss-number-assignees", 2, "Number of assignees to select for each PR.")
+	return nil
 }
 
 func chance(val, total int64) float64 {
@@ -116,7 +117,7 @@ func getPotentialOwners(author string, feats *features.Features, files []*github
 			glog.Warningf("Couldn't find an owner for: %s", *file.Filename)
 		}
 
-		if aliases != nil && aliases.IsEnabled {
+		if aliases != nil {
 			fileOwners = aliases.Expand(fileOwners)
 		}
 

--- a/mungegithub/mungers/cherrypick-auto-approve.go
+++ b/mungegithub/mungers/cherrypick-auto-approve.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -63,8 +64,8 @@ func (c *CherrypickAutoApprove) Initialize(config *github.Config, features *feat
 // EachLoop is called at the start of every munge loop
 func (c *CherrypickAutoApprove) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (c *CherrypickAutoApprove) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (c *CherrypickAutoApprove) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func getCherrypickParentPRs(obj *github.MungeObject, config *github.Config) []*github.MungeObject {
 	out := []*github.MungeObject{}

--- a/mungegithub/mungers/cherrypick-clear-after-merge.go
+++ b/mungegithub/mungers/cherrypick-clear-after-merge.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -56,8 +57,8 @@ func (c *ClearPickAfterMerge) Initialize(config *github.Config, features *featur
 // EachLoop is called at the start of every munge loop
 func (c *ClearPickAfterMerge) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (c *ClearPickAfterMerge) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (c *ClearPickAfterMerge) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func handleFound(obj *github.MungeObject, branch string) error {
 	msg := fmt.Sprintf("Commit found in the %q branch appears to be this PR. Removing the %q label. If this is an error find help to get your PR picked.", branch, cpCandidateLabel)

--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -19,6 +19,7 @@ package mungers
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -60,8 +61,8 @@ func (LabelUnapprovedPicks) Initialize(config *github.Config, features *features
 // EachLoop is called at the start of every munge loop
 func (LabelUnapprovedPicks) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (LabelUnapprovedPicks) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (LabelUnapprovedPicks) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Munge is the workhorse the will actually make updates to the PR
 func (LabelUnapprovedPicks) Munge(obj *github.MungeObject) {

--- a/mungegithub/mungers/cherrypick-must-have-milestone.go
+++ b/mungegithub/mungers/cherrypick-must-have-milestone.go
@@ -19,6 +19,7 @@ package mungers
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -59,8 +60,8 @@ func (PickMustHaveMilestone) Initialize(config *github.Config, features *feature
 // EachLoop is called at the start of every munge loop
 func (PickMustHaveMilestone) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (PickMustHaveMilestone) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (PickMustHaveMilestone) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Munge is the workhorse the will actually make updates to the PR
 func (PickMustHaveMilestone) Munge(obj *github.MungeObject) {

--- a/mungegithub/mungers/cherrypick-queue.go
+++ b/mungegithub/mungers/cherrypick-queue.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"
@@ -101,8 +102,8 @@ func (c *CherrypickQueue) Initialize(config *github.Config, features *features.F
 // EachLoop is called at the start of every munge loop
 func (c *CherrypickQueue) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (c *CherrypickQueue) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (c *CherrypickQueue) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Munge is the workhorse the will actually make updates to the PR
 func (c *CherrypickQueue) Munge(obj *github.MungeObject) {

--- a/mungegithub/mungers/close-stale.go
+++ b/mungegithub/mungers/close-stale.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"time"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"
@@ -78,8 +79,8 @@ func (CloseStale) Initialize(config *github.Config, features *features.Features)
 // EachLoop is called at the start of every munge loop
 func (CloseStale) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (CloseStale) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (CloseStale) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func findLastHumanPullRequestUpdate(obj *github.MungeObject) (*time.Time, bool) {
 	pr, ok := obj.GetPR()

--- a/mungegithub/mungers/comment-deleter.go
+++ b/mungegithub/mungers/comment-deleter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mungers
 
 import (
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -66,8 +67,8 @@ func (CommentDeleter) Initialize(config *github.Config, features *features.Featu
 // EachLoop is called at the start of every munge loop
 func (CommentDeleter) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (CommentDeleter) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (CommentDeleter) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func validComment(comment *githubapi.IssueComment) bool {
 	if comment.User == nil || comment.User.Login == nil {

--- a/mungegithub/mungers/docs-no-retest.go
+++ b/mungegithub/mungers/docs-no-retest.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 
 	githubapi "github.com/google/go-github/github"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -57,8 +58,8 @@ func (s *DocsNeedNoRetest) Initialize(config *github.Config, features *features.
 // EachLoop is called at the start of every munge loop
 func (DocsNeedNoRetest) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (DocsNeedNoRetest) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (DocsNeedNoRetest) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func areFilesDocOnly(files []*githubapi.CommitFile) bool {
 	for _, file := range files {

--- a/mungegithub/mungers/e2e/BUILD
+++ b/mungegithub/mungers/e2e/BUILD
@@ -16,7 +16,10 @@ go_test(
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//vendor:k8s.io/contrib/test-utils/utils"],
+    deps = [
+        "//mungegithub/options:go_default_library",
+        "//vendor:k8s.io/contrib/test-utils/utils",
+    ],
 )
 
 go_library(
@@ -28,6 +31,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//mungegithub/mungers/flakesync:go_default_library",
+        "//mungegithub/options:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/contrib/test-utils/utils",
         "//vendor:k8s.io/kubernetes/pkg/util/sets",

--- a/mungegithub/mungers/e2e/e2e_test.go
+++ b/mungegithub/mungers/e2e/e2e_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"k8s.io/contrib/test-utils/utils"
+	"k8s.io/test-infra/mungegithub/options"
 )
 
 type testHandler struct {
@@ -208,12 +209,10 @@ func TestCheckGCSBuilds(t *testing.T) {
 				res.Write(data)
 			},
 		})
+		jobs := []string{"foo", "bar", "baz"}
 		e2e := &RealE2ETester{
-			NonBlockingJobNames: []string{
-				"foo",
-				"bar",
-				"baz",
-			},
+			Opts:                 options.New(),
+			NonBlockingJobNames:  &jobs,
 			BuildStatus:          map[string]BuildInfo{},
 			GoogleGCSBucketUtils: utils.NewTestUtils("bucket", "logs", server.URL),
 		}

--- a/mungegithub/mungers/flakyjob-reporter.go
+++ b/mungegithub/mungers/flakyjob-reporter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 
 	githubapi "github.com/google/go-github/github"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"
@@ -91,11 +92,12 @@ func (fjr *FlakyJobReporter) Initialize(config *github.Config, features *feature
 	return nil
 }
 
-// RegisterOptions registers config options for this munger.
-func (fjr *FlakyJobReporter) RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (fjr *FlakyJobReporter) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterString(&fjr.flakyJobDataURL, "flakyjob-url", "https://storage.googleapis.com/k8s-metrics/flakes-latest.json", "The url where flaky job JSON data can be found.")
 	opts.RegisterInt(&fjr.syncCount, "flakyjob-count", 3, "The number of flaky jobs to try to sync to github.")
 	opts.RegisterDuration(&fjr.syncFreq, "flakyjob-freq", time.Hour*24, "The frequency at which to run the FlakyJobReporter.")
+	return nil
 }
 
 // EachLoop is called every munge loop.

--- a/mungegithub/mungers/inactive-review-handler.go
+++ b/mungegithub/mungers/inactive-review-handler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	githubapi "github.com/google/go-github/github"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/matchers"
@@ -59,8 +60,8 @@ func (i *InactiveReviewHandler) Initialize(config *github.Config, features *feat
 // EachLoop is called at the start of every munge loop
 func (i *InactiveReviewHandler) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (*InactiveReviewHandler) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (*InactiveReviewHandler) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func (i *InactiveReviewHandler) haveNonAuthorHuman(authorName *string, comments []*githubapi.IssueComment, reviewComments []*githubapi.PullRequestComment) bool {
 	return !matchers.Items{}.

--- a/mungegithub/mungers/issue-categorizer.go
+++ b/mungegithub/mungers/issue-categorizer.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/matchers/event"
@@ -48,9 +49,10 @@ func (*LabelMunger) Name() string { return "issue-triager" }
 // RequiredFeatures is a slice of 'features' that must be provided
 func (*LabelMunger) RequiredFeatures() []string { return []string{} }
 
-// RegisterOptions registers config options for this munger.
-func (lm *LabelMunger) RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (lm *LabelMunger) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterString(&lm.triagerUrl, "triager-url", "", "Url on which ml web service is listening")
+	return nil
 }
 
 func init() {

--- a/mungegithub/mungers/issue-creator_test.go
+++ b/mungegithub/mungers/issue-creator_test.go
@@ -90,10 +90,6 @@ func (c *fakeClient) getProject() string {
 	return c.project
 }
 
-func (c *fakeClient) RealConfig() *github.Config {
-	return nil
-}
-
 // Verify checks that exactly 1 issue in c.issues matches the parameters and that no
 // issues in c.issues have an empty body string (since that means they shouldn't have been created).
 func (c *fakeClient) Verify(title, body string, owners, labels []string) bool {

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"
@@ -61,8 +62,8 @@ func (LGTMAfterCommitMunger) Initialize(config *github.Config, features *feature
 // EachLoop is called at the start of every munge loop
 func (LGTMAfterCommitMunger) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (LGTMAfterCommitMunger) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (LGTMAfterCommitMunger) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Munge is the workhorse the will actually make updates to the PR
 func (LGTMAfterCommitMunger) Munge(obj *github.MungeObject) {

--- a/mungegithub/mungers/nag-flake-issues.go
+++ b/mungegithub/mungers/nag-flake-issues.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	mgh "k8s.io/test-infra/mungegithub/github"
 	c "k8s.io/test-infra/mungegithub/mungers/matchers/comment"
@@ -70,8 +71,8 @@ func (NagFlakeIssues) Initialize(config *mgh.Config, features *features.Features
 // EachLoop is called at the start of every munge loop
 func (NagFlakeIssues) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (NagFlakeIssues) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (NagFlakeIssues) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // findTimePeriod returns how often we should ping based on priority
 func findTimePeriod(labels []github.Label) time.Duration {

--- a/mungegithub/mungers/needs_rebase.go
+++ b/mungegithub/mungers/needs_rebase.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -62,8 +63,8 @@ func (NeedsRebaseMunger) Initialize(config *github.Config, features *features.Fe
 // EachLoop is called at the start of every munge loop
 func (NeedsRebaseMunger) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (NeedsRebaseMunger) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (NeedsRebaseMunger) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Munge is the workhorse the will actually make updates to the PR
 func (NeedsRebaseMunger) Munge(obj *github.MungeObject) {

--- a/mungegithub/mungers/old-test-getter.go
+++ b/mungegithub/mungers/old-test-getter.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/e2e"
@@ -99,9 +100,10 @@ func (p *OldTestGetter) getOldPostsubmitTests(e2eTester *e2e.RealE2ETester) {
 	}
 }
 
-// RegisterOptions registers config options for this munger.
-func (p *OldTestGetter) RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (p *OldTestGetter) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterInt(&p.numberOfOldTestsToGet, "number-of-old-test-results", 0, "The number of old test results to get (and therefore file issues for). In case submit queue has some downtime, set this to a higher number and it will file issues for older test runs.")
+	return nil
 }
 
 // Munge is unused by this munger.

--- a/mungegithub/mungers/owner-label.go
+++ b/mungegithub/mungers/owner-label.go
@@ -57,8 +57,8 @@ func (b *OwnerLabelMunger) Initialize(config *github.Config, features *features.
 // EachLoop is called at the start of every munge loop
 func (b *OwnerLabelMunger) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (b *OwnerLabelMunger) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (b *OwnerLabelMunger) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func (b *OwnerLabelMunger) getLabels(files []*githubapi.CommitFile) sets.String {
 	labels := sets.String{}

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -19,6 +19,7 @@ package mungers
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -81,8 +82,8 @@ func (r *ReleaseNoteLabel) Initialize(config *github.Config, features *features.
 // EachLoop is called at the start of every munge loop
 func (r *ReleaseNoteLabel) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (r *ReleaseNoteLabel) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (r *ReleaseNoteLabel) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func (r *ReleaseNoteLabel) prMustFollowRelNoteProcess(obj *github.MungeObject) bool {
 	boolean, ok := obj.IsForBranch("master")

--- a/mungegithub/mungers/sig-mention-handler.go
+++ b/mungegithub/mungers/sig-mention-handler.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
@@ -49,8 +50,8 @@ func (s *SigMentionHandler) Initialize(config *github.Config, features *features
 // EachLoop is called at the start of every munge loop
 func (*SigMentionHandler) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (*SigMentionHandler) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (*SigMentionHandler) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 func (*SigMentionHandler) HasSigLabel(obj *github.MungeObject) bool {
 	labels := obj.Issue.Labels

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"
@@ -60,21 +61,18 @@ func (s *StaleGreenCI) RequiredFeatures() []string { return []string{} }
 // Initialize will initialize the munger
 func (s *StaleGreenCI) Initialize(config *github.Config, features *features.Features) error {
 	s.features = features
-	s.getRetestContexts = func() []string {
-		return mungeopts.RequiredContexts.Retest
-	}
 	return nil
 }
 
 // EachLoop is called at the start of every munge loop
 func (s *StaleGreenCI) EachLoop() error { return nil }
 
-// RegisterOptions registers config options for this munger.
-func (s *StaleGreenCI) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (s *StaleGreenCI) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Munge is the workhorse the will actually make updates to the PR
 func (s *StaleGreenCI) Munge(obj *github.MungeObject) {
-	requiredContexts := s.getRetestContexts()
+	requiredContexts := mungeopts.RequiredContexts.Retest
 	if !obj.IsPR() {
 		return
 	}

--- a/mungegithub/mungers/stale-green-ci_test.go
+++ b/mungegithub/mungers/stale-green-ci_test.go
@@ -27,6 +27,7 @@ import (
 
 	github_util "k8s.io/test-infra/mungegithub/github"
 	github_test "k8s.io/test-infra/mungegithub/github/testing"
+	"k8s.io/test-infra/mungegithub/mungeopts"
 
 	"github.com/golang/glog"
 	"github.com/google/go-github/github"
@@ -149,9 +150,7 @@ func TestOldUnitTestMunge(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
-		s.getRetestContexts = func() []string {
-			return requiredContexts
-		}
+		mungeopts.RequiredContexts.Retest = requiredContexts
 		s.Munge(obj)
 
 		if tested != test.tested {

--- a/mungegithub/mungers/stale-pending-ci.go
+++ b/mungegithub/mungers/stale-pending-ci.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"
@@ -72,8 +73,8 @@ func (s *StalePendingCI) Initialize(config *github.Config, features *features.Fe
 // EachLoop is called at the start of every munge loop
 func (s *StalePendingCI) EachLoop() error { return nil }
 
-// RegisterOptions registers options used by this munger.
-func (s *StalePendingCI) RegisterOptions(opts *options.Options) {}
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (s *StalePendingCI) RegisterOptions(opts *options.Options) sets.String { return nil }
 
 // Munge is the workhorse the will actually make updates to the PR
 func (s *StalePendingCI) Munge(obj *github.MungeObject) {

--- a/mungegithub/mungers/submit-queue-batch_test.go
+++ b/mungegithub/mungers/submit-queue-batch_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"k8s.io/test-infra/mungegithub/mungeopts"
+	"k8s.io/test-infra/mungegithub/options"
 
 	githubapi "github.com/google/go-github/github"
 )
@@ -91,7 +92,7 @@ func TestBatchRefToBatch(t *testing.T) {
 func TestGetCompletedBatches(t *testing.T) {
 	mungeopts.RequiredContexts.Retest = []string{"rt"}
 	mungeopts.RequiredContexts.Merge = []string{"st"}
-	sq := SubmitQueue{}
+	sq := SubmitQueue{opts: options.New()}
 	for _, test := range []struct {
 		jobs    prowJobs
 		batches []Batch

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/test-infra/mungegithub/mungers/e2e"
 	fake_e2e "k8s.io/test-infra/mungegithub/mungers/e2e/fake"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"
+	"k8s.io/test-infra/mungegithub/options"
 
 	"github.com/google/go-github/github"
 )
@@ -206,6 +207,7 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 	// TODO: Remove this line when we fix the plumbing regarding the fake/real e2e tester.
 	admin.Mux = admin.NewConcurrentMux()
 	sq := new(SubmitQueue)
+	sq.opts = options.New()
 
 	sq.GateApproved = true
 	sq.GateCLA = true

--- a/mungegithub/mungers/triage-filer.go
+++ b/mungegithub/mungers/triage-filer.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	githubapi "github.com/google/go-github/github"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"
@@ -122,10 +123,11 @@ func (f *TriageFiler) FileIssues() error {
 	return nil
 }
 
-// RegisterOptions registers config options for this munger.
-func (f *TriageFiler) RegisterOptions(opts *options.Options) {
+// RegisterOptions registers options for this munger; returns any that require a restart when changed.
+func (f *TriageFiler) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterInt(&f.topClustersCount, "triage-count", 3, "The number of clusters to sync issues for on github.")
 	opts.RegisterInt(&f.windowDays, "triage-window", 1, "The size of the sliding time window (in days) that is used to determine which failures to consider.")
+	return nil
 }
 
 // Munge is unused by the TriageFiler.

--- a/mungegithub/options/BUILD
+++ b/mungegithub/options/BUILD
@@ -13,6 +13,7 @@ go_test(
     srcs = ["options_test.go"],
     library = ":go_default_library",
     tags = ["automanaged"],
+    deps = ["//vendor:k8s.io/kubernetes/pkg/util/sets"],
 )
 
 go_library(
@@ -22,6 +23,7 @@ go_library(
     deps = [
         "//vendor:github.com/ghodss/yaml",
         "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/kubernetes/pkg/util/sets",
     ],
 )
 

--- a/mungegithub/reports/BUILD
+++ b/mungegithub/reports/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//mungegithub/github:go_default_library",
         "//mungegithub/options:go_default_library",
         "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/kubernetes/pkg/util/sets",
     ],
 )
 


### PR DESCRIPTION
Mungers can handle config reload in any combination of 4 ways:
- Simply reading the value from the pointer that the option was registered to: Options that are not used by goroutines besides the main goroutine may be safely read from the fields they were registered to because options will never be updated while a munger is running its EachLoop, Munge, or Initialize functions. This way of handling changing config values is suitable for most options.
- Registering an update callback: Mungers may register an update callback function to be called immediately after any option in the config is updated. This way of handling changing config values is useful when reinitialization is required after an option changes, for example, if an option is used to specify a port number to serve from, a callback could be registered that shuts down the server and restarts it on the new port number when the option changes. The first method would not be suitable for this scenario.
- Reading the value from the pointer that the option was registered to while holding the options lock: If an option is used by a goroutine besides the main goroutine then it can be accessed normally if the options lock is held (options cannot be updated if the lock is already held by another goroutine). An update callback could be used instead of this method, but that callback would also require locks to synchronize with the other goroutine and this would necessitate creating locks wherever options are shared with another goroutine instead of using a single options lock. This method of handling changing config values is suitable for options that are not read frequently, and is more convenient than writing a callback in many cases. (The option lock is shared by all options and could suffer from contention if this method is abused.)
- Choosing not to handle the change: When mungers register their required options they return a set of option keys specifying options that are immutable. If the value for any of these options changes after a config reload then mungegithub exits, forcing a pod restart that will use the new config. (Many of the options that use this method of handling config changes can be switched to one of the other methods in the future, allowing those options to be changed without requiring a restart.)

/cc @rmmh @foxish 