### PR TITLE
Make the prow/heart plugin configurable

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.137
+HOOK_VERSION       ?= 0.138
 SINKER_VERSION     ?= 0.15
 DECK_VERSION       ?= 0.40
 SPLICE_VERSION     ?= 0.26

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.137
+        image: gcr.io/k8s-prow/hook:0.138
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -18,6 +18,10 @@ triggers:
   - google/cadvisor
   trusted_org: kubernetes
 
+heart:
+  adorees:
+  - k8s-merge-bot
+
 presubmits:
   # PR job triggering definitions.
   # Keys: Full repo name: "org/repo".

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Plank    Plank     `json:"plank,omitempty"`
 	Sinker   Sinker    `json:"sinker,omitempty"`
 	Triggers []Trigger `json:"triggers,omitempty"`
+	Heart    Heart     `json:"heart,omitempty"`
 
 	// ProwJobNamespace is the namespace in the cluster that prow
 	// components will use for looking up ProwJobs. The namespace
@@ -92,6 +93,13 @@ type Trigger struct {
 	// TrustedOrg is the org whose members' PRs will be automatically built
 	// for PRs to the above repos.
 	TrustedOrg string `json:"trusted_org,omitempty"`
+}
+
+// Heart is config for the heart plugin
+type Heart struct {
+	// Adorees is a list of GitHub logins for members
+	// for whom we will add emojis to comments
+	Adorees []string `json:"adorees,omitempty"`
 }
 
 // SlackEvent is config for the slackevents plugin.

--- a/prow/plugins/heart/BUILD
+++ b/prow/plugins/heart/BUILD
@@ -13,6 +13,7 @@ go_library(
     srcs = ["heart.go"],
     tags = ["automanaged"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
@@ -38,6 +39,7 @@ go_test(
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",


### PR DESCRIPTION
Repositories where the `kubernetes-merge-robot` is not active would also
like to share the love.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @spxtr 
/area prow