### PR TITLE
Update the sig-cli testgrid jobs

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -3176,37 +3176,50 @@ dashboards:
 - name: sig-cli
   dashboard_tab:
   - name: gce
-    test_group_name: ci-kubernetes-e2e-gce
+    test_group_name: ci-kubernetes-e2e-gci-gce
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gce e2e tests for master branch'
   - name: gke
-    test_group_name: ci-kubernetes-e2e-gke
+    test_group_name: ci-kubernetes-e2e-gci-gke
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gke e2e tests for master branch'
   - name: gce-flaky
-    test_group_name: ci-kubernetes-e2e-gce-flaky
+    test_group_name: ci-kubernetes-e2e-gci-gce-flaky
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gce flaky e2e tests for master branch'
   - name: gke-flaky
-    test_group_name: ci-kubernetes-e2e-gke-flaky
+    test_group_name: ci-kubernetes-e2e-gci-gke-flaky
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gke flaky e2e tests for master branch'
   - name: gce-slow
-    test_group_name: ci-kubernetes-e2e-gce-slow
+    test_group_name: ci-kubernetes-e2e-gci-gce-slow
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gce slow e2e tests for master branch'
   - name: gke-slow
-    test_group_name: ci-kubernetes-e2e-gke-slow
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gke slow e2e tests for master branch'
   - name: gce-serial
-    test_group_name: ci-kubernetes-e2e-gce-serial
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gce serial e2e tests for master branch'
   - name: gke-serial
-    test_group_name: ci-kubernetes-e2e-gke-serial
+    test_group_name: ci-kubernetes-e2e-gci-gke-serial
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gke serial e2e tests for master branch'
+  - name: gce-etcd3
+    test_group_name: ci-kubernetes-e2e-gci-gce-etcd3
+    base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
+    description: 'e2e tests run against a cluster with an etcd3 instance'
+  - name: aws
+    test_group_name: ci-kubernetes-e2e-kops-aws
+    base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
+  - name: soak-gce-gci-test
+    test_group_name: ci-kubernetes-soak-gce-gci-test
+    base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
+  - name: soak-gke-gci-test
+    test_group_name: ci-kubernetes-soak-gke-gci-test
+    base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
   - name: unit-integration-cmd
     test_group_name: ci-kubernetes-test-go
     base_options: 'include-filter-by-regex=kubectl%7COverall'


### PR DESCRIPTION
- Add test jobs that are missing
- Switch test jobs to use gci variants over cvm variants