### PR TITLE
Make pylint depend on python-requests for lint purposes

### DIFF
--- a/verify/BUILD
+++ b/verify/BUILD
@@ -30,6 +30,7 @@ py_binary(
     srcs = ["pylint_bin.py"],
     deps = [
         "@pylint//:pylint",
+        "@requests//:requests",  # TODO(fejta): figure out a better solution
         "@ruamel_yaml//ruamel/yaml:ruamel.yaml",
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/3617

/assign @krzyzacy @ixdy 

This is not the greatest solution, but it fixes the problem for now.

Jeff can we ask the bazel community how they recommend people do pylint with python bazel rules? The whole point is that bazel is supposed to download python-requests for me... Ideally they provide us with a recipe we can use.