### PR TITLE
Automate scalability tests

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -124,25 +124,25 @@
         job-name: ci-kubernetes-e2e-gce-large-correctness
         jenkins-timeout: 720
         timeout: 620
-        frequency: '' #manual
+        frequency: '1 3 * * SAT' # Run at 03:01 to avoid start-up clash with gke-large-performance
         trigger-job: ''
     - kubernetes-e2e-gce-large-performance:
         job-name: ci-kubernetes-e2e-gce-large-performance
-        jenkins-timeout: 1120
-        timeout: 1020
-        frequency: '' #manual
+        jenkins-timeout: 1020
+        timeout: 920
+        frequency: '1 0 * * SUN' # Run at 00:01 to avoid start-up clash with gke-large-correctness
         trigger-job: ''
     - kubernetes-e2e-gce-scale-correctness:
         job-name: ci-kubernetes-e2e-gce-scale-correctness
-        jenkins-timeout: 1320
-        timeout: 1220
-        frequency: '' #manual
+        jenkins-timeout: 1120
+        timeout: 1020
+        frequency: '1 0 * * TUE' # Run at 00:01 on tuesday
         trigger-job: ''
     - kubernetes-e2e-gce-scale-performance:
         job-name: ci-kubernetes-e2e-gce-scale-performance
-        jenkins-timeout: 1520
-        timeout: 1420
-        frequency: '' #manual
+        jenkins-timeout: 1420
+        timeout: 1320
+        frequency: '1 0 * * MON,WED,FRI' # Run at 00:01 on odd weekdays
         trigger-job: ''
     - kubernetes-e2e-gce-enormous-deploy:
         job-name: ci-kubernetes-e2e-gce-enormous-deploy
@@ -198,13 +198,13 @@
         job-name: ci-kubernetes-e2e-gke-large-correctness
         jenkins-timeout: 720
         timeout: 620
-        frequency: '' #manual
+        frequency: '1 3 * * SUN' # Run at 03:01 to avoid start-up clash with gce-large-performance
         trigger-job: ''
     - kubernetes-e2e-gke-large-performance:
         job-name: ci-kubernetes-e2e-gke-large-performance
-        jenkins-timeout: 1120
-        timeout: 1020
-        frequency: '' #manual
+        jenkins-timeout: 1020
+        timeout: 920
+        frequency: '1 0 * * SAT' # Run at 00:01 to avoid start-up clash with gce-large-correctness
         trigger-job: ''
     - kubernetes-e2e-gke-large-deploy:
         job-name: ci-kubernetes-e2e-gke-large-deploy
@@ -220,9 +220,9 @@
         trigger-job: ''
     - kubernetes-e2e-gke-scale-correctness:
         job-name: ci-kubernetes-e2e-gke-scale-correctness
-        jenkins-timeout: 1320
-        timeout: 1220
-        frequency: '' #manual
+        jenkins-timeout: 1120
+        timeout: 1020
+        frequency: '1 0 * * THU' # Run at 00:01 on thursday
         trigger-job: ''
 
     # START KUBEMARK

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2526,7 +2526,7 @@
       "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m --cluster-ip-range=10.160.0.0/13 --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
-      "--timeout=1000m"
+      "--timeout=900m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -2968,7 +2968,7 @@
       "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --cluster-ip-range=10.160.0.0/11 --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
-      "--timeout=1200m",
+      "--timeout=1000m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -2986,7 +2986,7 @@
       "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --cluster-ip-range=10.160.0.0/11 --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
-      "--timeout=1400m",
+      "--timeout=1300m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -6750,7 +6750,7 @@
       "--mode=docker",
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=30m",
-      "--timeout=1000m"
+      "--timeout=900m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -7143,7 +7143,7 @@
       "--mode=docker",
       "--provider=gke",
       "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=60m --minStartupPods=8",
-      "--timeout=1200m"
+      "--timeout=1000m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
Slightly off the [planned schedule](https://github.com/kubernetes/community/blob/master/contributors/devel/release/scalability-validation.md) in the following way:
- Running gce and gke 5k-node correctness tests weekly instead of bi-weekly (on tue and thu resp.) as we currently don't have a way in test-infra to specify sth like "every alternate tuesday" due to support for only single cron tab. We discussed other options offline, this one seems best for now.
- Running gce 5k-node performance test on 3 alternate weekdays instead of once a week as I need faster iteration to verify changes. We can reduce it to weekly later once it's stable (maybe?)

Related issue-  https://github.com/kubernetes/test-infra/issues/3774