### PR TITLE
Bump e2e-prow to :v20170731-2e38747a

### DIFF
--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170728-faff708c
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170731-402994f4
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -144,7 +144,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -283,7 +283,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -415,7 +415,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -554,7 +554,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1241,7 +1241,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1274,7 +1274,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1307,7 +1307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1340,7 +1340,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1372,7 +1372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1405,7 +1405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1438,7 +1438,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1471,7 +1471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1504,7 +1504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1537,7 +1537,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1570,7 +1570,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1603,7 +1603,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1636,7 +1636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1669,7 +1669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1702,7 +1702,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1735,7 +1735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1768,7 +1768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1801,7 +1801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1834,7 +1834,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1867,7 +1867,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1900,7 +1900,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1933,7 +1933,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1966,7 +1966,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1999,7 +1999,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2031,7 +2031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2064,7 +2064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2097,7 +2097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2130,7 +2130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2163,7 +2163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2196,7 +2196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2229,7 +2229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2261,7 +2261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2325,7 +2325,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2359,7 +2359,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2393,7 +2393,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2427,7 +2427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2461,7 +2461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2495,7 +2495,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2529,7 +2529,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2563,7 +2563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2597,7 +2597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2631,7 +2631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2665,7 +2665,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2699,7 +2699,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2733,7 +2733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2767,7 +2767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2801,7 +2801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2835,7 +2835,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2869,7 +2869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2903,7 +2903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2937,7 +2937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2971,7 +2971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3005,7 +3005,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3039,7 +3039,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3073,7 +3073,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3107,7 +3107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3141,7 +3141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3175,7 +3175,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3209,7 +3209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3243,7 +3243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3277,7 +3277,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3311,7 +3311,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3345,7 +3345,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3379,7 +3379,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3413,7 +3413,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3447,7 +3447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3481,7 +3481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3515,7 +3515,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3549,7 +3549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3583,7 +3583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3617,7 +3617,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3651,7 +3651,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3685,7 +3685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3717,7 +3717,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3749,7 +3749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3782,7 +3782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3814,7 +3814,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3847,7 +3847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3880,7 +3880,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3912,7 +3912,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3944,7 +3944,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3977,7 +3977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4009,7 +4009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4041,7 +4041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4074,7 +4074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4107,7 +4107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4140,7 +4140,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4173,7 +4173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4206,7 +4206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4239,7 +4239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4272,7 +4272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4305,7 +4305,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4338,7 +4338,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4371,7 +4371,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4404,7 +4404,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4437,7 +4437,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4470,7 +4470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4503,7 +4503,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4536,7 +4536,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4569,7 +4569,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4602,7 +4602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4635,7 +4635,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4668,7 +4668,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4701,7 +4701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4734,7 +4734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4767,7 +4767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4800,7 +4800,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4833,7 +4833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4866,7 +4866,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4899,7 +4899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4932,7 +4932,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4965,7 +4965,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4997,7 +4997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5029,7 +5029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5062,7 +5062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5095,7 +5095,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5128,7 +5128,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5161,7 +5161,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5193,7 +5193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5226,7 +5226,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5259,7 +5259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5292,7 +5292,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5325,7 +5325,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5358,7 +5358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5390,7 +5390,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5422,7 +5422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5455,7 +5455,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5488,7 +5488,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5521,7 +5521,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5554,7 +5554,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5587,7 +5587,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5620,7 +5620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5653,7 +5653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5686,7 +5686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5750,7 +5750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5782,7 +5782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5814,7 +5814,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5847,7 +5847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5880,7 +5880,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5913,7 +5913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5946,7 +5946,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5978,7 +5978,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6011,7 +6011,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6044,7 +6044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6077,7 +6077,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6110,7 +6110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6142,7 +6142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6174,7 +6174,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6208,7 +6208,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6242,7 +6242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6276,7 +6276,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6310,7 +6310,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6344,7 +6344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6378,7 +6378,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6412,7 +6412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6446,7 +6446,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6480,7 +6480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6514,7 +6514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6548,7 +6548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6582,7 +6582,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6616,7 +6616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6650,7 +6650,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6684,7 +6684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6718,7 +6718,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6752,7 +6752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6786,7 +6786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6818,7 +6818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6850,7 +6850,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6882,7 +6882,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6915,7 +6915,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6948,7 +6948,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6981,7 +6981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7014,7 +7014,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7047,7 +7047,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7080,7 +7080,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7112,7 +7112,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7144,7 +7144,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7176,7 +7176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7208,7 +7208,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7240,7 +7240,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7272,7 +7272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7304,7 +7304,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7336,7 +7336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7369,7 +7369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7402,7 +7402,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7435,7 +7435,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7468,7 +7468,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7500,7 +7500,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7532,7 +7532,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7564,7 +7564,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7597,7 +7597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7630,7 +7630,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7663,7 +7663,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7696,7 +7696,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7729,7 +7729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7762,7 +7762,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7795,7 +7795,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7828,7 +7828,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7860,7 +7860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7892,7 +7892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7924,7 +7924,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7957,7 +7957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7990,7 +7990,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8023,7 +8023,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8056,7 +8056,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8088,7 +8088,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8121,7 +8121,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8154,7 +8154,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8187,7 +8187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8220,7 +8220,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8252,7 +8252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8284,7 +8284,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8316,7 +8316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8348,7 +8348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8380,7 +8380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8412,7 +8412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8445,7 +8445,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8478,7 +8478,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8511,7 +8511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8543,7 +8543,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8575,7 +8575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8607,7 +8607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8640,7 +8640,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8672,7 +8672,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8705,7 +8705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8738,7 +8738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8771,7 +8771,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8804,7 +8804,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8837,7 +8837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8870,7 +8870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8902,7 +8902,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8935,7 +8935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8968,7 +8968,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9001,7 +9001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9033,7 +9033,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9066,7 +9066,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9099,7 +9099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9132,7 +9132,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9164,7 +9164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9196,7 +9196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9228,7 +9228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9260,7 +9260,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9292,7 +9292,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9324,7 +9324,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9357,7 +9357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9390,7 +9390,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9423,7 +9423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9456,7 +9456,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9489,7 +9489,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9522,7 +9522,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9555,7 +9555,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9588,7 +9588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9621,7 +9621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9654,7 +9654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9687,7 +9687,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9720,7 +9720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9752,7 +9752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9785,7 +9785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9818,7 +9818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9851,7 +9851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9915,7 +9915,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9948,7 +9948,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9981,7 +9981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10014,7 +10014,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10047,7 +10047,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10080,7 +10080,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10113,7 +10113,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10146,7 +10146,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10179,7 +10179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10212,7 +10212,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10245,7 +10245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10278,7 +10278,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10311,7 +10311,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10344,7 +10344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10377,7 +10377,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10410,7 +10410,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10443,7 +10443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10476,7 +10476,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10509,7 +10509,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10542,7 +10542,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10575,7 +10575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10608,7 +10608,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10641,7 +10641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10674,7 +10674,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10707,7 +10707,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10740,7 +10740,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10773,7 +10773,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10805,7 +10805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10838,7 +10838,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10871,7 +10871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10904,7 +10904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10937,7 +10937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10970,7 +10970,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11003,7 +11003,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11036,7 +11036,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11069,7 +11069,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11102,7 +11102,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11135,7 +11135,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11168,7 +11168,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11201,7 +11201,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11234,7 +11234,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11267,7 +11267,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11300,7 +11300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11333,7 +11333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11366,7 +11366,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11399,7 +11399,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11432,7 +11432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11466,7 +11466,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11499,7 +11499,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11532,7 +11532,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11565,7 +11565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11598,7 +11598,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11631,7 +11631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11664,7 +11664,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11697,7 +11697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11730,7 +11730,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11763,7 +11763,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11796,7 +11796,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11828,7 +11828,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11861,7 +11861,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11894,7 +11894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11927,7 +11927,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11960,7 +11960,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11992,7 +11992,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12025,7 +12025,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12058,7 +12058,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12090,7 +12090,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12122,7 +12122,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12154,7 +12154,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12186,7 +12186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12219,7 +12219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12252,7 +12252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12285,7 +12285,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12318,7 +12318,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12351,7 +12351,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12384,7 +12384,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12416,7 +12416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12449,7 +12449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12482,7 +12482,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12515,7 +12515,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12547,7 +12547,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12580,7 +12580,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12613,7 +12613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12646,7 +12646,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12678,7 +12678,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12710,7 +12710,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12742,7 +12742,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12774,7 +12774,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12809,7 +12809,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12843,7 +12843,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12877,7 +12877,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12911,7 +12911,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12945,7 +12945,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12979,7 +12979,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13013,7 +13013,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13047,7 +13047,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13081,7 +13081,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13115,7 +13115,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13149,7 +13149,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13183,7 +13183,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13218,7 +13218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13252,7 +13252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13286,7 +13286,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13320,7 +13320,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13354,7 +13354,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13388,7 +13388,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13422,7 +13422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13456,7 +13456,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13490,7 +13490,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13524,7 +13524,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13558,7 +13558,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13592,7 +13592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13626,7 +13626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13660,7 +13660,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13694,7 +13694,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13726,7 +13726,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13758,7 +13758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13822,7 +13822,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13843,7 +13843,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -13878,7 +13878,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170728-e1f1ad9b
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170731-2e38747a
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"


### PR DESCRIPTION
This picks up (from `kubetest/`):

402994f4d35309aa95d64db62df42bab22f107ed Merge pull request #3810 from zmerlynn/fix-whatever
abd94fadbac07bd23fe7f2e4cc5a8f6165a501b1 Fix up {KUBE_,}NODE_OS_DISTRUBTION for GCP
04e42754a071378351b19a1279b39e73232c0f9d Merge pull request #3727 from zmerlynn/add-passthru
186c8c1a7e6f6c1eb056a94f71347ecd91cec0cf Merge pull request #3785 from fejta/lint
68f4a5a9634ae18950ab7326edd5c6289b6d0640 Fix kubetest lint errors
6c7d23d46a2be58b7f11d953e6a3bba544d6957f gke kubetest: Allow pass-thru with --gke-create-args
