### PR TITLE
e2e-image: Statically compile kubetest (200k difference)

### DIFF
--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -18,7 +18,7 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 all: build
 
 kubetest:
-	GOOS=linux GOARCH=amd64 go build -o kubetest ../../kubetest
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubetest ../../kubetest
 
 build: kubetest
 	docker build -t $(IMG):$(TAG) .


### PR DESCRIPTION
This obviates a lot of toolchain discrepancies.