### PR TITLE
Enable apps/v1beta2 in e2e test clusters

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -35,8 +35,7 @@ func run(deploy deployer, o options) error {
 		os.Setenv("KUBECTL", "./cluster/kubectl.sh")
 	}
 	os.Setenv("KUBE_CONFIG_FILE", "config-test.sh")
-	// force having batch/v2alpha1 always on for e2e tests
-	os.Setenv("KUBE_RUNTIME_CONFIG", "batch/v2alpha1=true")
+	os.Setenv("KUBE_RUNTIME_CONFIG", o.runtimeConfig)
 
 	dump := o.dump
 	if dump != "" {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -87,6 +87,7 @@ type options struct {
 	test                bool
 	up                  bool
 	upgradeArgs         string
+	runtimeConfig       string
 }
 
 func defineFlags() *options {
@@ -125,6 +126,7 @@ func defineFlags() *options {
 	flag.DurationVar(&timeout, "timeout", time.Duration(0), "Terminate testing after the timeout duration (s/m/h)")
 	flag.BoolVar(&o.up, "up", false, "If true, start the the e2e cluster. If cluster is already up, recreate it.")
 	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests")
+	flag.StringVar(&o.runtimeConfig, "runtime-config", "batch/v2alpha1=true", "If set, API versions can be turned on or off while bringing up the API server.")
 
 	flag.BoolVar(&verbose, "v", false, "If true, print all command output.")
 	return &o


### PR DESCRIPTION
We recently added apps/v1beta2, but we cannot enable it by default because it's still WIP. We will enable apps/v1beta2 by default in 1.8 release. For now, force enabling it in all e2e test clusters so that we can add e2e tests for it. 

cc @fejta 