### PR TITLE
Stop mungegithub from waiting for mergeability if PR is already merged.

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -2344,7 +2344,7 @@ func (obj *MungeObject) IsMergeable() (bool, bool) {
 	}
 	prNum := obj.Number()
 	// Github might not have computed mergeability yet. Try again a few times.
-	for try := 1; try <= 5 && pr.Mergeable == nil; try++ {
+	for try := 1; try <= 5 && pr.Mergeable == nil && (pr.Merged == nil || *pr.Merged == false); try++ {
 		glog.V(4).Infof("Waiting for mergeability on %q %d", *pr.Title, prNum)
 		// Sleep for 2-32 seconds on successive attempts.
 		// Worst case, we'll wait for up to a minute for GitHub
@@ -2362,6 +2362,10 @@ func (obj *MungeObject) IsMergeable() (bool, bool) {
 		if !ok {
 			return false, ok
 		}
+	}
+	if pr.Merged != nil && *pr.Merged {
+		glog.Errorf("Found that PR #%d is merged while looking up mergeability, Skipping", prNum)
+		return false, false
 	}
 	if pr.Mergeable == nil {
 		glog.Errorf("No mergeability information for %q %d, Skipping", *pr.Title, prNum)


### PR DESCRIPTION
Mungegithub waits for mergeability to be non-nil before returning
mergeability, but mergeability is nil after PR is merged so mungegithub
waits for the full (~62 second) time out before failing. This commit
fixes this by reporting a failed mergeability lookup if the PR is
merged already, causing the submit-queue to skip it.
/cc @rmmh 