### PR TITLE
Expand submit queue ci results

### DIFF
--- a/mungegithub/mungers/prow.go
+++ b/mungegithub/mungers/prow.go
@@ -24,11 +24,15 @@ import (
 
 // xref k8s.io/test-infra/prow/cmd/deck/jobs.go
 type prowJob struct {
-	Type    string `json:"type"`
-	Repo    string `json:"repo"`
-	Refs    string `json:"refs"`
-	State   string `json:"state"`
-	Context string `json:"context"`
+	Type     string `json:"type"`
+	Repo     string `json:"repo"`
+	Refs     string `json:"refs"`
+	BuildID  string `json:"build_id"`
+	Job      string `json:"job"`
+	Finished string `json:"finished"`
+	State    string `json:"state"`
+	Context  string `json:"context"`
+	URL      string `json:"url"`
 }
 
 type prowJobs []prowJob

--- a/mungegithub/mungers/prow.go
+++ b/mungegithub/mungers/prow.go
@@ -27,6 +27,7 @@ type prowJob struct {
 	Type     string `json:"type"`
 	Repo     string `json:"repo"`
 	Refs     string `json:"refs"`
+	Number   int    `json:"number"`
 	BuildID  string `json:"build_id"`
 	Job      string `json:"job"`
 	Finished string `json:"finished"`

--- a/mungegithub/mungers/submit-queue-batch.go
+++ b/mungegithub/mungers/submit-queue-batch.go
@@ -213,7 +213,7 @@ func (sq *SubmitQueue) handleGithubE2EBatchMerge() {
 	repo := sq.githubConfig.Org + "/" + sq.githubConfig.Project
 	for range time.Tick(1 * time.Minute) {
 		sq.opts.Lock()
-		url := sq.ProwUrl + "/data.js"
+		url := sq.ProwURL + "/data.js"
 		sq.opts.Unlock()
 		allJobs, err := getJobs(url)
 		if err != nil {

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -489,7 +489,6 @@ func (sq *SubmitQueue) internalInitialize(config *github.Config, features *featu
 		http.Handle("/prs", gziphandler.GzipHandler(http.HandlerFunc(sq.servePRs)))
 		http.Handle("/history", gziphandler.GzipHandler(http.HandlerFunc(sq.serveHistory)))
 		http.Handle("/github-e2e-queue", gziphandler.GzipHandler(http.HandlerFunc(sq.serveGithubE2EStatus)))
-		http.Handle("/google-internal-ci", gziphandler.GzipHandler(http.HandlerFunc(sq.serveGoogleInternalStatus)))
 		http.Handle("/merge-info", gziphandler.GzipHandler(http.HandlerFunc(sq.serveMergeInfo)))
 		http.Handle("/priority-info", gziphandler.GzipHandler(http.HandlerFunc(sq.servePriorityInfo)))
 		http.Handle("/health", gziphandler.GzipHandler(http.HandlerFunc(sq.serveHealth)))
@@ -971,12 +970,6 @@ func (sq *SubmitQueue) getGithubE2EStatus() []byte {
 		BatchStatus: &sq.batchStatus,
 	}
 	return sq.marshal(status)
-}
-
-func (sq *SubmitQueue) getGoogleInternalStatus() []byte {
-	sq.Lock()
-	defer sq.Unlock()
-	return sq.marshal(sq.e2e.GetBuildStatus())
 }
 
 func (sq *SubmitQueue) getHealth() []byte {
@@ -1539,11 +1532,6 @@ func (sq *SubmitQueue) servePRs(res http.ResponseWriter, req *http.Request) {
 
 func (sq *SubmitQueue) serveGithubE2EStatus(res http.ResponseWriter, req *http.Request) {
 	data := sq.getGithubE2EStatus()
-	sq.serve(data, res, req)
-}
-
-func (sq *SubmitQueue) serveGoogleInternalStatus(res http.ResponseWriter, req *http.Request) {
-	data := sq.getGoogleInternalStatus()
 	sq.serve(data, res, req)
 }
 

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -161,16 +161,16 @@ type submitQueueInterruptedObject struct {
 type submitQueueMetadata struct {
 	ProjectName string
 
-	ChartUrl   string
-	HistoryUrl string
-	// chartUrl and historyUrl are option storage locations. They are distinct from ChartUrl and
-	// HistoryUrl since the the public variables are used asynchronously by a fileserver and updates
+	ChartURL   string
+	HistoryURL string
+	// chartURL and historyURL are option storage locations. They are distinct from ChartURL and
+	// HistoryURL since the the public variables are used asynchronously by a fileserver and updates
 	// to the options values should not cause a race condition.
-	chartUrl   string
-	historyUrl string
+	chartURL   string
+	historyURL string
 
-	RepoPullUrl string
-	ProwUrl     string
+	RepoPullURL string
+	ProwURL     string
 }
 
 type submitQueueBatchStatus struct {
@@ -268,7 +268,7 @@ type SubmitQueue struct {
 	features *features.Features
 
 	mergeLock    sync.Mutex // acquired when attempting to merge a specific PR
-	ProwUrl      string     // prow base page
+	ProwURL      string     // prow base page
 	BatchEnabled bool
 	ContextURL   string
 	batchStatus  submitQueueBatchStatus
@@ -429,20 +429,20 @@ func (sq *SubmitQueue) Initialize(config *github.Config, features *features.Feat
 }
 
 // internalInitialize will initialize the munger.
-// if overrideUrl is specified, will create testUtils
-func (sq *SubmitQueue) internalInitialize(config *github.Config, features *features.Features, overrideUrl string) error {
+// if overrideURL is specified, will create testUtils
+func (sq *SubmitQueue) internalInitialize(config *github.Config, features *features.Features, overrideURL string) error {
 	sq.Lock()
 	defer sq.Unlock()
 
-	sq.Metadata.ChartUrl = sq.Metadata.chartUrl
-	sq.Metadata.HistoryUrl = sq.Metadata.historyUrl
-	sq.Metadata.ProwUrl = sq.ProwUrl
-	sq.Metadata.RepoPullUrl = fmt.Sprintf("https://github.com/%s/%s/pulls/", config.Org, config.Project)
+	sq.Metadata.ChartURL = sq.Metadata.chartURL
+	sq.Metadata.HistoryURL = sq.Metadata.historyURL
+	sq.Metadata.ProwURL = sq.ProwURL
+	sq.Metadata.RepoPullURL = fmt.Sprintf("https://github.com/%s/%s/pulls/", config.Org, config.Project)
 	sq.Metadata.ProjectName = strings.Title(config.Project)
 	sq.githubConfig = config
 
-	if sq.BatchEnabled && sq.ProwUrl == "" {
-		return errors.New("batch merges require prow-url to be set!")
+	if sq.BatchEnabled && sq.ProwURL == "" {
+		return errors.New("batch merges require prow-url to be set")
 	}
 
 	// TODO: This is not how injection for tests should work.
@@ -450,8 +450,8 @@ func (sq *SubmitQueue) internalInitialize(config *github.Config, features *featu
 		sq.e2e = &fake_e2e.FakeE2ETester{}
 	} else {
 		var gcs *utils.Utils
-		if overrideUrl != "" {
-			gcs = utils.NewTestUtils("bucket", "logs", overrideUrl)
+		if overrideURL != "" {
+			gcs = utils.NewTestUtils("bucket", "logs", overrideURL)
 		} else {
 			gcs = utils.NewWithPresubmitDetection(
 				mungeopts.GCS.BucketName, mungeopts.GCS.LogDir,
@@ -566,9 +566,9 @@ func (sq *SubmitQueue) RegisterOptions(opts *options.Options) sets.String {
 	opts.RegisterBool(&sq.FakeE2E, "fake-e2e", false, "Whether to use a fake for testing E2E stability.")
 	opts.RegisterStringSlice(&sq.DoNotMergeMilestones, "do-not-merge-milestones", []string{}, "List of milestones which, when applied, will cause the PR to not be merged")
 	opts.RegisterInt(&sq.AdminPort, "admin-port", 9999, "If non-zero, will serve administrative actions on this port.")
-	opts.RegisterString(&sq.Metadata.historyUrl, "history-url", "", "URL to access the submit-queue instance's health history.")
-	opts.RegisterString(&sq.Metadata.chartUrl, "chart-url", "", "URL to access the submit-queue instance's health charts.")
-	opts.RegisterString(&sq.ProwUrl, "prow-url", "", "Prow deployment base URL to read batch results and direct users to.")
+	opts.RegisterString(&sq.Metadata.historyURL, "history-url", "", "URL to access the submit-queue instance's health history.")
+	opts.RegisterString(&sq.Metadata.chartURL, "chart-uRL", "", "URL to access the submit-queue instance's health charts.")
+	opts.RegisterString(&sq.ProwURL, "prow-url", "", "Prow deployment base URL to read batch results and direct users to.")
 	opts.RegisterBool(&sq.BatchEnabled, "batch-enabled", false, "Do batch merges (requires prow/splice coordination).")
 	opts.RegisterString(&sq.ContextURL, "context-url", "", "URL where the submit queue is serving - used in Github status contexts")
 	opts.RegisterBool(&sq.GateApproved, "gate-approved", false, "Gate on approved label")
@@ -576,8 +576,8 @@ func (sq *SubmitQueue) RegisterOptions(opts *options.Options) sets.String {
 
 	opts.RegisterUpdateCallback(func(changed sets.String) error {
 		if changed.HasAny("prow-url", "batch-enabled") {
-			if sq.BatchEnabled && sq.ProwUrl == "" {
-				return fmt.Errorf("batch merges require prow-url to be set!")
+			if sq.BatchEnabled && sq.ProwURL == "" {
+				return fmt.Errorf("batch merges require prow-url to be set")
 			}
 		}
 		return nil
@@ -637,7 +637,7 @@ func (sq *SubmitQueue) updateHealth() {
 	}
 	for _, record := range sq.healthHistory {
 		if record.Overall {
-			sq.health.NumStable += 1
+			sq.health.NumStable++
 		}
 		for job, stable := range record.Jobs {
 			if _, ok := sq.health.NumStablePerJob[job]; !ok {

--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -49,7 +49,7 @@
             </md-content>
             <md-list>
               <md-list-item class="md-3-line" ng-repeat="pr in cntl.prs | loginOrPR:cntl.prDisplayValue | orderBy:'Number' track by pr.Number">
-                <a class="md-avatar" ng-href="{{cntl.metadata.RepoPullUrl}}{{pr.Login}}">
+                <a class="md-avatar" ng-href="{{cntl.metadata.RepoPullURL}}{{pr.Login}}">
                   <img ng-src="{{pr.AvatarURL}}" alt="{{pr.Login}}">
                 </a>
                 <md-content class="md-list-item-text" layout="column">
@@ -95,7 +95,7 @@
               <md-subheader class="md-primary">CURRENTLY RUNNING BATCH</md-subheader>
               <md-content layout-padding>
                 <div class="md-body-1" layout-padding>
-                  <a href="{{ cntl.metadata.ProwUrl }}/?type=batch">{{(cntl.batch.Running.refs | refToPRs).join(" ")}}</a>
+                  <a href="{{ cntl.metadata.ProwURL }}/?type=batch">{{(cntl.batch.Running.refs | refToPRs).join(" ")}}</a>
                 </div>
               </md-content>
             </section>
@@ -104,7 +104,7 @@
               <md-subheader class="md-primary">QUEUE</md-subheader>
               <md-list layout-padding>
                 <md-list-item class="md-2-line" ng-repeat="pr in cntl.e2equeue track by pr.Number">
-                  <a class="md-avatar" ng-href="{{cntl.metadata.RepoPullUrl}}{{pr.Login}}">
+                  <a class="md-avatar" ng-href="{{cntl.metadata.RepoPullURL}}{{pr.Login}}">
                     <img ng-src="{{pr.AvatarURL}}" alt="{{pr.Login}}">
                   </a>
                   <md-content class="md-list-item-text" layout="column">
@@ -139,7 +139,7 @@
             </md-content>
             <md-list>
               <md-list-item class="md-3-line" ng-repeat="pr in cntl.historyPRs | loginOrPR:cntl.historyDisplayValue | orderBy: '-Time' track by pr.Time">
-                <a class="md-avatar" ng-href="{{cntl.metadata.RepoPullUrl}}{{pr.Login}}">
+                <a class="md-avatar" ng-href="{{cntl.metadata.RepoPullURL}}{{pr.Login}}">
                   <img ng-src="{{pr.AvatarURL}}" alt="{{pr.Login}}">
                 </a>
                 <md-content class="md-list-item-text" layout="column">
@@ -179,10 +179,10 @@
               <br>
               <br>
               <h2 class="md-title" ng-show="cntl.OverallHealth.length > 0">Overall Health: {{ cntl.OverallHealth }}</h2>
-              <p>Health percents are the fraction of the time that a given job is stable for the last day, or since the submit queue restarted ({{ cntl.sqStats.StartTime | date:'medium'}})</span>, whichever is shorter. The <a ng-href="{{cntl.metadata.HistoryUrl}}"><strong>24-Hour Test Report</strong></a> shows more detail, along with a list of flaky and broken tests in merge-blocking jobs.
+              <p>Health percents are the fraction of the time that a given job is stable for the last day, or since the submit queue restarted ({{ cntl.sqStats.StartTime | date:'medium'}})</span>, whichever is shorter. The <a ng-href="{{cntl.metadata.HistoryURL}}"><strong>24-Hour Test Report</strong></a> shows more detail, along with a list of flaky and broken tests in merge-blocking jobs.
               </p>
               <p>
-                <img ng-src="{{cntl.metadata.ChartUrl}}" style="max-width: 100%"/>
+                <img ng-src="{{cntl.metadata.ChartURL}}" style="max-width: 100%"/>
               </p>
             </md-tab-body>
           </md-tab>
@@ -255,7 +255,7 @@
                     <h2 class="md-toolbar-tools">Health chart for the past week</h2>
                   </md-toolbar>
                   <md-content class="md-padding">
-                    <span><img ng-src="{{cntl.metadata.ChartUrl}}" style="max-width: 100%"/></span>
+                    <span><img ng-src="{{cntl.metadata.ChartURL}}" style="max-width: 100%"/></span>
                   </md-content>
                 </md-tab>
 

--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -162,6 +162,12 @@
                   <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="{{$chip.url}}">{{$chip.name}}</a>
                 </md-chip-template>
               </md-chips>
+              <h2 class="md-title" ng-show="cntl.ciStatus.serial.length > 0">Serial Builds</h2>
+              <md-chips ng-model="cntl.ciStatus.serial" readonly="true">
+                <md-chip-template title="{{$chip.msg}}">
+                  <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="{{$chip.url}}">{{$chip.name}}</a>
+                </md-chip-template>
+              </md-chips>
               <br>
               <md-toolbar class="md-whiteframe-z2">
                 <h2 class="md-toolbar-tools">End-to-End Results</h2>

--- a/mungegithub/submit-queue/www/index.html
+++ b/mungegithub/submit-queue/www/index.html
@@ -22,12 +22,6 @@
         <h1 class="md-display-2">{{cntl.metadata.ProjectName}} Submit Queue Status</h1>
         <a ng-href="https://k8s.io"><img src="https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png" alt="kubernetes logo" class="titleLogo"></a>
       </md-toolbar>
-      <md-toolbar class="md-warn md-hue-1" ng-show="cntl.testResults.yellowBuilds">
-        <h2 class="md-toolbar-tools">E2E Tests Are Troubled But Not Failing</h2>
-      </md-toolbar>
-      <md-toolbar class="md-warn" ng-show="cntl.testResults.redBuilds">
-        <h2 class="md-toolbar-tools">E2E Tests Failing. Entire submit queue blocked. Last merge&nbsp;<span am-time-ago="cntl.lastMergeTime"></span>.</h2>
-      </md-toolbar>
       <md-content class="md-padding">
         <md-tabs md-selected="cntl.selected" md-dynamic-height md-border-bottom>
 
@@ -154,31 +148,32 @@
             </md-list>
           </md-tab>
 
-          <md-tab md-on-select="cntl.selectTab('e2e')">
+          <md-tab md-on-select="cntl.selectTab('ci')">
             <md-tab-label>
-              <span ng-class="{'redTab':cntl.testResults.redBuilds , 'yellowTab':cntl.testResults.yellowBuilds}">E2E Tests</span>
+              <span ng-class="">CI</span>
             </md-tab-label>
             <md-tab-body>
               <md-toolbar class="md-whiteframe-z2">
+                <h2 class="md-toolbar-tools">Presubmit Results</h2>
+              </md-toolbar>
+              <h2 class="md-title" ng-show="cntl.ciStatus.batch$requiredretest.length > 0">Batch Builds</h2>
+              <md-chips ng-model="cntl.ciStatus.batch$requiredretest" readonly="true">
+                <md-chip-template title="{{$chip.msg}}">
+                  <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="{{$chip.url}}">{{$chip.name}}</a>
+                </md-chip-template>
+              </md-chips>
+              <br>
+              <md-toolbar class="md-whiteframe-z2">
                 <h2 class="md-toolbar-tools">End-to-End Results</h2>
               </md-toolbar>
-              <h2 class="md-title" ng-show="cntl.testResults.blockingBuilds.length > 0">Queue-Blocking Builds</h2>
-              <md-chips ng-model="cntl.testResults.blockingBuilds" readonly="true">
+              <h2 class="md-title" ng-show="cntl.ciStatus.nonblocking.length > 0">Non-Queue-Blocking Builds</h2>
+              <md-chips ng-model="cntl.ciStatus.nonblocking" readonly="true">
                 <md-chip-template title="{{$chip.msg}}">
-                  <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="http://ci-test.k8s.io/{{$chip.name}}/{{$chip.id}}/">{{$chip.name}}</a>
-                  <span style="color: {{$chip.color}}">{{$chip.msg}}</span> <span title="Job stability">{{$chip.stability}}</span>
-                </md-chip-template>
-              </md-chips>
-              <h2 class="md-title" ng-show="cntl.testResults.nonBlockingBuilds.length > 0">Non-Queue-Blocking Builds</h2>
-              <md-chips ng-model="cntl.testResults.nonBlockingBuilds" readonly="true">
-                <md-chip-template title="{{$chip.msg}}">
-                  <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="http://ci-test.k8s.io/{{$chip.name}}/{{$chip.id}}/">{{$chip.name}}</a>
-                  <span style="color: {{$chip.color}}">{{$chip.msg}}</span>
+                  <span style="color: {{$chip.color}}">{{$chip.state}}</span> <a ng-href="{{$chip.url}}">{{$chip.name}}</a>
                 </md-chip-template>
               </md-chips>
               <br>
               <br>
-              <h2 class="md-title" ng-show="cntl.OverallHealth.length > 0">Overall Health: {{ cntl.OverallHealth }}</h2>
               <p>Health percents are the fraction of the time that a given job is stable for the last day, or since the submit queue restarted ({{ cntl.sqStats.StartTime | date:'medium'}})</span>, whichever is shorter. The <a ng-href="{{cntl.metadata.HistoryURL}}"><strong>24-Hour Test Report</strong></a> shows more detail, along with a list of flaky and broken tests in merge-blocking jobs.
               </p>
               <p>

--- a/mungegithub/submit-queue/www/script.js
+++ b/mungegithub/submit-queue/www/script.js
@@ -171,7 +171,7 @@ function SQCntl(dataService, $interval, $location) {
   function refreshSQStats() {
     dataService.getData('sq-stats').then(function successCallback(response) {
       self.sqStats = response.data;
-      self.lastMergeTimeciStatus = new Date(response.data.LastMergeTime)
+      self.lastMergeTime = new Date(response.data.LastMergeTime)
     });
   }
 

--- a/mungegithub/submit-queue/www/script.js
+++ b/mungegithub/submit-queue/www/script.js
@@ -46,7 +46,7 @@ function SQCntl(dataService, $interval, $location) {
       case "/history":
         self.selected=2;
         break;
-      // NOTE: "/e2e" was moved to /tests
+      // NOTE: /e2e was moved to /ci
       // TODO: display a toast noting this
       case "/e2e":
         self.selected=3;	

--- a/mungegithub/submit-queue/www/script.js
+++ b/mungegithub/submit-queue/www/script.js
@@ -13,7 +13,7 @@ function SQCntl(dataService, $interval, $location) {
   self.prsCount = 0;
   self.health = {};
   self.metadata = {};
-  self.testResults = {};
+  self.ciStatus = {};
   self.lastMergeTime = Date();
   self.prQuerySearch = prQuerySearch;
   self.historyQuerySearch = historyQuerySearch;
@@ -38,23 +38,29 @@ function SQCntl(dataService, $interval, $location) {
   if (path.length > 0) {
       switch (path) {
       case "/prs":
-          self.selected=0;
-          break;
+        self.selected=0;
+        break;
       case "/queue":
-          self.selected=1;
-          break;
+        self.selected=1;
+        break;
       case "/history":
-          self.selected=2;
-          break;
+        self.selected=2;
+        break;
+      // NOTE: "/e2e" was moved to /tests
+      // TODO: display a toast noting this
       case "/e2e":
-          self.selected=3;
-          break;
+        self.selected=3;	
+        self.location.path("/ci");
+        break;
+      case "/ci":
+        self.selected=3;
+        break;
       case "/info":
-          self.selected=4;
-          break;
+        self.selected=4;
+        break;
       default:
-          console.log("unknown path: " + path);
-          break;
+        console.log("unknown path: " + path);
+        break;
       }
   }
 
@@ -165,7 +171,7 @@ function SQCntl(dataService, $interval, $location) {
   function refreshSQStats() {
     dataService.getData('sq-stats').then(function successCallback(response) {
       self.sqStats = response.data;
-      self.lastMergeTime = new Date(response.data.LastMergeTime)
+      self.lastMergeTimeciStatus = new Date(response.data.LastMergeTime)
     });
   }
 
@@ -187,117 +193,63 @@ function SQCntl(dataService, $interval, $location) {
         var percentStable = self.health.NumStable * 100.0 / self.health.TotalLoops;
         self.OverallHealth = Math.round(percentStable) + "%";
       }
-      updateBuildStability(self.testResults.blockingBuilds, self.testResults.nonBlockingBuilds, self.health);
     });
   }
 
   function refreshContinuousTests() {
-    dataService.getData('google-internal-ci').then(function successCallback(response) {
-      self.testResults = processTests(response.data);
-      updateBuildStability(self.testResults.blockingBuilds, self.testResults.nonBlockingBuilds, self.health);
+    dataService.getData('ci-status').then(function successCallback(response) {
+      self.ciStatus = processTests(response.data);
     });
   }
 
-  function processTests(builds) {
-    var blockingResult = [];
-    var nonBlockingResult = [];
-    var redBuilds = false;
-    var yellowBuilds = false;
-    angular.forEach(builds, function(job, key) {
-      var obj = {
-        'name': key,
-        'id': job.ID,
-      };
-      switch (job.Status) {
-        case 'Stable':
-          // green check mark
-          obj.state = '\u2713';
-          obj.color = 'green';
-          break;
-        case 'Not Stable':
-          // red X mark
-          obj.state = '\u2716';
-          obj.color = 'red';
-          redBuilds = true;
-          break;
-        case 'Ignorable flake':
-          // orange X mark
-          obj.state = '\u2716';
-          obj.color = '#FF8A65';
-          obj.msg = 'Flake!';
-          yellowBuilds = true;
-          break;
-        case 'Problem Resolved':
-          // orange X mark
-          obj.state = '\u2716';
-          obj.color = '#FF8A65';
-          obj.msg = 'Manual override';
-          yellowBuilds = true;
-          break;
-        case '[nonblocking] Stable':
-          // green check mark
-          obj.state = '\u2713';
-          obj.color = 'green';
-          obj.msg = '[nonblocking]';
-          break;
-        case '[nonblocking] Not Stable':
-          // orange X mark
-          obj.state = '\u2716';
-          obj.color = '#FF8A65';
-          obj.msg = '[nonblocking]';
-          break;
-        case '[nonblocking] Ignorable flake':
-          // orange X mark
-          obj.state = '\u2716';
-          obj.color = '#FF8A65';
-          obj.msg = '[nonblocking] Flake!';
-          break;
-        default:
-          obj.state = 'Error';
-          obj.color = 'red';
-          obj.msg = job.Status;
-          redBuilds = true;
+  function processTests(data) {
+    var results = {};
+    angular.forEach(data, function(jobs, key) {
+      // job results are keyed by job.Type/category,
+      // but in javascript we can't use $ in a variable name so..
+      key = key.replace('/', '$');
+      results[key] = [];
+      var parts = key.split('$');
+      var type = parts[0];
+      var category = parts[1];
+      if (category != "") {
+          if (!(category in results)) {
+            results[category] = [];
+          }
       }
-      obj.stability = '';
-      if (!obj.msg) {
-        blockingResult.push(obj);
-      } else {
-        if (obj.msg.includes('[nonblocking]')) {
-          obj.msg = obj.msg.replace('[nonblocking]', '');
-          nonBlockingResult.push(obj);
+      angular.forEach(jobs, function(job, jobName) {
+        var obj = {
+          'name': jobName,
+          'id': job.build_id,
+          'url': job.url,
+          'msg': '',
+        };
+        if (job.state == 'success') {
+          // green heavy check mark
+          obj.state = '\u2714';
+          obj.color = 'green';
         } else {
-          blockingResult.push(obj);
+          //red x mark
+          obj.state = '\u2716';
+          obj.color = 'red';
         }
-      }
+        results[key].push(obj);
+        if (category != "") {
+          results[category].push(obj);
+        }
+      });
     });
-    if (redBuilds) {
-      yellowBuilds = false;
-    }
-    return {
-      blockingBuilds: blockingResult,
-      nonBlockingBuilds: nonBlockingResult,
-      yellowBuilds: yellowBuilds,
-      redBuilds: redBuilds,
-    };
-  }
-
-  function updateBuildStabilityHelper(builds, health) {
-    if (builds === undefined || Object.keys(builds).length === 0 ||
-        health.TotalLoops === 0 || health.NumStablePerJob === undefined) {
-      return;
-    }
-    angular.forEach(builds, function(build) {
-      var key = build.name;
-      if (key in self.health.NumStablePerJob) {
-        var percentStable = health.NumStablePerJob[key] * 100.0 / health.TotalLoops;
-        build.stability = Math.round(percentStable) + "%"
-      }
+    angular.forEach(results, function(r, key) {
+      results[key].sort(function(a, b) {
+        if (a.name < b.name) {
+          return -1;
+        } else if (a.name > b.name) {
+          return 1;
+        }
+        return 0;
+      });
     });
-  }
-
-  function updateBuildStability(blockingBuilds, nonBlockingBuilds, health) {
-    updateBuildStabilityHelper(blockingBuilds, health);
-    updateBuildStabilityHelper(nonBlockingBuilds, health);
+    return results;
   }
 
   function searchTermsContain(terms, value) {


### PR DESCRIPTION
This cleans up the submit queue www a bit and and replaces /google-internal-ci with a new /ci-status endpoint that tracks the most recent job results for jobs across (job.Type, category).

In the process I also fixed some lint issues (mostly with variable capitalization).

A preview:
![screenshot from 2017-07-27 17 39 48](https://user-images.githubusercontent.com/917931/28697726-c8f7c3d2-72f2-11e7-931d-cacf2e409b1d.png)


Fixes https://github.com/kubernetes/test-infra/issues/3661 and https://github.com/kubernetes/test-infra/issues/3619