### PR TITLE
Print mungegithub options sorted by key and pad the key column.

### DIFF
--- a/mungegithub/options/options.go
+++ b/mungegithub/options/options.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -456,12 +457,27 @@ func toString(optType optionType, val interface{}) string {
 	}
 }
 
+func (o *Options) keysSortedAndWidth() ([]string, int) {
+	keys := make([]string, 0, len(o.options))
+	width := 0
+	for key, _ := range o.options {
+		keys = append(keys, key)
+		if len(key) > width {
+			width = len(key)
+		}
+	}
+	sort.Strings(keys)
+	return keys, width
+}
+
 func (o *Options) Descriptions() string {
 	var buf bytes.Buffer
 	fmt.Fprint(&buf, "The below options are available. They are listed in the format 'option: (default value) \"Description\"'.\n")
-	for key, opt := range o.options {
-		if opt.optType != typeUnknown {
-			fmt.Fprintf(&buf, "%s: (%s) %q\n", key, toString(opt.optType, opt.defaultVal), opt.description)
+	sorted, width := o.keysSortedAndWidth()
+	width++
+	for _, key := range sorted {
+		if opt := o.options[key]; opt.optType != typeUnknown {
+			fmt.Fprintf(&buf, "%-*s (%s) %q\n", width, key+":", toString(opt.optType, opt.defaultVal), opt.description)
 		}
 	}
 	return buf.String()
@@ -470,9 +486,11 @@ func (o *Options) Descriptions() string {
 func (o *Options) CurrentValues() string {
 	var buf bytes.Buffer
 	fmt.Fprint(&buf, "Currently configured option values:\n")
-	for key, opt := range o.options {
-		if opt.optType != typeUnknown {
-			fmt.Fprintf(&buf, "%s: %s\n", key, toString(opt.optType, opt.val))
+	sorted, width := o.keysSortedAndWidth()
+	width++
+	for _, key := range sorted {
+		if opt := o.options[key]; opt.optType != typeUnknown {
+			fmt.Fprintf(&buf, "%-*s %s\n", width, key+":", toString(opt.optType, opt.val))
 		}
 	}
 	return buf.String()


### PR DESCRIPTION
The specified option values are dumped when the config is loaded, but they are not sorted so it is a pain to find option values from the logs. This change sorts the options by keys before printing and pads the key column to the maximum key width.
The output now looks like the following:
```
address:                                  ":8080"
admin-port:                               9999
alias-file:                               "/gitrepos/kubernetes/OWNERS_ALIASES"
allowed-shame-domains:                    []
batch-url:                                "https://prow.k8s.io/data.js"
block-path-config:                        "block-path.yaml"
blunderbuss-number-assignees:             2
blunderbuss-reassign:                     false
bulk-lgtm-changed-files:                  1
bulk-lgtm-cookie-duration:                24h0m0s
bulk-lgtm-github-oauth-redirect-url:      "http://localhost:8080/bulkprs/callback"
bulk-lgtm-insecure-disable-secure-cookie: false
bulk-lgtm-max-commits:                    1
bulk-lgtm-max-diff:                       10
bulk-lgtm-www-prefix:                     ""
chart-url:                                "https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg"
context-url:                              "https://submit-queue.k8s.io"
do-not-merge-milestones:                  []
...
```
/cc @rmmh 