### PR TITLE
Use a channel to aggregate report outputs in plank

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       ?= 0.41
 SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.7
-PLANK_VERSION      ?= 0.35
+PLANK_VERSION      ?= 0.36
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.35
+        image: gcr.io/k8s-prow/plank:0.36
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster


### PR DESCRIPTION
Instead of a slice that we manually lock and unlock over, the worker
goroutines in the plank controller can instead push their output reports
into a channel that we consume from once they're done.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @kargakis @spxtr 