### PR TITLE
prow: for config, triggers match recursively

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.140
+HOOK_VERSION       ?= 0.141
 SINKER_VERSION     ?= 0.16
 DECK_VERSION       ?= 0.41
 SPLICE_VERSION     ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.140
+        image: gcr.io/k8s-prow/hook:0.141
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -168,7 +168,17 @@ func TestCommentBodyMatches(t *testing.T) {
 		{
 			"org/repo2",
 			"/test all",
-			[]string{"cadveapster"},
+			[]string{"cadveapster", "after-cadveapster", "after-after-cadveapster"},
+		},
+		{
+			"org/repo2",
+			"/test really",
+			[]string{"after-cadveapster"},
+		},
+		{
+			"org/repo2",
+			"/test again really",
+			[]string{"after-after-cadveapster"},
 		},
 		{
 			"org/repo3",
@@ -205,6 +215,25 @@ func TestCommentBodyMatches(t *testing.T) {
 					Name:      "cadveapster",
 					re:        regexp.MustCompile(`/test all`),
 					AlwaysRun: true,
+					RunAfterSuccess: []Presubmit{
+						{
+							Name:      "after-cadveapster",
+							re:        regexp.MustCompile(`/test (really|all)`),
+							AlwaysRun: true,
+							RunAfterSuccess: []Presubmit{
+								{
+									Name:      "after-after-cadveapster",
+									re:        regexp.MustCompile(`/test (again really|all)`),
+									AlwaysRun: true,
+								},
+							},
+						},
+						{
+							Name:      "another-after-cadveapster",
+							re:        regexp.MustCompile(`@k8s-bot dont test this`),
+							AlwaysRun: true,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
See [this issue](https://github.com/kubernetes/test-infra/issues/3745) for context.

I introduce a separate recursive function that `MatchingPresubmits` calls to accumulate the jobs. I modify one test case, and add two additional test cases.

Closes https://github.com/kubernetes/test-infra/issues/3745