### PR TITLE
Update Prow jobs to use image based on the new kubekins-e2e

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170801-9babdb61
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170802-0255b192
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2359,7 +2359,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2393,7 +2393,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2427,7 +2427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2461,7 +2461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2495,7 +2495,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2529,7 +2529,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2563,7 +2563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2597,7 +2597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2631,7 +2631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2665,7 +2665,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2699,7 +2699,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2733,7 +2733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2767,7 +2767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2801,7 +2801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2835,7 +2835,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2869,7 +2869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2903,7 +2903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2937,7 +2937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2971,7 +2971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3005,7 +3005,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3039,7 +3039,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3073,7 +3073,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3107,7 +3107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3141,7 +3141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3175,7 +3175,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3209,7 +3209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3243,7 +3243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3277,7 +3277,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3311,7 +3311,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3345,7 +3345,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3379,7 +3379,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3413,7 +3413,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3447,7 +3447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3481,7 +3481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3515,7 +3515,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3549,7 +3549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3583,7 +3583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3617,7 +3617,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3651,7 +3651,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3685,7 +3685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6209,7 +6209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6243,7 +6243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6277,7 +6277,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6311,7 +6311,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6345,7 +6345,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6379,7 +6379,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6413,7 +6413,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6447,7 +6447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6481,7 +6481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6515,7 +6515,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6549,7 +6549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6583,7 +6583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6617,7 +6617,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6651,7 +6651,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6685,7 +6685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6719,7 +6719,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6753,7 +6753,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6787,7 +6787,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12810,7 +12810,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12844,7 +12844,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12878,7 +12878,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12912,7 +12912,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12946,7 +12946,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12980,7 +12980,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13014,7 +13014,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13048,7 +13048,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13082,7 +13082,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13116,7 +13116,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13150,7 +13150,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13184,7 +13184,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13219,7 +13219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13253,7 +13253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13287,7 +13287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13321,7 +13321,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13355,7 +13355,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13389,7 +13389,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13423,7 +13423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13457,7 +13457,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13491,7 +13491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13525,7 +13525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13559,7 +13559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13593,7 +13593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13627,7 +13627,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13661,7 +13661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13695,7 +13695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-9babdb61
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
The new kubekins-e2e image is based on golang:1.8.3, which is required to build Kubernetes.

/assign @krzyzacy 