### PR TITLE
Revert "Pin pull-kubernetes-bazel to bazel 0.4.5"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -71,7 +71,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170729-7ec13d8d  # https://github.com/kubernetes/kubernetes/issues/49824
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -342,7 +342,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170729-7ec13d8d  # https://github.com/kubernetes/kubernetes/issues/49824
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -488,9 +488,7 @@ func TestBazelbuildArgs(t *testing.T) {
 		}
 	}
 	pinnedJobs := map[string]string{
-		//job: reason for pinning
-		"pull-kubernetes-bazel":          "https://github.com/kubernetes/kubernetes/issues/49824",
-		"pull-security-kubernetes-bazel": "https://github.com/kubernetes/kubernetes/issues/49824",
+	//job: reason for pinning
 	}
 	maxTag := ""
 	maxN := 0


### PR DESCRIPTION
This reverts commit 50408c4e458f25b7004cbc7e096be13c1a8dc469.

Testing this in http://prow.k8s.io/log?job=pull-kubernetes-bazel&id=33182 with https://github.com/kubernetes/kubernetes/pull/49833. I think both this PR and https://github.com/kubernetes/kubernetes/pull/49833 will need to be merged simultaneously; merging them independently will break the bazel build in different ways.

/assign @spxtr @fejta 