### PR TITLE
Automatically retest PRs that failed retesting

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 
 go_repositories()
 
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "40d780165c0b9fbb3ddca858df7347381af0e87e430c74863e4ce9d6f6441023",
+    strip_prefix = "rules_docker-8359263f35227a3634ea023ff4ae163189eb4b26",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/8359263f35227a3634ea023ff4ae163189eb4b26.tar.gz"],
+)
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories", "docker_pull")
+docker_repositories()
+
+docker_pull(
+    name="distroless-base",
+    registry="gcr.io",
+    repository="distroless/base",
+    digest="sha256:d19b95495f226aa64cd63a95863aca4da123bde22410a273e68e091113222e4f",  # latest
+)
+
 git_repository(
     name = "org_pubref_rules_node",
     commit = "bd14a465063da90f632bad46c1efbf802c339e68",

--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -24,7 +24,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//experiment/commenter:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/experiment/commenter/BUILD
+++ b/experiment/commenter/BUILD
@@ -1,0 +1,61 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_push")
+
+docker_build(
+    name = "image",
+    base = "@distroless-base//image",
+    entrypoint = ["/commenter"],
+    files = [":commenter"],
+)
+
+docker_push(
+    name = "push",
+    image = ":image",
+    registry = "gcr.io",
+    repository = "k8s-testimages/commenter",
+    tag = "latest",
+)
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+    "go_test",
+)
+
+go_binary(
+    name = "commenter",
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    tags = ["automanaged"],
+    deps = ["//prow/github:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//prow/github:go_default_library"],
+)

--- a/experiment/commenter/main.go
+++ b/experiment/commenter/main.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Commenter provides a way to --query for issues and append a --comment to matches.
+//
+// The --token determines who interacts with github.
+// By default commenter runs in dry mode, add --confirm to make it leave comments.
+// The --updated, --include-closed, --ceiling options provide minor safeguards
+// around leaving excessive comments.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+const (
+	ClientUser   = "commenter-client"
+	TemplateHelp = `--comment is a golang text/template if set.
+	Valid placeholders:
+		.Org - github org
+		.Repo - github repo
+		.Number - issue number
+	Advanced (see kubernetes/test-infra/prow/github/types.go):
+		.Issue.User.Login - github account
+		.Issue.Title
+		.Issue.State
+		.Issue.HTMLURL
+		.Issue.Assignees - list of assigned .Users
+		.Issue.Labels - list of applied labels (.Name)
+`
+)
+
+func flagOptions() options {
+	o := options{}
+	flag.StringVar(&o.query, "query", "", "See https://help.github.com/articles/searching-issues-and-pull-requests/")
+	flag.DurationVar(&o.updated, "updated", 2*time.Hour, "Filter to issues unmodified for at least this long if set")
+	flag.BoolVar(&o.includeClosed, "include-closed", false, "Match closed issues if set")
+	flag.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
+	flag.StringVar(&o.comment, "comment", "", "Append the following comment to matching issues")
+	flag.BoolVar(&o.useTemplate, "template", false, TemplateHelp)
+	flag.IntVar(&o.ceiling, "ceiling", 3, "Maximum number of issues to modify, 0 for infinite")
+	flag.StringVar(&o.token, "token", "", "Path to github token")
+	flag.Parse()
+	return o
+}
+
+type meta struct {
+	Number int
+	Org    string
+	Repo   string
+	Issue  github.Issue
+}
+
+type options struct {
+	asc           bool
+	ceiling       int
+	comment       string
+	includeClosed bool
+	useTemplate   bool
+	query         string
+	sort          string
+	token         string
+	updated       time.Duration
+	confirm       bool
+}
+
+func parseHTMLURL(url string) (string, string, int, error) {
+	// Example: https://github.com/batterseapower/pinyin-toolkit/issues/132
+	re := regexp.MustCompile(`.+/(.+)/(.+)/(issues|pull)/(\d+)$`)
+	mat := re.FindStringSubmatch(url)
+	if mat == nil {
+		return "", "", 0, fmt.Errorf("failed to parse: %s", url)
+	}
+	n, err := strconv.Atoi(mat[4])
+	if err != nil {
+		return "", "", 0, err
+	}
+	return mat[1], mat[2], n, nil
+}
+
+func makeQuery(query string, includeClosed bool, minUpdated time.Duration) (string, error) {
+	parts := []string{query}
+	if !includeClosed {
+		if strings.Contains(query, "is:closed") {
+			return "", fmt.Errorf("--query='%s' containing is:closed requires --include-closed", query)
+		}
+		parts = append(parts, "is:open")
+	} else if strings.Contains(query, "is:open") {
+		return "", fmt.Errorf("--query='%s' should not contain is:open when using --include-closed", query)
+	}
+	if minUpdated != 0 {
+		latest := time.Now().Add(-minUpdated)
+		parts = append(parts, "updated:<="+latest.Format(time.RFC3339))
+	}
+	return strings.Join(parts, " "), nil
+}
+
+type client interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	o := flagOptions()
+
+	if o.query == "" {
+		log.Fatal("empty --query")
+	}
+	if o.token == "" {
+		log.Fatal("empty --token")
+	}
+	if o.comment == "" {
+		log.Fatal("empty --comment")
+	}
+	b, err := ioutil.ReadFile(o.token)
+	if err != nil {
+		log.Fatalf("cannot read --token: %v", err)
+	}
+
+	var c client
+	tok := strings.TrimSpace(string(b))
+	if o.confirm {
+		c = github.NewClient(ClientUser, tok)
+	} else {
+		c = github.NewDryRunClient(ClientUser, tok)
+	}
+
+	query, err := makeQuery(o.query, o.includeClosed, o.updated)
+	if err != nil {
+		log.Fatalf("Bad query: %v", err)
+	}
+	sort := ""
+	asc := false
+	if o.updated > 0 {
+		sort = "updated"
+		asc = true
+	}
+	commenter := makeCommenter(o.comment, o.useTemplate)
+	if err := run(c, query, sort, asc, commenter, o.ceiling); err != nil {
+		log.Fatalf("Failed run: %v", err)
+	}
+}
+
+func makeCommenter(comment string, useTemplate bool) func(meta) (string, error) {
+	if !useTemplate {
+		return func(_ meta) (string, error) {
+			return comment, nil
+		}
+	}
+	t := template.Must(template.New("comment").Parse(comment))
+	return func(m meta) (string, error) {
+		out := bytes.Buffer{}
+		err := t.Execute(&out, m)
+		return string(out.Bytes()), err
+	}
+}
+
+func run(c client, query, sort string, asc bool, commenter func(meta) (string, error), ceiling int) error {
+	log.Printf("Searching: %s", query)
+	issues, err := c.FindIssues(query, sort, asc)
+	if err != nil {
+		return fmt.Errorf("search failed: %v", err)
+	}
+	problems := []string{}
+	log.Printf("Found %d matches", len(issues))
+	for n, i := range issues {
+		if ceiling > 0 && n == ceiling {
+			log.Printf("Stopping at --ceiling=%d of %d results", n, len(issues))
+			break
+		}
+		log.Printf("Matched %s (%s)", i.HTMLURL, i.Title)
+		org, repo, number, err := parseHTMLURL(i.HTMLURL)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to parse %s: %v", i.HTMLURL, err)
+			log.Print(msg)
+			problems = append(problems, msg)
+		}
+		comment, err := commenter(meta{Number: number, Org: org, Repo: repo, Issue: i})
+		if err != nil {
+			msg := fmt.Sprintf("Failed to create comment for %s/%s#%d: %v", org, repo, number, err)
+			log.Print(msg)
+			problems = append(problems, msg)
+			continue
+		}
+		if err := c.CreateComment(org, repo, number, comment); err != nil {
+			msg := fmt.Sprintf("Failed to apply comment to %s/%s#%d: %v", org, repo, number, err)
+			log.Print(msg)
+			problems = append(problems, msg)
+			continue
+		}
+		log.Printf("Commented on %s", i.HTMLURL)
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("encoutered %d failures: %v", len(problems), problems)
+	}
+	return nil
+}

--- a/experiment/commenter/main_test.go
+++ b/experiment/commenter/main_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"k8s.io/test-infra/prow/github"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseHTMLURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		org  string
+		repo string
+		num  int
+		fail bool
+	}{
+		{
+			name: "normal issue",
+			url:  "https://github.com/org/repo/issues/1234",
+			org:  "org",
+			repo: "repo",
+			num:  1234,
+		},
+		{
+			name: "normal pull",
+			url:  "https://github.com/pull-org/pull-repo/pull/5555",
+			org:  "pull-org",
+			repo: "pull-repo",
+			num:  5555,
+		},
+		{
+			name: "different host",
+			url:  "ftp://gitlab.whatever/org/repo/issues/6666",
+			org:  "org",
+			repo: "repo",
+			num:  6666,
+		},
+		{
+			name: "string issue",
+			url:  "https://github.com/org/repo/issues/future",
+			fail: true,
+		},
+		{
+			name: "weird issue",
+			url:  "https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/11947/",
+			fail: true,
+		},
+	}
+
+	for _, tc := range cases {
+		org, repo, num, err := parseHTMLURL(tc.url)
+		if err != nil && !tc.fail {
+			t.Errorf("%s: should not have produced error: %v", tc.name, err)
+		} else if err == nil && tc.fail {
+			t.Errorf("%s: failed to produce an error", tc.name)
+		} else {
+			if org != tc.org {
+				t.Errorf("%s: org %s != expected %s", tc.name, org, tc.org)
+			}
+			if repo != tc.repo {
+				t.Errorf("%s: repo %s != expected %s", tc.name, repo, tc.repo)
+			}
+			if num != tc.num {
+				t.Errorf("%s: num %d != expected %d", tc.name, num, tc.num)
+			}
+		}
+	}
+}
+
+func TestMakeQuery(t *testing.T) {
+	cases := []struct {
+		name       string
+		query      string
+		closed     bool
+		dur        time.Duration
+		expected   []string
+		unexpected []string
+		err        bool
+	}{
+		{
+			name:       "basic query",
+			query:      "hello world",
+			expected:   []string{"hello world", "is:open"},
+			unexpected: []string{"updated:", "openhello", "worldis"},
+		},
+		{
+			name:       "basic closed",
+			query:      "hello world",
+			closed:     true,
+			expected:   []string{"hello world"},
+			unexpected: []string{"is:open"},
+		},
+		{
+			name:     "basic duration",
+			query:    "hello",
+			dur:      1 * time.Hour,
+			expected: []string{"hello", "updated:<"},
+		},
+		{
+			name:       "weird characters not escaped",
+			query:      "oh yeah!@#$&*()",
+			expected:   []string{"!", "@", "#", " "},
+			unexpected: []string{"%", "+"},
+		},
+		{
+			name:   "include closed with is:open query errors",
+			query:  "hello is:open",
+			closed: true,
+			err:    true,
+		},
+		{
+			name:  "is:closed without includeClosed",
+			query: "hello is:closed",
+			err:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := makeQuery(tc.query, tc.closed, tc.dur)
+		if err != nil && !tc.err {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+		} else if err == nil && tc.err {
+			t.Errorf("%s: failed to raise an error", tc.name)
+		}
+		for _, e := range tc.expected {
+			if !strings.Contains(actual, e) {
+				t.Errorf("%s: could not find %s in %s", tc.name, e, actual)
+			}
+		}
+		for _, u := range tc.unexpected {
+			if strings.Contains(actual, u) {
+				t.Errorf("%s: should not have found %s in %s", tc.name, u, actual)
+			}
+		}
+	}
+}
+
+func makeIssue(owner, repo string, number int, title string) github.Issue {
+	return github.Issue{
+		HTMLURL: fmt.Sprintf("fake://localhost/%s/%s/pull/%d", owner, repo, number),
+		Title:   title,
+	}
+}
+
+type fakeClient struct {
+	comments []int
+	issues   []github.Issue
+}
+
+// Fakes Creating a client, using the same signature as github.Client
+func (c *fakeClient) CreateComment(owner, repo string, number int, comment string) error {
+	if strings.Contains(comment, "error") || repo == "error" {
+		return errors.New(comment)
+	}
+	c.comments = append(c.comments, number)
+	return nil
+}
+
+// Fakes searching for issues, using the same signature as github.Client
+func (c *fakeClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
+	if strings.Contains(query, "error") {
+		return nil, errors.New(query)
+	}
+	ret := []github.Issue{}
+	for _, i := range c.issues {
+		if strings.Contains(i.Title, query) {
+			ret = append(ret, i)
+		}
+	}
+	return ret, nil
+}
+
+func TestRun(t *testing.T) {
+	manyIssues := []github.Issue{}
+	manyComments := []int{}
+	for i := 0; i < 100; i++ {
+		manyIssues = append(manyIssues, makeIssue("o", "r", i, "many "+strconv.Itoa(i)))
+		manyComments = append(manyComments, i)
+	}
+
+	cases := []struct {
+		name     string
+		query    string
+		comment  string
+		template bool
+		ceiling  int
+		client   fakeClient
+		expected []int
+		err      bool
+	}{
+		{
+			name:     "find all",
+			query:    "many",
+			comment:  "found you",
+			client:   fakeClient{issues: manyIssues},
+			expected: manyComments,
+		},
+		{
+			name:     "find first 10",
+			query:    "many",
+			ceiling:  10,
+			comment:  "hey",
+			client:   fakeClient{issues: manyIssues},
+			expected: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			name:    "find none",
+			query:   "none",
+			comment: "this should not happend",
+			client:  fakeClient{issues: manyIssues},
+		},
+		{
+			name:    "search error",
+			query:   "this search should error",
+			comment: "comment",
+			client:  fakeClient{issues: manyIssues},
+			err:     true,
+		},
+		{
+			name:    "comment error",
+			query:   "problematic",
+			comment: "rolo tomassi",
+			client: fakeClient{issues: []github.Issue{
+				makeIssue("o", "r", 1, "problematic this should work"),
+				makeIssue("o", "error", 2, "problematic expect an error"),
+				makeIssue("o", "r", 3, "problematic works as well"),
+			}},
+			err:      true,
+			expected: []int{1, 3},
+		},
+		{
+			name:     "template comment",
+			query:    "67",
+			client:   fakeClient{issues: manyIssues},
+			comment:  "https://gubernator.k8s.io/pr/{{.Org}}/{{.Repo}}/{{.Number}}",
+			template: true,
+			expected: []int{67},
+		},
+		{
+			name:     "bad template errors",
+			query:    "67",
+			client:   fakeClient{issues: manyIssues},
+			comment:  "Bad {{.UnknownField}}",
+			template: true,
+			err:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		ignoreSorting := ""
+		ignoreOrder := false
+		err := run(&tc.client, tc.query, ignoreSorting, ignoreOrder, makeCommenter(tc.comment, tc.template), tc.ceiling)
+		if tc.err && err == nil {
+			t.Errorf("%s: failed to received an error", tc.name)
+			continue
+		}
+		if !tc.err && err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if len(tc.expected) != len(tc.client.comments) {
+			t.Errorf("%s: expected comments %v != actual %v", tc.name, tc.expected, tc.client.comments)
+			continue
+		}
+		missing := []int{}
+		for _, e := range tc.expected {
+			found := false
+			for _, cmt := range tc.client.comments {
+				if cmt == e {
+					found = true
+					break
+				}
+			}
+			if !found {
+				missing = append(missing, e)
+			}
+		}
+		if len(missing) > 0 {
+			t.Errorf("%s: missing %v from actual comments %v", tc.name, missing, tc.client.comments)
+		}
+	}
+}
+
+func TestMakeCommenter(t *testing.T) {
+	m := meta{
+		Number: 10,
+		Org:    "org",
+		Repo:   "repo",
+		Issue: github.Issue{
+			Number:  10,
+			HTMLURL: "url",
+			Title:   "title",
+		},
+	}
+	cases := []struct {
+		name     string
+		comment  string
+		template bool
+		expected string
+		err      bool
+	}{
+		{
+			name:     "string works",
+			comment:  "hello world {{.Number}} {{.Invalid}}",
+			expected: "hello world {{.Number}} {{.Invalid}}",
+		},
+		{
+			name:     "template works",
+			comment:  "N={{.Number}} R={{.Repo}} O={{.Org}} U={{.Issue.HTMLURL}} T={{.Issue.Title}}",
+			template: true,
+			expected: "N=10 R=repo O=org U=url T=title",
+		},
+		{
+			name:     "bad template errors",
+			comment:  "Bad {{.UnknownField}} Template",
+			expected: "Bad ",
+			template: true,
+			err:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		c := makeCommenter(tc.comment, tc.template)
+		actual, err := c(m)
+		if actual != tc.expected {
+			t.Errorf("%s: expected '%s' != actual '%s'", tc.name, tc.expected, actual)
+		}
+		if err != nil && !tc.err {
+			t.Errorf("%s: unexpected err: %v", tc.name, err)
+		}
+		if err == nil && tc.err {
+			t.Errorf("%s: failed to raise an exception", tc.name)
+		}
+	}
+}

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14346,3 +14346,38 @@ periodics:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+
+- name: periodic-test-infra-retester
+  interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/commenter:latest
+      args:
+      - |-
+        --query=is:pr
+        -label:do-not-merge
+        label:lgtm
+        label:approved
+        status:failure
+        -label:needs-rebase
+        -label:needs-ok-to-test
+        -label:"cncf-cla: no"
+        repo:kubernetes/kubernetes
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=/retest
+        This bot automatically retries jobs that failed/flaked on approved PRs (send feedback to `@fejta`).
+
+        Review the [full test history](https://k8s-gubernator.appspot.com/pr/{{.Number}}) for this PR.
+
+      - --template
+      - --ceiling=1
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -743,13 +744,19 @@ func (c *Client) GetRef(org, repo, ref string) (string, error) {
 }
 
 // FindIssues uses the github search API to find issues which match a particular query.
-// TODO(foxish): we should accept map[string][]string and use net/url properly.
-func (c *Client) FindIssues(query string) ([]Issue, error) {
+func (c *Client) FindIssues(query, sort string, asc bool) ([]Issue, error) {
 	c.log("FindIssues", query)
+	path := fmt.Sprintf("%s/search/issues?q=%s", c.base, url.QueryEscape(query))
+	if sort != "" {
+		path += "&sort=" + url.QueryEscape(sort)
+		if asc {
+			path += "&order=asc"
+		}
+	}
 	var issSearchResult IssuesSearchResult
 	_, err := c.request(&request{
 		method:    http.MethodGet,
-		path:      fmt.Sprintf("%s/search/issues?q=%s", c.base, query),
+		path:      path,
 		exitCodes: []int{200},
 	}, &issSearchResult)
 	return issSearchResult.Issues, err

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -744,6 +744,12 @@ func (c *Client) GetRef(org, repo, ref string) (string, error) {
 }
 
 // FindIssues uses the github search API to find issues which match a particular query.
+//
+// Input query the same way you would into the website.
+// Order returned results with sort (usually "updated").
+// Control whether oldest/newest is first with asc.
+//
+// See https://help.github.com/articles/searching-issues-and-pull-requests/ for details.
 func (c *Client) FindIssues(query, sort string, asc bool) ([]Issue, error) {
 	c.log("FindIssues", query)
 	path := fmt.Sprintf("%s/search/issues?q=%s", c.base, url.QueryEscape(query))

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -157,7 +157,8 @@ func (f *FakeClient) RemoveLabel(owner, repo string, number int, label string) e
 	return nil
 }
 
-func (f *FakeClient) FindIssues(query string) ([]github.Issue, error) {
+// FindIssues returns f.Issues
+func (f *FakeClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
 	return f.Issues, nil
 }
 

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -18,7 +18,6 @@ package cla
 
 import (
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -63,7 +62,7 @@ type gitHubClient interface {
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
 	GetPullRequest(owner, repo string, number int) (*github.PullRequest, error)
-	FindIssues(query string) ([]github.Issue, error)
+	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
 }
 
 func handleStatusEvent(pc plugins.PluginClient, se github.StatusEvent) error {
@@ -97,7 +96,7 @@ func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
 	var issues []github.Issue
 	var err error
 	for i := 0; i < maxRetries; i++ {
-		issues, err = gc.FindIssues(url.QueryEscape(fmt.Sprintf("%s repo:%s/%s type:pr state:open", se.SHA, org, repo)))
+		issues, err = gc.FindIssues(fmt.Sprintf("%s repo:%s/%s type:pr state:open", se.SHA, org, repo), "", false)
 		if err != nil {
 			return fmt.Errorf("error searching for issues matching commit: %v", err)
 		}

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -933,6 +933,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-1-6
 - name: periodic-kubernetes-bazel-build-1-7
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-1-7
+- name: periodic-test-infra-retester
+  gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-retester
 - name: metrics-bigquery
   gcs_prefix: kubernetes-jenkins/logs/metrics-bigquery
 # perf tests
@@ -2706,6 +2708,11 @@ dashboards:
   - name: ci-janitor
     description: Deletes old GCP resources from periodic jobs
     test_group_name: maintenance-ci-janitor
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: retester
+    description: Automatically /retest for approved PRs that failed retesting
+    test_group_name: periodic-test-infra-retester
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
 


### PR DESCRIPTION
/assign @spxtr @foxish @grodrigues3 

Created
* a program that searches github for matching issues and leaves a comment on each match.
* bazel rules to build and push an image with this program, and then
* a periodic prow job that uses this to automatically request /retesting

Created a periodic prow job that runs every 20m to find PRs that are:
* approved and ready to merge
* but failed testing

It then leaves a comment to request retesting.

Note that I changed the `FindIssues()` signature and updated the only plugin that uses it right now (cla)

Example comment: https://github.com/kubernetes/kubernetes/pull/48486#issuecomment-318517250