### PR TITLE
prow: lgtm plugin, remove label on PR synchronize

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.144
+HOOK_VERSION       ?= 0.145
 SINKER_VERSION     ?= 0.16
 DECK_VERSION       ?= 0.42
 SPLICE_VERSION     ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.144
+        image: gcr.io/k8s-prow/hook:0.145
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -352,6 +352,23 @@ func TestRemoveLabel(t *testing.T) {
 	}
 }
 
+func TestRemoveLabelNotFound(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message": "Label does not exist"}`, 404)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	err := c.RemoveLabel("any", "old", 3, "label")
+
+	if err == nil {
+		t.Fatalf("RemoveLabel expected an error, got none")
+	}
+
+	if _, ok := err.(*LabelNotFound); !ok {
+		t.Fatalf("RemoveLabel expected LabelNotFound error, got %v", err)
+	}
+}
+
 func TestAssignIssue(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -141,12 +141,12 @@ func (f *FakeClient) GetIssueLabels(owner, repo string, number int) ([]github.La
 
 func (f *FakeClient) AddLabel(owner, repo string, number int, label string) error {
 	if f.ExistingLabels == nil {
-		f.LabelsAdded = append(f.LabelsAdded, fmt.Sprintf("%s/%s#%d:%s", owner, repo, number, label))
+		f.LabelsAdded = append(f.LabelsAdded, LabelID(owner, repo, number, label))
 		return nil
 	}
 	for _, l := range f.ExistingLabels {
 		if label == l {
-			f.LabelsAdded = append(f.LabelsAdded, fmt.Sprintf("%s/%s#%d:%s", owner, repo, number, label))
+			f.LabelsAdded = append(f.LabelsAdded, LabelID(owner, repo, number, label))
 			return nil
 		}
 	}
@@ -154,7 +154,7 @@ func (f *FakeClient) AddLabel(owner, repo string, number int, label string) erro
 }
 
 func (f *FakeClient) RemoveLabel(owner, repo string, number int, label string) error {
-	f.LabelsRemoved = append(f.LabelsRemoved, fmt.Sprintf("%s/%s#%d:%s", owner, repo, number, label))
+	f.LabelsRemoved = append(f.LabelsRemoved, LabelID(owner, repo, number, label))
 	return nil
 }
 
@@ -196,4 +196,8 @@ func (f *FakeClient) GetFile(org, repo, file, commit string) ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("could not find file %s with ref %s", file, commit)
+}
+
+func LabelID(org, repo string, number int, label string) string {
+	return fmt.Sprintf("%s/%s#%d:%s", org, repo, number, label)
 }

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -51,6 +51,9 @@ func init() {
 	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
 	plugins.RegisterReviewEventHandler(pluginName, handleReview)
 	plugins.RegisterReviewCommentEventHandler(pluginName, handleReviewComment)
+	plugins.RegisterPullRequestHandler(pluginName, func(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+		return handlePullRequest(pc.GitHubClient, pe)
+	})
 }
 
 type githubClient interface {
@@ -202,5 +205,36 @@ func handle(gc githubClient, log *logrus.Entry, e *event) error {
 		log.Info("Adding LGTM label.")
 		return gc.AddLabel(e.org, e.repo, e.number, lgtmLabel)
 	}
+	return nil
+}
+
+type ghLabelClient interface {
+	RemoveLabel(owner, repo string, number int, label string) error
+}
+
+func handlePullRequest(gc ghLabelClient, pe github.PullRequestEvent) error {
+	if pe.PullRequest.Merged {
+		return nil
+	}
+
+	if pe.Action != "synchronize" {
+		return nil
+	}
+
+	// Don't bother checking if it has the label...it's a race, and we'll have
+	// to handle failure due to not being labeled anyway.
+	if err := gc.RemoveLabel(
+		pe.PullRequest.Base.Repo.Owner.Login,
+		pe.PullRequest.Base.Repo.Name,
+		pe.PullRequest.Number,
+		lgtmLabel,
+	); err != nil {
+		if _, ok := err.(*github.LabelNotFound); !ok {
+			return fmt.Errorf("RemoveLabel error: %v", err)
+		}
+
+		// If the error is indeed *github.LabelNotFound, consider it a success.
+	}
+
 	return nil
 }

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -314,3 +314,105 @@ func TestPRLabelChecker(t *testing.T) {
 		}
 	}
 }
+
+type githubUnlabeler struct {
+	err           error
+	labelsRemoved []string
+}
+
+func (c *githubUnlabeler) RemoveLabel(owner, repo string, pr int, label string) error {
+	c.labelsRemoved = append(c.labelsRemoved, label)
+	return c.err
+}
+
+func TestHandlePullRequest(t *testing.T) {
+	cases := []struct {
+		name           string
+		event          github.PullRequestEvent
+		removeLabelErr error
+
+		err           error
+		labelsRemoved []string
+	}{
+		{
+			name: "pr_synchronize, no RemoveLabel error",
+			event: github.PullRequestEvent{
+				Action: "synchronize",
+				PullRequest: github.PullRequest{
+					Number: 101,
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "kubernetes",
+							},
+							Name: "kubernetes",
+						},
+					},
+				},
+			},
+			labelsRemoved: []string{lgtmLabel},
+		},
+		{
+			name: "pr_assigned",
+			event: github.PullRequestEvent{
+				Action: "assigned",
+			},
+		},
+		{
+			name: "pr_synchronize, with RemoveLabel github.LabelNotFound error",
+			event: github.PullRequestEvent{
+				Action: "synchronize",
+				PullRequest: github.PullRequest{
+					Number: 101,
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "kubernetes",
+							},
+							Name: "kubernetes",
+						},
+					},
+				},
+			},
+			removeLabelErr: &github.LabelNotFound{
+				Owner:  "kubernetes",
+				Repo:   "kubernetes",
+				Number: 101,
+				Label:  lgtmLabel,
+			},
+			labelsRemoved: []string{lgtmLabel},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fakeGitHub := &githubUnlabeler{}
+			err := handlePullRequest(fakeGitHub, c.event)
+
+			if err != nil && c.err == nil {
+				t.Fatalf("handlePullRequest error: %v", err)
+			}
+
+			if err == nil && c.err != nil {
+				t.Fatalf("handlePullRequest wanted error: %v, got nil", c.err)
+			}
+
+			if got, want := err, c.err; got != want {
+				t.Fatalf("handlePullRequest error mismatch: got %v, want %v", got, want)
+			}
+
+			if got, want := len(fakeGitHub.labelsRemoved), len(c.labelsRemoved); got != want {
+				t.Logf("labelsRemoved: got %v, want: %v", fakeGitHub.labelsRemoved, c.labelsRemoved)
+				t.Fatalf("labelsRemoved length mismatch: got %d, want %d", got, want)
+			}
+
+			for i, k := range c.labelsRemoved {
+				if got, want := k, fakeGitHub.labelsRemoved[i]; got != want {
+					t.Logf("labelsRemoved: got %v, want: %v", fakeGitHub.labelsRemoved, c.labelsRemoved)
+					t.Fatalf("at index %d got key: %s, want key: %s", i, got, want)
+					break
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Incorporate the functionality of the lgtm_after_commit munger into the prow lgtm plugin.

Closes https://github.com/kubernetes/test-infra/issues/3795 <-- see that issue for more context as well