### PR TITLE
Run plank controller sync with bounded concurrency

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       ?= 0.40
 SPLICE_VERSION     ?= 0.26
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.6
-PLANK_VERSION      ?= 0.31
+PLANK_VERSION      ?= 0.32
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.31
+        image: gcr.io/k8s-prow/plank:0.32
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster


### PR DESCRIPTION
When there are issues with the underlying Jenkins or Kubernetes servers
handling ProwJobs, the plank sync loop can take hours or longer as each
ProwJob is synced serially and client timeouts in each sync add up. Now,
the sync is batched with a limit of 20 concurrent routines at once.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/kubernetes/test-infra/issues/3742

/area prow
/cc @spxtr 