### PR TITLE
Refactor matchers to take the munger's name as config

### DIFF
--- a/mungegithub/mungers/matchers/comment/interactions.go
+++ b/mungegithub/mungers/matchers/comment/interactions.go
@@ -62,37 +62,32 @@ func (c *CommandArguments) Match(comment *Comment) bool {
 	return false
 }
 
-// MungeBotAuthor creates a matcher to find mungebot comments
-func MungeBotAuthor() Matcher {
-	return AuthorLogin("k8s-merge-robot")
-}
-
 // JenkinsBotAuthor creates a matcher to find jenkins bot comments
 func JenkinsBotAuthor() Matcher {
 	return AuthorLogin("k8s-bot")
 }
 
 // BotAuthor creates a matcher to find any bot comments
-func BotAuthor() Matcher {
+func BotAuthor(mungeBotName string) Matcher {
 	return Or([]Matcher{
-		MungeBotAuthor(),
+		AuthorLogin(mungeBotName),
 		JenkinsBotAuthor(),
 	})
 }
 
 // HumanActor creates a matcher to find non-bot comments.
 // ValidAuthor is used because a comment that doesn't have "Author" is NOT made by a human
-func HumanActor() Matcher {
+func HumanActor(mungeBotName string) Matcher {
 	return And([]Matcher{
 		ValidAuthor{},
-		Not{BotAuthor()},
+		Not{BotAuthor(mungeBotName)},
 	})
 }
 
 // MungerNotificationName finds notification posted by the munger, based on name
-func MungerNotificationName(notif string) Matcher {
+func MungerNotificationName(notif, mungeBotName string) Matcher {
 	return And([]Matcher{
-		MungeBotAuthor(),
+		AuthorLogin(mungeBotName),
 		NotificationName(notif),
 	})
 }

--- a/mungegithub/mungers/matchers/comment/pinger.go
+++ b/mungegithub/mungers/matchers/comment/pinger.go
@@ -23,6 +23,8 @@ import (
 // Pinger checks if it's time to send a ping.
 // You can build a pinger for a specific use-case and re-use it when you want.
 type Pinger struct {
+	botName string
+
 	keyword     string        // Short description for the ping
 	description string        // Long description for the ping
 	timePeriod  time.Duration // How often should we ping
@@ -30,8 +32,9 @@ type Pinger struct {
 }
 
 // NewPinger creates a new pinger. `keyword` is the name of the notification.
-func NewPinger(keyword string) *Pinger {
+func NewPinger(keyword, botName string) *Pinger {
 	return &Pinger{
+		botName: botName,
 		keyword: keyword,
 	}
 }
@@ -67,7 +70,7 @@ func (p *Pinger) PingNotification(comments []*Comment, who string, startDate *ti
 		comments,
 		And([]Matcher{
 			CreatedAfter(*startDate),
-			MungerNotificationName(p.keyword),
+			MungerNotificationName(p.keyword, p.botName),
 		}),
 	)
 
@@ -96,7 +99,7 @@ func (p *Pinger) IsMaxReached(comments []*Comment, startDate *time.Time) bool {
 		comments,
 		And([]Matcher{
 			CreatedAfter(*startDate),
-			MungerNotificationName(p.keyword),
+			MungerNotificationName(p.keyword, p.botName),
 		}),
 	))
 }

--- a/mungegithub/mungers/matchers/comment/pinger_test.go
+++ b/mungegithub/mungers/matchers/comment/pinger_test.go
@@ -40,7 +40,7 @@ func TestMaxReachNotReachedNoStart(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	pinger := NewPinger("NOTIF").SetMaxCount(2)
+	pinger := NewPinger("NOTIF", "k8s-merge-robot").SetMaxCount(2)
 
 	if pinger.IsMaxReached(comments, nil) {
 		t.Error("Should not have reached the maximum")
@@ -55,7 +55,7 @@ func TestMaxReachNotReachedWithStart(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	pinger := NewPinger("NOTIF").SetMaxCount(2)
+	pinger := NewPinger("NOTIF", "k8s-merge-robot").SetMaxCount(2)
 
 	if pinger.IsMaxReached(comments, timeAgo(11*time.Hour)) {
 		t.Error("Should not have reached the maximum")
@@ -70,7 +70,7 @@ func TestMaxReachNoLimit(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	pinger := NewPinger("NOTIF")
+	pinger := NewPinger("NOTIF", "k8s-merge-robot")
 
 	if pinger.IsMaxReached(comments, nil) {
 		t.Error("Should not have reached the non-existing maximum")
@@ -82,7 +82,7 @@ func TestNotification(t *testing.T) {
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").SetDescription("Description").PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetDescription("Description").PingNotification(comments, "who", nil)
 	if notif == nil {
 		t.Error("PingNotification should have created a notif")
 	}
@@ -101,7 +101,7 @@ func TestNotificationNilTimePeriod(t *testing.T) {
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").PingNotification(comments, "who", nil)
 	if notif == nil {
 		t.Error("PingNotification should have created a notif")
 	}
@@ -114,7 +114,7 @@ func TestNotificationTimePeriodNotReached(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 1*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").SetTimePeriod(2*time.Hour).PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetTimePeriod(2*time.Hour).PingNotification(comments, "who", nil)
 	if notif != nil {
 		t.Error("PingNotification shouldn't have created a notif")
 	}
@@ -127,7 +127,7 @@ func TestNotificationTimePeriodReached(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 2*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").SetTimePeriod(time.Hour).PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetTimePeriod(time.Hour).PingNotification(comments, "who", nil)
 	if notif == nil {
 		t.Error("PingNotification should have created a notif")
 	}
@@ -135,7 +135,7 @@ func TestNotificationTimePeriodReached(t *testing.T) {
 
 func TestNotificationStartDate(t *testing.T) {
 	comments := []*Comment{}
-	notif := NewPinger("NOTIF").SetTimePeriod(10*time.Hour).PingNotification(comments, "who", timeAgo(2*time.Hour))
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetTimePeriod(10*time.Hour).PingNotification(comments, "who", timeAgo(2*time.Hour))
 	if notif != nil {
 		t.Error("PingNotification shouldn't have created a notif")
 	}

--- a/mungegithub/mungers/matchers/event/event.go
+++ b/mungegithub/mungers/matchers/event/event.go
@@ -105,25 +105,20 @@ func (c CreatedBefore) Match(event *github.IssueEvent) bool {
 	return event.CreatedAt.Before(time.Time(c))
 }
 
-// MungeBotActor returns a matcher that checks if the event was completed by MungeBot
-func MungeBotActor() Matcher {
-	return Actor("k8s-merge-robot")
-}
-
 // JenkinsBotActor returns a matcher that checks if the event was completed by JenkinsBot
 func JenkinsBotActor() Matcher {
 	return Actor("k8s-bot")
 }
 
 // BotActor returns a matcher that checks if the event was done by either of the Bots
-func BotActor() Matcher {
+func BotActor(mungeBotName string) Matcher {
 	return Or([]Matcher{
-		MungeBotActor(),
+		Actor(mungeBotName),
 		JenkinsBotActor(),
 	})
 }
 
 // HumanActor returns a matcher that checks if the event was done by a Human (Not a Bot)
-func HumanActor() Matcher {
-	return Not{BotActor()}
+func HumanActor(mungeBotName string) Matcher {
+	return Not{BotActor(mungeBotName)}
 }

--- a/mungegithub/mungers/matchers/interactions.go
+++ b/mungegithub/mungers/matchers/interactions.go
@@ -91,37 +91,32 @@ func (*CommandArguments) MatchReviewComment(review *github.PullRequestComment) b
 	return false
 }
 
-// MungeBotAuthor creates a matcher to find mungebot comments
-func MungeBotAuthor() Matcher {
-	return AuthorLogin("k8s-merge-robot")
-}
-
 // JenkinsBotAuthor creates a matcher to find jenkins bot comments
 func JenkinsBotAuthor() Matcher {
 	return AuthorLogin("k8s-bot")
 }
 
 // BotAuthor creates a matcher to find any bot comments
-func BotAuthor() Matcher {
+func BotAuthor(mungeBotName string) Matcher {
 	return Or(
-		MungeBotAuthor(),
+		AuthorLogin(mungeBotName),
 		JenkinsBotAuthor(),
 	)
 }
 
 // HumanActor creates a matcher to find non-bot comments.
 // ValidAuthor is used because a comment that doesn't have "Author" is NOT made by a human
-func HumanActor() Matcher {
+func HumanActor(mungeBotName string) Matcher {
 	return And(
 		ValidAuthor(),
-		Not(BotAuthor()),
+		Not(BotAuthor(mungeBotName)),
 	)
 }
 
 // MungerNotificationName finds notification posted by the munger, based on name
-func MungerNotificationName(notif string) Matcher {
+func MungerNotificationName(notif, mungeBotName string) Matcher {
 	return And(
-		MungeBotAuthor(),
+		AuthorLogin(mungeBotName),
 		NotificationName(notif),
 	)
 }

--- a/mungegithub/mungers/matchers/matchers.go
+++ b/mungegithub/mungers/matchers/matchers.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"fmt"
+
 	"github.com/google/go-github/github"
 )
 
@@ -178,10 +180,13 @@ func (a AuthorLogin) MatchEvent(event *github.IssueEvent) bool {
 }
 
 func (a AuthorLogin) MatchComment(comment *github.IssueComment) bool {
+	fmt.Printf("matching comment: %v\n", comment)
 	if !(ValidAuthor()).MatchComment(comment) {
+		fmt.Println("comment does not have a valid author")
 		return false
 	}
 
+	fmt.Printf("comparing %s from comment to %s from matcher\n", strings.ToLower(*comment.User.Login), strings.ToLower(string(a)))
 	return strings.ToLower(*comment.User.Login) == strings.ToLower(string(a))
 }
 

--- a/mungegithub/mungers/matchers/pinger.go
+++ b/mungegithub/mungers/matchers/pinger.go
@@ -17,13 +17,16 @@ limitations under the License.
 package matchers
 
 import (
-	"github.com/google/go-github/github"
 	"time"
+
+	"github.com/google/go-github/github"
 )
 
 // Pinger checks if it's time to send a ping.
 // You can build a pinger for a specific use-case and re-use it when you want.
 type Pinger struct {
+	botName string
+
 	keyword     string        // Short description for the ping
 	description string        // Long description for the ping
 	timePeriod  time.Duration // How often should we ping
@@ -31,8 +34,9 @@ type Pinger struct {
 }
 
 // NewPinger creates a new pinger. `keyword` is the name of the notification.
-func NewPinger(keyword string) *Pinger {
+func NewPinger(keyword, botName string) *Pinger {
 	return &Pinger{
+		botName: botName,
 		keyword: keyword,
 	}
 }
@@ -93,7 +97,7 @@ func (p *Pinger) IsMaxReached(comments []*github.IssueComment, startDate *time.T
 func (p *Pinger) getPings(comments []*github.IssueComment, startDate *time.Time) Items {
 	return Items{}.
 		AddComments(comments...).
-		Filter(MungerNotificationName(p.keyword)).
+		Filter(MungerNotificationName(p.keyword, p.botName)).
 		Filter(UpdatedAfter(*startDate))
 }
 

--- a/mungegithub/mungers/matchers/pinger_test.go
+++ b/mungegithub/mungers/matchers/pinger_test.go
@@ -42,7 +42,7 @@ func TestMaxReachNotReachedNoStart(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	pinger := NewPinger("NOTIF").SetMaxCount(2)
+	pinger := NewPinger("NOTIF", "k8s-merge-robot").SetMaxCount(2)
 
 	if pinger.IsMaxReached(comments, nil) {
 		t.Error("Should not have reached the maximum")
@@ -57,7 +57,7 @@ func TestMaxReachNotReachedWithStart(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	pinger := NewPinger("NOTIF").SetMaxCount(2)
+	pinger := NewPinger("NOTIF", "k8s-merge-robot").SetMaxCount(2)
 
 	if pinger.IsMaxReached(comments, timeAgo(11*time.Hour)) {
 		t.Error("Should not have reached the maximum")
@@ -72,7 +72,7 @@ func TestMaxReachNoLimit(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	pinger := NewPinger("NOTIF")
+	pinger := NewPinger("NOTIF", "k8s-merge-robot")
 
 	if pinger.IsMaxReached(comments, nil) {
 		t.Error("Should not have reached the non-existing maximum")
@@ -84,7 +84,7 @@ func TestNotification(t *testing.T) {
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").SetDescription("Description").PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetDescription("Description").PingNotification(comments, "who", nil)
 	if notif == nil {
 		t.Error("PingNotification should have created a notif")
 	}
@@ -103,7 +103,7 @@ func TestNotificationNilTimePeriod(t *testing.T) {
 		makeComment("[SOMETHING] Something", "k8s-merge-robot", 10*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").PingNotification(comments, "who", nil)
 	if notif == nil {
 		t.Error("PingNotification should have created a notif")
 	}
@@ -116,7 +116,7 @@ func TestNotificationTimePeriodNotReached(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 1*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").SetTimePeriod(2*time.Hour).PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetTimePeriod(2*time.Hour).PingNotification(comments, "who", nil)
 	if notif != nil {
 		t.Error("PingNotification shouldn't have created a notif")
 	}
@@ -129,7 +129,7 @@ func TestNotificationTimePeriodReached(t *testing.T) {
 		makeComment("[NOTIF] Notification", "k8s-merge-robot", 2*time.Hour),
 	}
 
-	notif := NewPinger("NOTIF").SetTimePeriod(time.Hour).PingNotification(comments, "who", nil)
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetTimePeriod(time.Hour).PingNotification(comments, "who", nil)
 	if notif == nil {
 		t.Error("PingNotification should have created a notif")
 	}
@@ -137,7 +137,7 @@ func TestNotificationTimePeriodReached(t *testing.T) {
 
 func TestNotificationStartDate(t *testing.T) {
 	comments := []*github.IssueComment{}
-	notif := NewPinger("NOTIF").SetTimePeriod(10*time.Hour).PingNotification(comments, "who", timeAgo(2*time.Hour))
+	notif := NewPinger("NOTIF", "k8s-merge-robot").SetTimePeriod(10*time.Hour).PingNotification(comments, "who", timeAgo(2*time.Hour))
 	if notif != nil {
 		t.Error("PingNotification shouldn't have created a notif")
 	}


### PR DESCRIPTION
For the same justification as in 022f93debc369476aada221e07ee7e952fa9c38d,
it is necessary to be able to configure the name of the robot that is
munging GitHub data. This patch threads through this information into
the various places the "k8s-merge-robot" was hard-coded in the matchers.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/kubernetes/test-infra/issues/3677

/cc @eparis @kargakis @spxtr 

I'm not super sure about this approach. On a different PR the argument was made that a `MungeObject` was an abstraction for a pull request or issue, etc. This means that the previous direction from @eparis to move the `IsRobot()` method onto the `MungeObject` from the `Config` is incorrect. However, if we don't do that, we _do_ end up needing to thread through this bot's name to every munger in `Initialize`. That is not the best. However, if we remove the `IsRobot` and use matchers where appropriate, we're going to need to pass the bot name through anyway. Also, these matchers had very clean syntax before, when they were not parameterized. Plumbing this through seems wrong but I'm not really sure how to get these matchers to internalize that data in another way... I like the downward flow of state, but it is less clean in the matchers.