### PR TITLE
kubetest gke: Move DumpClusterLogs to the deployer, implement

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -161,6 +161,10 @@ func (k kubernetesAnywhere) IsUp() error {
 	return isUp(k)
 }
 
+func (k kubernetesAnywhere) DumpClusterLogs(localPath, gcsPath string) error {
+	return defaultDumpClusterLogs(localPath, gcsPath)
+}
+
 func (k kubernetesAnywhere) TestSetup() error {
 	o, err := output(exec.Command("make", "--silent", "-C", k.path, "kubeconfig-path"))
 	if err != nil {

--- a/kubetest/bash.go
+++ b/kubetest/bash.go
@@ -32,6 +32,10 @@ func (b bash) IsUp() error {
 	return finishRunning(exec.Command("./hack/e2e-internal/e2e-status.sh"))
 }
 
+func (b bash) DumpClusterLogs(localPath, gcsPath string) error {
+	return defaultDumpClusterLogs(localPath, gcsPath)
+}
+
 func (b bash) TestSetup() error {
 	return nil
 }

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -113,7 +113,7 @@ func run(deploy deployer, o options) error {
 					// Thus DumpClusterLogs() typically fails.
 					// Therefore always return null for this scenarios.
 					// TODO(fejta): report a green E in testgrid if it errors.
-					DumpClusterLogs(dump, o.logexporterGCSPath)
+					deploy.DumpClusterLogs(dump, o.logexporterGCSPath)
 					return nil
 				})
 			}
@@ -194,7 +194,7 @@ func run(deploy deployer, o options) error {
 
 	if len(errs) > 0 && dump != "" {
 		errs = appendError(errs, xmlWrap("DumpClusterLogs", func() error {
-			return DumpClusterLogs(dump, o.logexporterGCSPath)
+			return deploy.DumpClusterLogs(dump, o.logexporterGCSPath)
 		}))
 		if o.federation {
 			errs = appendError(errs, xmlWrap("DumpFederationLogs", func() error {
@@ -429,7 +429,7 @@ func waitForNodes(d deployer, nodes int, timeout time.Duration) error {
 	return fmt.Errorf("waiting for nodes timed out")
 }
 
-func DumpClusterLogs(localArtifactsDir, logexporterGCSPath string) error {
+func defaultDumpClusterLogs(localArtifactsDir, logexporterGCSPath string) error {
 	var cmd *exec.Cmd
 	if logexporterGCSPath != "" {
 		log.Printf("Dumping logs from nodes to GCS directly at path: %v", logexporterGCSPath)

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -195,6 +195,10 @@ func (k kops) IsUp() error {
 	return isUp(k)
 }
 
+func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
+	return defaultDumpClusterLogs(localPath, gcsPath)
+}
+
 func (k kops) TestSetup() error {
 	info, err := os.Stat(k.kubecfg)
 	if err != nil {

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -191,6 +191,7 @@ func writeXML(dump string, start time.Time) {
 type deployer interface {
 	Up() error
 	IsUp() error
+	DumpClusterLogs(localPath, gcsPath string) error
 	TestSetup() error
 	Down() error
 }

--- a/kubetest/none.go
+++ b/kubetest/none.go
@@ -34,6 +34,10 @@ func (n noneDeploy) IsUp() error {
 	return nil
 }
 
+func (n noneDeploy) DumpClusterLogs(localPath, gcsPath string) error {
+	return defaultDumpClusterLogs(localPath, gcsPath)
+}
+
 func (n noneDeploy) TestSetup() error {
 	log.Print("Noop TestSetup()")
 	return nil


### PR DESCRIPTION
This adds a DumpClusterLogs in the deployer interface in a
kinda-polymorphic way - most of the interfaces just thunk to a
defaultDumpClusterLogs that does what we did before, and I implemented
a new, extra hacky one for GKE.

The hacky one for GKE uses the custom function interface I added for
kops. This whole area is a big TODO, though - we need to get this out
of `k8s/cluster/log-dump.sh`.