### PR TITLE
Log sync time in horologium

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,7 +20,7 @@ SINKER_VERSION     ?= 0.16
 DECK_VERSION       ?= 0.41
 SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
-HOROLOGIUM_VERSION ?= 0.7
+HOROLOGIUM_VERSION ?= 0.8
 PLANK_VERSION      ?= 0.36
 
 # These are the usual GKE variables.

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.7
+        image: gcr.io/k8s-prow/horologium:0.8
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -45,9 +45,11 @@ func main() {
 	}
 
 	for now := range time.Tick(1 * time.Minute) {
+		start := time.Now()
 		if err := sync(kc, configAgent.Config(), now); err != nil {
 			logrus.WithError(err).Error("Error syncing periodic jobs.")
 		}
+		logrus.Infof("Sync time: %v", time.Since(start))
 	}
 }
 


### PR DESCRIPTION
[Similar to plank](https://github.com/kubernetes/test-infra/blob/939a54b04dbba53ea179d8e410c0d8631ea82388/prow/cmd/plank/main.go#L106) - right now horologium outputs nothing.