### PR TITLE
Make logexporter write a marker file to a GCS registry on success

### DIFF
--- a/logexporter/Makefile
+++ b/logexporter/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT = google-containers
 IMG = gcr.io/$(PROJECT)/logexporter
-TAG = v0.1.0
+TAG = v0.1.1
 
 .PHONY: build push
 

--- a/logexporter/cluster/logexporter-daemonset.yaml
+++ b/logexporter/cluster/logexporter-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/google-containers/logexporter:v0.1.0
+        image: gcr.io/google-containers/logexporter:v0.1.1
         env:
         - name: NODE_NAME
           valueFrom:

--- a/logexporter/cluster/logexporter-pod.yaml
+++ b/logexporter/cluster/logexporter-pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
   - name: logexporter-test
-    image: gcr.io/google-containers/logexporter:v0.1.0
+    image: gcr.io/google-containers/logexporter:v0.1.1
     env:
     - name: NODE_NAME
       valueFrom:


### PR DESCRIPTION
This will help us get rid of all those 5000 `kubectl logs <logexporter-pod>` calls (one per pod). And we can replace it with a single `gsutil ls <path-to-registry-dir>` call.
Does this idea seem reasonable to you?

/cc @wojtek-t @gmarek 