### PR TITLE
Sort job arguments in config.json

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1,9 +1,9 @@
 {
   "ci-cadvisor-canarypush": {
     "args": [
+      "--file=deploy/canary/Dockerfile",
       "--owner=stclair@google.com",
-      "--target=google/cadvisor:canary",
-      "--file=deploy/canary/Dockerfile"
+      "--target=google/cadvisor:canary"
     ],
     "scenario": "canarypush",
     "sigOwners": [
@@ -143,18 +143,18 @@
   },
   "ci-kubernetes-charts-gce": {
     "args": [
+      "--charts",
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-charts-gce.env",
-      "--test=false",
-      "--mount-paths=$GOPATH/src/k8s.io/charts:/src/k8s.io/charts",
-      "--charts",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--mode=docker",
       "--gcp-project=k8s-jenkins-charts",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--mount-paths=$GOPATH/src/k8s.io/charts:/src/k8s.io/charts",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test=false",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -174,14 +174,14 @@
   },
   "ci-kubernetes-e2e-aws-release-1.5": {
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-aws-release-1.5.env",
       "--aws",
       "--cluster=e2e-aws-1-5",
-      "--timeout=120m",
+      "--env-file=jobs/ci-kubernetes-e2e-aws-release-1.5.env",
       "--extract=ci/latest-1.5",
       "--mode=docker",
+      "--provider=aws",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|NodeProblemDetector --minStartupPods=8",
-      "--provider=aws"
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -190,15 +190,15 @@
   },
   "ci-kubernetes-e2e-cos-docker-validation": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-cos-docker-validation.env",
-      "--timeout=50m",
       "--extract=gci/gci-next-canary",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-cos-docker-val",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -207,15 +207,15 @@
   },
   "ci-kubernetes-e2e-cos-docker-validation-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-cos-docker-validation-serial.env",
-      "--timeout=300m",
       "--extract=gci/gci-next-canary",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-cos-docker-val-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -224,15 +224,15 @@
   },
   "ci-kubernetes-e2e-cos-docker-validation-slow": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-cos-docker-validation-slow.env",
-      "--timeout=150m",
       "--extract=gci/gci-next-canary",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-cos-docker-val-slow",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -241,16 +241,16 @@
   },
   "ci-kubernetes-e2e-gce": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce.env",
-      "--publish=gs://kubernetes-release-dev/ci/latest-green.txt",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--publish=gs://kubernetes-release-dev/ci/latest-green.txt",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -259,16 +259,16 @@
   },
   "ci-kubernetes-e2e-gce-1-5-1-6-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-5-1-6-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-5-1-6-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.5",
       "--gcp-project=k8s-gce-cvm-1-5-1-6-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -277,17 +277,17 @@
   },
   "ci-kubernetes-e2e-gce-1-5-1-6-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-5-1-6-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-5-1-6-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.5",
       "--gcp-project=k8s-gce-gci-1-5-1-6-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -296,18 +296,18 @@
   },
   "ci-kubernetes-e2e-gce-1-5-1-6-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-5-1-6-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-project=k8s-gce-upg-1-5-1-6-up-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -316,18 +316,18 @@
   },
   "ci-kubernetes-e2e-gce-1-5-1-6-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-5-1-6-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6",
-      "--check-version-skew=false",
       "--gcp-project=k8s-gce-upg-1-5-1-6-up-clu-n",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -336,18 +336,18 @@
   },
   "ci-kubernetes-e2e-gce-1-5-1-6-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-5-1-6-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-project=k8s-gce-upg-1-5-1-6-up-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -356,18 +356,18 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-5-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-5-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.5",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-5-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.6",
       "--gcp-project=k8s-gce-cvm-1-6-1-5-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -376,16 +376,16 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-5-downgrade-cluster": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-5-downgrade-cluster.env",
-      "--timeout=300m",
-      "--extract=ci/latest-1.5",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-5-downgrade-cluster.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.6",
       "--gcp-project=k8s-gce-dg-1-6-1-5-dwngr-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -394,18 +394,18 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-5-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-5-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.5",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-5-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.6",
       "--gcp-project=k8s-gce-gci-1-6-1-5-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -414,17 +414,17 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-project=k8s-gce-cvm-1-6-mstr-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -433,17 +433,17 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-project=k8s-gce-cvm-1-6-m-ctl-skw-srl",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -452,17 +452,17 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-project=k8s-gce-gci-1-6-mstr-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -471,17 +471,17 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-gci-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-project=k8s-gce-gci-1-6-m-ctl-skw-srl",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -490,18 +490,18 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-project=gce-up-c1-3-g1-4-up-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -510,19 +510,19 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=gce-up-c1-3-g1-4-up-clu-n",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -531,18 +531,18 @@
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-project=gce-up-c1-3-g1-4-up-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -551,18 +551,18 @@
   },
   "ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-project=k8s-gce-cvm-mstr-1-6-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -571,18 +571,18 @@
   },
   "ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-cvm-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-project=k8s-gce-cvm-m-1-6-ctl-skw-srl",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -591,18 +591,18 @@
   },
   "ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-project=k8s-gce-gci-mstr-1-6-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -611,18 +611,18 @@
   },
   "ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-1-7-1-6-gci-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-project=k8s-gce-gci-m-1-6-ctl-skw-srl",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -631,15 +631,15 @@
   },
   "ci-kubernetes-e2e-gce-alpha-features": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(DynamicKubeletConfig|Audit|LocalPersistentVolumes)\\]|Initializers --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-alpha",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(DynamicKubeletConfig|Audit|LocalPersistentVolumes)\\]|Initializers --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -648,14 +648,14 @@
   },
   "ci-kubernetes-e2e-gce-alpha-features-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-4.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|PetSet|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -664,14 +664,14 @@
   },
   "ci-kubernetes-e2e-gce-alpha-features-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-5.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -680,15 +680,15 @@
   },
   "ci-kubernetes-e2e-gce-alpha-features-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-6.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-alpha-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -697,15 +697,15 @@
   },
   "ci-kubernetes-e2e-gce-alpha-features-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-alpha-features-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]|Initializers --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-serial-1-2",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]|Initializers --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -714,15 +714,15 @@
   },
   "ci-kubernetes-e2e-gce-audit": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-audit.env",
-      "--timeout=180m",
-      "--check-leaked-resources",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gke-1-4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -731,15 +731,15 @@
   },
   "ci-kubernetes-e2e-gce-audit-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-audit-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--timeout=180m",
-      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gke-slow-1-4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -748,15 +748,15 @@
   },
   "ci-kubernetes-e2e-gce-autoscaling": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-autoscaling.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--gcp-project=k8s-jnks-e2e-gce-autoscaling",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -765,15 +765,15 @@
   },
   "ci-kubernetes-e2e-gce-autoscaling-migs": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-autoscaling-migs.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--gcp-project=k8s-jnks-e2e-gce-autoscl-migs",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -782,21 +782,21 @@
   },
   "ci-kubernetes-e2e-gce-canary": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--cluster=canary-e2e",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-canary.env",
-      "--publish=gs://kubernetes-release-dev/ci/latest-canarygreen.txt",
-      "--tag=latest",
-      "--timeout=40m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Variable.Expansion --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--publish=gs://kubernetes-release-dev/ci/latest-canarygreen.txt",
+      "--tag=latest",
+      "--test_args=--ginkgo.focus=Variable.Expansion --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=40m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -805,15 +805,15 @@
   },
   "ci-kubernetes-e2e-gce-container-vm": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-container-vm.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jenkins-cvm",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -823,17 +823,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sbeta-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sbeta-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-e629d25701",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sbeta-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -846,17 +846,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sbeta-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sbeta-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-c41a7aaf03",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sbeta-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -869,17 +869,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sbeta-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sbeta-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-d4e43e5c09",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sbeta-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -892,17 +892,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sdev-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-4ebf21441e",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -915,17 +915,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sdev-nosnat": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-nosnat.env",
-      "--cluster=test-eb37105e71",
       "--check-leaked-resources",
-      "--provider=gce",
+      "--cluster=test-eb37105e71",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-nosnat.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-e2e-170223",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=20m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\\\[Feature:NoSNAT\\\\] --minStartupPods=8",
-      "--gcp-project=k8s-e2e-170223"
+      "--timeout=20m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -938,17 +938,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sdev-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-52f5d909b5",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -961,17 +961,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sdev-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-0cc7e0a4a8",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -984,17 +984,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable1-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-45011ec97a",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-default.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1007,17 +1007,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable1-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-2d7a8aa9e6",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-serial.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1030,17 +1030,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable1-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-6a3a13513d",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable1-slow.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1053,17 +1053,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable2-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-981311ee2d",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-default.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.6",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1076,17 +1076,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable2-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-ed00047953",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-serial.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.6",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1099,17 +1099,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable2-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-d29293ae78",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable2-slow.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.6",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1122,17 +1122,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable3-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable3-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-d19fb74eb5",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable3-default.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.5",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1145,17 +1145,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable3-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable3-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-9b5cf462ff",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable3-serial.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.5",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1168,17 +1168,17 @@
   "ci-kubernetes-e2e-gce-cosbeta-k8sstable3-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable3-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-069c75dc09",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosbeta-k8sstable3-slow.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.5",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1191,17 +1191,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sbeta-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-349504ad4b",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1214,17 +1214,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-ce1e942232",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1237,17 +1237,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-7c91d4db34",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sbeta-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1260,17 +1260,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sdev-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-cd3f14e5ae",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1283,17 +1283,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sdev-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-16f7a6f1b2",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1306,17 +1306,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sdev-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-018ded2eb1",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sdev-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1329,17 +1329,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sstable1-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-26653b91cd",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-default.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1352,17 +1352,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-12c21e8bb2",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-serial.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1375,17 +1375,17 @@
   "ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-603851a011",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosdev-k8sstable1-slow.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-dev",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1398,17 +1398,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sbeta-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-860e3c0e94",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1421,17 +1421,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-85dd292325",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1444,17 +1444,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-2448497393",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sbeta-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1467,17 +1467,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sdev-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-f76fffef8e",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1490,17 +1490,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-b829ee97f8",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1513,17 +1513,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-0eae043a2d",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sdev-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1536,17 +1536,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable1-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-63180d3429",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-default.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1559,17 +1559,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-ba4378bb1a",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-serial.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1582,17 +1582,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-86260199f2",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable1-slow.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.7",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1605,17 +1605,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable2-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-fa64f85611",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-default.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.6",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1628,17 +1628,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-f76dcc51ae",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-serial.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.6",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1651,17 +1651,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-58d04d5cd7",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable2-slow.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.6",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1674,17 +1674,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable3-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-28f4c52467",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-default.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.5",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1697,17 +1697,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-9f6a2cfa0f",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-serial.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.5",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1720,17 +1720,17 @@
   "ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-3e0b31d18c",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-cosstable1-k8sstable3-slow.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=cos-image-validation",
       "--gcp-zone=us-central1-f",
       "--image-family=cos-stable",
       "--image-project=cos-cloud",
-      "--extract=ci/latest-1.5",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=cos-image-validation"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1742,16 +1742,16 @@
   },
   "ci-kubernetes-e2e-gce-enormous-deploy": {
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-enormous-deploy.env",
       "--cluster=gce-enormous-deploy",
       "--down=false",
-      "--timeout=300m",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-enormous-deploy.env",
       "--extract=ci/latest-1.6",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --cluster-ip-range=10.224.0.0/13",
       "--gcp-project=kubernetes-scale",
+      "--gcp-zone=us-east1-a",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-east1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --cluster-ip-range=10.224.0.0/13",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1760,16 +1760,16 @@
   },
   "ci-kubernetes-e2e-gce-enormous-teardown": {
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-enormous-teardown.env",
       "--cluster=gce-enormous-deploy",
-      "--up=false",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-enormous-teardown.env",
+      "--extract=ci/latest",
+      "--gcp-project=kubernetes-scale",
+      "--gcp-zone=us-east1-a",
+      "--mode=docker",
+      "--provider=gce",
       "--test=false",
       "--timeout=180m",
-      "--extract=ci/latest",
-      "--mode=docker",
-      "--gcp-project=kubernetes-scale",
-      "--provider=gce",
-      "--gcp-zone=us-east1-a"
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1778,15 +1778,15 @@
   },
   "ci-kubernetes-e2e-gce-es-logging": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-es-logging.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Elasticsearch\\] --minStartupPods=8",
       "--gcp-project=kubernetes-es-logging",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Elasticsearch\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1795,15 +1795,15 @@
   },
   "ci-kubernetes-e2e-gce-etcd2-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd2-release-1-6.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-etcd2-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1812,15 +1812,15 @@
   },
   "ci-kubernetes-e2e-gce-etcd3": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-etcd3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1829,16 +1829,16 @@
   },
   "ci-kubernetes-e2e-gce-etcd3-pr-validate": {
     "args": [
+      "--check-leaked-resources",
+      "--cluster=pr-validation",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3-pr-validate.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--cluster=pr-validation",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=1",
       "--gcp-project=k8s-jkns-e2e-gke-alpha-1-4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=1",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1847,15 +1847,15 @@
   },
   "ci-kubernetes-e2e-gce-etcd3-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-etcd3-release-1-5.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-gce-etcd3-1-5",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1864,15 +1864,15 @@
   },
   "ci-kubernetes-e2e-gce-examples": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-examples.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Example\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-examples",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Example\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1881,16 +1881,16 @@
   },
   "ci-kubernetes-e2e-gce-federation": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation.env",
-      "--federation",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
+      "--federation",
       "--gcp-project=k8s-jkns-e2e-gce-federation",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
+      "--timeout=900m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1899,16 +1899,16 @@
   },
   "ci-kubernetes-e2e-gce-federation-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-release-1-6.env",
-      "--federation",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
+      "--federation",
       "--gcp-project=k8s-jkns-e2e-gce-f8n-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
+      "--timeout=900m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1917,16 +1917,16 @@
   },
   "ci-kubernetes-e2e-gce-federation-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--federation",
-      "--timeout=900m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-f8n-1-7",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
+      "--timeout=900m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1935,16 +1935,16 @@
   },
   "ci-kubernetes-e2e-gce-federation-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-serial.env",
-      "--federation",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=(\\[Feature:Federation\\].*(\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\])) --minStartupPods=8",
+      "--federation",
       "--gcp-project=k8s-jkns-e2e-gce-f8n-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=(\\[Feature:Federation\\].*(\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\])) --minStartupPods=8",
+      "--timeout=900m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1953,15 +1953,15 @@
   },
   "ci-kubernetes-e2e-gce-flaky": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-flaky.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-flaky",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1970,16 +1970,16 @@
   },
   "ci-kubernetes-e2e-gce-garbage": {
     "args": [
+      "--check-leaked-resources",
+      "--cluster=gc-feature",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-garbage.env",
-      "--cluster=gc-feature",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:GarbageCollector\\] --minStartupPods=8",
       "--gcp-project=k8s-jenkins-garbagecollector",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:GarbageCollector\\] --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -1988,18 +1988,18 @@
   },
   "ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=gce-up-g1-5-rb-etcd",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
       "--test=false",
       "--timeout=60m",
-      "--extract=ci/latest-1.5",
-      "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1",
-      "--check-version-skew=false",
-      "--gcp-project=gce-up-g1-5-rb-etcd",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2008,18 +2008,18 @@
   },
   "ci-kubernetes-e2e-gce-gci-1-5-upgrade-etcd": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-1-5-upgrade-etcd.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=gce-up-g1-5-up-etcd",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
       "--test=false",
       "--timeout=60m",
-      "--extract=ci/latest-1.5",
-      "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd3 --etcd-upgrade-version=3.0.17",
-      "--check-version-skew=false",
-      "--gcp-project=gce-up-g1-5-up-etcd",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd3 --etcd-upgrade-version=3.0.17"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2028,15 +2028,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-master": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-master.env",
-      "--timeout=50m",
       "--extract=gci/gci-canary/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-ci-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2045,14 +2045,14 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-release-1-4": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-56/latest-1.4",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env",
-      "--timeout=50m",
       "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-4.env",
+      "--extract=gci/gci-56/latest-1.4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2061,14 +2061,14 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-release-1-5": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-56/latest-1.5",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env",
-      "--timeout=50m",
       "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-release-1-5.env",
+      "--extract=gci/gci-56/latest-1.5",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2077,15 +2077,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-serial-master": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-master.env",
-      "--timeout=300m",
       "--extract=gci/gci-canary/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-ci-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2094,14 +2094,14 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-56/latest-1.4",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env",
-      "--timeout=300m",
       "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-4.env",
+      "--extract=gci/gci-56/latest-1.4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2110,14 +2110,14 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-56/latest-1.5",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env",
-      "--timeout=300m",
       "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-serial-release-1-5.env",
+      "--extract=gci/gci-56/latest-1.5",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2126,15 +2126,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-slow-master": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-master.env",
-      "--timeout=150m",
       "--extract=gci/gci-canary/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-ci-master-slow",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2143,14 +2143,14 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-56/latest-1.4",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env",
-      "--timeout=150m",
       "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-4.env",
+      "--extract=gci/gci-56/latest-1.4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2159,14 +2159,14 @@
   },
   "ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--extract=gci/gci-56/latest-1.5",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env",
-      "--timeout=150m",
       "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-ci-slow-release-1-5.env",
+      "--extract=gci/gci-56/latest-1.5",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2175,18 +2175,18 @@
   },
   "ci-kubernetes-e2e-gce-gci-latest-rollback-etcd": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest",
+      "--gcp-project=gce-up-glat-rb-etcd",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
       "--test=false",
       "--timeout=60m",
-      "--extract=ci/latest",
-      "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1",
-      "--check-version-skew=false",
-      "--gcp-project=gce-up-glat-rb-etcd",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd2 --etcd-upgrade-version=2.2.1"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2195,18 +2195,18 @@
   },
   "ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest",
+      "--gcp-project=gce-up-glat-up-etcd",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
       "--test=false",
       "--timeout=60m",
-      "--extract=ci/latest",
-      "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd3 --etcd-upgrade-version=3.0.17",
-      "--check-version-skew=false",
-      "--gcp-project=gce-up-glat-up-etcd",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:EtcdUpgrade\\] --etcd-upgrade-storage=etcd3 --etcd-upgrade-version=3.0.17"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2215,15 +2215,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-m59": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-m59.env",
-      "--timeout=50m",
       "--extract=gci/gci-59",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-m59",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2232,15 +2232,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-m60": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-m60.env",
-      "--timeout=50m",
       "--extract=gci/gci-60",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-m60",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2249,15 +2249,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-m61": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-m61.env",
-      "--timeout=50m",
       "--extract=gci/gci-61",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-m61",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2266,15 +2266,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-master": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-master.env",
-      "--timeout=50m",
       "--extract=gci/gci-canary",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2283,15 +2283,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m59": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m59.env",
-      "--timeout=300m",
       "--extract=gci/gci-59",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-serial-m59",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2300,15 +2300,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m60": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m60.env",
-      "--timeout=300m",
       "--extract=gci/gci-60",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-serial-m60",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2317,15 +2317,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m61": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-m61.env",
-      "--timeout=300m",
       "--extract=gci/gci-61",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-serial-m61",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2334,14 +2334,14 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-master": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-serial-master.env",
-      "--timeout=150m",
       "--extract=gci/gci-canary",
-      "--check-leaked-resources",
       "--gcp-project=e2e-gce-gci-qa-serial-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2350,15 +2350,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-m59": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m59.env",
-      "--timeout=150m",
       "--extract=gci/gci-59",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-slow-m59",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2367,15 +2367,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-m60": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m60.env",
-      "--timeout=150m",
       "--extract=gci/gci-60",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-slow-m60",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2384,15 +2384,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-m61": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-m61.env",
-      "--timeout=150m",
       "--extract=gci/gci-61",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-slow-m61",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2401,15 +2401,15 @@
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-master": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gci-qa-slow-master.env",
-      "--timeout=150m",
       "--extract=gci/gci-canary",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=e2e-gce-gci-qa-slow-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2418,15 +2418,15 @@
   },
   "ci-kubernetes-e2e-gce-gpu": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gpu.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-gpus",
+      "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--gcp-zone=us-west1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2435,16 +2435,16 @@
   },
   "ci-kubernetes-e2e-gce-gpu-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gpu.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-gpu-1-7.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-gpus-1-7",
+      "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--gcp-zone=us-west1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2455,12 +2455,12 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-ha-master.env",
-      "--timeout=220m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:HAMaster\\] --minStartupPods=8",
       "--gcp-project=kubernetes-ha-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:HAMaster\\] --minStartupPods=8",
+      "--timeout=220m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2471,12 +2471,12 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-ingress.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-project=kubernetes-ingress",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2485,15 +2485,15 @@
   },
   "ci-kubernetes-e2e-gce-large-correctness": {
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-large-correctness.env",
       "--cluster=gce-large-cluster",
-      "--timeout=600m",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-large-correctness.env",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m --cluster-ip-range=10.160.0.0/13 --minStartupPods=8",
       "--gcp-project=kubernetes-scale",
+      "--gcp-zone=us-east1-a",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-east1-a"
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m --cluster-ip-range=10.160.0.0/13 --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2502,15 +2502,15 @@
   },
   "ci-kubernetes-e2e-gce-large-performance": {
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-large-performance.env",
       "--cluster=gce-large-cluster",
-      "--timeout=1000m",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-large-performance.env",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m --cluster-ip-range=10.160.0.0/13 --minStartupPods=8",
       "--gcp-project=kubernetes-scale",
+      "--gcp-zone=us-east1-a",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-east1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m --cluster-ip-range=10.160.0.0/13 --minStartupPods=8",
+      "--timeout=1000m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2519,18 +2519,18 @@
   },
   "ci-kubernetes-e2e-gce-latest-upgrade-cluster": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-cluster.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.6",
       "--gcp-project=kube-gce-upg-lat-cluster",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2539,18 +2539,18 @@
   },
   "ci-kubernetes-e2e-gce-latest-upgrade-master": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-latest-upgrade-master.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.6",
       "--gcp-project=kube-gce-upg-lat-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2559,18 +2559,18 @@
   },
   "ci-kubernetes-e2e-gce-master-new-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-master-new-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--skew",
-      "--extract=ci/latest",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-master-new-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest",
       "--gcp-project=gce-cvm-upg-1-5-1-4-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2579,18 +2579,18 @@
   },
   "ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--skew",
-      "--extract=ci/latest",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest",
       "--gcp-project=gce-gci-upg-1-5-1-4-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2599,16 +2599,16 @@
   },
   "ci-kubernetes-e2e-gce-multizone": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=bootstrap-e2e-gce-mz",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-multizone.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-ubelite",
+      "--gcp-zone=us-central1-a",
       "--provider=gce",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2617,17 +2617,17 @@
   },
   "ci-kubernetes-e2e-gce-new-master-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-new-master-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-new-master-cvm-kubectl-skew.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.7",
       "--gcp-project=gce-cvm-upg-1-4-1-5-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2636,17 +2636,17 @@
   },
   "ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.7",
       "--gcp-project=gce-gci-upg-1-4-1-5-ctl-skew",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2655,18 +2655,18 @@
   },
   "ci-kubernetes-e2e-gce-new-master-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-project=kube-gce-upg-1-4-1-5-upg-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2675,18 +2675,18 @@
   },
   "ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-new-master-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--skew",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest",
-      "--check-version-skew=false",
       "--gcp-project=kube-gce-upg-1-4-1-5-upg-clu-n",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2695,18 +2695,18 @@
   },
   "ci-kubernetes-e2e-gce-new-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-new-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-project=kube-gce-upg-1-4-1-5-upg-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2715,15 +2715,15 @@
   },
   "ci-kubernetes-e2e-gce-proto": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-proto.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-protobuf",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2732,15 +2732,15 @@
   },
   "ci-kubernetes-e2e-gce-reboot": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-ci-reboot",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2749,15 +2749,15 @@
   },
   "ci-kubernetes-e2e-gce-reboot-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=err-e2e",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-4.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2766,14 +2766,14 @@
   },
   "ci-kubernetes-e2e-gce-reboot-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-5.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2782,16 +2782,16 @@
   },
   "ci-kubernetes-e2e-gce-reboot-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=err-e2e",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-6.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-reboot-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2800,16 +2800,16 @@
   },
   "ci-kubernetes-e2e-gce-reboot-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=err-e2e",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-reboot-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2818,14 +2818,14 @@
   },
   "ci-kubernetes-e2e-gce-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-4.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2834,14 +2834,14 @@
   },
   "ci-kubernetes-e2e-gce-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-5.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2850,15 +2850,15 @@
   },
   "ci-kubernetes-e2e-gce-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-6.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2867,15 +2867,15 @@
   },
   "ci-kubernetes-e2e-gce-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=50m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2884,15 +2884,15 @@
   },
   "ci-kubernetes-e2e-gce-scalability": {
     "args": [
+      "--cluster=e2e-scalability",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-scalability.env",
-      "--cluster=e2e-scalability",
-      "--timeout=120m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--gcp-project=google.com:k8s-jenkins-scalability",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2901,16 +2901,16 @@
   },
   "ci-kubernetes-e2e-gce-scalability-release-1-6": {
     "args": [
+      "--cluster=e2e-scalability-1-6",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-scalability-release-1-6.env",
-      "--cluster=e2e-scalability-1-6",
-      "--timeout=120m",
       "--extract=ci/latest-1.6",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--gcp-project=k8s-e2e-gce-scalability-1-1",
+      "--gcp-zone=us-east1-b",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-east1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2919,16 +2919,16 @@
   },
   "ci-kubernetes-e2e-gce-scalability-release-1-7": {
     "args": [
+      "--cluster=e2e-scalability-1-7",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-scalability-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--cluster=e2e-scalability-1-7",
-      "--timeout=120m",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--gcp-project=k8s-e2e-gce-scalability-1-1",
+      "--gcp-zone=us-east1-b",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-east1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2937,15 +2937,15 @@
   },
   "ci-kubernetes-e2e-gce-scale-correctness": {
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-scale-correctness.env",
       "--cluster=gce-scale-cluster",
-      "--timeout=1200m",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-scale-correctness.env",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --cluster-ip-range=10.160.0.0/11 --minStartupPods=8",
       "--gcp-project=kubernetes-scale",
-      "--provider=gce",
       "--gcp-zone=us-east1-a",
+      "--mode=docker",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --cluster-ip-range=10.160.0.0/11 --minStartupPods=8",
+      "--timeout=1200m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -2955,15 +2955,15 @@
   },
   "ci-kubernetes-e2e-gce-scale-performance": {
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-scale-performance.env",
       "--cluster=gce-scale-cluster",
-      "--timeout=1400m",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-scale-performance.env",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --cluster-ip-range=10.160.0.0/11 --minStartupPods=8",
       "--gcp-project=kubernetes-scale",
-      "--provider=gce",
       "--gcp-zone=us-east1-a",
+      "--mode=docker",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --cluster-ip-range=10.160.0.0/11 --minStartupPods=8",
+      "--timeout=1400m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -2973,15 +2973,15 @@
   },
   "ci-kubernetes-e2e-gce-sd-logging": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-sd-logging.env",
-      "--timeout=1320m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-sd-log",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2990,15 +2990,15 @@
   },
   "ci-kubernetes-e2e-gce-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial.env",
-      "--timeout=500m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=kubernetes-jkns-e2e-gce-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3007,14 +3007,14 @@
   },
   "ci-kubernetes-e2e-gce-serial-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-4.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3023,14 +3023,14 @@
   },
   "ci-kubernetes-e2e-gce-serial-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-5.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3039,15 +3039,15 @@
   },
   "ci-kubernetes-e2e-gce-serial-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-6.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-serial-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3056,15 +3056,15 @@
   },
   "ci-kubernetes-e2e-gce-serial-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=500m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-serial-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3073,15 +3073,15 @@
   },
   "ci-kubernetes-e2e-gce-slow": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-slow",
+      "--gcp-zone=europe-west1-c",
       "--provider=gce",
-      "--gcp-zone=europe-west1-c"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3090,14 +3090,14 @@
   },
   "ci-kubernetes-e2e-gce-slow-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-4.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3106,14 +3106,14 @@
   },
   "ci-kubernetes-e2e-gce-slow-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-5.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3122,15 +3122,15 @@
   },
   "ci-kubernetes-e2e-gce-slow-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-6.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-slow-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3139,15 +3139,15 @@
   },
   "ci-kubernetes-e2e-gce-slow-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-slow-release-1-7.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-slow-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3156,15 +3156,15 @@
   },
   "ci-kubernetes-e2e-gce-stackdriver": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-stackdriver.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:StackdriverMonitoring\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-stackdriver",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverMonitoring\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3175,12 +3175,12 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-statefulset.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:StatefulSet\\] --minStartupPods=8",
       "--gcp-project=kubernetes-petset",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:StatefulSet\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3191,12 +3191,12 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-taint-evict.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:TaintEviction\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-taintevict",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:TaintEviction\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3264,17 +3264,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-4f454c8522",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3287,17 +3287,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-bdd5648636",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3310,17 +3310,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-b5d96c1598",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3333,17 +3333,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-b3fd097a64",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3356,17 +3356,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-52428544e5",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3379,17 +3379,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-5d6257d272",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sdev-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3402,17 +3402,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-default.env",
+      "--check-leaked-resources=false",
       "--cluster=test-f99af785cf",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-default.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest-1.7",
-      "--timeout=50m",
+      "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3425,17 +3425,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial.env",
+      "--check-leaked-resources=false",
       "--cluster=test-7dcacf28c9",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-serial.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest-1.7",
-      "--timeout=500m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3448,17 +3448,17 @@
   "ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow.env",
+      "--check-leaked-resources=false",
       "--cluster=test-5978e38009",
-      "--provider=gce",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntudev-k8sstable1-slow.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
       "--gcp-zone=us-central1-f",
       "--image-family=ubuntu-gke-1604-lts",
       "--image-project=ubuntu-os-gke-cloud-devel",
-      "--extract=ci/latest-1.7",
-      "--timeout=150m",
+      "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3471,15 +3471,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env",
-      "--cluster=test-2e79fbd2ec",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest",
-      "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-2e79fbd2ec",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-default.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3492,15 +3492,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env",
-      "--cluster=test-c858633e76",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest",
-      "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-c858633e76",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-serial.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3513,15 +3513,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env",
-      "--cluster=test-70b21a36b2",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest",
-      "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-70b21a36b2",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sdev-slow.env",
+      "--extract=ci/latest",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3534,15 +3534,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env",
-      "--cluster=test-b9bc64dba5",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest-1.7",
-      "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-b9bc64dba5",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-default.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3555,15 +3555,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env",
-      "--cluster=test-4c9af8b031",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest-1.7",
-      "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-4c9af8b031",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-serial.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3576,15 +3576,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env",
-      "--cluster=test-7214dd78b9",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest-1.7",
-      "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-7214dd78b9",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable1-slow.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3597,15 +3597,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-default.env",
-      "--cluster=test-2245e27031",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest-1.6",
-      "--timeout=50m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-2245e27031",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-default.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3618,15 +3618,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial.env",
-      "--cluster=test-9dcf8231c6",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest-1.6",
-      "--timeout=500m",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-dev-tests"
+      "--cluster=test-9dcf8231c6",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-serial.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=ubuntu-os-gke-cloud-dev-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3639,15 +3639,15 @@
   "ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow.env",
-      "--cluster=test-e5822f389c",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
-      "--extract=ci/latest-1.6",
-      "--timeout=150m",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--check-leaked-resources=false",
-      "--gcp-project=ubuntu-os-gke-cloud-tests"
+      "--cluster=test-e5822f389c",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-ubuntustable1-k8sstable2-slow.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=ubuntu-os-gke-cloud-tests",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3659,15 +3659,15 @@
   },
   "ci-kubernetes-e2e-gci-gce": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-gci",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3676,15 +3676,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-alpha-features": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(Audit|LocalPersistentVolumes)\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gci-gce-alpha",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(Audit|LocalPersistentVolumes)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3693,14 +3693,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3709,14 +3709,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-5.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3725,15 +3725,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-alpha-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3742,15 +3742,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-alpha-features-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-alpha-features-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-serial-1-2",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3759,15 +3759,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-audit": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-audit.env",
-      "--timeout=180m",
-      "--check-leaked-resources",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gke-slow-1-4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3776,15 +3776,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-audit-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-audit-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--timeout=180m",
-      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gke-reboot-1-4",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Audit\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3793,15 +3793,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-autoscaling": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-autoscaling.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-autoscaling",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\]|\\[Feature:InitialResources\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3810,15 +3810,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-autoscaling-migs": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-autoscaling-migs.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-autoscaling-migs",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3827,15 +3827,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-docker": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-docker.env",
-      "--timeout=50m",
       "--extract=gci/gci-canary-test/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-docker-validation-gci",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3844,15 +3844,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-es-logging": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-es-logging.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Elasticsearch\\] --minStartupPods=8",
       "--gcp-project=kubernetes-gci-es-logging",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Elasticsearch\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3861,15 +3861,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-etcd3": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-etcd3.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-etcd3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3878,15 +3878,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-examples": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-examples.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Example\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gci-examples",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Example\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3895,15 +3895,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-flaky": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-flaky.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-flaky",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3912,16 +3912,16 @@
   },
   "ci-kubernetes-e2e-gci-gce-garbage": {
     "args": [
+      "--check-leaked-resources",
+      "--cluster=gc-feature",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-garbage.env",
-      "--cluster=gc-feature",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:GarbageCollector\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-garbage",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:GarbageCollector\\] --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3932,12 +3932,12 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-project=kubernetes-gci-ingress",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3946,14 +3946,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-ingress-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-4.env",
-      "--timeout=90m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3962,14 +3962,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-ingress-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-5.env",
-      "--timeout=90m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3978,15 +3978,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-ingress-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-6.env",
-      "--timeout=90m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-ingress-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -3995,15 +3995,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-ingress-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ingress-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=90m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-project=kubernetes-gci-ingress-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4012,15 +4012,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-ip-alias": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-ip-alias.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --cluster-ip-range=10.100.0.0/14 --minStartupPods=8",
       "--gcp-project=k8s-jenkins-gce-gci-ip-aliases",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --cluster-ip-range=10.100.0.0/14 --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4029,15 +4029,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-proto": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-proto.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-protobuf",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4046,16 +4046,16 @@
   },
   "ci-kubernetes-e2e-gci-gce-reboot": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=err-e2e",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-reboot",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4064,14 +4064,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-reboot-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-4.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4080,14 +4080,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-reboot-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-5.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4096,15 +4096,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-reboot-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-6.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-reboot-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4113,15 +4113,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-reboot-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-reboot-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4130,14 +4130,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-4.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4146,14 +4146,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-5.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4162,15 +4162,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-6.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gci-gce-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4179,15 +4179,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=50m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4196,15 +4196,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-scalability": {
     "args": [
+      "--cluster=e2e-scalability",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability.env",
-      "--cluster=e2e-scalability",
-      "--timeout=120m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--gcp-project=k8s-jenkins-gci-scalability",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4213,16 +4213,16 @@
   },
   "ci-kubernetes-e2e-gci-gce-scalability-release-1-6": {
     "args": [
+      "--cluster=e2e-scalability-1-6",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-6.env",
-      "--cluster=e2e-scalability-1-6",
-      "--timeout=120m",
       "--extract=ci/latest-1.6",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--gcp-project=k8s-e2e-gci-gce-scale-1-4",
+      "--gcp-zone=us-east1-b",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-east1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4231,16 +4231,16 @@
   },
   "ci-kubernetes-e2e-gci-gce-scalability-release-1-7": {
     "args": [
+      "--cluster=e2e-scalability-1-7",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-scalability-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--cluster=e2e-scalability-1-7",
-      "--timeout=120m",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--gcp-project=k8s-e2e-gci-gce-scale-1-4",
+      "--gcp-zone=us-east1-b",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-east1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4249,15 +4249,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-sd-logging": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-sd-logging.env",
-      "--timeout=1320m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-sd-log",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4266,15 +4266,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial.env",
-      "--timeout=500m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-gci-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4283,14 +4283,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-serial-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-4.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4299,14 +4299,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-serial-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-5.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4315,15 +4315,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-serial-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-6.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-serial-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4332,15 +4332,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-serial-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=500m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-serial-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4349,15 +4349,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-slow": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-e2e-gce-gci-slow",
+      "--gcp-zone=europe-west1-c",
       "--provider=gce",
-      "--gcp-zone=europe-west1-c"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4366,14 +4366,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-slow-release-1-4": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-4.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.4",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4382,14 +4382,14 @@
   },
   "ci-kubernetes-e2e-gci-gce-slow-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-5.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4398,15 +4398,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-slow-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-6.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-slow-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4415,15 +4415,15 @@
   },
   "ci-kubernetes-e2e-gci-gce-slow-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-slow-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=150m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-slow-1-3",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4434,12 +4434,12 @@
     "args": [
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gce-statefulset.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:StatefulSet\\] --minStartupPods=8",
       "--gcp-project=kubernetes-gci-petset",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:StatefulSet\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4494,10 +4494,10 @@
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-autoscaling.env",
       "--extract=ci/latest",
-      "--provider=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=cos",
       "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--timeout=300m"
     ],
@@ -4514,10 +4514,10 @@
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-flaky.env",
       "--extract=ci/latest",
-      "--provider=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=cos",
       "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=300m"
     ],
@@ -4533,9 +4533,9 @@
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress.env",
       "--extract=ci/latest",
-      "--provider=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--timeout=300m"
     ],
@@ -4546,16 +4546,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-ingress-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-5.env",
-      "--timeout=90m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gci-gke-ingress-1-5",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4564,16 +4564,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-ingress-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-6.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-ingress-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4582,16 +4582,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-ingress-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-ingress-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-gci-gke-ingress-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4600,16 +4600,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-multizone": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-multizone.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gci-gke-multizone",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4618,15 +4618,15 @@
   },
   "ci-kubernetes-e2e-gci-gke-pre-release": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-pre-release.env",
-      "--timeout=480m",
       "--extract=release/latest",
-      "--check-leaked-resources",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gci-gke-prerel",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4635,17 +4635,17 @@
   },
   "ci-kubernetes-e2e-gci-gke-prod": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-prod.env",
-      "--timeout=600m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-prod.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gci-gke-prod",
+      "--gcp-zone=us-central1-b",
       "--provider=gke",
-      "--gcp-zone=us-central1-b"
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4654,17 +4654,17 @@
   },
   "ci-kubernetes-e2e-gci-gke-prod-parallel": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.env",
-      "--timeout=80m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-prod-parallel.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-e2e-gci-gke-prod-parallel",
+      "--gcp-zone=us-central1-b",
       "--provider=gke",
-      "--gcp-zone=us-central1-b"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4673,17 +4673,17 @@
   },
   "ci-kubernetes-e2e-gci-gke-prod-smoke": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.env",
-      "--timeout=80m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-prod-smoke.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-e2e-gci-gke-prod-smoke",
+      "--gcp-zone=us-east1-d",
       "--provider=gke",
-      "--gcp-zone=us-east1-d"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4692,16 +4692,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-reboot": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gci-gke-ci-reboot",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4710,16 +4710,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-reboot-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-5.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gci-gke-reboot-1-5",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4728,16 +4728,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-reboot-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-6.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-reboot-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4746,16 +4746,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-reboot-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-reboot-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4764,15 +4764,15 @@
   },
   "ci-kubernetes-e2e-gci-gke-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1-5.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4781,16 +4781,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1-6.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4799,16 +4799,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=50m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4817,16 +4817,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=jenkins-gke-gci-e2e-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4835,14 +4835,14 @@
   },
   "ci-kubernetes-e2e-gci-gke-serial-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-5.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4851,16 +4851,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-serial-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-6.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-serial-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4869,16 +4869,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-serial-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=500m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-serial-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4887,16 +4887,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-slow": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-gci-slow",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4905,15 +4905,15 @@
   },
   "ci-kubernetes-e2e-gci-gke-slow-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-5.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4922,16 +4922,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-slow-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-6.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-slow-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4940,16 +4940,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-slow-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-slow-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=150m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-slow-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4958,17 +4958,17 @@
   },
   "ci-kubernetes-e2e-gci-gke-staging": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-staging.env",
-      "--timeout=600m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-staging.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gci-gke-staging",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4977,17 +4977,17 @@
   },
   "ci-kubernetes-e2e-gci-gke-staging-parallel": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.env",
-      "--timeout=80m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-staging-parallel.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-e2e-gci-gke-staging-plel",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4996,17 +4996,17 @@
   },
   "ci-kubernetes-e2e-gci-gke-subnet": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-subnet.env",
-      "--cluster=auto-subnet",
-      "--timeout=480m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--cluster=auto-subnet",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-subnet.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gci-gke-subnet",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5015,16 +5015,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-test": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-test.env",
-      "--timeout=480m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gci-gke-test.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gci-gke-test",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5033,16 +5033,16 @@
   },
   "ci-kubernetes-e2e-gci-gke-updown": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gci-gke-updown.env",
-      "--timeout=30m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-e2e-gci-gke-updown",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
+      "--timeout=30m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5051,16 +5051,16 @@
   },
   "ci-kubernetes-e2e-gke": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-ci",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5069,18 +5069,18 @@
   },
   "ci-kubernetes-e2e-gke-1-5-1-6-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-5-1-6-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-5-1-6-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.5",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-cvm-1-5-1-6-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5089,18 +5089,18 @@
   },
   "ci-kubernetes-e2e-gke-1-5-1-6-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-5-1-6-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--extract=ci/latest-1.5",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-5-1-6-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.5",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-gci-1-5-1-6-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5109,19 +5109,19 @@
   },
   "ci-kubernetes-e2e-gke-1-6-1-5-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-5-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.5",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-5-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-cvm-1-6-1-5-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5130,19 +5130,19 @@
   },
   "ci-kubernetes-e2e-gke-1-6-1-5-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-5-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.5",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-5-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-gci-1-6-1-5-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5151,18 +5151,18 @@
   },
   "ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-cvm-1-6-mstr-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5171,18 +5171,18 @@
   },
   "ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-cvm-1-6-m-ctl-skw-srl",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5191,18 +5191,18 @@
   },
   "ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-gci-1-6-mstr-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5211,18 +5211,18 @@
   },
   "ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-6-1-7-gci-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-gci-1-6-m-ctl-skw-srl",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5231,19 +5231,19 @@
   },
   "ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-cvm-mstr-1-6-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5252,19 +5252,19 @@
   },
   "ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-cvm-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-cvm-m-1-6-ctl-skw-srl",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5273,19 +5273,19 @@
   },
   "ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-gci-mstr-1-6-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5294,19 +5294,19 @@
   },
   "ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew-serial": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew-serial.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.6",
-      "--skew",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew-serial.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-gci-m-1-6-ctl-skw-srl",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl.*\\[Serial\\] --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5315,16 +5315,16 @@
   },
   "ci-kubernetes-e2e-gke-alpha-features": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-alpha",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5333,16 +5333,16 @@
   },
   "ci-kubernetes-e2e-gke-alpha-features-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=err-e2e",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-5.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly)\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5351,16 +5351,16 @@
   },
   "ci-kubernetes-e2e-gke-alpha-features-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-6.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-alpha-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5369,16 +5369,16 @@
   },
   "ci-kubernetes-e2e-gke-alpha-features-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-alpha-features-release-1-7.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]|Initializers --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gci-gke-alpha-1-4",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\\]|Initializers --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5387,16 +5387,16 @@
   },
   "ci-kubernetes-e2e-gke-autoscaling": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-autoscaling.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-e2e-gke-autoscaling",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5412,8 +5412,8 @@
       "--env-file=jobs/ci-kubernetes-e2e-gke-canary.env",
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
-      "--gcp-zone=us-central1-f",
       "--gcp-node-image=cos",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=50m"
@@ -5438,8 +5438,8 @@
       "--gcp-zone=us-central1-a",
       "--provider=gke",
       "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--timeout=900m"
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5448,19 +5448,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-5-c1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5469,19 +5469,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-5-c1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5490,19 +5490,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-clat-up-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5511,20 +5511,20 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-clat-up-clu-n",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5533,19 +5533,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-clat-up-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5554,19 +5554,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-5-g1-6-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5575,19 +5575,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-5-g1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5596,19 +5596,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-6-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-5-g1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5617,19 +5617,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-glat-up-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5638,20 +5638,20 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-glat-up-clu-n",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5660,19 +5660,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-gci-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-glat-up-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5681,19 +5681,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-3-1-4-upg-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5702,20 +5702,20 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-3-1-4-upg-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5724,19 +5724,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-cvm-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-3-1-4-upg-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5745,19 +5745,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-g1-4-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5766,20 +5766,20 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-g1-4-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5788,19 +5788,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-6-gci-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-c1-3-g1-4-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5809,19 +5809,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-4-c1-6-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5830,19 +5830,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--skew",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-4-c1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5851,19 +5851,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-new-cvm-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-4-c1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5872,19 +5872,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-4-g1-6-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5893,19 +5893,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--skew",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest--upgrade-image=gci",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-4-g1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest--upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5914,19 +5914,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-new-gci-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-c1-4-g1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5935,19 +5935,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-stable-cvm-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-stable-cvm-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-1-1-2-upg-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5956,19 +5956,19 @@
   },
   "ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-stable-gci-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-2-1-3-upg-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5977,16 +5977,16 @@
   },
   "ci-kubernetes-e2e-gke-flaky": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-flaky.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-ci-flaky",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -5995,19 +5995,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-5-c1-6-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6016,19 +6016,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-5-c1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6037,19 +6037,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-6-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-5-c1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6058,19 +6058,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-clat-up-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6079,20 +6079,20 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-clat-up-clu-n",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6101,19 +6101,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-cvm-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-clat-up-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6122,19 +6122,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-5-g1-6-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6143,19 +6143,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-5-g1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6164,19 +6164,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-6-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest-1.6",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-5-g1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.6 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6185,19 +6185,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-glat-up-clu",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6206,20 +6206,20 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-glat-up-clu-n",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6228,19 +6228,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-5-gci-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-glat-up-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6249,19 +6249,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-c1-4-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6270,20 +6270,20 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-c1-4-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6292,19 +6292,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-cvm-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-c1-4-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6313,18 +6313,18 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-6-gci-1-5-downgrade-cluster": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-5-downgrade-cluster.env",
-      "--timeout=300m",
-      "--extract=ci/latest-1.5",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterDowngrade\\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-5-downgrade-cluster.env",
+      "--extract=ci/latest-1.5",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-dg-g1-6-g1-5-dwngr-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterDowngrade\\] --upgrade-target=ci/latest-1.5 --upgrade-image=gci --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6333,19 +6333,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-g1-4-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6354,20 +6354,20 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-cluster-new.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
-      "--skew",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-g1-4-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6376,19 +6376,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-1-6-gci-1-7-upgrade-master.env",
-      "--timeout=120m",
       "--extract=ci/latest-1.7",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-up-g1-3-g1-4-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6397,16 +6397,16 @@
   },
   "ci-kubernetes-e2e-gke-gci-ci-master": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-ci-master.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=e2e-gke-gci-ci-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6415,19 +6415,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-4-c1-6-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6436,19 +6436,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--skew",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-4-c1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6457,19 +6457,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-new-cvm-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-4-c1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6478,19 +6478,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-4-g1-6-up-clu",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6499,19 +6499,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new.env",
-      "--timeout=900m",
       "--extract=ci/latest",
-      "--skew",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-4-g1-6-up-clu-n",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--skew",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6520,19 +6520,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-gke-upg-g1-4-g1-6-up-mas",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6541,18 +6541,18 @@
   },
   "ci-kubernetes-e2e-gke-gci-stable-cvm-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-stable-cvm-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm",
-      "--check-version-skew=false",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-1-1-3-upg-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=container_vm"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6561,19 +6561,19 @@
   },
   "ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master": {
     "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master.env",
-      "--timeout=900m",
       "--extract=ci/latest",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci",
-      "--check-version-skew=false",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-2-1-4-upg-mas",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=900m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6582,16 +6582,16 @@
   },
   "ci-kubernetes-e2e-gke-gpu": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gpu.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-gpus",
+      "--gcp-zone=us-west1-b",
       "--provider=gke",
-      "--gcp-zone=us-west1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6600,17 +6600,17 @@
   },
   "ci-kubernetes-e2e-gke-gpu-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gpu.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-gpu-1-7.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.7",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:GPU\\]",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-gpus-1-7",
+      "--gcp-zone=us-west1-b",
       "--provider=gke",
-      "--gcp-zone=us-west1-b"
+      "--test_args=--ginkgo.focus=\\[Feature:GPU\\]",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6621,13 +6621,13 @@
     "args": [
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-ingress.env",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-gke-ingress",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6636,17 +6636,17 @@
   },
   "ci-kubernetes-e2e-gke-large-correctness": {
     "args": [
+      "--cluster=gke-large-cluster",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-large-correctness.env",
-      "--cluster=gke-large-cluster",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-scale",
-      "--provider=gke",
       "--gcp-zone=us-east1-a",
-      "--mode=docker"
+      "--mode=docker",
+      "--provider=gke",
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6655,18 +6655,18 @@
   },
   "ci-kubernetes-e2e-gke-large-deploy": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-large-deploy.env",
       "--cluster=gke-large-deploy",
       "--down=false",
-      "--timeout=1200m",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-large-deploy.env",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --allowed-not-ready-nodes=0 --node-schedulable-timeout=360m --system-pods-startup-timeout=60m --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-scale",
-      "--provider=gke",
       "--gcp-zone=us-east1-a",
-      "--mode=docker"
+      "--mode=docker",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --allowed-not-ready-nodes=0 --node-schedulable-timeout=360m --system-pods-startup-timeout=60m --minStartupPods=8",
+      "--timeout=1200m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6675,17 +6675,17 @@
   },
   "ci-kubernetes-e2e-gke-large-performance": {
     "args": [
+      "--cluster=gke-large-cluster",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-large-performance.env",
-      "--cluster=gke-large-cluster",
-      "--timeout=1000m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-scale",
-      "--provider=gke",
       "--gcp-zone=us-east1-a",
-      "--mode=docker"
+      "--mode=docker",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m",
+      "--timeout=1000m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6694,18 +6694,18 @@
   },
   "ci-kubernetes-e2e-gke-large-teardown": {
     "args": [
+      "--cluster=gke-large-deploy",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-large-teardown.env",
-      "--cluster=gke-large-deploy",
-      "--up=false",
-      "--test=false",
-      "--timeout=180m",
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-scale",
-      "--provider=gke",
       "--gcp-zone=us-east1-a",
-      "--mode=docker"
+      "--mode=docker",
+      "--provider=gke",
+      "--test=false",
+      "--timeout=180m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6714,19 +6714,19 @@
   },
   "ci-kubernetes-e2e-gke-latest-upgrade-cluster": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-cluster.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-lat-cluster",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6735,19 +6735,19 @@
   },
   "ci-kubernetes-e2e-gke-latest-upgrade-master": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--skew",
-      "--extract=ci/latest-1.6",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-latest-upgrade-master.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-lat-master",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6756,19 +6756,19 @@
   },
   "ci-kubernetes-e2e-gke-master-new-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-master-new-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--skew",
-      "--extract=ci/latest",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-master-new-cvm-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-5-1-4-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6777,19 +6777,19 @@
   },
   "ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest-1.7",
-      "--skew",
-      "--extract=ci/latest",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-gci-upg-1-5-1-4-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--skew",
+      "--test_args=--ginkgo.focus=Kubectl --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6798,16 +6798,16 @@
   },
   "ci-kubernetes-e2e-gke-multizone": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-multizone.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-multizone",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6816,18 +6816,18 @@
   },
   "ci-kubernetes-e2e-gke-new-master-cvm-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-new-master-cvm-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-new-master-cvm-kubectl-skew.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kube-gke-upg-1-4-1-5-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6836,18 +6836,18 @@
   },
   "ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew.env",
-      "--timeout=120m",
-      "--extract=ci/latest",
-      "--extract=ci/latest-1.7",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=gke-gci-upg-1-4-1-5-ctl-skew",
+      "--gcp-zone=us-central1-c",
       "--provider=gke",
-      "--gcp-zone=us-central1-c"
+      "--test_args=--ginkgo.focus=Kubectl --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6856,15 +6856,15 @@
   },
   "ci-kubernetes-e2e-gke-pre-release": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-pre-release.env",
-      "--timeout=480m",
       "--extract=release/latest",
-      "--check-leaked-resources",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gke-prerel",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6873,17 +6873,17 @@
   },
   "ci-kubernetes-e2e-gke-prod": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-prod.env",
-      "--timeout=600m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-prod.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gke-prod",
+      "--gcp-zone=us-central1-b",
       "--provider=gke",
-      "--gcp-zone=us-central1-b"
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6892,17 +6892,17 @@
   },
   "ci-kubernetes-e2e-gke-prod-parallel": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-prod-parallel.env",
-      "--timeout=80m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-prod-parallel.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-e2e-gke-prod-parallel",
+      "--gcp-zone=us-central1-b",
       "--provider=gke",
-      "--gcp-zone=us-central1-b"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6911,17 +6911,17 @@
   },
   "ci-kubernetes-e2e-gke-prod-smoke": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-prod-smoke.env",
-      "--timeout=80m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-prod-smoke.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-e2e-gke-prod-smoke",
+      "--gcp-zone=us-east1-d",
       "--provider=gke",
-      "--gcp-zone=us-east1-d"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6930,16 +6930,16 @@
   },
   "ci-kubernetes-e2e-gke-reboot": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-ci-reboot",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6948,15 +6948,15 @@
   },
   "ci-kubernetes-e2e-gke-reboot-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1-5.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6965,16 +6965,16 @@
   },
   "ci-kubernetes-e2e-gke-reboot-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1-6.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-reboot-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -6983,16 +6983,16 @@
   },
   "ci-kubernetes-e2e-gke-reboot-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-reboot-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-reboot-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7001,15 +7001,15 @@
   },
   "ci-kubernetes-e2e-gke-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1-5.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7018,17 +7018,17 @@
   },
   "ci-kubernetes-e2e-gke-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=err-e2e",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1-6.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7037,16 +7037,16 @@
   },
   "ci-kubernetes-e2e-gke-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=50m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7055,17 +7055,17 @@
   },
   "ci-kubernetes-e2e-gke-scale-correctness": {
     "args": [
+      "--cluster=gke-scale-cluster",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-scale-correctness.env",
-      "--cluster=gke-scale-cluster",
-      "--timeout=1200m",
       "--extract=ci/latest",
-      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-scale",
-      "--provider=gke",
       "--gcp-zone=us-east1-a",
-      "--mode=docker"
+      "--mode=docker",
+      "--provider=gke",
+      "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --minStartupPods=8",
+      "--timeout=1200m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7074,16 +7074,16 @@
   },
   "ci-kubernetes-e2e-gke-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=jenkins-gke-e2e-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7092,15 +7092,15 @@
   },
   "ci-kubernetes-e2e-gke-serial-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1-5.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7109,16 +7109,16 @@
   },
   "ci-kubernetes-e2e-gke-serial-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1-6.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-serial-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7127,16 +7127,16 @@
   },
   "ci-kubernetes-e2e-gke-serial-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-serial-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=500m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-serial-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7145,16 +7145,16 @@
   },
   "ci-kubernetes-e2e-gke-slow": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-slow",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7163,15 +7163,15 @@
   },
   "ci-kubernetes-e2e-gke-slow-release-1-5": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1-5.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.5",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7180,16 +7180,16 @@
   },
   "ci-kubernetes-e2e-gke-slow-release-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1-6.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-slow-1-6",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7198,16 +7198,16 @@
   },
   "ci-kubernetes-e2e-gke-slow-release-1-7": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-slow-release-1-7.env",
       "--extract=ci/latest-1.7",
-      "--timeout=150m",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-slow-1-3",
+      "--gcp-zone=us-central1-a",
       "--provider=gke",
-      "--gcp-zone=us-central1-a"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7216,16 +7216,16 @@
   },
   "ci-kubernetes-e2e-gke-stackdriver": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-stackdriver.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:StackdriverMonitoring\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-e2e-gke-stackdriver",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverMonitoring\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7234,17 +7234,17 @@
   },
   "ci-kubernetes-e2e-gke-staging": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-staging.env",
-      "--timeout=600m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-staging.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gke-staging",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=600m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7253,17 +7253,17 @@
   },
   "ci-kubernetes-e2e-gke-staging-parallel": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-staging-parallel.env",
-      "--timeout=80m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-staging-parallel.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-e2e-gke-staging-parallel",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7272,17 +7272,17 @@
   },
   "ci-kubernetes-e2e-gke-subnet": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-subnet.env",
-      "--cluster=auto-subnet",
-      "--timeout=480m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--cluster=auto-subnet",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-subnet.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gke-subnet",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7291,16 +7291,16 @@
   },
   "ci-kubernetes-e2e-gke-test": {
     "args": [
-      "--env-file=jobs/platform/gke.env",
-      "--env-file=jobs/ci-kubernetes-e2e-gke-test.env",
-      "--timeout=480m",
-      "--extract=gke",
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env-file=jobs/platform/gke.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-test.env",
+      "--extract=gke",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
       "--gcp-project=k8s-jkns-e2e-gke-test",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7310,16 +7310,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures.env",
-      "--cluster=test-761f0eadc1",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-761f0eadc1",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-alphafeatures.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-761f0eadc1",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-761f0eadc1"
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7332,16 +7332,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling.env",
-      "--cluster=test-4b6146a96f",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-4b6146a96f",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-autoscaling.env",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-4b6146a96f",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-4b6146a96f"
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7354,16 +7354,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default.env",
-      "--cluster=test-f08378c6bb",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-f08378c6bb",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-default.env",
       "--extract=ci/latest-1.7",
-      "--timeout=50m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-f08378c6bb",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-f08378c6bb"
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7376,16 +7376,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky.env",
-      "--cluster=test-7b1edb0409",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-7b1edb0409",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-flaky.env",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-7b1edb0409",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-7b1edb0409"
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7398,16 +7398,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress.env",
-      "--cluster=test-73afed9487",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-73afed9487",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-ingress.env",
       "--extract=ci/latest-1.7",
-      "--timeout=300m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-73afed9487",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-73afed9487"
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7420,16 +7420,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot.env",
-      "--cluster=test-139569f31c",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-139569f31c",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-reboot.env",
       "--extract=ci/latest-1.7",
-      "--timeout=180m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-139569f31c",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-139569f31c"
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7442,16 +7442,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial.env",
-      "--cluster=test-aac0a04ffb",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-aac0a04ffb",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial.env",
       "--extract=ci/latest-1.7",
-      "--timeout=500m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-aac0a04ffb",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-aac0a04ffb"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7464,16 +7464,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow.env",
-      "--cluster=test-3e74ad8150",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-3e74ad8150",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow.env",
       "--extract=ci/latest-1.7",
-      "--timeout=150m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-3e74ad8150",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-3e74ad8150"
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7486,16 +7486,16 @@
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown": {
     "_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT.",
     "args": [
-      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown.env",
-      "--cluster=test-7f37c1d417",
       "--check-leaked-resources",
-      "--provider=gke",
-      "--gcp-zone=us-central1-f",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--cluster=test-7f37c1d417",
+      "--env-file=jobs/ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown.env",
       "--extract=ci/latest-1.7",
-      "--timeout=30m",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-project=k8s-test-7f37c1d417",
+      "--gcp-zone=us-central1-f",
+      "--provider=gke",
       "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
-      "--gcp-project=k8s-test-7f37c1d417"
+      "--timeout=30m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7507,17 +7507,17 @@
   },
   "ci-kubernetes-e2e-gke-updown": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=err-e2e",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-updown.env",
-      "--timeout=30m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=kubernetes-e2e-gke-updown",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
+      "--timeout=30m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7619,11 +7619,11 @@
     "args": [
       "--aws-role-arn=arn:aws:iam::660757973107:role/job-kops-aws-updown",
       "--cluster=e2e.kops-aws-updown.test-aws.k8s.io",
-      "--state=s3://kops-aws-updown-store",
-      "--zones=us-west-1b",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/ci-kubernetes-e2e-kops-aws-updown.env",
-      "--timeout=30m"
+      "--state=s3://kops-aws-updown-store",
+      "--timeout=30m",
+      "--zones=us-west-1b"
     ],
     "scenario": "kubernetes_kops_aws",
     "sigOwners": [
@@ -7632,10 +7632,10 @@
   },
   "ci-kubernetes-e2e-kops-aws-weave": {
     "args": [
-      "--kops-args=\"--networking=weave\"",
       "--cluster=e2e-kops-aws-weave.test-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
-      "--env-file=jobs/ci-kubernetes-e2e-kops-aws.env"
+      "--env-file=jobs/ci-kubernetes-e2e-kops-aws.env",
+      "--kops-args=\"--networking=weave\""
     ],
     "scenario": "kubernetes_kops_aws",
     "sigOwners": [
@@ -7645,17 +7645,17 @@
   "ci-kubernetes-e2e-kubeadm-gce": {
     "args": [
       "--cluster=",
+      "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-jkns-e2e-kubeadm-gce-ci",
+      "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
       "--kubernetes-anywhere-kubernetes-version=latest",
-      "--deployment=kubernetes-anywhere",
-      "--timeout=300m",
-      "--extract=ci/latest",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\] --minStartupPods=8",
-      "--gcp-project=k8s-jkns-e2e-kubeadm-gce-ci",
       "--provider=kubernetes-anywhere",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7665,17 +7665,17 @@
   "ci-kubernetes-e2e-kubeadm-gce-1-6": {
     "args": [
       "--cluster=",
+      "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce-1-6.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=k8s-jkns-e2e-kubeadm-ci-1-6",
+      "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
-      "--deployment=kubernetes-anywhere",
-      "--timeout=300m",
-      "--extract=ci/latest-1.6",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--gcp-project=k8s-jkns-e2e-kubeadm-ci-1-6",
       "--provider=kubernetes-anywhere",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7685,17 +7685,17 @@
   "ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7": {
     "args": [
       "--cluster=",
+      "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=k8s-kubeadm-1-6-on-1-7",
+      "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
-      "--deployment=kubernetes-anywhere",
-      "--timeout=300m",
-      "--extract=ci/latest-1.6",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--gcp-project=k8s-kubeadm-1-6-on-1-7",
       "--provider=kubernetes-anywhere",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7705,17 +7705,17 @@
   "ci-kubernetes-e2e-kubeadm-gce-1-7": {
     "args": [
       "--cluster=",
+      "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-kubeadm-gce-1-7.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=k8s-jkns-gci-gke-reboot-1-4",
+      "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
       "--kubernetes-anywhere-kubernetes-version=latest-1.7",
-      "--deployment=kubernetes-anywhere",
-      "--timeout=300m",
-      "--extract=ci/latest-1.7",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--gcp-project=k8s-jkns-gci-gke-reboot-1-4",
       "--provider=kubernetes-anywhere",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7724,18 +7724,18 @@
   },
   "ci-kubernetes-e2e-mlkube-gke": {
     "args": [
+      "--charts",
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-mlkube-gke.env",
-      "--test=false",
-      "--charts",
-      "--mount-paths=$GOPATH/src/github.com/foxish/mlkube.io:/src/k8s.io/charts",
-      "--timeout=50m",
       "--extract=gke",
-      "--check-leaked-resources",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=mlkube-testing",
+      "--gcp-zone=us-central1-b",
+      "--mount-paths=$GOPATH/src/github.com/foxish/mlkube.io:/src/k8s.io/charts",
       "--provider=gke",
-      "--gcp-zone=us-central1-b"
+      "--test=false",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7744,16 +7744,16 @@
   },
   "ci-kubernetes-e2e-prow-canary": {
     "args": [
+      "--check-leaked-resources",
       "--cluster=canary-e2e-prow",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-prow-canary.env",
-      "--tag=latest",
-      "--timeout=40m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=Variable.Expansion --minStartupPods=8",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--tag=latest",
+      "--test_args=--ginkgo.focus=Variable.Expansion --minStartupPods=8",
+      "--timeout=40m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7762,16 +7762,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=50m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7780,16 +7780,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=50m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7798,16 +7798,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-alpha-features.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-alpha",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7816,16 +7816,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-autoscaling.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-as",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7834,16 +7834,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-flaky": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-flaky.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-flaky",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7852,16 +7852,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-ingress": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-ingress.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-ingres",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7870,16 +7870,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-reboot": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-reboot.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=180m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-reboot",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7888,16 +7888,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-serial.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7906,16 +7906,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-slow": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-slow.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=150m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-slow",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7924,16 +7924,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-1-6-updown": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-1-6-updown.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=30m",
       "--extract=ci/latest-1.6",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-1-6-updown",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
+      "--timeout=30m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7942,16 +7942,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-alpha-features": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-alpha-features.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-alpha",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:DynamicKubeletConfig\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7960,16 +7960,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-autoscaling": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-autoscaling.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-as",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:ClusterSizeAutoscalingScaleUp\\]|\\[Feature:ClusterSizeAutoscalingScaleDown\\] --ginkgo.skip=\\[Flaky\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7978,16 +7978,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-flaky": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-flaky.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-flaky",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Flaky\\] --ginkgo.skip=\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7996,16 +7996,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-ingress": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-ingress.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-ingress",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8014,16 +8014,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-reboot": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-reboot.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=180m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-reboot",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Feature:Reboot\\] --minStartupPods=8",
+      "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8032,16 +8032,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-serial": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-serial.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=300m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-serial",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8050,16 +8050,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-slow": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-slow.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=150m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-slow",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Slow\\] --ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=150m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8068,16 +8068,16 @@
   },
   "ci-kubernetes-e2e-ubuntu-gke-updown": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/ci-kubernetes-e2e-ubuntu-gke-updown.env",
       "--env-file=jobs/platform/gke.env",
-      "--timeout=30m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
-      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-ubuntu-updown",
+      "--gcp-zone=us-central1-f",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[k8s.io\\]\\sNetworking.*\\[Conformance\\] --minStartupPods=8",
+      "--timeout=30m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8119,21 +8119,21 @@
   },
   "ci-kubernetes-kubemark-100-gce": {
     "args": [
+      "--cluster=kubemark-100",
+      "--docker-in-docker",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-kubemark-100-gce.env",
-      "--docker-in-docker",
-      "--cluster=kubemark-100",
-      "--test=false",
-      "--kubemark",
-      "--timeout=240m",
       "--extract=ci/latest",
-      "--mode=docker",
       "--gcp-project=k8s-jenkins-kubemark",
-      "--provider=gce",
       "--gcp-zone=us-central1-f",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-4",
       "--kubemark-nodes=100",
-      "--kubemark-master-size=n1-standard-4"
+      "--mode=docker",
+      "--provider=gce",
+      "--test=false",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--timeout=240m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8142,21 +8142,21 @@
   },
   "ci-kubernetes-kubemark-5-gce": {
     "args": [
+      "--cluster=kubemark-5",
+      "--docker-in-docker",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-kubemark-5-gce.env",
-      "--docker-in-docker",
-      "--cluster=kubemark-5",
-      "--test=false",
-      "--kubemark",
-      "--timeout=60m",
       "--extract=ci/latest",
-      "--mode=docker",
       "--gcp-project=k8s-jenkins-kubemark",
-      "--provider=gce",
       "--gcp-zone=us-central1-f",
-      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-1",
       "--kubemark-nodes=5",
-      "--kubemark-master-size=n1-standard-1"
+      "--mode=docker",
+      "--provider=gce",
+      "--test=false",
+      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8165,21 +8165,21 @@
   },
   "ci-kubernetes-kubemark-5-gce-1.5": {
     "args": [
+      "--cluster=kubemark-5-1-5",
+      "--docker-in-docker",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-kubemark-5-gce-1.5.env",
-      "--docker-in-docker",
-      "--cluster=kubemark-5-1-5",
-      "--test=false",
-      "--kubemark",
-      "--timeout=60m",
       "--extract=ci/latest-1.5",
-      "--mode=docker",
       "--gcp-project=k8s-kubemark-1-5",
-      "--provider=gce",
       "--gcp-zone=us-central1-f",
-      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-1",
       "--kubemark-nodes=5",
-      "--kubemark-master-size=n1-standard-1"
+      "--mode=docker",
+      "--provider=gce",
+      "--test=false",
+      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8188,21 +8188,21 @@
   },
   "ci-kubernetes-kubemark-500-gce": {
     "args": [
+      "--cluster=kubemark-500",
+      "--docker-in-docker",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-kubemark-500-gce.env",
-      "--docker-in-docker",
-      "--cluster=kubemark-500",
-      "--test=false",
-      "--kubemark",
-      "--timeout=120m",
       "--extract=ci/latest",
-      "--mode=docker",
       "--gcp-project=k8s-jenkins-blocking-kubemark",
-      "--provider=gce",
       "--gcp-zone=us-central1-f",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-16",
       "--kubemark-nodes=500",
-      "--kubemark-master-size=n1-standard-16"
+      "--mode=docker",
+      "--provider=gce",
+      "--test=false",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--timeout=120m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8211,21 +8211,21 @@
   },
   "ci-kubernetes-kubemark-gce-scale": {
     "args": [
+      "--cluster=kubemark-5000",
+      "--docker-in-docker",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-kubemark-gce-scale.env",
-      "--cluster=kubemark-5000",
-      "--test=false",
-      "--docker-in-docker",
-      "--kubemark",
-      "--timeout=1080m",
       "--extract=ci/latest",
-      "--mode=docker",
       "--gcp-project=kubernetes-scale",
-      "--provider=gce",
       "--gcp-zone=us-central1-b",
-      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-64",
       "--kubemark-nodes=5000",
-      "--kubemark-master-size=n1-standard-64"
+      "--mode=docker",
+      "--provider=gce",
+      "--test=false",
+      "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--timeout=1080m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8234,21 +8234,21 @@
   },
   "ci-kubernetes-kubemark-high-density-100-gce": {
     "args": [
+      "--cluster=kubemark-100pods",
+      "--docker-in-docker",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-kubemark-high-density-100-gce.env",
-      "--docker-in-docker",
-      "--cluster=kubemark-100pods",
-      "--test=false",
-      "--kubemark",
-      "--timeout=280m",
       "--extract=ci/latest",
-      "--mode=docker",
       "--gcp-project=k8s-jenkins-kubemark",
-      "--provider=gce",
       "--gcp-zone=us-central1-f",
-      "--test_args=--ginkgo.focus=\\[Feature:HighDensityPerformance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-32",
       "--kubemark-nodes=600",
-      "--kubemark-master-size=n1-standard-32"
+      "--mode=docker",
+      "--provider=gce",
+      "--test=false",
+      "--test_args=--ginkgo.focus=\\[Feature:HighDensityPerformance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
+      "--timeout=280m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8373,17 +8373,17 @@
   },
   "ci-kubernetes-pull-gce-federation-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-jkns-pr-bldr-e2e-gce-fdrtn",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-pr-bldr-e2e-gce-fdrtn",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8392,17 +8392,17 @@
   },
   "ci-kubernetes-pull-gce-federation-deploy-canary": {
     "args": [
+      "--check-leaked-resources",
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy.env",
       "--env-file=jobs/ci-kubernetes-pull-gce-federation-deploy-canary.env",
-      "--test=false",
-      "--down=false",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
       "--gcp-project=k8s-jkns-pr-cnry-e2e-gce-fdrtn",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test=false",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8411,17 +8411,17 @@
   },
   "ci-kubernetes-soak-cos-docker-validation-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-cos-docker-validation-deploy.env",
+      "--extract=gci/gci-next-canary",
+      "--gcp-project=cos-docker-validation-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-cos-docker-validation-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=gci/gci-next-canary",
-      "--mode=docker",
-      "--gcp-project=cos-docker-validation-soak",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8430,18 +8430,18 @@
   },
   "ci-kubernetes-soak-cos-docker-validation-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-cos-docker-validation-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-cos-docker-validation-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=gci/gci-next-canary",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=cos-docker-validation-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-cos-docker-validation-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8450,17 +8450,17 @@
   },
   "ci-kubernetes-soak-gce-1-7-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1-7-deploy.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1-7-deploy",
       "--extract=ci/latest-1.7",
-      "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--mode=docker",
       "--gcp-project=k8s-jkns-gce-soak-1-3",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1-7-deploy",
+      "--test=false",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8469,18 +8469,18 @@
   },
   "ci-kubernetes-soak-gce-1-7-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1-7-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1-7-deploy",
       "--extract=ci/latest-1.7",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-soak-1-3",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1-7-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8489,17 +8489,17 @@
   },
   "ci-kubernetes-soak-gce-1.4-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1.4-deploy.env",
+      "--extract=ci/latest-1.4",
+      "--gcp-project=k8s-jkns-gce-soak-1-4",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.4-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest-1.4",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gce-soak-1-4",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8508,18 +8508,18 @@
   },
   "ci-kubernetes-soak-gce-1.4-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1.4-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.4-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest-1.4",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-soak-1-4",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.4-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8528,17 +8528,17 @@
   },
   "ci-kubernetes-soak-gce-1.5-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1.5-deploy.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=k8s-gce-soak-1-5",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.5-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest-1.5",
-      "--mode=docker",
-      "--gcp-project=k8s-gce-soak-1-5",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8547,17 +8547,17 @@
   },
   "ci-kubernetes-soak-gce-1.5-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1.5-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.5-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest-1.5",
-      "--mode=docker",
       "--gcp-project=k8s-gce-soak-1-5",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.5-deploy",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8566,17 +8566,17 @@
   },
   "ci-kubernetes-soak-gce-1.6-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1.6-deploy.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=k8s-jkns-gce-soak-1-6",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.6-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest-1.6",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gce-soak-1-6",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8585,18 +8585,18 @@
   },
   "ci-kubernetes-soak-gce-1.6-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-1.6-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.6-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest-1.6",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-soak-1-6",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-1.6-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8605,17 +8605,17 @@
   },
   "ci-kubernetes-soak-gce-2-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-2-deploy.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-jkns-gce-soak-2",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-2-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gce-soak-2",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8624,18 +8624,18 @@
   },
   "ci-kubernetes-soak-gce-2-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-2-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-2-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-soak-2",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-2-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8644,17 +8644,17 @@
   },
   "ci-kubernetes-soak-gce-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-deploy.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-jkns-gce-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gce-soak",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8663,20 +8663,20 @@
   },
   "ci-kubernetes-soak-gce-federation-deploy": {
     "args": [
+      "--build",
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-federation-deploy.env",
       "--extract=local",
       "--federation",
+      "--gcp-project=k8s-jkns-gce-federation-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-federation-deploy",
-      "--build",
       "--stage=gs://kubernetes-release-dev/ci/ci-kubernetes-soak-gce-federation-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gce-federation-soak",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8685,19 +8685,19 @@
   },
   "ci-kubernetes-soak-gce-federation-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-federation-test.env",
-      "--federation",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-federation-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --clean-start=true --minStartupPods=8",
+      "--federation",
       "--gcp-project=k8s-jkns-gce-federation-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-federation-deploy",
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --clean-start=true --minStartupPods=8",
+      "--timeout=90m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8706,18 +8706,18 @@
   },
   "ci-kubernetes-soak-gce-gci-deploy": {
     "args": [
+      "--check-version-skew=false",
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-gci-deploy.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-jkns-gce-gci-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-gci-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest",
-      "--check-version-skew=false",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gce-gci-soak",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8726,18 +8726,18 @@
   },
   "ci-kubernetes-soak-gce-gci-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-gci-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-gci-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-gci-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-gci-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8746,19 +8746,19 @@
   },
   "ci-kubernetes-soak-gce-test": {
     "args": [
+      "--check-version-skew=false",
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gce-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--check-version-skew=false",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gce-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gce-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8767,17 +8767,17 @@
   },
   "ci-kubernetes-soak-gci-gce-1-7-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1-7-deploy.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1-7-deploy",
       "--extract=ci/latest-1.7",
-      "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--mode=docker",
       "--gcp-project=k8s-jkns-gci-gce-soak-1-7",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1-7-deploy",
+      "--test=false",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8786,18 +8786,18 @@
   },
   "ci-kubernetes-soak-gci-gce-1-7-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1-7-test.env",
       "--extract=ci/latest-1.7",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1-7-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-soak-1-7",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1-7-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8806,17 +8806,17 @@
   },
   "ci-kubernetes-soak-gci-gce-1.4-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.4-deploy.env",
+      "--extract=ci/latest-1.4",
+      "--gcp-project=k8s-jkns-gci-gce-soak-1-4",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.4-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest-1.4",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gci-gce-soak-1-4",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8825,18 +8825,18 @@
   },
   "ci-kubernetes-soak-gci-gce-1.4-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.4-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.4-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest-1.4",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-soak-1-4",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.4-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8845,17 +8845,17 @@
   },
   "ci-kubernetes-soak-gci-gce-1.5-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.5-deploy.env",
+      "--extract=ci/latest-1.5",
+      "--gcp-project=k8s-gci-gce-soak-1-5",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.5-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest-1.5",
-      "--mode=docker",
-      "--gcp-project=k8s-gci-gce-soak-1-5",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8864,18 +8864,18 @@
   },
   "ci-kubernetes-soak-gci-gce-1.5-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.5-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.5-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest-1.5",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-gci-gce-soak-1-5",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.5-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8884,17 +8884,17 @@
   },
   "ci-kubernetes-soak-gci-gce-1.6-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.6-deploy.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=k8s-jkns-gci-gce-soak-1-6",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
       "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.6-deploy",
       "--test=false",
-      "--down=false",
-      "--timeout=90m",
-      "--extract=ci/latest-1.6",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-gci-gce-soak-1-6",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8903,18 +8903,18 @@
   },
   "ci-kubernetes-soak-gci-gce-1.6-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-soak-gci-gce-1.6-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.6-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest-1.6",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-project=k8s-jkns-gci-gce-soak-1-6",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gci-gce-1.6-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8923,19 +8923,19 @@
   },
   "ci-kubernetes-soak-gke-deploy": {
     "args": [
+      "--check-version-skew=false",
+      "--down=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-soak-gke-deploy.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-deploy",
-      "--test=false",
-      "--down=false",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--check-version-skew=false",
-      "--mode=docker",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-deploy",
+      "--test=false",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8944,18 +8944,18 @@
   },
   "ci-kubernetes-soak-gke-gci-deploy": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-soak-gke-gci-deploy.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-gci-deploy",
-      "--test=false",
-      "--down=false",
-      "--timeout=90m",
       "--extract=ci/latest",
-      "--mode=docker",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-gci-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-gci-deploy",
+      "--test=false",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8964,20 +8964,20 @@
   },
   "ci-kubernetes-soak-gke-gci-test": {
     "args": [
+      "--check-version-skew=false",
+      "--down=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-soak-gke-gci-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-gci-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--check-version-skew=false",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-gci-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-gci-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -8986,19 +8986,19 @@
   },
   "ci-kubernetes-soak-gke-test": {
     "args": [
+      "--down=false",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-soak-gke-test.env",
-      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-deploy",
-      "--up=false",
-      "--down=false",
-      "--timeout=600m",
       "--extract=ci/latest",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-gke-soak",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/soak/ci-kubernetes-soak-gke-deploy",
+      "--test_args=--ginkgo.skip=\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --clean-start=true --minStartupPods=8",
+      "--timeout=600m",
+      "--up=false"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9112,16 +9112,16 @@
   },
   "ci-perf-tests-e2e-gce-clusterloader": {
     "args": [
+      "--check-leaked-resources",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-perf-tests-e2e-gce-clusterloader.env",
-      "--test=false",
-      "--perf-tests",
-      "--timeout=60m",
       "--extract=ci/latest",
-      "--check-leaked-resources",
       "--gcp-project=k8s-jkns-clusterloader",
+      "--gcp-zone=us-central1-f",
+      "--perf-tests",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--test=false",
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9139,8 +9139,8 @@
   },
   "maintenance-ci-aws-janitor": {
     "args": [
-      "--mode=aws",
-      "--aws-image=gcr.io/k8s-test-infra-aws/aws-janitor"
+      "--aws-image=gcr.io/k8s-test-infra-aws/aws-janitor",
+      "--mode=aws"
     ],
     "scenario": "kubernetes_janitor",
     "sigOwners": [
@@ -9227,17 +9227,17 @@
   "periodic-kubernetes-e2e-kubeadm-gce-1-6": {
     "args": [
       "--cluster=",
+      "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/periodic-kubernetes-e2e-kubeadm-gce-1-6.env",
+      "--extract=ci/latest-1.6",
+      "--gcp-project=k8s-jkns-e2e-kubeadm-per-1-6",
+      "--gcp-zone=us-central1-f",
       "--kubeadm=periodic",
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
-      "--deployment=kubernetes-anywhere",
-      "--timeout=300m",
-      "--extract=ci/latest-1.6",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--gcp-project=k8s-jkns-e2e-kubeadm-per-1-6",
       "--provider=kubernetes-anywhere",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9247,17 +9247,17 @@
   "periodic-kubernetes-e2e-kubeadm-gce-1-7": {
     "args": [
       "--cluster=",
+      "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/periodic-kubernetes-e2e-kubeadm-gce-1-7.env",
+      "--extract=ci/latest-1.7",
+      "--gcp-project=k8s-jkns-gci-gke-serial-1-4",
+      "--gcp-zone=us-central1-f",
       "--kubeadm=periodic",
       "--kubernetes-anywhere-kubernetes-version=latest-1.7",
-      "--deployment=kubernetes-anywhere",
-      "--timeout=300m",
-      "--extract=ci/latest-1.7",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--gcp-project=k8s-jkns-gci-gke-serial-1-4",
       "--provider=kubernetes-anywhere",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9291,13 +9291,13 @@
   },
   "pull-kops-e2e-kubernetes-aws": {
     "args": [
-      "--extract=release/stable",
       "--build-kops",
+      "--check-leaked-resources=false",
       "--cluster=",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/pull-kops-e2e-kubernetes-aws.env",
-      "--check-leaked-resources=false",
+      "--extract=release/stable",
       "--timeout=55m"
     ],
     "scenario": "kubernetes_kops_aws",
@@ -9318,19 +9318,19 @@
   },
   "pull-kubernetes-e2e-gce": {
     "args": [
+      "--build",
+      "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gce.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce",
-      "--cluster=",
-      "--timeout=55m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-pr-gce",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9339,18 +9339,18 @@
   },
   "pull-kubernetes-e2e-gce-bazel": {
     "args": [
+      "--build=bazel",
+      "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gce-bazel.env",
       "--extract=local",
-      "--build=bazel",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-bazel",
-      "--cluster=",
-      "--timeout=55m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-pr-gce-bazel",
+      "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-bazel",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9359,19 +9359,19 @@
   },
   "pull-kubernetes-e2e-gce-canary": {
     "args": [
+      "--build",
+      "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gce-canary.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary",
-      "--cluster=",
-      "--timeout=55m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-pr-gce",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9380,19 +9380,19 @@
   },
   "pull-kubernetes-e2e-gce-etcd3": {
     "args": [
+      "--build",
+      "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gce-etcd3.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-etcd3",
-      "--cluster=",
-      "--timeout=65m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-pr-gce-etcd3",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-etcd3",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=65m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9401,19 +9401,19 @@
   },
   "pull-kubernetes-e2e-gce-gci": {
     "args": [
+      "--build",
+      "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gce-gci.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gci",
-      "--cluster=",
-      "--timeout=55m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-pr-gci-gce",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gci",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9422,21 +9422,21 @@
   },
   "pull-kubernetes-e2e-gke": {
     "args": [
+      "--build",
+      "--cluster=",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gke.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-dev/ci",
-      "--stage-suffix=pull-gke",
-      "--cluster=",
-      "--timeout=55m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-pr-gke",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--stage=gs://kubernetes-release-dev/ci",
+      "--stage-suffix=pull-gke",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9445,21 +9445,21 @@
   },
   "pull-kubernetes-e2e-gke-gci": {
     "args": [
+      "--build",
+      "--cluster=",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gke-gci.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-dev/ci",
-      "--stage-suffix=pull-gke-gci",
-      "--cluster=",
-      "--timeout=55m",
-      "--mode=docker",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-project=k8s-jkns-pr-gci-gke",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
       "--provider=gke",
-      "--gcp-zone=us-central1-f"
+      "--stage=gs://kubernetes-release-dev/ci",
+      "--stage-suffix=pull-gke-gci",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9469,15 +9469,15 @@
   "pull-kubernetes-e2e-kops-aws": {
     "args": [
       "--build",
+      "--check-leaked-resources=false",
       "--cluster=",
-      "--extract=local",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/pull-kubernetes-e2e-kops-aws.env",
-      "--check-leaked-resources=false",
-      "--timeout=55m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort"
+      "--extract=local",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_kops_aws",
     "sigOwners": [
@@ -9487,17 +9487,17 @@
   "pull-kubernetes-e2e-kubeadm-gce": {
     "args": [
       "--cluster=",
+      "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e-kubeadm-gce.env",
       "--extract=local",
+      "--gcp-project=k8s-jkns-pr-kubeadm",
+      "--gcp-zone=us-central1-f",
       "--kubeadm=pull",
       "--kubernetes-anywhere-kubernetes-version=latest",
-      "--deployment=kubernetes-anywhere",
-      "--timeout=55m",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\] --minStartupPods=8",
-      "--gcp-project=k8s-jkns-pr-kubeadm",
       "--provider=kubernetes-anywhere",
-      "--gcp-zone=us-central1-f"
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\] --minStartupPods=8",
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9506,23 +9506,23 @@
   },
   "pull-kubernetes-federation-e2e-gce": {
     "args": [
+      "--build",
+      "--cluster=",
+      "--deployment=none",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-federation-e2e-gce.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce",
-      "--cluster=",
-      "--multiple-federations",
       "--federation",
-      "--deployment=none",
-      "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
-      "--timeout=90m",
-      "--mode=docker",
-      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-pr-bldr-e2e-gce-fdrtn",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--multiple-federations",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9531,23 +9531,23 @@
   },
   "pull-kubernetes-federation-e2e-gce-canary": {
     "args": [
+      "--build",
+      "--cluster=",
+      "--deployment=none",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-federation-e2e-gce.env",
       "--env-file=jobs/pull-kubernetes-federation-e2e-gce-canary.env",
       "--extract=local",
-      "--build",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce-canary",
-      "--cluster=",
-      "--multiple-federations",
       "--federation",
-      "--deployment=none",
-      "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy-canary",
-      "--timeout=90m",
-      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--gcp-project=k8s-jkns-pr-cnry-e2e-gce-fdrtn",
+      "--gcp-zone=us-central1-f",
+      "--multiple-federations",
       "--provider=gce",
-      "--gcp-zone=us-central1-f"
+      "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy-canary",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce-canary",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9562,17 +9562,17 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-kubemark-e2e-gce.env",
       "--extract=local",
+      "--gcp-project=k8s-jkns-pr-kubemark",
+      "--gcp-zone=us-central1-f",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-1",
+      "--kubemark-nodes=5",
+      "--mode=docker",
+      "--provider=gce",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce",
       "--test=false",
-      "--kubemark",
-      "--timeout=45m",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-pr-kubemark",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --garbage-collector-enabled=true",
-      "--kubemark-nodes=5",
-      "--kubemark-master-size=n1-standard-1"
+      "--timeout=45m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9587,17 +9587,17 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/pull-kubernetes-kubemark-e2e-gce-gci.env",
       "--extract=local",
+      "--gcp-project=k8s-jkns-pr-gci-kubemark",
+      "--gcp-zone=us-central1-f",
+      "--kubemark",
+      "--kubemark-master-size=n1-standard-1",
+      "--kubemark-nodes=5",
+      "--mode=docker",
+      "--provider=gce",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce-gci",
       "--test=false",
-      "--kubemark",
-      "--timeout=55m",
-      "--mode=docker",
-      "--gcp-project=k8s-jkns-pr-gci-kubemark",
-      "--provider=gce",
-      "--gcp-zone=us-central1-f",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --garbage-collector-enabled=true",
-      "--kubemark-nodes=5",
-      "--kubemark-master-size=n1-standard-1"
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -17,7 +17,6 @@
 """Tests for config.json and Prow configuration."""
 
 
-import json
 import unittest
 
 import config_sort
@@ -29,12 +28,7 @@ class JobTest(unittest.TestCase):
         """Test jobs/config.json, prow/config.yaml and boskos/resources.json are sorted."""
         with open(config_sort.test_infra('jobs/config.json')) as fp:
             original = fp.read()
-            expect = json.dumps(
-                json.loads(original),
-                sort_keys=True,
-                indent=2,
-                separators=(',', ': ')
-                ) + '\n'
+            expect = config_sort.sorted_job_config().getvalue()
             if original != expect:
                 self.fail('jobs/config.json is not sorted, please run '
                           '`bazel run //jobs:config_sort`')

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -408,5 +408,14 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
             self.envs['KUBE_GCE_NODE_IMAGE'], 'cos-stable-59-9460-64-0')
         self.assertEqual(self.envs['KUBE_GCE_NODE_PROJECT'], 'cos-cloud')
 
+    def test_parse_args_order_agnostic(self):
+        args = kubernetes_e2e.parse_args([
+            '--mode=local',
+            '--some-kubetest-arg=foo',
+            '--cluster=test'])
+        self.assertEqual(args.kubetest_args, ['--some-kubetest-arg=foo'])
+        self.assertEqual(args.mode, 'local')
+        self.assertEqual(args.cluster, 'test')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This sorts the arguments for jobs in `config.json`, with two fiddly bits:
* The `execute` scenario is a free-for-all, ignore it.
* The arguments are kept in the original order based on the argument name, because both `--extract` and `--env-file` are cumulative.