### PR TITLE
fix another spelling error

### DIFF
--- a/mungegithub/mungers/matchers/comment/pinger.go
+++ b/mungegithub/mungers/matchers/comment/pinger.go
@@ -28,7 +28,7 @@ type Pinger struct {
 	keyword     string        // Short description for the ping
 	description string        // Long description for the ping
 	timePeriod  time.Duration // How often should we ping
-	maxCount    int           // Will stop pinging after that many occurences
+	maxCount    int           // Will stop pinging after that many occurrences
 }
 
 // NewPinger creates a new pinger. `keyword` is the name of the notification.


### PR DESCRIPTION
It turns out there was one more that wasn't caught in https://github.com/kubernetes/test-infra/pull/3919 because go report card's scan was a day old.