### PR TITLE
Revert "Temporarily increase gce-scalability-release-1-7 frequency to hourly"

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -162,7 +162,7 @@
         job-name: ci-kubernetes-e2e-gce-scalability-release-1-7
         jenkins-timeout: 240
         timeout: 140
-        frequency: '@hourly'
+        frequency: '@daily'
         trigger-job: 'ci-kubernetes-build-1.7'
         use-blocker: true
         blocker: 'ci-kubernetes-e2e-gce-scalability-release-1-6'


### PR DESCRIPTION
Reverts kubernetes/test-infra#3540

As issue https://github.com/kubernetes/kubernetes/issues/49005 seems to be fixed now.

/cc @gmarek 