### PR TITLE
Set GCE_USER in prow config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6204,6 +6204,8 @@ periodics:
         value: /go
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
+      - name: GCE_USER
+        value: prow
       - name: USER
         value: prow
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE


### PR DESCRIPTION
This should fix the `Please login as the user "ubuntu" rather than the user "root".` issue in `ci-kubernetes-e2e-gce-ubuntu-1-7-node-prow`.

/assign @krzyzacy 