### PR TITLE
Allow prow components to run on any namespace

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,13 +15,13 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.138
-SINKER_VERSION     ?= 0.15
-DECK_VERSION       ?= 0.40
-SPLICE_VERSION     ?= 0.26
+HOOK_VERSION       ?= 0.139
+SINKER_VERSION     ?= 0.16
+DECK_VERSION       ?= 0.41
+SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
-HOROLOGIUM_VERSION ?= 0.6
-PLANK_VERSION      ?= 0.33
+HOROLOGIUM_VERSION ?= 0.7
+PLANK_VERSION      ?= 0.34
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.40
+        image: gcr.io/k8s-prow/deck:0.41
         ports:
           - name: http
             containerPort: 8080

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.138
+        image: gcr.io/k8s-prow/hook:0.139
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.6
+        image: gcr.io/k8s-prow/horologium:0.7
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.33
+        image: gcr.io/k8s-prow/plank:0.34
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.15
+        image: gcr.io/k8s-prow/sinker:0.16
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.26
+        image: gcr.io/k8s-prow/splice:0.27
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	inClusterBaseURL = "https://kubernetes"
+	inClusterBaseURL = "https://kubernetes.default"
 	maxRetries       = 8
 	retryDelay       = 2 * time.Second
 )


### PR DESCRIPTION
Resolve kubernetes service outside the default namespace

/area prow

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>