### PR TITLE
Fix KOPS_BASE_URL

### DIFF
--- a/scenarios/kubernetes_kops_aws.py
+++ b/scenarios/kubernetes_kops_aws.py
@@ -126,7 +126,7 @@ def main(args):
         version = 'pull-' + check_output('git', 'describe', '--always').strip()
         gcs = 'gs://kops-ci/pulls/%s' % os.getenv('JOB_NAME', 'pull-kops-e2e-kubernetes-aws')
         gapi = 'https://storage.googleapis.com'
-        cmd.extend(['-e', 'KOPS_BASE_URL=%s/gs://%s/%s' % (gcs, gapi, version),
+        cmd.extend(['-e', 'KOPS_BASE_URL=%s/kops-ci/pulls/%s' % (gapi, version),
                     '-e', 'GCS_LOCATION=%s' % gcs])
         check('make', 'gcs-publish-ci', 'VERSION=%s' % version, 'GCS_LOCATION=%s' % gcs)
 


### PR DESCRIPTION
I'm kinda confused by `KOPS_BASE_URL="${GCS_LOCATION/gs:\/\//https:\/\/storage.googleapis.com\/}/${KOPS_VERSION}"`

but the running one sets `KOPS_BASE_URL=https://storage.googleapis.com/kops-ci/pulls/pull-kops-e2e-kubernetes-aws/pull-3664a846f` so I assume this will be more correct.

/assign @chrislovecnm @zmerlynn @justinsb 