### PR TITLE
Create --cluster-ip-range kubetest flag, refactor upgrade/skew

### DIFF
--- a/kubetest/bash.go
+++ b/kubetest/bash.go
@@ -20,11 +20,20 @@ import (
 	"os/exec"
 )
 
-type bash struct{}
+type bash struct {
+	clusterIPRange *string
+}
 
 var _ deployer = bash{}
 
 func (b bash) Up() error {
+	if b.clusterIPRange != nil && *b.clusterIPRange != "" {
+		pop, err := pushEnv("CLUSTER_IP_RANGE", *b.clusterIPRange)
+		if err != nil {
+			return err
+		}
+		defer pop()
+	}
 	return finishRunning(exec.Command("./hack/e2e-internal/e2e-up.sh"))
 }
 

--- a/kubetest/federation.go
+++ b/kubetest/federation.go
@@ -18,18 +18,15 @@ package main
 
 import (
 	"os/exec"
-	"strings"
 )
 
 func FedUp() error {
 	return finishRunning(exec.Command("./federation/cluster/federation-up.sh"))
 }
 
-func FederationTest(testArgs, dump string) error {
-	f := strings.Fields(testArgs)
-	f = setReportDir(f, dump)
-	f = setFieldDefault(f, "--ginkgo.focus", "\\[Feature:Federation\\]")
-	return finishRunning(exec.Command("./hack/federated-ginkgo-e2e.sh", f...))
+func federationTest(testArgs []string) error {
+	testArgs = setFieldDefault(testArgs, "--ginkgo.focus", "\\[Feature:Federation\\]")
+	return finishRunning(exec.Command("./hack/federated-ginkgo-e2e.sh", testArgs...))
 }
 
 func FedDown() error {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -61,6 +61,7 @@ type options struct {
 	checkLeaks          bool
 	checkSkew           bool
 	cluster             string
+	clusterIPRange      string
 	deployment          string
 	down                bool
 	dump                string
@@ -107,6 +108,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.gcpZone, "gcp-zone", "", "For use with gcloud commands")
 	flag.StringVar(&o.gcpNetwork, "gcp-network", "e2e", "Cluster network. Must be set for --deployment=gke (TODO: other deployments).")
 	flag.StringVar(&o.cluster, "cluster", "", "Cluster name. Must be set for --deployment=gke (TODO: other deployments).")
+	flag.StringVar(&o.clusterIPRange, "cluster-ip-range", "", "Specify CLUSTER_IP_RANGE during --up and --test")
 	flag.BoolVar(&o.kubemark, "kubemark", false, "If true, run kubemark tests.")
 	flag.StringVar(&o.kubemarkMasterSize, "kubemark-master-size", "", "Kubemark master size")
 	flag.StringVar(&o.kubemarkNodes, "kubemark-nodes", "", "Number of kubemark nodes to start")
@@ -199,7 +201,7 @@ type deployer interface {
 func getDeployer(o *options) (deployer, error) {
 	switch o.deployment {
 	case "bash":
-		return bash{}, nil
+		return bash{&o.clusterIPRange}, nil
 	case "gke":
 		return newGKE(o.provider, o.gcpProject, o.gcpZone, o.gcpNetwork, o.cluster)
 	case "kops":
@@ -635,6 +637,7 @@ func prepare(o *options) error {
 	}); err != nil {
 		return err
 	}
+
 	switch o.provider {
 	case "gce", "gke", "kubemark":
 		if err := prepareGcp(o); err != nil {

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -351,13 +351,6 @@ func setFieldDefault(fields []string, flag, val string) []string {
 	return append(fields, flag+"="+cur)
 }
 
-func setReportDir(fields []string, dir string) []string {
-	if len(dir) == 0 {
-		return fields
-	}
-	return setFieldDefault(fields, "--report-dir", dir)
-}
-
 // extractField("--a=this --b=that --c=other", "--b") returns [--a=this, --c=other"], "that"
 func extractField(fields []string, target string) ([]string, string, bool) {
 	f := []string{}


### PR DESCRIPTION
--cluster-ip-range is referenced as CLUSTER_IP_RANGE in kube up, start kubemark and as --cluster-ip-range in test/e2e, so add the env there

Also combine the UpgradeTest SkewTest methods as they only differ by a) the report prefix and b) the testArgs.

/assign @krzyzacy @madhusudancs @shyamjvs 

ref https://github.com/kubernetes/test-infra/issues/3375