### PR TITLE
Filter OWNERS entries for valid assignees

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -199,7 +199,7 @@ func (o *RepoInfo) updateRepoUsers() error {
 	glog.Infof("Loaded config from %s:%s", o.projectDir, sha)
 	glog.V(5).Infof("approvers: %v", o.approvers)
 	glog.V(5).Infof("reviewers: %v", o.reviewers)
-	return nil
+	return o.pruneRepoUsers()
 }
 
 // Initialize will initialize the munger
@@ -242,6 +242,21 @@ func (o *RepoInfo) cloneRepo() (string, error) {
 		glog.Errorf("Failed to clone github repo: %s", output)
 	}
 	return cloneUrl, err
+}
+
+func (o *RepoInfo) pruneRepoUsers() error {
+	whitelist, err := o.config.Collaborators()
+	if err != nil {
+		return err
+	}
+
+	for repo, users := range o.approvers {
+		o.approvers[repo] = whitelist.Intersection(users)
+	}
+	for repo, users := range o.reviewers {
+		o.reviewers[repo] = whitelist.Intersection(users)
+	}
+	return nil
 }
 
 // EachLoop is called at the start of every munge loop

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1229,6 +1229,23 @@ func (obj *MungeObject) Priority() int {
 // MungeFunction is the type that must be implemented and passed to ForEachIssueDo
 type MungeFunction func(*MungeObject) error
 
+// Collaborators is a set of all logins who can be
+// listed as assignees, reviewers or approvers for
+// issues and pull requests in this repo
+func (config *Config) Collaborators() (sets.String, error) {
+	logins := sets.NewString()
+	users, err := config.fetchAllCollaborators()
+	if err != nil {
+		return logins, err
+	}
+	for _, user := range users {
+		if user.Login != nil && *user.Login != "" {
+			logins.Insert(*user.Login)
+		}
+	}
+	return logins, nil
+}
+
 func (config *Config) fetchAllCollaborators() ([]*github.User, error) {
 	page := 1
 	var result []*github.User


### PR DESCRIPTION
When Blunderbuss is evaluating OWNERS files, it should only choose from
OWNERS entries that are valid assignees in the project it is munging.


Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area mungegithub
/cc @kargakis 