### PR TITLE
Add simple CODEOWNERS file to see what it's like.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+boskos/* @krzyzacy
+gubernator/* @rmmh
+prow/* @spxtr
+prow/config.yaml @krzyzacy


### PR DESCRIPTION
Then I guess GitHub will automatically request a review from the relevant people when someone opens a PR. This is pretty nice, and I don't think we need to enable required reviews in order to use it.

cc @kubernetes/sig-contributor-experience-proposals, since if this goes well we will be more likely to want to play with it in other repos.