### PR TITLE
evaluate plank URL when pj -> Success|Failure

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION       ?= 0.42
 SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.8
-PLANK_VERSION      ?= 0.38
+PLANK_VERSION      ?= 0.39
 JENKINS_VERSION    ?= 0.38
 
 # These are the usual GKE variables.

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.38
+        image: gcr.io/k8s-prow/plank:0.39
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster


### PR DESCRIPTION
This is a ~~strawman~~ implementation of addressing https://github.com/kubernetes/test-infra/issues/3828.

Re-executes the URL template when a job becomes Failed or Succeeded so that the URL can change to the durable log storage as opposed to pointing at the streaming logs. 

/area prow