### PR TITLE
Fix bug where submit-queue modifies option value.

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -806,7 +806,6 @@ func (sq *SubmitQueue) SetMergeStatus(obj *github.MungeObject, reason string) {
 // setContextFailedStatus calls SetMergeStatus after determining a particular github status
 // which is failed.
 func (sq *SubmitQueue) setContextFailedStatus(obj *github.MungeObject, contexts []string) {
-	sort.Strings(contexts)
 	for i, context := range contexts {
 		contextSlice := contexts[i : i+1]
 		success, ok := obj.IsStatusSuccess(contextSlice)

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -14,16 +14,17 @@ repo-dir: /gitrepos
 github-key-file: /etc/hook-secret-volume/secret
 
 # status context options.
+# Please keep these lists in sorted order.
 required-contexts: ""
 required-retest-contexts: "\
-  pull-kubernetes-unit,\
-  pull-kubernetes-verify,\
-  pull-kubernetes-node-e2e,\
-  pull-kubernetes-kubemark-e2e-gce,\
-  pull-kubernetes-e2e-gce-etcd3,\
   pull-kubernetes-bazel,\
+  pull-kubernetes-e2e-gce-etcd3,\
   pull-kubernetes-e2e-kops-aws,\
-  pull-kubernetes-federation-e2e-gce"
+  pull-kubernetes-federation-e2e-gce,\
+  pull-kubernetes-kubemark-e2e-gce,\
+  pull-kubernetes-node-e2e,\
+  pull-kubernetes-unit,\
+  pull-kubernetes-verify"
 protected-branches-extra-contexts: "cla/linuxfoundation"
 
 # submit-queue options. Keep job lists sorted!
@@ -89,13 +90,13 @@ nonblocking-jobs: "\
   ci-kubernetes-node-kubelet,\
   ci-kubernetes-node-kubelet-serial,\
   ci-kubernetes-soak-gce-deploy,\
-  ci-kubernetes-verify-master,\
   ci-kubernetes-soak-gce-test,\
   ci-kubernetes-soak-gke-deploy,\
   ci-kubernetes-soak-gke-gci-deploy,\
   ci-kubernetes-soak-gke-gci-test,\
   ci-kubernetes-soak-gke-test,\
-  ci-kubernetes-test-go"
+  ci-kubernetes-test-go,\
+  ci-kubernetes-verify-master"
 do-not-merge-milestones: ""
 admin-port: 9999
 chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg


### PR DESCRIPTION
This causes the options package to think that the value was changed when
the config is reloaded even if it hasn't changed.
I sorted the required-retest-contexts in the kubernetes config to
prevent the submit-queue from updating the SQ status context for every
open PR.
/cc @rmmh 