### PR TITLE
Allow empty patch in golint plugin.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.133
+HOOK_VERSION       ?= 0.134
 SINKER_VERSION     ?= 0.14
 DECK_VERSION       ?= 0.39
 SPLICE_VERSION     ?= 0.26

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.133
+        image: gcr.io/k8s-prow/hook:0.134
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -362,7 +362,7 @@ func (c *Client) GetPullRequestChanges(org, repo string, number int) ([]PullRequ
 	if c.fake {
 		return []PullRequestChange{}, nil
 	}
-	nextURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files", c.base, org, repo, number)
+	nextURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?per_page=100", c.base, org, repo, number)
 	var changes []PullRequestChange
 	for nextURL != "" {
 		resp, err := c.requestRetry(http.MethodGet, nextURL, "", nil)

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -235,11 +235,14 @@ func numProblems(ps map[string]map[int]lint.Problem) int {
 // PullRequestChange object.
 func addedLines(patch string) (map[int]int, error) {
 	result := make(map[int]int)
+	if patch == "" {
+		return result, nil
+	}
 	lines := strings.Split(patch, "\n")
 	for i := 0; i < len(lines); i++ {
 		_, oldLen, newLine, newLen, err := parseHunkLine(lines[i])
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("couldn't parse hunk on line %d in patch %s: %v", i, patch, err)
 		}
 		oldAdd := 0
 		newAdd := 0
@@ -258,7 +261,7 @@ func addedLines(patch string) (map[int]int, error) {
 				result[newLine+newAdd] = i
 				newAdd++
 			default:
-				return nil, fmt.Errorf("bad line in patch: %s", lines[i])
+				return nil, fmt.Errorf("bad prefix on line %d in patch %s", i, patch)
 			}
 		}
 	}

--- a/prow/plugins/golint/golint_test.go
+++ b/prow/plugins/golint/golint_test.go
@@ -199,6 +199,9 @@ func TestAddedLines(t *testing.T) {
 			patch: "@@ -1 +1 @@",
 			err:   true,
 		},
+		{
+			patch: "",
+		},
 	}
 	for _, tc := range testcases {
 		als, err := addedLines(tc.patch)


### PR DESCRIPTION
Sometimes GitHub doesn't give a patch. Lets not fail in that case.