### PR TITLE
unblock generated docs in https://github.com/kubernetes/kubernetes/pull/43443

### DIFF
--- a/mungegithub/block-path.yaml
+++ b/mungegithub/block-path.yaml
@@ -1,24 +1,24 @@
 blockRegexp:
-  - ^docs/getting-started-guides
   - ^docs/admin
-  - ^docs/user-guide
-  - ^docs/devel
   - ^docs/design
+  - ^docs/devel
+  - ^docs/getting-started-guides
   - ^docs/proposals
+  - ^docs/user-guide
 doNotBlockRegexp:
+  - ^docs/admin/federation-apiserver.md$
+  - ^docs/admin/federation-controller-manager.md$
+  - ^docs/admin/high-availability/.*\.(yaml)$
   - ^docs/admin/kube-apiserver.md$
   - ^docs/admin/kube-controller-manager.md$
   - ^docs/admin/kube-proxy.md$
   - ^docs/admin/kube-scheduler.md$
-  - ^docs/admin/kubelet.md$
-  - ^docs/admin/federation-apiserver.md$
-  - ^docs/admin/federation-controller-manager.md$
-  - ^docs/admin/high-availability/.*\.(yaml)$
-  - ^docs/man/man1/kubectl.*\.1$
-  - ^docs/user-guide/kubectl/kubectl.*\.md$
   - ^docs/admin/kubefed.md$
   - ^docs/admin/kubefed_init.md$
   - ^docs/admin/kubefed_join.md$
   - ^docs/admin/kubefed_options.md$
   - ^docs/admin/kubefed_unjoin.md$
   - ^docs/admin/kubefed_version.md$
+  - ^docs/admin/kubelet.md$
+  - ^docs/man/man1/kubectl.*\.1$
+  - ^docs/user-guide/kubectl/kubectl.*\.md$

--- a/mungegithub/block-path.yaml
+++ b/mungegithub/block-path.yaml
@@ -16,3 +16,9 @@ doNotBlockRegexp:
   - ^docs/admin/high-availability/.*\.(yaml)$
   - ^docs/man/man1/kubectl.*\.1$
   - ^docs/user-guide/kubectl/kubectl.*\.md$
+  - ^docs/admin/kubefed.md$
+  - ^docs/admin/kubefed_init.md$
+  - ^docs/admin/kubefed_join.md$
+  - ^docs/admin/kubefed_options.md$
+  - ^docs/admin/kubefed_unjoin.md$
+  - ^docs/admin/kubefed_version.md$


### PR DESCRIPTION
updates block-path.yaml to sync with [changes for kubefed](https://github.com/kubernetes/kubernetes/pull/43443)

/cc @chenopis 