### PR TITLE
Add a Makefile to automate submit-queue update and deployment for all SQs.

### DIFF
--- a/mungegithub/Makefile
+++ b/mungegithub/Makefile
@@ -52,7 +52,7 @@ deploy: push deployment
 # A new configuration is pushed by using the configmap specified using $(TARGET) and $(APP).
 push_config:
 	# pushes a new configmap.
-	kubectl --kubeconfig=$(KUBECONFIG) create configmap $(TARGET)-sq-config --from-file=config=$(APP)/deployment/$(TARGET)/configmap.yaml --dry-run -o yaml | kubectl replace configmap $(TARGET)-sq-config -f -
+	kubectl --kubeconfig=$(KUBECONFIG) create configmap $(TARGET)-sq-config --from-file=config=$(APP)/deployment/$(TARGET)/configmap.yaml --dry-run -o yaml | kubectl apply -f -
 
 # Creates a service resource spec for the specified target and app.
 service:
@@ -109,9 +109,11 @@ push_volume: volume
 ifneq ("", "$(and $(wildcard $(APP)/pv.yaml), $(wildcard $(APP)/pvc.yaml))")
 	# Creating persistent volume and persistent volume claim.
 	kubectl --kubeconfig=$(KUBECONFIG) create -f $(APP)/local.pv.yaml
+	# Sleeping for 1s to allow persistent volume to be created.
+	@sleep 1
 	kubectl --kubeconfig=$(KUBECONFIG) create -f $(APP)/local.pvc.yaml
-	# Sleeping for 2s to allow claim to bind to volume.
-	@sleep 2
+	# Sleeping for 4s to allow claim to bind to volume.
+	@sleep 4
 endif
 
 # Deploys after completeing first time setup such as creating the volume and volume claim, and creating the token secret, and service.

--- a/mungegithub/submit-queue/Makefile
+++ b/mungegithub/submit-queue/Makefile
@@ -1,0 +1,24 @@
+KUBECONFIG ?= $(HOME)/.kube/config
+
+# Updates nginx https proxy and the ingress with the local nginx-redirect/nginx.conf and ingress.yaml files.
+push-network:
+	# Replace the nginx config and restart the pod.
+	kubectl --kubeconfig=$(KUBECONFIG) delete configmap nginx-https-redirect && \
+	kubectl --kubeconfig=$(KUBECONFIG) create configmap nginx-https-redirect --from-file=nginx.conf=nginx-redirect/nginx.conf && \
+	kubectl --kubeconfig=$(KUBECONFIG) delete pod -l app=nginx-https-redirect && \
+	# Update the ingress.
+	kubectl --kubeconfig=$(KUBECONFIG) apply --record -f ingress.yaml
+
+targets := $(shell ls -d deployment/*/ | sed -e "s|deployment/\(.*\)/|\1|"| sed -e "s|^$$||")
+
+update-all:
+	@echo "Updating submit queues for repo(s) [$(targets)] in 4 seconds..."
+	@sleep 4
+	@$(foreach repo,$(targets),echo "Updating $(repo) submit-queue:"; APP=submit-queue TARGET=$(repo) make --no-print-directory -f ../Makefile push_config deploy;)
+
+deploy-all:
+	@echo "Deploying submit queues for repo(s) [$(targets)] in 4 seconds..."
+	@sleep 4
+	@$(foreach repo,$(targets),echo "Deploying $(repo) submit-queue:"; APP=submit-queue TARGET=$(repo) make --no-print-directory -f ../Makefile first_time_deploy;)
+
+.PHONY: push-network update-all deploy-all


### PR DESCRIPTION
This Makefile adds the ability to deploy or update all submit-queues with one make target and adds a target that updates the nginx-https-redirect and ingress used on the mungegithub cluster.
I put these targets in a new Makefile in the submit-queue directory because they only apply to the submit-queue mungegithub app.

This PR also includes a commit to improve the main mungegithub Makefile.

I could add targets that generate the nginx.conf and ingress.yaml files, but those are easy to update and updated infrequently so that might be overkill. Thoughts?