### PR TITLE
Fix log spam from adding empty labels in release note munger.

### DIFF
--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -165,7 +165,7 @@ func (r *ReleaseNoteLabel) Munge(obj *github.MungeObject) {
 // correctly implemented in the PR template.  returns nil otherwise
 func determineReleaseNoteLabel(obj *github.MungeObject) string {
 	if obj.Issue.Body == nil {
-		return ""
+		return releaseNoteLabelNeeded
 	}
 	potentialMatch := getReleaseNote(*obj.Issue.Body)
 	return chooseLabel(potentialMatch)


### PR DESCRIPTION
`determineReleaseNoteLabel` can return an empty string, we should not try to add the string as a label if it is empty.
/cc @spxtr 