### PR TITLE
Update the Prow URL in the SubmitQueue configuration

### DIFF
--- a/charts/mungegithub/chart/values.kubernetes.kubernetes.yaml
+++ b/charts/mungegithub/chart/values.kubernetes.kubernetes.yaml
@@ -110,7 +110,7 @@ config:
   admin-port: 9999
   chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
   history-url: https://storage.googleapis.com/kubernetes-test-history/static/index.html
-  prow-url: https://prow.k8s.io/data.js
+  prow-url: https://prow.k8s.io
   batch-enabled: true
   context-url: https://submit-queue.k8s.io
 

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -101,7 +101,7 @@ do-not-merge-milestones: ""
 admin-port: 9999
 chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
 history-url: https://storage.googleapis.com/kubernetes-test-history/static/index.html
-prow-url: https://prow.k8s.io/data.js
+prow-url: https://prow.k8s.io
 batch-enabled: true
 context-url: https://submit-queue.k8s.io
 


### PR DESCRIPTION
Changes in ea20db5f2b72375fadfdbc82c14eef5ddb4c1c44 mean that the path
suffix for this URL is no longer necessary in the configuration.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area mungegithub
/cc @rmmh 