### PR TITLE
bootstrap: flags to turn off magic env, and add custom jobs script dir

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -475,6 +475,7 @@ def finish(gsutil, paths, success, artifacts, build, version, repos, call):
 
 
 # Note the assumption that bootstrap is running from within the kubernetes/test-infra repo
+# TODO(nlandolfi): remove assumption
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""
     return os.path.join(ORIG_CWD, os.path.dirname(__file__), '..', *paths)
@@ -740,7 +741,7 @@ def job_script(job, use_json, jobs_dir):
     """Return path to script for job."""
     jobs_dir_resolver = lambda f: test_infra('jobs/%s' % f)
 
-    if not jobs_dir == '':
+    if jobs_dir:
         jobs_dir_resolver = lambda f: os.path.join(jobs_dir, f)
 
     if not use_json:
@@ -895,7 +896,7 @@ def bootstrap(args):
             version = find_version(call)
         else:
             version = ''
-        if not args.no_magic_env:
+        if not args.raw_env:
             setup_magic_environment(job)
         setup_credentials(call, args.service_account, upload)
         setup_creds = True
@@ -978,7 +979,7 @@ def parse_args(arguments=None):
     # is to have magic environment, so the default value for this flag
     # (false) needs to match this behavior.
     parser.add_argument(
-        '--no-magic-env',
+        '--raw-env',
         action='store_true',
         help='Disable Jenkins magic environment')
     # If specified, this is the (relative) path to jobs configuration directory
@@ -990,7 +991,6 @@ def parse_args(arguments=None):
         # find the path of the kubernetes/test-infra repo (assuming it has been
         # cloned). It then uses the root of the kubernetes/test-infra repo as the
         # implicit jobs-config-dir.
-        default="",
         help='Explicit location for where to look for job scripts relative to repo root.')
     args = parser.parse_args(arguments)
     if bool(args.repo) == bool(args.bare):

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -975,23 +975,15 @@ def parse_args(arguments=None):
         '--clean',
         action='store_true',
         help='Clean the git repo before running tests.')
-    # Use "_no_-magic-env" because the default (current functionality)
-    # is to have magic environment, so the default value for this flag
-    # (false) needs to match this behavior.
     parser.add_argument(
         '--raw-env',
         action='store_true',
-        help='Disable Jenkins magic environment')
-    # If specified, this is the (relative) path to jobs configuration directory
-    # the cloned repo.
+        help='Disable the environment specific to kubernetes project.')
     parser.add_argument(
         '--jobs-dir',
-        # The default behavior assumes that bootstrap.py is run from the jenkins/
-        # directory of the kubernetes/test-infra repo, and uses this assumption to
-        # find the path of the kubernetes/test-infra repo (assuming it has been
-        # cloned). It then uses the root of the kubernetes/test-infra repo as the
-        # implicit jobs-config-dir.
-        help='Look for job configuration inside this dir rather than relative to the script.')
+        # Default behavior assumes bootstrap.py is run from the jenkins/ dir of
+        # k8s/test-infra and that the jobs are in k8s/test-infra repo.
+        help='Look for job config in this dir rather than relative to this script.')
     args = parser.parse_args(arguments)
     if bool(args.repo) == bool(args.bare):
         raise argparse.ArgumentTypeError(

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -991,7 +991,7 @@ def parse_args(arguments=None):
         # find the path of the kubernetes/test-infra repo (assuming it has been
         # cloned). It then uses the root of the kubernetes/test-infra repo as the
         # implicit jobs-config-dir.
-        help='Explicit location for where to look for job scripts relative to repo root.')
+        help='Look for job configuration inside this dir rather than relative to the script.')
     args = parser.parse_args(arguments)
     if bool(args.repo) == bool(args.bare):
         raise argparse.ArgumentTypeError(

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1043,7 +1043,7 @@ class FakeArgs(object):
     timeout = 0
     upload = UPLOAD
     json = False
-    no_magic_env = False
+    raw_env = False
     jobs_dir = ''
 
     def __init__(self, **kw):

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1044,7 +1044,7 @@ class FakeArgs(object):
     upload = UPLOAD
     json = False
     no_magic_env = False
-    jobs_config_dir = ''
+    jobs_dir = ''
 
     def __init__(self, **kw):
         self.branch = BRANCH

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1045,6 +1045,7 @@ class FakeArgs(object):
     json = False
     raw_env = False
     jobs_dir = ''
+    scenarios_dir = ''
 
     def __init__(self, **kw):
         self.branch = BRANCH
@@ -1507,7 +1508,7 @@ class JobTest(unittest.TestCase):
     def jobs(self):
         """[(job, job_path)] sequence"""
         for path, _, filenames in os.walk(
-                os.path.dirname(bootstrap.job_script(JOB, False, '')[0])):
+                os.path.dirname(bootstrap.job_script(JOB, False, '', '')[0])):
             for job in [f for f in filenames if f not in self.excludes]:
                 job_path = os.path.join(path, job)
                 yield job, job_path
@@ -1803,20 +1804,20 @@ class JobTest(unittest.TestCase):
                 modern = use_json(name)
             else:
                 modern = use_json
-            cmd = bootstrap.job_script(real_job.get('job-name'), modern, '')
+            cmd = bootstrap.job_script(real_job.get('job-name'), modern, '', '')
             path = cmd[0]
             args = cmd[1:]
             self.assertTrue(os.path.isfile(path), (name, path))
             if modern:
                 self.assertTrue(all(isinstance(a, basestring) for a in args), args)
                 # Ensure the .sh script isn't there
-                other = bootstrap.job_script(real_job.get('job-name'), False, '')
+                other = bootstrap.job_script(real_job.get('job-name'), False, '', '')
                 self.assertFalse(os.path.isfile(other[0]), name)
             else:
                 self.assertEquals(1, len(cmd))
                 # Ensure the job isn't in the json
                 with self.assertRaises(KeyError):
-                    bootstrap.job_script(real_job.get('job-name'), True, '')
+                    bootstrap.job_script(real_job.get('job-name'), True, '', '')
                     self.fail(name)
             for key, value in real_job.items():
                 if not isinstance(value, (basestring, int)):

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1043,6 +1043,8 @@ class FakeArgs(object):
     timeout = 0
     upload = UPLOAD
     json = False
+    no_magic_env = False
+    jobs_config_dir = ''
 
     def __init__(self, **kw):
         self.branch = BRANCH
@@ -1505,7 +1507,7 @@ class JobTest(unittest.TestCase):
     def jobs(self):
         """[(job, job_path)] sequence"""
         for path, _, filenames in os.walk(
-                os.path.dirname(bootstrap.job_script(JOB, False)[0])):
+                os.path.dirname(bootstrap.job_script(JOB, False, '')[0])):
             for job in [f for f in filenames if f not in self.excludes]:
                 job_path = os.path.join(path, job)
                 yield job, job_path
@@ -1801,20 +1803,20 @@ class JobTest(unittest.TestCase):
                 modern = use_json(name)
             else:
                 modern = use_json
-            cmd = bootstrap.job_script(real_job.get('job-name'), modern)
+            cmd = bootstrap.job_script(real_job.get('job-name'), modern, '')
             path = cmd[0]
             args = cmd[1:]
             self.assertTrue(os.path.isfile(path), (name, path))
             if modern:
                 self.assertTrue(all(isinstance(a, basestring) for a in args), args)
                 # Ensure the .sh script isn't there
-                other = bootstrap.job_script(real_job.get('job-name'), False)
+                other = bootstrap.job_script(real_job.get('job-name'), False, '')
                 self.assertFalse(os.path.isfile(other[0]), name)
             else:
                 self.assertEquals(1, len(cmd))
                 # Ensure the job isn't in the json
                 with self.assertRaises(KeyError):
-                    bootstrap.job_script(real_job.get('job-name'), True)
+                    bootstrap.job_script(real_job.get('job-name'), True, '')
                     self.fail(name)
             for key, value in real_job.items():
                 if not isinstance(value, (basestring, int)):


### PR DESCRIPTION
These are the two modifications that we (the istio team) needed to make to bootstrap.py to suit our deployment.

The first is disabling the jenkins magic environment stuff. Primarily because it re-writes $HOME. The second allows us to specify that the jobs file lives in the the repo which is being checked out, not in kubernetes/test-infra.

Summary:
1. Add ability to disable setting up the kubernetes-specific magic environment (`--raw-env` flag)
2. Add ability to specify where to look for jobs files (`--jobs_dir` flag)

cc @sebastienvas @fejta 