### PR TITLE
Make acquire resource round robin

### DIFF
--- a/boskos/deployment.yaml
+++ b/boskos/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-testimages/boskos:v20170711-1a80241f
+        image: gcr.io/k8s-testimages/boskos:v20170725-ef5f2dc3
         args:
         - -storage=/store/boskos.json
         - -config=/etc/config/config

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -185,6 +185,57 @@ func TestAcquire(t *testing.T) {
 	}
 }
 
+func TestAcquireRoundRobin(t *testing.T) {
+	FakeNow := time.Now()
+	resources := []common.Resource{
+		{
+			Name:       "res-1",
+			Type:       "t",
+			State:      "s",
+			Owner:      "",
+			LastUpdate: FakeNow,
+		},
+		{
+			Name:       "res-2",
+			Type:       "t",
+			State:      "s",
+			Owner:      "",
+			LastUpdate: FakeNow,
+		},
+		{
+			Name:       "res-3",
+			Type:       "t",
+			State:      "s",
+			Owner:      "",
+			LastUpdate: FakeNow,
+		},
+		{
+			Name:       "res-4",
+			Type:       "t",
+			State:      "s",
+			Owner:      "",
+			LastUpdate: FakeNow,
+		},
+	}
+
+	expected := []string{"res-3", "res-4", "res-1", "res-2"}
+
+	c := MakeTestRanch(resources)
+	for i := 0; i < 2; i++ {
+		_, err := c.Acquire("t", "s", "d", "foo")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+	}
+
+	for idx, _ := range c.Resources {
+		if c.Resources[idx].Name != expected[idx] {
+			t.Errorf("Resource %d, expected %v, got %v", idx, expected[idx], c.Resources[idx].Name)
+		}
+	}
+
+}
+
 func TestRelease(t *testing.T) {
 	FakeNow := time.Now()
 	var testcases = []struct {


### PR DESCRIPTION
Currently the first resource is almost always busy, which will be bad, like, if we want to delete/edit it from config, it's less likely to happen.

/assign @fejta @zmerlynn 