### PR TITLE
Bump e2e-prow to v20170807-80aef0ad, add bump script, fix GKE

### DIFF
--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: bump_e2e_image.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+dirty="$(git status --porcelain)"
+if [[ -n ${dirty} ]]; then
+  echo "Tree not clean:"
+  echo "${dirty}"
+  exit 1
+fi
+
+TREE="$(dirname ${BASH_SOURCE[0]})/.."
+
+DATE="$(date +v%Y%m%d)"
+TAG="${DATE}-$(git describe --tags --always --dirty)"
+pushd "${TREE}/jenkins/e2e-image"
+make push TAG="${TAG}"
+popd
+
+sed -i "s/\/kubekins-e2e:.*$/\/kubekins-e2e:${TAG}/" "${TREE}/images/e2e-prow/Dockerfile"
+git commit -am "Bump e2e-prow base image to ${TAG}"
+
+TAG="${DATE}-$(git describe --tags --always --dirty)"
+pushd "${TREE}/images/e2e-prow"
+make push TAG="${TAG}"
+popd
+
+sed -i "s/\/kubekins-e2e-prow:v.*$/\/kubekins-e2e-prow:${TAG}/" "${TREE}/experiment/generate_tests.py"
+pushd "${TREE}"
+bazel run //experiment:generate_tests -- \
+  --yaml-config-path=experiment/test_config.yaml \
+  --json-config-path=jobs/config.json \
+  --prow-config-path=prow/config.yaml
+bazel run //jobs:config_sort
+
+# Scan for kubekins-e2e-prow:v.* as a rudimentary way to avoid
+# replacing :latest.
+sed -i "s/\/kubekins-e2e-prow:v.*$/\/kubekins-e2e-prow:${TAG}/" "${TREE}/prow/config.yaml"
+git commit -am "Bump e2e-prow to ${TAG} (using generate_tests and manual)"

--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -55,7 +55,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170801-9babdb61
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170807-c980addf
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -235,6 +235,7 @@ func (g *gkeDeployer) Up() error {
 	if v := os.Getenv("CLUSTER_API_VERSION"); v != "" {
 		args = append(args, "--cluster-version="+v)
 	}
+	args = append(args, g.cluster)
 	if err := finishRunning(exec.Command("gcloud", args...)); err != nil {
 		return fmt.Errorf("error creating cluster: %v", err)
 	}

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -147,7 +147,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -286,7 +286,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -421,7 +421,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -560,7 +560,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1264,7 +1264,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1297,7 +1297,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1330,7 +1330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1363,7 +1363,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1395,7 +1395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1428,7 +1428,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1461,7 +1461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1494,7 +1494,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1527,7 +1527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1560,7 +1560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1593,7 +1593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1626,7 +1626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1659,7 +1659,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1692,7 +1692,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1725,7 +1725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1758,7 +1758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1791,7 +1791,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1824,7 +1824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1857,7 +1857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1890,7 +1890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1923,7 +1923,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1956,7 +1956,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1989,7 +1989,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2022,7 +2022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2054,7 +2054,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2087,7 +2087,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2120,7 +2120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2153,7 +2153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2186,7 +2186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2219,7 +2219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2252,7 +2252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2284,7 +2284,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2348,7 +2348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2382,7 +2382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2416,7 +2416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2450,7 +2450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2484,7 +2484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2518,7 +2518,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2552,7 +2552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2586,7 +2586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2620,7 +2620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2654,7 +2654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2688,7 +2688,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2722,7 +2722,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2756,7 +2756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2790,7 +2790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2824,7 +2824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2858,7 +2858,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2892,7 +2892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2926,7 +2926,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2960,7 +2960,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2994,7 +2994,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3028,7 +3028,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3062,7 +3062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3096,7 +3096,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3130,7 +3130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3164,7 +3164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3198,7 +3198,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3232,7 +3232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3266,7 +3266,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3300,7 +3300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3334,7 +3334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3368,7 +3368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3402,7 +3402,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3436,7 +3436,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3470,7 +3470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3504,7 +3504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3538,7 +3538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3572,7 +3572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3606,7 +3606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3640,7 +3640,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3674,7 +3674,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3708,7 +3708,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3740,7 +3740,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3772,7 +3772,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3805,7 +3805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3837,7 +3837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3870,7 +3870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3903,7 +3903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3935,7 +3935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3967,7 +3967,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4000,7 +4000,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4032,7 +4032,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4064,7 +4064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4097,7 +4097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4130,7 +4130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4163,7 +4163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4196,7 +4196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4229,7 +4229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4262,7 +4262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4295,7 +4295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4328,7 +4328,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4361,7 +4361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4394,7 +4394,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4427,7 +4427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4460,7 +4460,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4493,7 +4493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4526,7 +4526,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4559,7 +4559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4592,7 +4592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4625,7 +4625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4658,7 +4658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4691,7 +4691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4724,7 +4724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4757,7 +4757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4790,7 +4790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4823,7 +4823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4856,7 +4856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4889,7 +4889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4922,7 +4922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4954,7 +4954,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4987,7 +4987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5020,7 +5020,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5052,7 +5052,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5084,7 +5084,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5117,7 +5117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5150,7 +5150,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5183,7 +5183,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5216,7 +5216,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5249,7 +5249,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5282,7 +5282,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5315,7 +5315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5348,7 +5348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5381,7 +5381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5414,7 +5414,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5446,7 +5446,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5478,7 +5478,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5511,7 +5511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5544,7 +5544,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5577,7 +5577,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5610,7 +5610,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5643,7 +5643,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5676,7 +5676,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5709,7 +5709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5742,7 +5742,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5806,7 +5806,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5838,7 +5838,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5870,7 +5870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5903,7 +5903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5936,7 +5936,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5969,7 +5969,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6002,7 +6002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6034,7 +6034,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6067,7 +6067,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6100,7 +6100,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6133,7 +6133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6166,7 +6166,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6198,7 +6198,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6230,7 +6230,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6267,7 +6267,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6301,7 +6301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6335,7 +6335,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6369,7 +6369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6403,7 +6403,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6437,7 +6437,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6471,7 +6471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6505,7 +6505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6539,7 +6539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6573,7 +6573,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6607,7 +6607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6641,7 +6641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6675,7 +6675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6709,7 +6709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6743,7 +6743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6777,7 +6777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6811,7 +6811,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6845,7 +6845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6879,7 +6879,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6911,7 +6911,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6943,7 +6943,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6975,7 +6975,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7008,7 +7008,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7041,7 +7041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7074,7 +7074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7107,7 +7107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7140,7 +7140,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7173,7 +7173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7205,7 +7205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7237,7 +7237,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7269,7 +7269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7301,7 +7301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7333,7 +7333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7365,7 +7365,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7397,7 +7397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7429,7 +7429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7462,7 +7462,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7495,7 +7495,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7528,7 +7528,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7561,7 +7561,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7593,7 +7593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7625,7 +7625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7657,7 +7657,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7690,7 +7690,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7723,7 +7723,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7756,7 +7756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7789,7 +7789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7822,7 +7822,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7855,7 +7855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7888,7 +7888,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7921,7 +7921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7953,7 +7953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7985,7 +7985,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8017,7 +8017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8050,7 +8050,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8083,7 +8083,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8116,7 +8116,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8149,7 +8149,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8181,7 +8181,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8214,7 +8214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8247,7 +8247,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8280,7 +8280,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8313,7 +8313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8345,7 +8345,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8377,7 +8377,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8409,7 +8409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8441,7 +8441,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8473,7 +8473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8505,7 +8505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8538,7 +8538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8571,7 +8571,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8604,7 +8604,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8636,7 +8636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8668,7 +8668,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8700,7 +8700,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8733,7 +8733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8765,7 +8765,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8798,7 +8798,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8831,7 +8831,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8864,7 +8864,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8897,7 +8897,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8930,7 +8930,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8963,7 +8963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8995,7 +8995,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9028,7 +9028,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9061,7 +9061,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9094,7 +9094,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9126,7 +9126,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9159,7 +9159,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9192,7 +9192,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9225,7 +9225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9257,7 +9257,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9289,7 +9289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9321,7 +9321,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9353,7 +9353,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9385,7 +9385,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9417,7 +9417,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9450,7 +9450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9483,7 +9483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9516,7 +9516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9549,7 +9549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9582,7 +9582,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9615,7 +9615,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9648,7 +9648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9681,7 +9681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9714,7 +9714,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9747,7 +9747,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9780,7 +9780,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9813,7 +9813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9845,7 +9845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9878,7 +9878,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9911,7 +9911,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9944,7 +9944,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10008,7 +10008,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10041,7 +10041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10074,7 +10074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10107,7 +10107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10140,7 +10140,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10173,7 +10173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10206,7 +10206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10239,7 +10239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10272,7 +10272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10305,7 +10305,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10338,7 +10338,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10371,7 +10371,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10404,7 +10404,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10437,7 +10437,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10470,7 +10470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10503,7 +10503,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10536,7 +10536,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10569,7 +10569,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10602,7 +10602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10635,7 +10635,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10668,7 +10668,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10701,7 +10701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10734,7 +10734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10767,7 +10767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10800,7 +10800,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10833,7 +10833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10866,7 +10866,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10898,7 +10898,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10931,7 +10931,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10964,7 +10964,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10997,7 +10997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11030,7 +11030,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11063,7 +11063,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11096,7 +11096,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11129,7 +11129,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11162,7 +11162,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11195,7 +11195,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11228,7 +11228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11261,7 +11261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11294,7 +11294,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11327,7 +11327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11360,7 +11360,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11393,7 +11393,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11426,7 +11426,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11459,7 +11459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11492,7 +11492,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11525,7 +11525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11559,7 +11559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11592,7 +11592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11625,7 +11625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11658,7 +11658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11691,7 +11691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11724,7 +11724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11757,7 +11757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11790,7 +11790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11823,7 +11823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11856,7 +11856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11889,7 +11889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11921,7 +11921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11954,7 +11954,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11987,7 +11987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12020,7 +12020,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12053,7 +12053,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12086,7 +12086,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12119,7 +12119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12152,7 +12152,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12185,7 +12185,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12218,7 +12218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12250,7 +12250,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12282,7 +12282,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12315,7 +12315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12348,7 +12348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12381,7 +12381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12414,7 +12414,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12447,7 +12447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12480,7 +12480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12513,7 +12513,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12545,7 +12545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12578,7 +12578,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12611,7 +12611,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12644,7 +12644,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12676,7 +12676,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12709,7 +12709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12742,7 +12742,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12775,7 +12775,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12807,7 +12807,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12839,7 +12839,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12871,7 +12871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12903,7 +12903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12938,7 +12938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12972,7 +12972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13006,7 +13006,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13040,7 +13040,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13074,7 +13074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13108,7 +13108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13142,7 +13142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13176,7 +13176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13210,7 +13210,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13244,7 +13244,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13278,7 +13278,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13312,7 +13312,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13347,7 +13347,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13381,7 +13381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13415,7 +13415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13449,7 +13449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13483,7 +13483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13517,7 +13517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13551,7 +13551,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13585,7 +13585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13619,7 +13619,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13653,7 +13653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13687,7 +13687,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13721,7 +13721,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13755,7 +13755,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13789,7 +13789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13823,7 +13823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13855,7 +13855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13887,7 +13887,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13958,7 +13958,7 @@ periodics:
         value: /go
       - name: GCE_USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170802-c4ea9089
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13990,7 +13990,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14011,7 +14011,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -14046,7 +14046,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"


### PR DESCRIPTION
This is a re-drive of #3954 with a GKE deployment fix included (mistake from #3875). This previously passed normal canaries, except I forgot to check the GKE canary (sigh). New test here: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-canary/607/