### PR TITLE
add documentation for pods_namespace

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -160,10 +160,11 @@ Jenkins' URL, such as `http://pull-jenkins-master:8080`.
  kubectl create -f cluster/prow_job.yaml
  ```
 
-6. Create a namespace for test pods named "test-pods".
+6. Create a namespace for test pods named "test-pods". Its name must match the
+value of `pod_namespace` in [config.yaml](config.yaml). 
 
  ```
- kubectl create -f cluster/test_pod_namespace.yaml
+ kubectl create namespace test-pods
  ```
 
 7. *Optional*: Create service account and SSH keys for your pods to run as.

--- a/prow/cluster/test_pod_namespace.yaml
+++ b/prow/cluster/test_pod_namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: test-pods


### PR DESCRIPTION
Removed unnecessary namespace file and improved documentation.
Continuing #3736