### PR TITLE
Bump aws default tag. This should fix errors publishing builds.

### DIFF
--- a/scenarios/kubernetes_kops_aws.py
+++ b/scenarios/kubernetes_kops_aws.py
@@ -319,7 +319,8 @@ if __name__ == '__main__':
         '--state', default='s3://k8s-kops-jenkins/',
         help='Name of the aws state storage')
     PARSER.add_argument(
-        '--tag', default='v20170314-bb0669b0', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170314-bb0669b0-pyopenssl',
+        help='Use a specific kubekins-e2e tag if set')
     PARSER.add_argument(
         '--test', default='true', help='If we need to set --test in e2e.go')
     PARSER.add_argument(


### PR DESCRIPTION
The characteristic error is: [Your "OAuth 2.0 Service Account" credentials are invalid.](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/49962/pull-kubernetes-e2e-kops-aws/39525?log#log)