### PR TITLE
Stop spamming about generated files configuration

### DIFF
--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -118,7 +118,6 @@ func (s *SizeMunger) getGeneratedFiles(obj *github.MungeObject) {
 
 	file := s.generatedFilesFile
 	if len(file) == 0 {
-		glog.Infof("No 'generated-files-config' option supplied, applying no labels.")
 		return
 	}
 


### PR DESCRIPTION
When someone does not supply `--generated-files-config`, this plugin
spams a log message on every single pull request considered. This
information is not useful for someone that has not supplied the flag and
only serves to spam the logs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @eparis 