### PR TITLE
Fix API path for PR Close/Reopen

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.135
+HOOK_VERSION       ?= 0.136
 SINKER_VERSION     ?= 0.14
 DECK_VERSION       ?= 0.39
 SPLICE_VERSION     ?= 0.26

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.135
+        image: gcr.io/k8s-prow/hook:0.136
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -704,7 +704,7 @@ func (c *Client) ClosePR(org, repo string, number int) error {
 	c.log("ClosePR", org, repo, number)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
-		path:        fmt.Sprintf("%s/repos/%s/%s/pull/%d", c.base, org, repo, number),
+		path:        fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.base, org, repo, number),
 		requestBody: map[string]string{"state": "closed"},
 		exitCodes:   []int{200},
 	}, nil)
@@ -716,7 +716,7 @@ func (c *Client) ReopenPR(org, repo string, number int) error {
 	c.log("ReopenPR", org, repo, number)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
-		path:        fmt.Sprintf("%s/repos/%s/%s/pull/%d", c.base, org, repo, number),
+		path:        fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.base, org, repo, number),
 		requestBody: map[string]string{"state": "open"},
 		exitCodes:   []int{200},
 	}, nil)

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -660,7 +660,7 @@ func TestClosePR(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("Bad method: %s", r.Method)
 		}
-		if r.URL.Path != "/repos/k8s/kuber/pull/5" {
+		if r.URL.Path != "/repos/k8s/kuber/pulls/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
 		b, err := ioutil.ReadAll(r.Body)
@@ -688,7 +688,7 @@ func TestReopenPR(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("Bad method: %s", r.Method)
 		}
-		if r.URL.Path != "/repos/k8s/kuber/pull/5" {
+		if r.URL.Path != "/repos/k8s/kuber/pulls/5" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
 		b, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
Fixes #3697

Typo in API path was causing this to 404:
https://developer.github.com/v3/pulls/#update-a-pull-request