### PR TITLE
Update kubekins-e2e to use the new kubekins-test

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-test:1.7-v20170418-f54c7fbd
+FROM gcr.io/k8s-testimages/kubekins-test:1.7-v20170713-c28e0556
 MAINTAINER  Erick Fejta <fejta@google.com>
 
 # https://github.com/GoogleCloudPlatform/gsutil/issues/446 for python-openssl


### PR DESCRIPTION
The new kubekins-test is based on golang:1.8.3, while the old one is based on golang:1.8.1. Kubernetes requires go1.8.3 to build.

/assign @krzyzacy 