### PR TITLE
Decrease size of Nodes in kubemark-scale test

### DIFF
--- a/jobs/ci-kubernetes-kubemark-gce-scale.env
+++ b/jobs/ci-kubernetes-kubemark-gce-scale.env
@@ -12,7 +12,7 @@ NUM_NODES=80
 MASTER_SIZE=n1-standard-4
 # Note: can fit about ~9 hollow nodes per core so NUM_NODES x
 # cores_per_node should be set accordingly.
-NODE_SIZE=n1-highmem-8
+NODE_SIZE=n1-standard-8
 KUBEMARK_MASTER_SIZE=n1-standard-64
 # Increase disk size to check if that helps for etcd latency.
 MASTER_DISK_SIZE=100GB


### PR DESCRIPTION
After fixed in kube-proxy this shouldn't be necessary. @wojtek-t 