### PR TITLE
Determine the bot name using the GitHub API

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -194,7 +194,7 @@ func humanAddedApproved(obj *github.MungeObject) bool {
 	if lastAdded == nil || lastAdded.Actor == nil || lastAdded.Actor.Login == nil {
 		return false
 	}
-	return *lastAdded.Actor.Login != botName
+	return !obj.IsRobot(lastAdded.Actor)
 }
 
 func getApproveComments(comments []*c.Comment) c.FilteredComments {

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -162,7 +162,7 @@ func (b *BlockPath) Munge(obj *github.MungeObject) {
 }
 
 func (b *BlockPath) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if *comment.Body != blockPathBody {

--- a/mungegithub/mungers/cherrypick-auto-approve_test.go
+++ b/mungegithub/mungers/cherrypick-auto-approve_test.go
@@ -36,6 +36,7 @@ var (
 )
 
 func TestCherrypickAuthApprove(t *testing.T) {
+	const testBotName = "dummy"
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	tests := []struct {
@@ -52,60 +53,60 @@ func TestCherrypickAuthApprove(t *testing.T) {
 	}{
 		{
 			name:                "Add cpApproved and milestone",
-			issue:               github_test.Issue(botName, 1, []string{}, true),
+			issue:               github_test.Issue(testBotName, 1, []string{}, true),
 			issueBody:           "Cherry pick of #2 on release-1.2.",
 			prBranch:            "release-1.2",
-			parentIssue:         github_test.Issue(botName, 2, []string{cpApprovedLabel}, true),
+			parentIssue:         github_test.Issue(testBotName, 2, []string{cpApprovedLabel}, true),
 			milestone:           &github.Milestone{Title: stringPtr("v1.2"), Number: intPtr(1)},
 			shouldHaveLabel:     cpApprovedLabel,
 			shouldHaveMilestone: "v1.2",
 		},
 		{
 			name:                "Add milestone",
-			issue:               github_test.Issue(botName, 1, []string{cpApprovedLabel}, true),
+			issue:               github_test.Issue(testBotName, 1, []string{cpApprovedLabel}, true),
 			issueBody:           "Cherry pick of #2 on release-1.2.",
 			prBranch:            "release-1.2",
-			parentIssue:         github_test.Issue(botName, 2, []string{cpApprovedLabel}, true),
+			parentIssue:         github_test.Issue(testBotName, 2, []string{cpApprovedLabel}, true),
 			milestone:           &github.Milestone{Title: stringPtr("v1.2"), Number: intPtr(1)},
 			shouldHaveLabel:     cpApprovedLabel,
 			shouldHaveMilestone: "v1.2",
 		},
 		{
 			name:               "Do not add because parent not have",
-			issue:              github_test.Issue(botName, 1, []string{}, true),
+			issue:              github_test.Issue(testBotName, 1, []string{}, true),
 			issueBody:          "Cherry pick of #2 on release-1.2.",
 			prBranch:           "release-1.2",
-			parentIssue:        github_test.Issue(botName, 2, []string{}, true),
+			parentIssue:        github_test.Issue(testBotName, 2, []string{}, true),
 			milestone:          &github.Milestone{Title: stringPtr("v1.2"), Number: intPtr(1)},
 			shouldNotHaveLabel: cpApprovedLabel,
 			shouldNotHaveMile:  "v1.2",
 		},
 		{
 			name:               "PR against wrong branch",
-			issue:              github_test.Issue(botName, 1, []string{}, true),
+			issue:              github_test.Issue(testBotName, 1, []string{}, true),
 			issueBody:          "Cherry pick of #2 on release-1.2.",
 			prBranch:           "release-1.1",
-			parentIssue:        github_test.Issue(botName, 2, []string{cpApprovedLabel}, true),
+			parentIssue:        github_test.Issue(testBotName, 2, []string{cpApprovedLabel}, true),
 			milestone:          &github.Milestone{Title: stringPtr("v1.2"), Number: intPtr(1)},
 			shouldNotHaveLabel: cpApprovedLabel,
 			shouldNotHaveMile:  "v1.2",
 		},
 		{
 			name:               "Parent milestone against other branch",
-			issue:              github_test.Issue(botName, 1, []string{}, true),
+			issue:              github_test.Issue(testBotName, 1, []string{}, true),
 			issueBody:          "Cherry pick of #2 on release-1.2.",
 			prBranch:           "release-1.2",
-			parentIssue:        github_test.Issue(botName, 2, []string{cpApprovedLabel}, true),
+			parentIssue:        github_test.Issue(testBotName, 2, []string{cpApprovedLabel}, true),
 			milestone:          &github.Milestone{Title: stringPtr("v1.1"), Number: intPtr(1)},
 			shouldNotHaveLabel: cpApprovedLabel,
 			shouldNotHaveMile:  "v1.1",
 		},
 		{
 			name:               "Parent has no milestone",
-			issue:              github_test.Issue(botName, 1, []string{}, true),
+			issue:              github_test.Issue(testBotName, 1, []string{}, true),
 			issueBody:          "Cherry pick of #2 on release-1.2.",
 			prBranch:           "release-1.2",
-			parentIssue:        github_test.Issue(botName, 2, []string{cpApprovedLabel}, true),
+			parentIssue:        github_test.Issue(testBotName, 2, []string{cpApprovedLabel}, true),
 			shouldNotHaveLabel: cpApprovedLabel,
 			shouldNotHaveMile:  "v1.2",
 		},
@@ -161,6 +162,7 @@ func TestCherrypickAuthApprove(t *testing.T) {
 			Project: "r",
 		}
 		config.SetClient(client)
+		config.BotName = testBotName
 
 		c := CherrypickAutoApprove{}
 		err := c.Initialize(config, nil)

--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -89,7 +89,7 @@ func (LabelUnapprovedPicks) Munge(obj *github.MungeObject) {
 }
 
 func (LabelUnapprovedPicks) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if *comment.Body != labelUnapprovedBody {

--- a/mungegithub/mungers/cherrypick-must-have-milestone.go
+++ b/mungegithub/mungers/cherrypick-must-have-milestone.go
@@ -85,7 +85,7 @@ func (PickMustHaveMilestone) Munge(obj *github.MungeObject) {
 }
 
 func (PickMustHaveMilestone) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if *comment.Body != pickMustHaveMilestoneBody {

--- a/mungegithub/mungers/close-stale.go
+++ b/mungegithub/mungers/close-stale.go
@@ -99,7 +99,7 @@ func findLastHumanPullRequestUpdate(obj *github.MungeObject) (*time.Time, bool) 
 		if comment.User == nil || comment.User.Login == nil || comment.CreatedAt == nil || comment.Body == nil {
 			continue
 		}
-		if *comment.User.Login == botName || *comment.User.Login == jenkinsBotName {
+		if obj.IsRobot(comment.User) || *comment.User.Login == jenkinsBotName {
 			continue
 		}
 		if lastHuman.Before(*comment.UpdatedAt) {
@@ -123,7 +123,7 @@ func findLastHumanIssueUpdate(obj *github.MungeObject) (*time.Time, bool) {
 		if !validComment(comment) {
 			continue
 		}
-		if mergeBotComment(comment) || jenkinsBotComment(comment) {
+		if obj.IsRobot(comment.User) || jenkinsBotComment(comment) {
 			continue
 		}
 		if lastHuman.Before(*comment.UpdatedAt) {
@@ -203,7 +203,7 @@ func findLatestWarningComment(obj *github.MungeObject) (*githubapi.IssueComment,
 		if !validComment(comment) {
 			continue
 		}
-		if !mergeBotComment(comment) {
+		if !obj.IsRobot(comment.User) {
 			continue
 		}
 
@@ -340,7 +340,7 @@ func (CloseStale) Munge(obj *github.MungeObject) {
 }
 
 func (CloseStale) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 

--- a/mungegithub/mungers/comment-deleter.go
+++ b/mungegithub/mungers/comment-deleter.go
@@ -110,10 +110,6 @@ func (CommentDeleter) Munge(obj *github.MungeObject) {
 	}
 }
 
-func mergeBotComment(comment *githubapi.IssueComment) bool {
-	return *comment.User.Login == botName
-}
-
 func jenkinsBotComment(comment *githubapi.IssueComment) bool {
 	return *comment.User.Login == jenkinsBotName
 }

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -94,7 +94,7 @@ func (LGTMAfterCommitMunger) Munge(obj *github.MungeObject) {
 }
 
 func (LGTMAfterCommitMunger) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if !lgtmRemovedRegex.MatchString(*comment.Body) {

--- a/mungegithub/mungers/mungerutil/util.go
+++ b/mungegithub/mungers/mungerutil/util.go
@@ -28,11 +28,6 @@ import (
 	"github.com/google/go-github/github"
 )
 
-const (
-	// BotName is the name of merge-bot
-	BotName = "k8s-merge-robot"
-)
-
 // UserSet is a set a of users
 type UserSet sets.String
 
@@ -110,11 +105,6 @@ func (u *IssueUsers) AllUsers() UserSet {
 // IsValidUser returns true only if given user has valid github username.
 func IsValidUser(u *github.User) bool {
 	return u != nil && u.Login != nil
-}
-
-// IsMungeBot returns true only if given user is this bot.
-func IsMungeBot(u *github.User) bool {
-	return IsValidUser(u) && *u.Login == BotName
 }
 
 // ReadHTTP fetches file contents from a URL with retries.

--- a/mungegithub/mungers/needs_rebase.go
+++ b/mungegithub/mungers/needs_rebase.go
@@ -91,7 +91,7 @@ func (NeedsRebaseMunger) Munge(obj *github.MungeObject) {
 }
 
 func (NeedsRebaseMunger) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if !rebaseRE.MatchString(*comment.Body) {

--- a/mungegithub/mungers/owner-label_test.go
+++ b/mungegithub/mungers/owner-label_test.go
@@ -43,6 +43,7 @@ func (t testOwnerLabeler) FindLabelsForPath(path string) sets.String {
 }
 
 func TestOwnerLabelMunge(t *testing.T) {
+	const testBotName = "dummy"
 	tests := []struct {
 		files       []*github.CommitFile
 		events      []*github.IssueEvent
@@ -51,13 +52,13 @@ func TestOwnerLabelMunge(t *testing.T) {
 	}{
 		{
 			files:       commitFiles([]string{"docs/proposals"}),
-			events:      BotAddedDesign(),
+			events:      BotAddedDesign(testBotName),
 			mustHave:    []string{"kind/design"},
 			mustNotHave: []string{},
 		},
 	}
 	for testNum, test := range tests {
-		client, server, mux := github_test.InitServer(t, docsProposalIssue(), ValidPR(), test.events, nil, nil, nil, test.files)
+		client, server, mux := github_test.InitServer(t, docsProposalIssue(testBotName), ValidPR(), test.events, nil, nil, nil, test.files)
 		mux.HandleFunc("/repos/o/r/issues/1/labels/kind/design", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte{})
@@ -78,6 +79,7 @@ func TestOwnerLabelMunge(t *testing.T) {
 			Project: "r",
 		}
 		config.SetClient(client)
+		config.BotName = testBotName
 
 		o := OwnerLabelMunger{labeler: testOwnerLabeler{}}
 

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -204,7 +204,7 @@ func releaseNoteAlreadyAdded(obj *github.MungeObject) bool {
 }
 
 func (r *ReleaseNoteLabel) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if *comment.Body != releaseNoteBody && *comment.Body != parentReleaseNoteFormat {

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -36,6 +36,7 @@ var (
 )
 
 func TestReleaseNoteLabel(t *testing.T) {
+	const testBotName = "dummy"
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	tests := []struct {
@@ -49,120 +50,120 @@ func TestReleaseNoteLabel(t *testing.T) {
 	}{
 		{
 			name:        "LGTM with release-note",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNote}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel, releaseNote}, true),
 			mustHave:    []string{lgtmLabel, releaseNote},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-none",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteNone}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel, releaseNoteNone}, true),
 			mustHave:    []string{lgtmLabel, releaseNoteNone},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-action-required",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteActionRequired}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel, releaseNoteActionRequired}, true),
 			mustHave:    []string{lgtmLabel, releaseNoteActionRequired},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-experimental",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteExperimental}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel, releaseNoteExperimental}, true),
 			mustHave:    []string{lgtmLabel, releaseNoteExperimental},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "LGTM with release-note-label-needed",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel, releaseNoteLabelNeeded}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel, releaseNoteLabelNeeded}, true),
 			mustHave:    []string{lgtmLabel, doNotMergeLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 		{
 			name:        "LGTM only",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel}, true),
 			mustHave:    []string{lgtmLabel, doNotMergeLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 		{
 			name:     "No labels",
-			issue:    github_test.Issue(botName, 1, []string{}, true),
+			issue:    github_test.Issue(testBotName, 1, []string{}, true),
 			mustHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:     "release-note",
-			issue:    github_test.Issue(botName, 1, []string{releaseNote}, true),
+			issue:    github_test.Issue(testBotName, 1, []string{releaseNote}, true),
 			mustHave: []string{releaseNote},
 		},
 		{
 			name:     "release-note-none",
-			issue:    github_test.Issue(botName, 1, []string{releaseNoteNone}, true),
+			issue:    github_test.Issue(testBotName, 1, []string{releaseNoteNone}, true),
 			mustHave: []string{releaseNoteNone},
 		},
 		{
 			name:     "release-note-action-required",
-			issue:    github_test.Issue(botName, 1, []string{releaseNoteActionRequired}, true),
+			issue:    github_test.Issue(testBotName, 1, []string{releaseNoteActionRequired}, true),
 			mustHave: []string{releaseNoteActionRequired},
 		},
 		{
 			name:     "release-note-experimental",
-			issue:    github_test.Issue(botName, 1, []string{releaseNoteExperimental}, true),
+			issue:    github_test.Issue(testBotName, 1, []string{releaseNoteExperimental}, true),
 			mustHave: []string{releaseNoteExperimental},
 		},
 		{
 			name:        "release-note and release-note-label-needed",
-			issue:       github_test.Issue(botName, 1, []string{releaseNote, releaseNoteLabelNeeded}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{releaseNote, releaseNoteLabelNeeded}, true),
 			mustHave:    []string{releaseNote},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "release-note-none and release-note-label-needed",
-			issue:       github_test.Issue(botName, 1, []string{releaseNoteNone, releaseNoteLabelNeeded}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{releaseNoteNone, releaseNoteLabelNeeded}, true),
 			mustHave:    []string{releaseNoteNone},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "release-note-action-required and release-note-label-needed",
-			issue:       github_test.Issue(botName, 1, []string{releaseNoteActionRequired, releaseNoteLabelNeeded}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{releaseNoteActionRequired, releaseNoteLabelNeeded}, true),
 			mustHave:    []string{releaseNoteActionRequired},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "release-note-experimental and release-note-label-needed",
-			issue:       github_test.Issue(botName, 1, []string{releaseNoteExperimental, releaseNoteLabelNeeded}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{releaseNoteExperimental, releaseNoteLabelNeeded}, true),
 			mustHave:    []string{releaseNoteExperimental},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "do not add needs label when parent PR has releaseNote label",
 			branch:      "release-1.2",
-			issue:       github_test.Issue(botName, 1, []string{}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
-			secondIssue: github_test.Issue(botName, 2, []string{releaseNote}, true),
+			secondIssue: github_test.Issue(testBotName, 2, []string{releaseNote}, true),
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "do not touch LGTM on non-master when parent PR has releaseNote label",
 			branch:      "release-1.2",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
-			secondIssue: github_test.Issue(botName, 2, []string{releaseNote}, true),
+			secondIssue: github_test.Issue(testBotName, 2, []string{releaseNote}, true),
 			mustHave:    []string{lgtmLabel},
 			mustNotHave: []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "add needs label when parent PR does not have releaseNote label",
 			branch:      "release-1.2",
-			issue:       github_test.Issue(botName, 1, []string{}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
-			secondIssue: github_test.Issue(botName, 2, []string{releaseNoteNone}, true),
+			secondIssue: github_test.Issue(testBotName, 2, []string{releaseNoteNone}, true),
 			mustHave:    []string{releaseNoteLabelNeeded},
 		},
 		{
 			name:        "add doNotMergeLabel on non-master when parent PR has releaseNoteNone label",
 			branch:      "release-1.2",
-			issue:       github_test.Issue(botName, 1, []string{lgtmLabel}, true),
+			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
-			secondIssue: github_test.Issue(botName, 2, []string{releaseNoteNone}, true),
+			secondIssue: github_test.Issue(testBotName, 2, []string{releaseNoteNone}, true),
 			mustHave:    []string{doNotMergeLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
@@ -204,6 +205,7 @@ func TestReleaseNoteLabel(t *testing.T) {
 			Project: "r",
 		}
 		config.SetClient(client)
+		config.BotName = testBotName
 
 		r := ReleaseNoteLabel{}
 		err := r.Initialize(config, nil)

--- a/mungegithub/mungers/size.go
+++ b/mungegithub/mungers/size.go
@@ -276,7 +276,7 @@ func calculateSize(adds, dels int) string {
 }
 
 func (s *SizeMunger) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	stale := sizeRE.MatchString(*comment.Body)

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -115,7 +115,7 @@ func (s *StaleGreenCI) Munge(obj *github.MungeObject) {
 }
 
 func (s *StaleGreenCI) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if *comment.Body != greenMsgBody {

--- a/mungegithub/mungers/stale-pending-ci.go
+++ b/mungegithub/mungers/stale-pending-ci.go
@@ -109,7 +109,7 @@ func (s *StalePendingCI) Munge(obj *github.MungeObject) {
 }
 
 func isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if *comment.Body != pendingMsgBody {

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -1606,7 +1606,7 @@ func (sq *SubmitQueue) serveHealthSVG(res http.ResponseWriter, req *http.Request
 }
 
 func (sq *SubmitQueue) isStaleIssueComment(obj *github.MungeObject, comment *githubapi.IssueComment) bool {
-	if !mergeBotComment(comment) {
+	if !obj.IsRobot(comment.User) {
 		return false
 	}
 	if *comment.Body != newRetestBody && *comment.Body != oldRetestBody {


### PR DESCRIPTION
Instead of hard-coding the "k8s-merge-robot" name into the mungers, we
need to read the name of the authenticated user from GitHub once we have
configured the client.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/kubernetes/test-infra/issues/3677

/area mungegithub

/cc @kargakis @eparis 