### PR TITLE
Revert "Don't create new _artifacts dir if artifacts dir pre-exists on GCS upload path"

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -338,7 +338,7 @@ class GSUtil(object):
                 self.gsutil, '-m', '-q',
                 '-o', 'GSUtil:use_magicfile=True',
                 'cp', '-r', '-c', '-z', 'log,txt,xml',
-                '%s/*' % artifacts, path,
+                artifacts, path,
             ]
             self.call(cmd)
 


### PR DESCRIPTION
Reverts kubernetes/test-infra#3830

Now it losts directory structure.
http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-audit/1060/artifacts/
http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-audit/1059/artifacts/

/assign @fejta @shyamjvs 