### PR TITLE
Lock the reports list in plank.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       ?= 0.41
 SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.7
-PLANK_VERSION      ?= 0.34
+PLANK_VERSION      ?= 0.35
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.34
+        image: gcr.io/k8s-prow/plank:0.35
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster


### PR DESCRIPTION
This fixes a race when the sync functions run in parallel.

cc @stevekuznetsov 