### PR TITLE
Don't create new _artifacts dir if artifacts dir pre-exists on GCS upload path

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -338,7 +338,7 @@ class GSUtil(object):
                 self.gsutil, '-m', '-q',
                 '-o', 'GSUtil:use_magicfile=True',
                 'cp', '-r', '-c', '-z', 'log,txt,xml',
-                artifacts, path,
+                '%s/*' % artifacts, path,
             ]
             self.call(cmd)
 


### PR DESCRIPTION
This was the reason why we were creating a new '_artifacts' dir inside the 'artifacts' dir if it's already present. This bug was visible on using logexporter (as we already create the 'artifacts' dir on GCS while the nodes upload their logs). For e.g - http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/11/artifacts/

/cc @krzyzacy @fejta 