### PR TITLE
Refactor bazelbuild usage

### DIFF
--- a/images/pull_kubernetes_bazel/Makefile
+++ b/images/pull_kubernetes_bazel/Makefile
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.13
+IMG = gcr.io/k8s-testimages/bazelbuild
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
-image:
-	docker build -t "gcr.io/k8s-testimages/bazelbuild:$(VERSION)" .
+all: build
 
-push:
-	gcloud docker -- push "gcr.io/k8s-testimages/bazelbuild:$(VERSION)"
+build:
+	docker build -t $(IMG):$(TAG) .
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	@echo Built $(IMG):$(TAG) and tagged with latest
 
-.PHONY: image push
+push: build
+	gcloud docker -- push $(IMG):$(TAG)
+	gcloud docker -- push $(IMG):latest
+	@echo Pushed $(IMG) with :latest and :$(TAG) tags
+
+.PHONY: all build push
+

--- a/images/pull_kubernetes_bazel/runner
+++ b/images/pull_kubernetes_bazel/runner
@@ -16,10 +16,8 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
-    --repo="k8s.io/${REPO_NAME}=${PULL_REFS:-master}" \
-    --job=${JOB_NAME} \
-    --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     "$@"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -71,17 +71,17 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -342,17 +342,17 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -613,17 +613,17 @@ presubmits:
     trigger: "((?m)^@k8s-bot (pull-test-infra-bazel )?test this,?(\\s+|$)|(?m)^/test( all| pull-test-infra-bazel),?(\\s+|$))"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -788,18 +788,18 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
         - "--json"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -820,17 +820,17 @@ postsubmits:
     - name: ci-kubernetes-bazel-test
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:0.13
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
           args:
-          - "--upload=gs://kubernetes-jenkins/logs"
-          - "--git-cache=/root/.cache/git"
           - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--job=$(JOB_NAME)"
           - "--json"
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--service-account=/etc/service-account/service-account.json"
+          - "--upload=gs://kubernetes-jenkins/logs"
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           volumeMounts:
           - name: service
             mountPath: /etc/service-account
@@ -897,18 +897,18 @@ postsubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
         - "--json"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -929,17 +929,17 @@ postsubmits:
     - name: ci-kubernetes-bazel-test-1-6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:0.13
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
           args:
-          - "--upload=gs://kubernetes-jenkins/logs"
-          - "--git-cache=/root/.cache/git"
           - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--job=$(JOB_NAME)"
           - "--json"
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--service-account=/etc/service-account/service-account.json"
+          - "--upload=gs://kubernetes-jenkins/logs"
           securityContext:
             privileged: true
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           volumeMounts:
           - name: service
             mountPath: /etc/service-account
@@ -1006,18 +1006,19 @@ postsubmits:
     - release-1.7
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
         - "--json"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # Make Bazel use shared cache for its root
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
@@ -1042,17 +1043,18 @@ postsubmits:
     - name: ci-kubernetes-bazel-test-1-7
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:0.13
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
           args:
-          - "--upload=gs://kubernetes-jenkins/logs"
-          - "--git-cache=/root/.cache/git"
           - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--job=$(JOB_NAME)"
           - "--json"
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--service-account=/etc/service-account/service-account.json"
+          - "--upload=gs://kubernetes-jenkins/logs"
           securityContext:
             privileged: true
           env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
           # Make Bazel use shared cache for its root
           # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
           - name: TEST_TMPDIR
@@ -1167,17 +1169,17 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -1200,10 +1202,15 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
         - "--json"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -14022,19 +14029,17 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.13
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
       args:
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--git-cache=/root/.cache/git"
       - "--clean"
+      - "--git-cache=/root/.cache/git"
+      - "--job=$(JOB_NAME)"
+      - "--repo=k8s.io/test-infra=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
-      env:
-      - name: REPO_NAME
-        value: test-infra
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       volumeMounts:
       - name: service
         mountPath: /etc/service-account
@@ -14099,20 +14104,18 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.13
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
       args:
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--git-cache=/root/.cache/git"
       - "--clean"
+      - "--git-cache=/root/.cache/git"
+      - "--job=$(JOB_NAME)"
       - "--json"
+      - "--repo=k8s.io/kubernetes=release-1.6"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
-      env:
-      - name: REPO_NAME
-        value: kubernetes=release-1.6
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       volumeMounts:
       - name: service
         mountPath: /etc/service-account
@@ -14133,19 +14136,17 @@ periodics:
   - name: periodic-kubernetes-bazel-test-1-6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
         - "--json"
+        - "--repo=k8s.io/kubernetes=release-1.6"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
         securityContext:
           privileged: true
-        env:
-        - name: REPO_NAME
-          value: kubernetes=release-1.6
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
@@ -14213,20 +14214,19 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:0.13
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
       args:
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--git-cache=/root/.cache/git"
       - "--clean"
+      - "--git-cache=/root/.cache/git"
+      - "--job=$(JOB_NAME)"
       - "--json"
+      - "--repo=k8s.io/kubernetes=release-1.7"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
       # Bazel needs privileged mode in order to sandbox builds.
       securityContext:
         privileged: true
       env:
-      - name: REPO_NAME
-        value: kubernetes=release-1.7
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
       # Make Bazel use shared cache for its root
       # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
       - name: TEST_TMPDIR
@@ -14251,19 +14251,18 @@ periodics:
   - name: periodic-kubernetes-bazel-test-1-7
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:0.13
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
-        - "--upload=gs://kubernetes-jenkins/logs"
-        - "--git-cache=/root/.cache/git"
         - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
         - "--json"
+        - "--repo=k8s.io/kubernetes=release-1.7"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
         securityContext:
           privileged: true
         env:
-        - name: REPO_NAME
-          value: kubernetes=release-1.7
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
         # Make Bazel use shared cache for its root
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/3629
/assign

Ensure concrete bootstrap.py command makes it into the test log.

Make bazelbuild image follow the same format as the rest of the test-infra images, which makes it easier to find what commit a given image was built with.

Replace global variable usage (REPO_NAME, GOOGLE_APPLICATION_CREDENTIALS) with explicit configuration passed through args.

Eliminate hidden and automatic bootstrap.py arg injection from the bazelbuild image.
Explicitly send all bootstrap.py args into the container via configuration.

Update all bazelbuild image usage to the same tag.

Added unit testing to validate how bazelbuild images are used