### PR TITLE
Refactor hook plugin config loading, expose configuration for label plugin

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -53,7 +53,7 @@
 		},
 		{
 			"ImportPath": "github.com/ghodss/yaml",
-			"Rev": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
+			"Rev": "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
 		},
 		{
 			"ImportPath": "github.com/golang/lint",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -10,18 +10,6 @@ sinker:
 prowjob_namespace: default
 pod_namespace: test-pods
 
-triggers:
-- repos:
-  - kubernetes
-  - kubernetes-incubator
-  - kubernetes-security
-  - google/cadvisor
-  trusted_org: kubernetes
-
-heart:
-  adorees:
-  - k8s-merge-bot
-
 presubmits:
   # PR job triggering definitions.
   # Keys: Full repo name: "org/repo".

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -36,10 +36,8 @@ type Config struct {
 	// Periodics are not associated with any repo.
 	Periodics []Periodic `json:"periodics,omitempty"`
 
-	Plank    Plank     `json:"plank,omitempty"`
-	Sinker   Sinker    `json:"sinker,omitempty"`
-	Triggers []Trigger `json:"triggers,omitempty"`
-	Heart    Heart     `json:"heart,omitempty"`
+	Plank  Plank  `json:"plank,omitempty"`
+	Sinker Sinker `json:"sinker,omitempty"`
 
 	// ProwJobNamespace is the namespace in the cluster that prow
 	// components will use for looking up ProwJobs. The namespace
@@ -84,22 +82,6 @@ type Sinker struct {
 	MaxPodAgeString string `json:"max_pod_age,omitempty"`
 	// MaxPodAge is how old a Pod can be before it is garbage-collected.
 	MaxPodAge time.Duration `json:"-"`
-}
-
-// Trigger is config for the trigger plugin.
-type Trigger struct {
-	// Repos is either of the form org/repos or just org.
-	Repos []string `json:"repos,omitempty"`
-	// TrustedOrg is the org whose members' PRs will be automatically built
-	// for PRs to the above repos.
-	TrustedOrg string `json:"trusted_org,omitempty"`
-}
-
-// Heart is config for the heart plugin
-type Heart struct {
-	// Adorees is a list of GitHub logins for members
-	// for whom we will add emojis to comments
-	Adorees []string `json:"adorees,omitempty"`
 }
 
 // SlackEvent is config for the slackevents plugin.

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -36,10 +36,7 @@ func (s *Server) handleReviewEvent(re github.ReviewEvent) {
 	org, repo := re.PullRequest.Base.Repo.Owner.Login, re.PullRequest.Base.Repo.Name
 	for p, h := range s.Plugins.ReviewEventHandlers(org, repo) {
 		go func(p string, h plugins.ReviewEventHandler) {
-			pc := s.Plugins.PluginClient
-			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
-				pc.PluginConfig.Trigger = *trigger
-			}
+			pc := s.pluginClientFor(org, repo)
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, re); err != nil {
@@ -62,10 +59,7 @@ func (s *Server) handleReviewCommentEvent(rce github.ReviewCommentEvent) {
 	org, repo := rce.PullRequest.Base.Repo.Owner.Login, rce.PullRequest.Base.Repo.Name
 	for p, h := range s.Plugins.ReviewCommentEventHandlers(org, repo) {
 		go func(p string, h plugins.ReviewCommentEventHandler) {
-			pc := s.Plugins.PluginClient
-			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
-				pc.PluginConfig.Trigger = *trigger
-			}
+			pc := s.pluginClientFor(org, repo)
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, rce); err != nil {
@@ -87,10 +81,7 @@ func (s *Server) handlePullRequestEvent(pr github.PullRequestEvent) {
 	org, repo := pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name
 	for p, h := range s.Plugins.PullRequestHandlers(org, repo) {
 		go func(p string, h plugins.PullRequestHandler) {
-			pc := s.Plugins.PluginClient
-			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
-				pc.PluginConfig.Trigger = *trigger
-			}
+			pc := s.pluginClientFor(org, repo)
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, pr); err != nil {
@@ -111,10 +102,7 @@ func (s *Server) handlePushEvent(pe github.PushEvent) {
 	org, repo := pe.Repo.Owner.Name, pe.Repo.Name
 	for p, h := range s.Plugins.PushEventHandlers(org, repo) {
 		go func(p string, h plugins.PushEventHandler) {
-			pc := s.Plugins.PluginClient
-			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
-				pc.PluginConfig.Trigger = *trigger
-			}
+			pc := s.pluginClientFor(org, repo)
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, pe); err != nil {
@@ -136,10 +124,7 @@ func (s *Server) handleIssueEvent(i github.IssueEvent) {
 	org, repo := i.Repo.Owner.Login, i.Repo.Name
 	for p, h := range s.Plugins.IssueHandlers(org, repo) {
 		go func(p string, h plugins.IssueHandler) {
-			pc := s.Plugins.PluginClient
-			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
-				pc.PluginConfig.Trigger = *trigger
-			}
+			pc := s.pluginClientFor(org, repo)
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, i); err != nil {
@@ -161,10 +146,7 @@ func (s *Server) handleIssueCommentEvent(ic github.IssueCommentEvent) {
 	org, repo := ic.Repo.Owner.Login, ic.Repo.Name
 	for p, h := range s.Plugins.IssueCommentHandlers(org, repo) {
 		go func(p string, h plugins.IssueCommentHandler) {
-			pc := s.Plugins.PluginClient
-			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
-				pc.PluginConfig.Trigger = *trigger
-			}
+			pc := s.pluginClientFor(org, repo)
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, ic); err != nil {
@@ -187,10 +169,7 @@ func (s *Server) handleStatusEvent(se github.StatusEvent) {
 	org, repo := se.Repo.Owner.Login, se.Repo.Name
 	for p, h := range s.Plugins.StatusEventHandlers(org, repo) {
 		go func(p string, h plugins.StatusEventHandler) {
-			pc := s.Plugins.PluginClient
-			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
-				pc.PluginConfig.Trigger = *trigger
-			}
+			pc := s.pluginClientFor(org, repo)
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, se); err != nil {
@@ -198,4 +177,13 @@ func (s *Server) handleStatusEvent(se github.StatusEvent) {
 			}
 		}(p, h)
 	}
+}
+
+func (s *Server) pluginClientFor(org, repo string) plugins.PluginClient {
+	client := s.Plugins.PluginClient
+	if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+		client.PluginConfig.Trigger = *trigger
+	}
+
+	return client
 }

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -33,9 +33,13 @@ func (s *Server) handleReviewEvent(re github.ReviewEvent) {
 		"url":      re.Review.HTMLURL,
 	})
 	l.Infof("Review %s.", re.Action)
-	for p, h := range s.Plugins.ReviewEventHandlers(re.PullRequest.Base.Repo.Owner.Login, re.PullRequest.Base.Repo.Name) {
+	org, repo := re.PullRequest.Base.Repo.Owner.Login, re.PullRequest.Base.Repo.Name
+	for p, h := range s.Plugins.ReviewEventHandlers(org, repo) {
 		go func(p string, h plugins.ReviewEventHandler) {
 			pc := s.Plugins.PluginClient
+			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+				pc.PluginConfig.Trigger = *trigger
+			}
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, re); err != nil {
@@ -55,9 +59,13 @@ func (s *Server) handleReviewCommentEvent(rce github.ReviewCommentEvent) {
 		"url":       rce.Comment.HTMLURL,
 	})
 	l.Infof("Review comment %s.", rce.Action)
-	for p, h := range s.Plugins.ReviewCommentEventHandlers(rce.PullRequest.Base.Repo.Owner.Login, rce.PullRequest.Base.Repo.Name) {
+	org, repo := rce.PullRequest.Base.Repo.Owner.Login, rce.PullRequest.Base.Repo.Name
+	for p, h := range s.Plugins.ReviewCommentEventHandlers(org, repo) {
 		go func(p string, h plugins.ReviewCommentEventHandler) {
 			pc := s.Plugins.PluginClient
+			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+				pc.PluginConfig.Trigger = *trigger
+			}
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, rce); err != nil {
@@ -76,9 +84,13 @@ func (s *Server) handlePullRequestEvent(pr github.PullRequestEvent) {
 		"url":    pr.PullRequest.HTMLURL,
 	})
 	l.Infof("Pull request %s.", pr.Action)
-	for p, h := range s.Plugins.PullRequestHandlers(pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name) {
+	org, repo := pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name
+	for p, h := range s.Plugins.PullRequestHandlers(org, repo) {
 		go func(p string, h plugins.PullRequestHandler) {
 			pc := s.Plugins.PluginClient
+			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+				pc.PluginConfig.Trigger = *trigger
+			}
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, pr); err != nil {
@@ -96,9 +108,13 @@ func (s *Server) handlePushEvent(pe github.PushEvent) {
 		"head": pe.After,
 	})
 	l.Info("Push event.")
-	for p, h := range s.Plugins.PushEventHandlers(pe.Repo.Owner.Name, pe.Repo.Name) {
+	org, repo := pe.Repo.Owner.Name, pe.Repo.Name
+	for p, h := range s.Plugins.PushEventHandlers(org, repo) {
 		go func(p string, h plugins.PushEventHandler) {
 			pc := s.Plugins.PluginClient
+			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+				pc.PluginConfig.Trigger = *trigger
+			}
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, pe); err != nil {
@@ -117,9 +133,13 @@ func (s *Server) handleIssueEvent(i github.IssueEvent) {
 		"url":    i.Issue.HTMLURL,
 	})
 	l.Infof("Issue %s.", i.Action)
-	for p, h := range s.Plugins.IssueHandlers(i.Repo.Owner.Login, i.Repo.Name) {
+	org, repo := i.Repo.Owner.Login, i.Repo.Name
+	for p, h := range s.Plugins.IssueHandlers(org, repo) {
 		go func(p string, h plugins.IssueHandler) {
 			pc := s.Plugins.PluginClient
+			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+				pc.PluginConfig.Trigger = *trigger
+			}
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, i); err != nil {
@@ -138,9 +158,13 @@ func (s *Server) handleIssueCommentEvent(ic github.IssueCommentEvent) {
 		"url":    ic.Comment.HTMLURL,
 	})
 	l.Infof("Issue comment %s.", ic.Action)
-	for p, h := range s.Plugins.IssueCommentHandlers(ic.Repo.Owner.Login, ic.Repo.Name) {
+	org, repo := ic.Repo.Owner.Login, ic.Repo.Name
+	for p, h := range s.Plugins.IssueCommentHandlers(org, repo) {
 		go func(p string, h plugins.IssueCommentHandler) {
 			pc := s.Plugins.PluginClient
+			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+				pc.PluginConfig.Trigger = *trigger
+			}
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, ic); err != nil {
@@ -160,9 +184,13 @@ func (s *Server) handleStatusEvent(se github.StatusEvent) {
 		"id":      se.ID,
 	})
 	l.Infof("Status description %s.", se.Description)
-	for p, h := range s.Plugins.StatusEventHandlers(se.Repo.Owner.Login, se.Repo.Name) {
+	org, repo := se.Repo.Owner.Login, se.Repo.Name
+	for p, h := range s.Plugins.StatusEventHandlers(org, repo) {
 		go func(p string, h plugins.StatusEventHandler) {
 			pc := s.Plugins.PluginClient
+			if trigger := s.Plugins.TriggerFor(org, repo); trigger != nil && trigger.TrustedOrg != "" {
+				pc.PluginConfig.Trigger = *trigger
+			}
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			if err := h(pc, se); err != nil {

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -53,7 +53,7 @@ func TestHook(t *testing.T) {
 		return nil
 	})
 	pa := &plugins.PluginAgent{}
-	if err := pa.Set(map[string][]string{"foo/bar": {"baz"}}); err != nil {
+	if err := pa.Set(plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}}); err != nil {
 		t.Fatalf("Setting plugins: %v", err)
 	}
 	ca := &config.Agent{}

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -2,50 +2,61 @@
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
 ---
-google/cadvisor:
-- trigger
+triggers:
+- repos:
+  - kubernetes
+  - kubernetes-incubator
+  - kubernetes-security
+  - google/cadvisor
+  trusted_org: kubernetes
+heart:
+  adorees:
+  - k8s-merge-bot
+plugins:
+  google/cadvisor:
+  - trigger
 
-kubernetes/charts:
-- trigger
+  kubernetes/charts:
+  - trigger
 
-kubernetes/heapster:
-- trigger
+  kubernetes/heapster:
+  - trigger
 
-kubernetes/kops:
-- trigger
+  kubernetes/kops:
+  - trigger
 
-kubernetes/kubernetes:
-- trigger
-- release-note
+  kubernetes/kubernetes:
+  - trigger
+  - release-note
 
-kubernetes/test-infra:
-- trigger
-- config-updater
+  kubernetes/test-infra:
+  - trigger
+  - config-updater
 
-kubernetes:
-- assign
-- cla
-- close
-- reopen
-- golint
-- heart
-- label
-- lgtm
-- yuks
+  kubernetes:
+  - assign
+  - cla
+  - close
+  - reopen
+  - golint
+  - heart
+  - label
+  - lgtm
+  - yuks
 
-kubernetes-incubator:
-- cla
-- assign
+  kubernetes-incubator:
+  - cla
+  - assign
 
-kubernetes-incubator/kube-aws:
-- lgtm
+  kubernetes-incubator/kube-aws:
+  - lgtm
 
-kubernetes-security/kubernetes:
-- trigger
+  kubernetes-security/kubernetes:
+  - trigger
 
-spxtr/envoy:
-- assign
-- close
-- reopen
-- lgtm
-- trigger
+  spxtr/envoy:
+  - assign
+  - close
+  - reopen
+  - lgtm
+  - trigger

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -14,6 +14,11 @@ heart:
   - k8s-merge-bot
 label:
   sig_org: kubernetes
+  prefixes:
+  - sig
+  - kind
+  - area
+  - priority
 plugins:
   google/cadvisor:
   - trigger

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -12,6 +12,8 @@ triggers:
 heart:
   adorees:
   - k8s-merge-bot
+label:
+  sig_org: kubernetes
 plugins:
   google/cadvisor:
   - trigger

--- a/prow/plugins/heart/BUILD
+++ b/prow/plugins/heart/BUILD
@@ -13,7 +13,6 @@ go_library(
     srcs = ["heart.go"],
     tags = ["automanaged"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",
@@ -39,7 +38,6 @@ go_test(
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//vendor:github.com/Sirupsen/logrus",

--- a/prow/plugins/heart/heart.go
+++ b/prow/plugins/heart/heart.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -55,37 +54,31 @@ type githubClient interface {
 
 type client struct {
 	GitHubClient githubClient
-	Config       *config.Heart
 	Logger       *logrus.Entry
-}
-
-func heartConfig(c *config.Config) *config.Heart {
-	return &c.Heart
 }
 
 func getClient(pc plugins.PluginClient) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
-		Config:       heartConfig(pc.Config),
 		Logger:       pc.Logger,
 	}
 }
 
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
-	return handleIC(getClient(pc), ic)
+	return handleIC(getClient(pc), pc.PluginConfig.Heart.Adorees, ic)
 }
 
 func handlePullRequest(pc plugins.PluginClient, pre github.PullRequestEvent) error {
 	return handlePR(getClient(pc), pre)
 }
 
-func handleIC(c client, ic github.IssueCommentEvent) error {
+func handleIC(c client, adorees []string, ic github.IssueCommentEvent) error {
 	// Only consider new comments on PRs.
 	if !ic.Issue.IsPullRequest() || ic.Action != "created" {
 		return nil
 	}
 	adoredLogin := false
-	for _, login := range c.Config.Adorees {
+	for _, login := range adorees {
 		if ic.Comment.User.Login == login {
 			adoredLogin = true
 			break

--- a/prow/plugins/heart/heart_test.go
+++ b/prow/plugins/heart/heart_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 )
@@ -109,12 +108,7 @@ func TestHandlePR(t *testing.T) {
 		}
 		fakeClient := client{
 			GitHubClient: fakeGitHubClient,
-			Config: &config.Heart{
-				Adorees: []string{
-					"kubernetes",
-				},
-			},
-			Logger: logrus.WithField("plugin", pluginName),
+			Logger:       logrus.WithField("plugin", pluginName),
 		}
 
 		err := handlePR(fakeClient, event)

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -44,7 +44,6 @@ type assignEvent struct {
 var (
 	labelRegex              = regexp.MustCompile(`(?m)^/(area|priority|kind|sig)\s*(.*)$`)
 	removeLabelRegex        = regexp.MustCompile(`(?m)^/remove-(area|priority|kind|sig)\s*(.*)$`)
-	sigMatcher              = regexp.MustCompile(`(?m)@kubernetes/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`)
 	chatBack                = "Reiterating the mentions to trigger a notification: \n%v"
 	nonExistentLabelOnIssue = "Those labels are not set on the issue: `%v`"
 	kindMap                 = map[string]string{
@@ -54,6 +53,10 @@ var (
 		"proposals":        "kind/design",
 	}
 )
+
+func sigMatcher(org string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf(`(?m)@%s/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`, org))
+}
 
 func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
@@ -86,7 +89,7 @@ func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) er
 		issue:   ic.Issue,
 		comment: ic.Comment,
 	}
-	return handle(pc.GitHubClient, pc.Logger, ae, pc.SlackClient)
+	return handle(pc.GitHubClient, pc.Logger, pc.PluginConfig.Label.SigOrg, ae, pc.SlackClient)
 }
 
 func handleIssue(pc plugins.PluginClient, i github.IssueEvent) error {
@@ -100,7 +103,7 @@ func handleIssue(pc plugins.PluginClient, i github.IssueEvent) error {
 		number: i.Issue.Number,
 		issue:  i.Issue,
 	}
-	return handle(pc.GitHubClient, pc.Logger, ae, pc.SlackClient)
+	return handle(pc.GitHubClient, pc.Logger, pc.PluginConfig.Label.SigOrg, ae, pc.SlackClient)
 }
 
 func handlePullRequest(pc plugins.PluginClient, pr github.PullRequestEvent) error {
@@ -113,7 +116,7 @@ func handlePullRequest(pc plugins.PluginClient, pr github.PullRequestEvent) erro
 		url:    pr.PullRequest.HTMLURL,
 		number: pr.Number,
 	}
-	return handle(pc.GitHubClient, pc.Logger, ae, pc.SlackClient)
+	return handle(pc.GitHubClient, pc.Logger, pc.PluginConfig.Label.SigOrg, ae, pc.SlackClient)
 }
 
 // Get Lables from Regexp matches
@@ -139,7 +142,7 @@ func (ae assignEvent) getRepeats(sigMatches [][]string, existingLabels map[strin
 	return
 }
 
-func handle(gc githubClient, log *logrus.Entry, ae assignEvent, sc slackClient) error {
+func handle(gc githubClient, log *logrus.Entry, sigOrg string, ae assignEvent, sc slackClient) error {
 	// only parse newly created comments/issues/PRs and if non bot author
 	if ae.login == gc.BotName() || !(ae.action == "created" || ae.action == "opened") {
 		return nil
@@ -147,7 +150,7 @@ func handle(gc githubClient, log *logrus.Entry, ae assignEvent, sc slackClient) 
 
 	labelMatches := labelRegex.FindAllStringSubmatch(ae.body, -1)
 	removeLabelMatches := removeLabelRegex.FindAllStringSubmatch(ae.body, -1)
-	sigMatches := sigMatcher.FindAllStringSubmatch(ae.body, -1)
+	sigMatches := sigMatcher(sigOrg).FindAllStringSubmatch(ae.body, -1)
 	if len(labelMatches) == 0 && len(sigMatches) == 0 && len(removeLabelMatches) == 0 {
 		return nil
 	}

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -539,7 +539,7 @@ func TestLabel(t *testing.T) {
 			fakeSlackClient := &fakeslack.FakeClient{
 				SentMessages: make(map[string][]string),
 			}
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), ae, fakeSlackClient); err != nil {
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), "kubernetes", ae, fakeSlackClient); err != nil {
 				t.Errorf("For case %s, didn't expect error from label test: %v", tc.name, err)
 				return
 			}
@@ -671,7 +671,7 @@ func TestRepeat(t *testing.T) {
 			member, _ := fakeClient.IsMember(ae.org, ae.login)
 			toRepeat := []string{}
 			if !member {
-				toRepeat = ae.getRepeats(sigMatcher.FindAllStringSubmatch(tc.body, -1), m)
+				toRepeat = ae.getRepeats(sigMatcher("kubernetes").FindAllStringSubmatch(tc.body, -1), m)
 			}
 
 			sort.Strings(toRepeat)
@@ -754,7 +754,7 @@ func TestSlackMessages(t *testing.T) {
 				SentMessages: make(map[string][]string),
 			}
 
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), ae, fakeSlackClient); err != nil {
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), "kubernetes", ae, fakeSlackClient); err != nil {
 				t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)
 			}
 			if len(tc.expectedMessages) != len(fakeSlackClient.SentMessages) {

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -206,6 +206,8 @@ func TestLabel(t *testing.T) {
 		expectedRemovedLabels []string
 		repoLabels            []string
 		issueLabels           []string
+		sigOrg                string
+		prefixes              []string
 	}
 	testcases := []testCase{
 		{
@@ -215,6 +217,8 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			repoLabels:            []string{},
 			issueLabels:           []string{},
+			sigOrg:                "",
+			prefixes:              []string{},
 			commenter:             orgMember,
 		},
 		{
@@ -224,6 +228,8 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			repoLabels:            []string{},
 			issueLabels:           []string{"area/infra"},
+			sigOrg:                "",
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -231,8 +237,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area infra",
 			repoLabels:            []string{"area/infra"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("area/infra"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -240,8 +248,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area infra",
 			repoLabels:            []string{"area/infra"},
 			issueLabels:           []string{"area/infra"},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -249,8 +259,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/priority critical",
 			repoLabels:            []string{"area/infra", "priority/critical"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("priority/critical"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"priority"},
 			commenter:             orgMember,
 		},
 		{
@@ -258,8 +270,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/kind bug",
 			repoLabels:            []string{"area/infra", "priority/critical", "kind/bug"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("kind/bug"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"kind"},
 			commenter:             orgMember,
 		},
 		{
@@ -267,8 +281,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/kind BuG",
 			repoLabels:            []string{"area/infra", "priority/critical", "kind/bug"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("kind/bug"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"kind"},
 			commenter:             orgMember,
 		},
 		{
@@ -276,8 +292,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/kind bug",
 			repoLabels:            []string{"area/infra", "priority/critical", "kind/BUG"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("kind/BUG"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"kind"},
 			commenter:             orgMember,
 		},
 		{
@@ -285,8 +303,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/priority critical",
 			repoLabels:            []string{"area/infra"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -294,8 +314,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area infra",
 			repoLabels:            []string{"area/infra", "priority/critical", "kind/bug"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("area/infra"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             nonOrgMember,
 		},
 		{
@@ -303,8 +325,10 @@ func TestLabel(t *testing.T) {
 			body:                  "  /area infra",
 			repoLabels:            []string{"area/infra", "area/api", "priority/critical", "priority/urgent", "priority/important", "kind/bug"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -312,8 +336,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area lgtm",
 			repoLabels:            []string{"area/infra", "area/api", "priority/critical"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -321,8 +347,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area api infra",
 			repoLabels:            []string{"area/infra", "area/api", "priority/critical", "priority/urgent"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("area/api", "area/infra"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -330,8 +358,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area api infra",
 			repoLabels:            []string{"area/infra", "area/api", "priority/critical", "priority/urgent"},
 			issueLabels:           []string{"area/api"},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("area/infra"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -339,8 +369,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/priority critical important",
 			repoLabels:            []string{"priority/critical", "priority/important"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("priority/critical", "priority/important"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"priority"},
 			commenter:             orgMember,
 		},
 		{
@@ -348,8 +380,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area urgent",
 			repoLabels:            []string{"area/infra", "area/api", "priority/critical", "priority/urgent"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -357,8 +391,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/priority infra",
 			repoLabels:            []string{"area/infra", "area/api", "priority/critical", "priority/urgent"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"priority"},
 			commenter:             orgMember,
 		},
 		{
@@ -366,8 +402,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area lgtm infra",
 			repoLabels:            []string{"area/infra", "area/api"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("area/infra"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -375,8 +413,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/priority urgent\n/area infra",
 			repoLabels:            []string{"area/infra", "priority/urgent"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("priority/urgent", "area/infra"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area", "priority"},
 			commenter:             orgMember,
 		},
 		{
@@ -384,8 +424,10 @@ func TestLabel(t *testing.T) {
 			body:                  "@kubernetes/sig-node-misc",
 			repoLabels:            []string{"area/infra", "priority/urgent", "sig/node"},
 			issueLabels:           []string{},
+			sigOrg:                "kubernetes",
 			expectedNewLabels:     formatLabels("sig/node"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{},
 			commenter:             orgMember,
 		},
 		{
@@ -393,8 +435,10 @@ func TestLabel(t *testing.T) {
 			body:                  "@kubernetes/sig-node-misc @kubernetes/sig-api-machinery-bugs",
 			repoLabels:            []string{"area/infra", "priority/urgent", "sig/node", "sig/api-machinery"},
 			issueLabels:           []string{},
+			sigOrg:                "kubernetes",
 			expectedNewLabels:     formatLabels("sig/node", "sig/api-machinery"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{},
 			commenter:             orgMember,
 		},
 		{
@@ -402,8 +446,10 @@ func TestLabel(t *testing.T) {
 			body:                  "@kubernetes/sig-node-misc\n@kubernetes/sig-api-machinery-bugs",
 			repoLabels:            []string{"area/infra", "priority/urgent", "sig/node", "sig/api-machinery"},
 			issueLabels:           []string{},
+			sigOrg:                "kubernetes",
 			expectedNewLabels:     formatLabels("sig/node", "sig/api-machinery"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{},
 			commenter:             orgMember,
 		},
 		{
@@ -411,8 +457,10 @@ func TestLabel(t *testing.T) {
 			body:                  "Code Comment.  Design Review\n@kubernetes/sig-node-misc\ncc @kubernetes/sig-api-machinery-bugs",
 			repoLabels:            []string{"area/infra", "priority/urgent", "sig/node", "sig/api-machinery"},
 			issueLabels:           []string{},
+			sigOrg:                "kubernetes",
 			expectedNewLabels:     formatLabels("sig/node", "sig/api-machinery"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{},
 			commenter:             orgMember,
 		},
 		{
@@ -420,8 +468,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/area infra\n/priority urgent Design Review\n@kubernetes/sig-node-misc\ncc @kubernetes/sig-api-machinery-bugs",
 			repoLabels:            []string{"area/infra", "priority/urgent", "sig/node", "sig/api-machinery"},
 			issueLabels:           []string{},
+			sigOrg:                "kubernetes",
 			expectedNewLabels:     formatLabels("area/infra", "priority/urgent", "sig/node", "sig/api-machinery"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area", "priority"},
 			commenter:             orgMember,
 		},
 		{
@@ -429,8 +479,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/sig testing\ncc @kubernetes/sig-api-machinery-misc\n",
 			repoLabels:            []string{"area/infra", "sig/testing", "sig/api-machinery"},
 			issueLabels:           []string{},
+			sigOrg:                "kubernetes",
 			expectedNewLabels:     formatLabels("sig/testing", "sig/api-machinery"),
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"sig"},
 			commenter:             orgMember,
 		},
 		{
@@ -438,8 +490,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-area infra",
 			repoLabels:            []string{},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -447,8 +501,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-area infra",
 			repoLabels:            []string{"area/infra"},
 			issueLabels:           []string{},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: []string{},
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -456,8 +512,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-area infra",
 			repoLabels:            []string{"area/infra"},
 			issueLabels:           []string{"area/infra"},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("area/infra"),
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -465,8 +523,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-kind api-server",
 			repoLabels:            []string{"area/infra", "priority/high", "kind/api-server"},
 			issueLabels:           []string{"area/infra", "priority/high", "kind/api-server"},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("kind/api-server"),
+			prefixes:              []string{"kind"},
 			commenter:             orgMember,
 		},
 		{
@@ -474,8 +534,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-priority high",
 			repoLabels:            []string{"area/infra", "priority/high"},
 			issueLabels:           []string{"area/infra", "priority/high"},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("priority/high"),
+			prefixes:              []string{"priority"},
 			commenter:             orgMember,
 		},
 		{
@@ -483,8 +545,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-sig testing",
 			repoLabels:            []string{"area/infra", "sig/testing"},
 			issueLabels:           []string{"area/infra", "sig/testing"},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("sig/testing"),
+			prefixes:              []string{"sig"},
 			commenter:             orgMember,
 		},
 		{
@@ -492,8 +556,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-priority low high\n/remove-kind api-server\n/remove-area  infra",
 			repoLabels:            []string{"area/infra", "priority/high", "priority/low", "kind/api-server"},
 			issueLabels:           []string{"area/infra", "priority/high", "priority/low", "kind/api-server"},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("priority/low", "priority/high", "kind/api-server", "area/infra"),
+			prefixes:              []string{"area", "kind", "priority"},
 			commenter:             orgMember,
 		},
 		{
@@ -501,8 +567,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-area infra\n/area test",
 			repoLabels:            []string{"area/infra", "area/test"},
 			issueLabels:           []string{"area/infra"},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("area/test"),
 			expectedRemovedLabels: formatLabels("area/infra"),
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -510,8 +578,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-area infra\n/area infra",
 			repoLabels:            []string{"area/infra"},
 			issueLabels:           []string{"area/infra"},
+			sigOrg:                "",
 			expectedNewLabels:     []string{},
 			expectedRemovedLabels: formatLabels("area/infra"),
+			prefixes:              []string{"area"},
 			commenter:             orgMember,
 		},
 		{
@@ -519,8 +589,10 @@ func TestLabel(t *testing.T) {
 			body:                  "/remove-area ruby\n/remove-kind srv\n/remove-priority l m\n/area go\n/kind cli\n/priority h",
 			repoLabels:            []string{"area/go", "area/ruby", "kind/cli", "kind/srv", "priority/h", "priority/m", "priority/l"},
 			issueLabels:           []string{"area/ruby", "kind/srv", "priority/l", "priority/m"},
+			sigOrg:                "",
 			expectedNewLabels:     formatLabels("area/go", "kind/cli", "priority/h"),
 			expectedRemovedLabels: formatLabels("area/ruby", "kind/srv", "priority/l", "priority/m"),
+			prefixes:              []string{"area", "kind", "priority"},
 			commenter:             orgMember,
 		},
 	}
@@ -539,7 +611,7 @@ func TestLabel(t *testing.T) {
 			fakeSlackClient := &fakeslack.FakeClient{
 				SentMessages: make(map[string][]string),
 			}
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), "kubernetes", ae, fakeSlackClient); err != nil {
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), tc.sigOrg, tc.prefixes, ae, fakeSlackClient); err != nil {
 				t.Errorf("For case %s, didn't expect error from label test: %v", tc.name, err)
 				return
 			}
@@ -699,8 +771,10 @@ func TestSlackMessages(t *testing.T) {
 		body                   string
 		expectedMessages       map[string][]string
 		expectedRepeatedLabels []string
-		issueLabels            []string
 		repoLabels             []string
+		issueLabels            []string
+		sigOrg                 string
+		prefxes                []string
 		commenter              string
 	}
 	testcases := []testCase{
@@ -710,6 +784,8 @@ func TestSlackMessages(t *testing.T) {
 			expectedMessages: map[string][]string{"sig-node": {"This issue needs update."}},
 			repoLabels:       []string{"sig/node", "sig/api-machinery"},
 			issueLabels:      []string{},
+			sigOrg:           "kubernetes",
+			prefxes:          []string{},
 			commenter:        orgMember,
 		},
 		{
@@ -718,6 +794,8 @@ func TestSlackMessages(t *testing.T) {
 			expectedMessages: map[string][]string{"sig-testing": {"Message sent to multiple sigs."}, "sig-node": {"Message sent to multiple sigs."}},
 			repoLabels:       []string{"sig/node", "sig/api-machinery"},
 			issueLabels:      []string{},
+			sigOrg:           "kubernetes",
+			prefxes:          []string{},
 			commenter:        orgMember,
 		},
 		{
@@ -726,6 +804,8 @@ func TestSlackMessages(t *testing.T) {
 			expectedMessages: map[string][]string{},
 			repoLabels:       []string{"sig/node", "sig/api-machinery"},
 			issueLabels:      []string{},
+			sigOrg:           "kubernetes",
+			prefxes:          []string{},
 			commenter:        orgMember,
 		},
 		{
@@ -734,6 +814,8 @@ func TestSlackMessages(t *testing.T) {
 			expectedMessages: map[string][]string{"sig-api-machinery": {"Message sent to matching sigs."}},
 			repoLabels:       []string{"sig/node", "sig/api-machinery"},
 			issueLabels:      []string{},
+			sigOrg:           "kubernetes",
+			prefxes:          []string{},
 			commenter:        orgMember,
 		},
 	}
@@ -754,7 +836,7 @@ func TestSlackMessages(t *testing.T) {
 				SentMessages: make(map[string][]string),
 			}
 
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), "kubernetes", ae, fakeSlackClient); err != nil {
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), tc.sigOrg, tc.prefxes, ae, fakeSlackClient); err != nil {
 				t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)
 			}
 			if len(tc.expectedMessages) != len(fakeSlackClient.SentMessages) {

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -146,7 +146,10 @@ type Heart struct {
 type Label struct {
 	// SigOrg is the organization that owns the
 	// special interest groups tagged in this repo
-	SigOrg string `json:"sig_org,omitempty"`
+	SigOrg string `json:"sig_org"`
+	// Prefixes are the label prefixes that the
+	// robot will allow users to apply
+	Prefixes []string `json:"prefixes"`
 }
 
 // TriggerFor finds the Trigger for a repo, if one exists

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -100,15 +100,67 @@ type PluginClient struct {
 	GitClient    *git.Client
 	SlackClient  *slack.Client
 	Config       *config.Config
+	PluginConfig *Config
 	Logger       *logrus.Entry
+}
+
+// Config holds a read-only copy of the plugin Configuration
+// for a repository
+type Config struct {
+	Trigger Trigger
+	Heart   Heart
+	Label   Label
 }
 
 type PluginAgent struct {
 	PluginClient
 
-	mut sync.Mutex
+	mut           sync.Mutex
+	configuration Configuration
+}
+
+// Configuration is the top-level serialization
+// target for plugin Configuration
+type Configuration struct {
 	// Repo (eg "k/k") -> list of handler names.
-	ps map[string][]string
+	Plugins  map[string][]string `json:"plugins,omitempty"`
+	Triggers []Trigger           `json:"trigger,omitempty"`
+	Heart    Heart               `json:"heart,omitempty"`
+	Label    Label               `json:"label,omitempty"`
+}
+
+type Trigger struct {
+	// Repos is either of the form org/repos or just org.
+	Repos []string `json:"repos,omitempty"`
+	// TrustedOrg is the org whose members' PRs will be automatically built
+	// for PRs to the above repos.
+	TrustedOrg string `json:"trusted_org,omitempty"`
+}
+
+type Heart struct {
+	// Adorees is a list of GitHub logins for members
+	// for whom we will add emojis to comments
+	Adorees []string `json:"adorees,omitempty"`
+}
+
+type Label struct {
+	// SigOrg is the organization that owns the
+	// special interest groups tagged in this repo
+	SigOrg string `json:"sig_org,omitempty"`
+}
+
+// TriggerFor finds the Trigger for a repo, if one exists
+// a trigger can be listed for the repo itself or for the
+// owning organization
+func (c *PluginAgent) TriggerFor(org, repo string) *Trigger {
+	for _, tr := range c.configuration.Triggers {
+		for _, r := range tr.Repos {
+			if r == org || r == fmt.Sprintf("%s/%s", org, repo) {
+				return &tr
+			}
+		}
+	}
+	return nil
 }
 
 // Load attempts to load config from the path. It returns an error if either
@@ -118,43 +170,60 @@ func (pa *PluginAgent) Load(path string) error {
 	if err != nil {
 		return err
 	}
-	np := map[string][]string{}
+	np := Configuration{}
 	if err := yaml.Unmarshal(b, &np); err != nil {
+		return err
+	}
+
+	if err := validatePlugins(np.Plugins); err != nil {
 		return err
 	}
 	return pa.Set(np)
 }
 
+// validatePlugins will return error if
+// there are unknown or duplicated plugins.
+func validatePlugins(plugins map[string][]string) error {
+	for _, configuration := range plugins {
+		for _, plugin := range configuration {
+			if _, ok := allPlugins[plugin]; !ok {
+				return fmt.Errorf("unknown plugin: %s", plugin)
+			}
+		}
+	}
+	for repo, repoConfig := range plugins {
+		if strings.Contains(repo, "/") {
+			org := strings.Split(repo, "/")[0]
+			if dupes := findDuplicatedPluginConfig(repoConfig, plugins[org]); len(dupes) > 0 {
+				return fmt.Errorf("plugins %v are duplicated for %s and %s", dupes, repo, org)
+			}
+		}
+	}
+
+	return nil
+}
+
+func findDuplicatedPluginConfig(repoConfig, orgConfig []string) []string {
+	dupes := []string{}
+	for _, repoPlugin := range repoConfig {
+		for _, orgPlugin := range orgConfig {
+			if repoPlugin == orgPlugin {
+				dupes = append(dupes, repoPlugin)
+			}
+		}
+	}
+
+	return dupes
+}
+
 // Set attempts to set the plugins that are enabled on repos. The input is a
 // map from repositories to the list of plugins that are enabled on them.
 // Specifying simply an org name will also work, and will enable the plugin on
-// all repos in the org. It will return error if there are unknown or duplicated
-// plugins.
-func (pa *PluginAgent) Set(np map[string][]string) error {
-	// Check that there are no plugins that we don't know about.
-	for _, v := range np {
-		for _, p := range v {
-			if _, ok := allPlugins[p]; !ok {
-				return fmt.Errorf("unknown plugin: %s", p)
-			}
-		}
-	}
-	// Check that there are no duplicates.
-	for k, v := range np {
-		if strings.Contains(k, "/") {
-			org := strings.Split(k, "/")[0]
-			for _, p1 := range v {
-				for _, p2 := range np[org] {
-					if p1 == p2 {
-						return fmt.Errorf("plugin %s is duplicated for %s and %s", p1, k, org)
-					}
-				}
-			}
-		}
-	}
+// all repos in the org.
+func (pa *PluginAgent) Set(pc Configuration) error {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
-	pa.ps = np
+	pa.configuration = pc
 	return nil
 }
 
@@ -284,8 +353,8 @@ func (pa *PluginAgent) getPlugins(owner, repo string) []string {
 	var plugins []string
 
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
-	plugins = append(plugins, pa.ps[owner]...)
-	plugins = append(plugins, pa.ps[fullName]...)
+	plugins = append(plugins, pa.configuration.Plugins[owner]...)
+	plugins = append(plugins, pa.configuration.Plugins[fullName]...)
 
 	return plugins
 }

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -119,6 +119,7 @@ type PluginAgent struct {
 	configuration Configuration
 }
 
+<<<<<<< HEAD
 // Configuration is the top-level serialization
 // target for plugin Configuration
 type Configuration struct {
@@ -127,6 +128,16 @@ type Configuration struct {
 	Triggers []Trigger           `json:"trigger,omitempty"`
 	Heart    Heart               `json:"heart,omitempty"`
 	Label    Label               `json:"label,omitempty"`
+=======
+// Config holds the plugin configuration
+// for a repository or an organization
+type Config struct {
+	EnabledPlugins []string `json:"-"`
+
+	Trigger *Trigger `json:"trigger,omitempty"`
+	Heart   *Heart   `json:"heart,omitempty"`
+	Label   *Label   `json:"label,omitempty"`
+>>>>>>> fb398b7... Configure organization for SIG labels
 }
 
 type Trigger struct {
@@ -149,6 +160,7 @@ type Label struct {
 	SigOrg string `json:"sig_org,omitempty"`
 }
 
+<<<<<<< HEAD
 // TriggerFor finds the Trigger for a repo, if one exists
 // a trigger can be listed for the repo itself or for the
 // owning organization
@@ -162,6 +174,12 @@ func (c *PluginAgent) TriggerFor(org, repo string) *Trigger {
 	}
 	return nil
 }
+=======
+// pluginConfig is used as a deserialization
+// target to validate the plugins requested
+// by users in the plugin configuration YAML
+type pluginConfig map[string]interface{}
+>>>>>>> fb398b7... Configure organization for SIG labels
 
 // Load attempts to load config from the path. It returns an error if either
 // the file can't be read or it contains an unknown plugin.
@@ -348,6 +366,54 @@ func (pa *PluginAgent) PushEventHandlers(owner, repo string) map[string]PushEven
 	return hs
 }
 
+<<<<<<< HEAD
+=======
+// Config returns the plugin configuration for the repo, which
+// will either be the owning organization's config, the repo
+// config or a merged version of the two
+func (pa *PluginAgent) PluginConfig(owner, repo string) Config {
+	pa.mut.Lock()
+	defer pa.mut.Unlock()
+
+	fullName := fmt.Sprintf("%s/%s", owner, repo)
+	orgConfig, orgOk := pa.pc[owner]
+	repoConfig, repoOk := pa.pc[fullName]
+
+	if repoOk && !orgOk {
+		return repoConfig
+	} else if !repoOk && orgOk {
+		return orgConfig
+	} else if orgOk && repoOk {
+		return mergeConfig(orgConfig, repoConfig)
+	}
+
+	panic(fmt.Sprintf("No configuration was found for %s!", fullName))
+}
+
+// mergeConfig merges organization and repository plugin config
+// to create the full configuration for a set of repository plugins.
+func mergeConfig(org, repo Config) Config {
+	mergedConfig := Config{
+		EnabledPlugins: append(org.EnabledPlugins, repo.EnabledPlugins...),
+		Trigger:        org.Trigger,
+		Heart:          org.Heart,
+		Label:          org.Label,
+	}
+
+	if mergedConfig.Trigger == nil && repo.Trigger != nil {
+		mergedConfig.Trigger = repo.Trigger
+	}
+	if mergedConfig.Heart == nil && repo.Heart != nil {
+		mergedConfig.Heart = repo.Heart
+	}
+	if mergedConfig.Label == nil && repo.Label != nil {
+		mergedConfig.Label = repo.Label
+	}
+
+	return mergedConfig
+}
+
+>>>>>>> fb398b7... Configure organization for SIG labels
 // getPlugins returns a list of plugins that are enabled on a given (org, repository).
 func (pa *PluginAgent) getPlugins(owner, repo string) []string {
 	var plugins []string

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -119,7 +119,6 @@ type PluginAgent struct {
 	configuration Configuration
 }
 
-<<<<<<< HEAD
 // Configuration is the top-level serialization
 // target for plugin Configuration
 type Configuration struct {
@@ -128,16 +127,6 @@ type Configuration struct {
 	Triggers []Trigger           `json:"trigger,omitempty"`
 	Heart    Heart               `json:"heart,omitempty"`
 	Label    Label               `json:"label,omitempty"`
-=======
-// Config holds the plugin configuration
-// for a repository or an organization
-type Config struct {
-	EnabledPlugins []string `json:"-"`
-
-	Trigger *Trigger `json:"trigger,omitempty"`
-	Heart   *Heart   `json:"heart,omitempty"`
-	Label   *Label   `json:"label,omitempty"`
->>>>>>> fb398b7... Configure organization for SIG labels
 }
 
 type Trigger struct {
@@ -160,7 +149,6 @@ type Label struct {
 	SigOrg string `json:"sig_org,omitempty"`
 }
 
-<<<<<<< HEAD
 // TriggerFor finds the Trigger for a repo, if one exists
 // a trigger can be listed for the repo itself or for the
 // owning organization
@@ -174,12 +162,6 @@ func (c *PluginAgent) TriggerFor(org, repo string) *Trigger {
 	}
 	return nil
 }
-=======
-// pluginConfig is used as a deserialization
-// target to validate the plugins requested
-// by users in the plugin configuration YAML
-type pluginConfig map[string]interface{}
->>>>>>> fb398b7... Configure organization for SIG labels
 
 // Load attempts to load config from the path. It returns an error if either
 // the file can't be read or it contains an unknown plugin.
@@ -366,54 +348,6 @@ func (pa *PluginAgent) PushEventHandlers(owner, repo string) map[string]PushEven
 	return hs
 }
 
-<<<<<<< HEAD
-=======
-// Config returns the plugin configuration for the repo, which
-// will either be the owning organization's config, the repo
-// config or a merged version of the two
-func (pa *PluginAgent) PluginConfig(owner, repo string) Config {
-	pa.mut.Lock()
-	defer pa.mut.Unlock()
-
-	fullName := fmt.Sprintf("%s/%s", owner, repo)
-	orgConfig, orgOk := pa.pc[owner]
-	repoConfig, repoOk := pa.pc[fullName]
-
-	if repoOk && !orgOk {
-		return repoConfig
-	} else if !repoOk && orgOk {
-		return orgConfig
-	} else if orgOk && repoOk {
-		return mergeConfig(orgConfig, repoConfig)
-	}
-
-	panic(fmt.Sprintf("No configuration was found for %s!", fullName))
-}
-
-// mergeConfig merges organization and repository plugin config
-// to create the full configuration for a set of repository plugins.
-func mergeConfig(org, repo Config) Config {
-	mergedConfig := Config{
-		EnabledPlugins: append(org.EnabledPlugins, repo.EnabledPlugins...),
-		Trigger:        org.Trigger,
-		Heart:          org.Heart,
-		Label:          org.Label,
-	}
-
-	if mergedConfig.Trigger == nil && repo.Trigger != nil {
-		mergedConfig.Trigger = repo.Trigger
-	}
-	if mergedConfig.Heart == nil && repo.Heart != nil {
-		mergedConfig.Heart = repo.Heart
-	}
-	if mergedConfig.Label == nil && repo.Label != nil {
-		mergedConfig.Label = repo.Label
-	}
-
-	return mergedConfig
-}
-
->>>>>>> fb398b7... Configure organization for SIG labels
 // getPlugins returns a list of plugins that are enabled on a given (org, repository).
 func (pa *PluginAgent) getPlugins(owner, repo string) []string {
 	var plugins []string

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -70,7 +70,7 @@ func TestGetPlugins(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		pa := PluginAgent{}
-		pa.ps = tc.pluginMap
+		pa.configuration.Plugins = tc.pluginMap
 
 		plugins := pa.getPlugins(tc.owner, tc.repo)
 		if len(plugins) != len(tc.expectedPlugins) {

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -29,7 +29,7 @@ import (
 var okToTest = regexp.MustCompile(`((?m)^(@k8s-bot )?ok to test\s*$|(?m)^/ok-to-test\s*$)`)
 var retest = regexp.MustCompile(`(?m)^/retest\s*$`)
 
-func handleIC(c client, ic github.IssueCommentEvent) error {
+func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 	org := ic.Repo.Owner.Login
 	repo := ic.Repo.Name
 	number := ic.Issue.Number
@@ -49,12 +49,9 @@ func handleIC(c client, ic github.IssueCommentEvent) error {
 	if commentAuthor == c.GitHubClient.BotName() {
 		return nil
 	}
-	var trustedOrg string
-	if tr := triggerConfig(c.Config, org, repo); tr != nil && tr.TrustedOrg == "" {
+	if trustedOrg == "" {
 		c.Logger.Info("Ignoring PR Event, no TrustedOrg set in config.")
 		return nil
-	} else if tr != nil {
-		trustedOrg = tr.TrustedOrg
 	}
 
 	if okToTest.MatchString(ic.Comment.Body) && ic.Issue.HasLabel(needsOkToTest) {

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -229,7 +229,7 @@ func TestHandleIssueComment(t *testing.T) {
 			},
 		}
 
-		if err := handleIC(c, event); err != nil {
+		if err := handleIC(c, "kubernetes", event); err != nil {
 			t.Fatalf("Didn't expect error: %s", err)
 		}
 		if len(kc.started) > 0 && !tc.ShouldBuild {

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -29,16 +29,11 @@ const (
 	needsOkToTest = "needs-ok-to-test"
 )
 
-func handlePR(c client, pr github.PullRequestEvent) error {
-	org := pr.PullRequest.Base.Repo.Owner.Login
-	repo := pr.PullRequest.Base.Repo.Name
+func handlePR(c client, trustedOrg string, pr github.PullRequestEvent) error {
 	author := pr.PullRequest.User.Login
-	var trustedOrg string
-	if tr := triggerConfig(c.Config, org, repo); tr != nil && tr.TrustedOrg == "" {
+	if trustedOrg == "" {
 		c.Logger.Info("Ignoring PR Event, no TrustedOrg set in config.")
 		return nil
-	} else if tr != nil {
-		trustedOrg = tr.TrustedOrg
 	}
 	switch pr.Action {
 	case "opened":

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -17,8 +17,6 @@ limitations under the License.
 package trigger
 
 import (
-	"fmt"
-
 	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/config"
@@ -63,17 +61,6 @@ type client struct {
 	Logger       *logrus.Entry
 }
 
-func triggerConfig(c *config.Config, org, repo string) *config.Trigger {
-	for _, tr := range c.Triggers {
-		for _, r := range tr.Repos {
-			if r == org || r == fmt.Sprintf("%s/%s", org, repo) {
-				return &tr
-			}
-		}
-	}
-	return nil
-}
-
 func getClient(pc plugins.PluginClient) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
@@ -84,11 +71,11 @@ func getClient(pc plugins.PluginClient) client {
 }
 
 func handlePullRequest(pc plugins.PluginClient, pr github.PullRequestEvent) error {
-	return handlePR(getClient(pc), pr)
+	return handlePR(getClient(pc), pc.PluginConfig.Trigger.TrustedOrg, pr)
 }
 
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
-	return handleIC(getClient(pc), ic)
+	return handleIC(getClient(pc), pc.PluginConfig.Trigger.TrustedOrg, ic)
 }
 
 func handlePush(pc plugins.PluginClient, pe github.PushEvent) error {

--- a/vendor/github.com/ghodss/yaml/README.md
+++ b/vendor/github.com/ghodss/yaml/README.md
@@ -4,13 +4,13 @@
 
 ## Introduction
 
-A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs. 
+A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs.
 
 In short, this library first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml. For a detailed overview of the rationale behind this method, [see this blog post](http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
 
 ## Compatibility
 
-This package uses [go-yaml v2](https://github.com/go-yaml/yaml) and therefore supports [everything go-yaml supports](https://github.com/go-yaml/yaml#compatibility).
+This package uses [go-yaml](https://github.com/go-yaml/yaml) and therefore supports [everything go-yaml supports](https://github.com/go-yaml/yaml#compatibility).
 
 ## Caveats
 
@@ -44,6 +44,8 @@ import "github.com/ghodss/yaml"
 Usage is very similar to the JSON library:
 
 ```go
+package main
+
 import (
 	"fmt"
 
@@ -51,8 +53,8 @@ import (
 )
 
 type Person struct {
-	Name string `json:"name"`  // Affects YAML field names too.
-	Age int `json:"name"`
+	Name string `json:"name"` // Affects YAML field names too.
+	Age  int    `json:"age"`
 }
 
 func main() {
@@ -65,13 +67,13 @@ func main() {
 	}
 	fmt.Println(string(y))
 	/* Output:
-	name: John
 	age: 30
+	name: John
 	*/
 
 	// Unmarshal the YAML back into a Person struct.
 	var p2 Person
-	err := yaml.Unmarshal(y, &p2)
+	err = yaml.Unmarshal(y, &p2)
 	if err != nil {
 		fmt.Printf("err: %v\n", err)
 		return
@@ -86,11 +88,14 @@ func main() {
 `yaml.YAMLToJSON` and `yaml.JSONToYAML` methods are also available:
 
 ```go
+package main
+
 import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
 )
+
 func main() {
 	j := []byte(`{"name": "John", "age": 30}`)
 	y, err := yaml.JSONToYAML(j)

--- a/vendor/github.com/ghodss/yaml/fields.go
+++ b/vendor/github.com/ghodss/yaml/fields.go
@@ -45,7 +45,11 @@ func indirect(v reflect.Value, decodingNull bool) (json.Unmarshaler, encoding.Te
 			break
 		}
 		if v.IsNil() {
-			v.Set(reflect.New(v.Type().Elem()))
+			if v.CanSet() {
+				v.Set(reflect.New(v.Type().Elem()))
+			} else {
+				v = reflect.New(v.Type().Elem())
+			}
 		}
 		if v.Type().NumMethod() > 0 {
 			if u, ok := v.Interface().(json.Unmarshaler); ok {

--- a/vendor/github.com/ghodss/yaml/yaml.go
+++ b/vendor/github.com/ghodss/yaml/yaml.go
@@ -15,12 +15,12 @@ import (
 func Marshal(o interface{}) ([]byte, error) {
 	j, err := json.Marshal(o)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling into JSON: ", err)
+		return nil, fmt.Errorf("error marshaling into JSON: %v", err)
 	}
 
 	y, err := JSONToYAML(j)
 	if err != nil {
-		return nil, fmt.Errorf("error converting JSON to YAML: ", err)
+		return nil, fmt.Errorf("error converting JSON to YAML: %v", err)
 	}
 
 	return y, nil
@@ -48,7 +48,7 @@ func JSONToYAML(j []byte) ([]byte, error) {
 	var jsonObj interface{}
 	// We are using yaml.Unmarshal here (instead of json.Unmarshal) because the
 	// Go JSON library doesn't try to pick the right number type (int, float,
-	// etc.) when unmarshling to interface{}, it just picks float64
+	// etc.) when unmarshalling to interface{}, it just picks float64
 	// universally. go-yaml does go through the effort of picking the right
 	// number type, so we can preserve number type throughout this process.
 	err := yaml.Unmarshal(j, &jsonObj)


### PR DESCRIPTION
vendor: ghodss/yaml: update to 0ca9ea5df5451ffdf184b4428c902747c2c11cd7

Update to latest ghodss/yaml version to allow for unmarshalling into
structs containing struct pointers.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Bring hook plugin configuration into plugins.yaml

As more and more plugins gain configuration options, it is becoming
clear that the overall Prow configuration is not the appropriate place
for these options. Configuration options for these plugins are almost
always created in order to support more organizations or projects, so
the mapping of project --> plugins we already have in config.yaml is
the correct place to put these options. With this patch, that config
file now maps project --> plugins and config. Config for the repository
being operated on is exposed to handlers at run-time.

---

Configure organization for SIG labels

Supporting SIG labels for SIGs in other organizations requires that the
label-matching regular expression be configurable with the name of the
organization that owns SIGs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/area prow
/cc @spxtr @kargakis I was trying to configure the `label` plugin... but as per the older discussion, adding everything into the global Prow config was getting ugly so I took a stab at refactoring that mechanism.