### PR TITLE
Remove configuring network in kubetest k8s-anywhere deployer

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -53,7 +53,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase1.gce.project="{{.Project}}"
 .phase1.gce.region="us-central1"
 .phase1.gce.zone="{{.Zone}}"
-.phase1.gce.network="{{.Network}}"
+.phase1.gce.network="default"
 
 .phase2.installer_container="docker.io/colemickens/k8s-ignition:latest"
 .phase2.docker_registry="gcr.io/google-containers"
@@ -78,12 +78,11 @@ type kubernetesAnywhere struct {
 	Project           string
 	Cluster           string
 	Zone              string
-	Network           string
 }
 
 var _ deployer = kubernetesAnywhere{}
 
-func newKubernetesAnywhere(project, zone, network string) (*kubernetesAnywhere, error) {
+func newKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, error) {
 	if *kubernetesAnywherePath == "" {
 		return nil, fmt.Errorf("--kubernetes-anywhere-path is required")
 	}
@@ -100,10 +99,6 @@ func newKubernetesAnywhere(project, zone, network string) (*kubernetesAnywhere, 
 		zone = "us-central1-c"
 	}
 
-	if network == "" {
-		network = "default"
-	}
-
 	// Set KUBERNETES_CONFORMANCE_TEST so the auth info is picked up
 	// from kubectl instead of bash inference.
 	if err := os.Setenv("KUBERNETES_CONFORMANCE_TEST", "yes"); err != nil {
@@ -118,7 +113,6 @@ func newKubernetesAnywhere(project, zone, network string) (*kubernetesAnywhere, 
 		Project:           project,
 		Cluster:           *kubernetesAnywhereCluster,
 		Zone:              zone,
-		Network:           network,
 	}
 
 	if err := k.writeConfig(); err != nil {

--- a/kubetest/anywhere_test.go
+++ b/kubetest/anywhere_test.go
@@ -79,7 +79,7 @@ func TestNewKubernetesAnywhere(t *testing.T) {
 		*kubernetesAnywhereKubeadmVersion = tc.kubeadmVersion
 		*kubernetesAnywhereKubernetesVersion = tc.kubernetesVersion
 
-		_, err = newKubernetesAnywhere("fake-project", "fake-zone", "fake-network")
+		_, err = newKubernetesAnywhere("fake-project", "fake-zone")
 		if err != nil {
 			t.Errorf("newKubernetesAnywhere(%s) failed: %v", tc.name, err)
 			continue

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -215,7 +215,7 @@ func getDeployer(o *options) (deployer, error) {
 	case "kops":
 		return newKops()
 	case "kubernetes-anywhere":
-		return newKubernetesAnywhere(o.gcpProject, o.gcpZone, o.gcpNetwork)
+		return newKubernetesAnywhere(o.gcpProject, o.gcpZone)
 	case "none":
 		return noneDeploy{}, nil
 	default:


### PR DESCRIPTION
Ref #3858 

This PR removes configuring network in kubetest k8s-anywhere deployer, as we found that k8s-anywhere does not have this capability yet. In the long-run we should add this functionality to k8s-anywhere. But there is no hard requirement yet and we are happy using the "default" network of GCE.

/assign @luxas 
/cc @madhusudancs 