### PR TITLE
Improve errors in walkFunc

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -130,13 +130,13 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 
 	file, err := os.Open(path)
 	if err != nil {
-		glog.Errorf("%v", err)
+		glog.Errorf("Could not open %q: %v", path, err)
 		return nil
 	}
 	defer file.Close()
 
 	if err := yaml.NewYAMLToJSONDecoder(file).Decode(c); err != nil {
-		glog.Errorf("%v", err)
+		glog.Errorf("Could not decode %q: %v", path, err)
 		return nil
 	}
 


### PR DESCRIPTION
When a file cannot be opened or parsed, the current error does not
supply which file is causing issues. This makes debugging the error
difficult.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @kargakis 