### PR TITLE
Copy sig-cli gce serial tests to their own job.

### DIFF
--- a/boskos/resources.json
+++ b/boskos/resources.json
@@ -209,6 +209,7 @@
   {
     "names": [
       "ci-k8s-e2e-gci-tip-gce",
+      "ci-kubernetes-e2e-gce-gci-serial-sig-cli",
       "ci-kubernetes-e2e-gke-gpu",
       "e2e-gce-gci-ci-1-4",
       "e2e-gce-gci-ci-1-5",

--- a/jobs/ci-kubernetes-e2e-gce-gci-serial-sig-cli.env
+++ b/jobs/ci-kubernetes-e2e-gce-gci-serial-sig-cli.env
@@ -1,0 +1,3 @@
+### job-env
+KUBE_NODE_OS_DISTRIBUTION=gci
+

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2416,6 +2416,22 @@
       "UNKNOWN"
     ]
   },
+  "ci-kubernetes-e2e-gce-gci-serial-sig-cli": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/ci-kubernetes-e2e-gce-gci-serial-sig-cli.env",
+      "--extract=ci/latest",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[sig-cli\\].*\\[Serial\\]|\\[sig-cli\\].*\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=500m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cli"
+    ]
+  },
   "ci-kubernetes-e2e-gce-gpu": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4883,6 +4883,38 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
+- interval: 30m
+  name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
+  spec:
+    containers:
+    - args:
+      - --timeout=520
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
 - name: ci-kubernetes-e2e-gce-gpu
   interval: 2h
   spec:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -234,6 +234,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ip-alias
 - name: ci-kubernetes-e2e-gci-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
+- name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-serial-sig-cli
 - name: ci-kubernetes-e2e-gci-gce-serial-release-1-4
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1-4
 - name: ci-kubernetes-e2e-gci-gce-serial-release-1-5
@@ -3204,8 +3206,7 @@ dashboards:
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
     description: 'kubectl gke slow e2e tests for master branch'
   - name: gce-serial
-    test_group_name: ci-kubernetes-e2e-gci-gce-serial
-    base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
+    test_group_name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
     description: 'kubectl gce serial e2e tests for master branch'
   - name: gke-serial
     test_group_name: ci-kubernetes-e2e-gci-gke-serial


### PR DESCRIPTION
Trial balloon for splitting all kubectl tests out of shared jobs.