### PR TITLE
Make mungegithub use PST timezone for midnight refresh time.

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -2523,7 +2523,9 @@ func (config *Config) ForEachIssueDo(fn MungeFunction) error {
 	}
 
 	// It's a new day, let's restart from scratch.
-	if time.Now().Format("Jan 2 2006") != config.since.Format("Jan 2 2006") {
+	// Use PST timezone to determine when its a new day.
+	pst := time.FixedZone("PacificStandardTime", -8*60*60 /* seconds offset from UTC */)
+	if time.Now().In(pst).Format("Jan 2 2006") != config.since.In(pst).Format("Jan 2 2006") {
 		config.since = time.Time{}
 	}
 


### PR DESCRIPTION
Mungegithub remunges all issues at midnight, but uses UTC time to
determine when it is midnight.  This causes a refresh (which can take
time) to occur around 4 or 5pm on the west coast which is earlier than
ideal.

I could also make it update earlier in the morning if that is better (2am?).

/cc @apelisse 