### PR TITLE
Fix canary images, add canary dashboard

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2280,7 +2280,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170725-1044fad2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9934,7 +9934,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170725-1044fad2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13250,7 +13250,7 @@ periodics:
   interval: 1h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170725-1044fad2
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
       args:
       - --bare
       - --timeout=60

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -3539,6 +3539,16 @@ dashboards:
     test_group_name: ppc64le-conformance
     description: 'conformance test results for ppc64le'
 
+- name: canaries
+  dashboard_tab:
+  - name: gce-canary
+    test_group_name: ci-kubernetes-e2e-gce-canary
+  - name: gke-canary
+    test_group_name: ci-kubernetes-e2e-gke-canary
+  - name: kops-aws-canary
+    test_group_name: ci-kubernetes-e2e-kops-aws-canary
+  - name: prow-canary
+    test_group_name: ci-kubernetes-e2e-prow-canary
 
 #
 # Start dashboard groups


### PR DESCRIPTION
This fixes the canary jobs so they're back at the :latest tab, injected by #3671, and adds a canary dashboard.