### PR TITLE
Bind pull-kubernetes-bazel to bazel v 0.4.5

### DIFF
--- a/images/pull_kubernetes_bazel/Dockerfile
+++ b/images/pull_kubernetes_bazel/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
     python-pip && \
     apt-get clean
 
-ENV BAZEL_VERSION 0.5.2
+ENV BAZEL_VERSION 0.4.5
 RUN wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     rm "bazel_${BAZEL_VERSION}-linux-x86_64.deb"

--- a/images/pull_kubernetes_bazel/Dockerfile
+++ b/images/pull_kubernetes_bazel/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
     python-pip && \
     apt-get clean
 
-ENV BAZEL_VERSION 0.4.5
+ENV BAZEL_VERSION 0.5.2
 RUN wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     rm "bazel_${BAZEL_VERSION}-linux-x86_64.deb"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -71,7 +71,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170729-7ec13d8d  # https://github.com/kubernetes/kubernetes/issues/49824
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -342,7 +342,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170729-7ec13d8d  # https://github.com/kubernetes/kubernetes/issues/49824
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -488,7 +488,9 @@ func TestBazelbuildArgs(t *testing.T) {
 		}
 	}
 	pinnedJobs := map[string]string{
-	//job: reason for pinning
+		//job: reason for pinning
+		"pull-kubernetes-bazel":          "https://github.com/kubernetes/kubernetes/issues/49824",
+		"pull-security-kubernetes-bazel": "https://github.com/kubernetes/kubernetes/issues/49824",
 	}
 	maxTag := ""
 	maxN := 0


### PR DESCRIPTION
One way to tackle https://github.com/kubernetes/kubernetes/issues/49824
/assign @ixdy 

Note that one commit downgrades us to 0.4.5 to build the image, the second updates the job to use this image and the third reverts things to 0.5.2 (so only the config.yaml change appears in the files changed section)