### PR TITLE
Plumb the Prow URL through to the SubmitQueue batch link

### DIFF
--- a/mungegithub/mungers/submit-queue-batch.go
+++ b/mungegithub/mungers/submit-queue-batch.go
@@ -213,7 +213,7 @@ func (sq *SubmitQueue) handleGithubE2EBatchMerge() {
 	repo := sq.githubConfig.Org + "/" + sq.githubConfig.Project
 	for range time.Tick(1 * time.Minute) {
 		sq.opts.Lock()
-		url := sq.ProwURL
+		url := sq.ProwUrl
 		sq.opts.Unlock()
 		allJobs, err := getJobs(url)
 		if err != nil {

--- a/mungegithub/mungers/submit-queue-batch.go
+++ b/mungegithub/mungers/submit-queue-batch.go
@@ -213,7 +213,7 @@ func (sq *SubmitQueue) handleGithubE2EBatchMerge() {
 	repo := sq.githubConfig.Org + "/" + sq.githubConfig.Project
 	for range time.Tick(1 * time.Minute) {
 		sq.opts.Lock()
-		url := sq.ProwUrl
+		url := sq.ProwUrl + "/data.js"
 		sq.opts.Unlock()
 		allJobs, err := getJobs(url)
 		if err != nil {

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -170,6 +170,7 @@ type submitQueueMetadata struct {
 	historyUrl string
 
 	RepoPullUrl string
+	ProwUrl     string
 }
 
 type submitQueueBatchStatus struct {
@@ -267,7 +268,7 @@ type SubmitQueue struct {
 	features *features.Features
 
 	mergeLock    sync.Mutex // acquired when attempting to merge a specific PR
-	ProwUrl      string     // prow json jobs results page
+	ProwUrl      string     // prow base page
 	BatchEnabled bool
 	ContextURL   string
 	batchStatus  submitQueueBatchStatus
@@ -435,6 +436,7 @@ func (sq *SubmitQueue) internalInitialize(config *github.Config, features *featu
 
 	sq.Metadata.ChartUrl = sq.Metadata.chartUrl
 	sq.Metadata.HistoryUrl = sq.Metadata.historyUrl
+	sq.Metadata.ProwUrl = sq.ProwUrl
 	sq.Metadata.RepoPullUrl = fmt.Sprintf("https://github.com/%s/%s/pulls/", config.Org, config.Project)
 	sq.Metadata.ProjectName = strings.Title(config.Project)
 	sq.githubConfig = config
@@ -566,7 +568,7 @@ func (sq *SubmitQueue) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterInt(&sq.AdminPort, "admin-port", 9999, "If non-zero, will serve administrative actions on this port.")
 	opts.RegisterString(&sq.Metadata.historyUrl, "history-url", "", "URL to access the submit-queue instance's health history.")
 	opts.RegisterString(&sq.Metadata.chartUrl, "chart-url", "", "URL to access the submit-queue instance's health charts.")
-	opts.RegisterString(&sq.ProwUrl, "prow-url", "", "Prow data.json URL to read batch results")
+	opts.RegisterString(&sq.ProwUrl, "prow-url", "", "Prow deployment base URL to read batch results and direct users to.")
 	opts.RegisterBool(&sq.BatchEnabled, "batch-enabled", false, "Do batch merges (requires prow/splice coordination).")
 	opts.RegisterString(&sq.ContextURL, "context-url", "", "URL where the submit queue is serving - used in Github status contexts")
 	opts.RegisterBool(&sq.GateApproved, "gate-approved", false, "Gate on approved label")

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -267,7 +267,7 @@ type SubmitQueue struct {
 	features *features.Features
 
 	mergeLock    sync.Mutex // acquired when attempting to merge a specific PR
-	ProwURL      string     // prow json jobs results page
+	ProwUrl      string     // prow json jobs results page
 	BatchEnabled bool
 	ContextURL   string
 	batchStatus  submitQueueBatchStatus
@@ -439,7 +439,7 @@ func (sq *SubmitQueue) internalInitialize(config *github.Config, features *featu
 	sq.Metadata.ProjectName = strings.Title(config.Project)
 	sq.githubConfig = config
 
-	if sq.BatchEnabled && sq.ProwURL == "" {
+	if sq.BatchEnabled && sq.ProwUrl == "" {
 		return errors.New("batch merges require prow-url to be set!")
 	}
 
@@ -566,7 +566,7 @@ func (sq *SubmitQueue) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterInt(&sq.AdminPort, "admin-port", 9999, "If non-zero, will serve administrative actions on this port.")
 	opts.RegisterString(&sq.Metadata.historyUrl, "history-url", "", "URL to access the submit-queue instance's health history.")
 	opts.RegisterString(&sq.Metadata.chartUrl, "chart-url", "", "URL to access the submit-queue instance's health charts.")
-	opts.RegisterString(&sq.ProwURL, "prow-url", "", "Prow data.json URL to read batch results")
+	opts.RegisterString(&sq.ProwUrl, "prow-url", "", "Prow data.json URL to read batch results")
 	opts.RegisterBool(&sq.BatchEnabled, "batch-enabled", false, "Do batch merges (requires prow/splice coordination).")
 	opts.RegisterString(&sq.ContextURL, "context-url", "", "URL where the submit queue is serving - used in Github status contexts")
 	opts.RegisterBool(&sq.GateApproved, "gate-approved", false, "Gate on approved label")
@@ -574,7 +574,7 @@ func (sq *SubmitQueue) RegisterOptions(opts *options.Options) sets.String {
 
 	opts.RegisterUpdateCallback(func(changed sets.String) error {
 		if changed.HasAny("prow-url", "batch-enabled") {
-			if sq.BatchEnabled && sq.ProwURL == "" {
+			if sq.BatchEnabled && sq.ProwUrl == "" {
 				return fmt.Errorf("batch merges require prow-url to be set!")
 			}
 		}

--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -95,7 +95,7 @@
               <md-subheader class="md-primary">CURRENTLY RUNNING BATCH</md-subheader>
               <md-content layout-padding>
                 <div class="md-body-1" layout-padding>
-                  <a href="https://prow.k8s.io/?type=batch">{{(cntl.batch.Running.refs | refToPRs).join(" ")}}</a>
+                  <a href="{{ cntl.metadata.ProwUrl }}/?type=batch">{{(cntl.batch.Running.refs | refToPRs).join(" ")}}</a>
                 </div>
               </md-content>
             </section>


### PR DESCRIPTION
Rename ProwURL to ProwUrl to match other URL options

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Plumb the Prow URL through to the SubmitQueue batch link

The Prow URL was already being passed to the SubmitQueue as a
configuration option, but the link for batch merges was hard-coded to
use the k8s Prow instance. Now, the correct URL is plumbed through from
the configuration.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/cc @kargakis 

The first commit is optional, it just seemed reasonable to make `ProwUrl` match _e.g._  `ChartUrl` `HistoryUrl`...