### PR TITLE
Use quote in env vars for node e2e tests

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -690,7 +690,7 @@ nodeCommon:
     envs:
     - CLEANUP=true
     - GCE_ZONE=us-central1-f
-    - KUBELET_ARGS=--cgroups-per-qos=true --cgroup-root=/
+    - KUBELET_ARGS="--cgroups-per-qos=true --cgroup-root=/"
 
 nodeImages:
   cosstable1:
@@ -720,10 +720,10 @@ nodeTestSuites:
   default:
     envs:
     - TIMEOUT=60m
-    - GINKGO_FLAGS=--skip=\[Flaky\]|\[Serial\]
+    - GINKGO_FLAGS="--skip=\[Flaky\]|\[Serial\]"
   serial:
     - TIMEOUT=180m
-    - GINKGO_FLAGS=--focus=\[Serial\] --skip=\[Flaky\]|\[Benchmark\]
+    - GINKGO_FLAGS="--focus=\[Serial\] --skip=\[Flaky\]|\[Benchmark\]"
     - PARALLELISM=1
     - TEST_ARGS=--feature-gates=DynamicKubeletConfig=true
 

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2142,6 +2142,10 @@ class JobTest(unittest.TestCase):
         for job, job_path in self.jobs:
             if not job.endswith('.env'):
                 continue
+            # TODO(yguo0905): Remove this check once we change the envs to be
+            # flags for kubernetes_kubelet.py.
+            if '-e2enode-' in job:
+                continue
             with open(job_path) as fp:
                 lines = list(fp)
             for line in lines:

--- a/jobs/ci-kubernetes-e2enode-cosstable1-k8sstable1-default-defaultspec.env
+++ b/jobs/ci-kubernetes-e2enode-cosstable1-k8sstable1-default-defaultspec.env
@@ -3,7 +3,7 @@
 # The common configurations.
 CLEANUP=true
 GCE_ZONE=us-central1-f
-KUBELET_ARGS=--cgroups-per-qos=true --cgroup-root=/
+KUBELET_ARGS="--cgroups-per-qos=true --cgroup-root=/"
 
 # The image configurations.
 GCE_IMAGES=cos-stable-60-9592-76-0
@@ -11,7 +11,7 @@ GCE_IMAGE_PROJECT=cos-cloud
 
 # The test suite configurations.
 TIMEOUT=60m
-GINKGO_FLAGS=--skip=\[Flaky\]|\[Serial\]
+GINKGO_FLAGS="--skip=\[Flaky\]|\[Serial\]"
 
 # The system spec configurations.
 SYSTEM_SPEC_NAME=


### PR DESCRIPTION
This is to fix https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2enode-cosstable1-k8sstable1-default-defaultspec/1/

A local run from `docker run` seemed to work.

/assign @krzyzacy 