### PR TITLE
Do not set the ssh username in kubernetes_kubelet.py

### DIFF
--- a/scenarios/kubernetes_kubelet.py
+++ b/scenarios/kubernetes_kubelet.py
@@ -119,7 +119,6 @@ def run_local_mode(script, properties, private_key, public_key):
     k8s = os.getcwd()
     if not os.path.basename(k8s) == 'kubernetes':
         raise ValueError(k8s)
-    os.environ['GCE_USER'] = 'jenkins'
     add_gce_ssh(private_key, public_key)
     check('%s/%s' % (test_infra(), script), '%s/%s' % (test_infra(), properties))
 


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/2632

Instead, we use the keys for user `prow` as configured in Prow config.

/assign @krzyzacy 