### PR TITLE
kubetest GKE: Fix env for list-resources, fix bug

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -479,6 +479,11 @@ func migrateGcpEnvAndOptions(o *options) error {
 			name:   "--gcp-service-account",
 		},
 		{
+			env:    "NETWORK",
+			option: &o.gcpNetwork,
+			name:   "--gcp-network",
+		},
+		{
 			env:      "CLOUDSDK_BUCKET",
 			option:   &o.gcpCloudSdk,
 			name:     "--gcp-cloud-sdk",
@@ -620,6 +625,11 @@ func prepare(o *options) error {
 			env:    "KUBERNETES_PROVIDER",
 			option: &o.provider,
 			name:   "--provider",
+		},
+		{
+			env:    "CLUSTER_NAME",
+			option: &o.cluster,
+			name:   "--cluster",
 		},
 	}); err != nil {
 		return err


### PR DESCRIPTION
list-resources is called 4 times in different parts of the main e2e function, but the environment isn't necessarily right. This shuffles some code up from gke:TestSetup to the newGKE constructor so the env is consistent.

Along the way: Fix a bug in firewall naming.