### PR TITLE
GKE deployment: Revert release branches to --deployment=bash

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2318,7 +2318,7 @@ class JobTest(unittest.TestCase):
                     if len(extracts) != expected:
                         self.fail('Wrong number of --extract args (%d != %d) in %s' % (
                             len(extracts), expected, job))
-                    no_matching_whitelisted = '--deployment=gke' in args
+                    no_matching_whitelisted = '--provider=gke' in args
                     self.assertTrue(has_matching_env or no_matching_whitelisted,
                                     'jobs/%s.env does not exist' % job)
 

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4529,7 +4529,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.5",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4548,7 +4548,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4567,7 +4567,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4688,7 +4688,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.5",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4707,7 +4707,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4726,7 +4726,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4745,7 +4745,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/platform/ginkgo-parallel.env",
       "--extract=ci/latest-1.5",
@@ -4765,7 +4765,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/platform/ginkgo-parallel.env",
       "--extract=ci/latest-1.6",
@@ -4785,7 +4785,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/platform/ginkgo-parallel.env",
       "--extract=ci/latest-1.7",
@@ -4824,7 +4824,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.5",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4842,7 +4842,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.6",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4861,7 +4861,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--extract=ci/latest-1.7",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -4900,7 +4900,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/platform/ginkgo-parallel.env",
       "--extract=ci/latest-1.5",
@@ -4920,7 +4920,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/platform/ginkgo-parallel.env",
       "--extract=ci/latest-1.6",
@@ -4940,7 +4940,7 @@
     "args": [
       "--check-leaked-resources",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/platform/ginkgo-parallel.env",
       "--extract=ci/latest-1.7",
@@ -5431,7 +5431,7 @@
       "--check-leaked-resources",
       "--check-version-skew=false",
       "--cluster=",
-      "--deployment=gke",
+      "--deployment=bash",
       "--env-file=jobs/platform/gke.env",
       "--env-file=jobs/ci-kubernetes-e2e-gke-cvm-1-5-cvm-1-6-upgrade-cluster.env",
       "--extract=ci/latest-1.6",


### PR DESCRIPTION
I believe with the state of `kubetest`, this is enough of a revert, but we'll see soon.

Fixes kubernetes/kubernetes#49939

