### PR TITLE
Fix canary job & e2e-runner syntax

### DIFF
--- a/jenkins/e2e-image/e2e-runner.sh
+++ b/jenkins/e2e-image/e2e-runner.sh
@@ -26,10 +26,10 @@ echo 'WARNING: e2e-runner.sh is deprecated! This will error on August 2nd' >&2
 echo 'Call kubetest directly' >&2
 echo 'More info: https://github.com/kubernetes/test-infra/issues/2829' >&2
 
-if [[ "$(date +%s)" -gt "$(date --date='August 1 2017' +%s)"]]; then
+if [[ "$(date +%s)" -gt "$(date --date='August 1 2017' +%s)" ]]; then
   echo 'e2e-runner.sh expired on August 1st, failing'
   exit 1
-elif [[ "$(date +%s)" -gt "$(date --date='July 25 2017' +%s)"]]; then
+elif [[ "$(date +%s)" -gt "$(date --date='July 25 2017' +%s)" ]]; then
   # Delay five minutes and spam the logs
   for i in {1..100}; do
     echo "e2e-runner.sh will expire in a week, please update job (notice ${i})" >&2

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -757,13 +757,12 @@
       "--check-version-skew=false",
       "--test_args=--ginkgo.focus=Variable.Expansion --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
-      "--gcp-project=k8s-jkns-e2e-gce",
       "--provider=gce",
       "--gcp-zone=us-central1-f"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "ci-kubernetes-e2e-gce-container-vm": {
@@ -7708,7 +7707,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "ci-kubernetes-e2e-ubuntu-gke": {
@@ -9285,7 +9284,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "pull-kubernetes-e2e-gce-etcd3": {


### PR DESCRIPTION
Don't specify project name for gce-canary job so it would not suffer from cluster up failures.

Also fix some syntax error in e2e-runner.sh which does not print out the right warning :-)

/assign @fejta 