### PR TITLE
remove RUNTIME_CONFIG codes from pull-kubernetes-e2e-gce-etcd3.env file

### DIFF
--- a/jobs/pull-kubernetes-e2e-gce-etcd3.env
+++ b/jobs/pull-kubernetes-e2e-gce-etcd3.env
@@ -4,7 +4,3 @@ KUBE_NODE_OS_DISTRIBUTION=debian
 # Panic if anything mutates a shared informer cache
 ENABLE_CACHE_MUTATION_DETECTOR=true
 
-# Enable apps/v1beta2
-# TODO (juntee): remove this when k8s v1.8 is out 
-RUNTIME_CONFIG=apps/v1beta2
-


### PR DESCRIPTION
The codes are not needed anymore.
/assign @foxish 