### PR TITLE
Use --workspace_status_command to configure images

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+build --workspace_status_command=./print-workspace-status.sh
+run --workspace_status_command=./print-workspace-status.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,9 +10,9 @@ go_repositories()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "40d780165c0b9fbb3ddca858df7347381af0e87e430c74863e4ce9d6f6441023",
-    strip_prefix = "rules_docker-8359263f35227a3634ea023ff4ae163189eb4b26",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/8359263f35227a3634ea023ff4ae163189eb4b26.tar.gz"],
+    sha256 = "a6f30b7806ac49ef89d4b5d84a3fd37a460d12e8d3d83324ea7db6c247e125a1",
+    strip_prefix = "rules_docker-9eda1acbc4781894c452de0e49d528eb221f1a66",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/9eda1acbc4781894c452de0e49d528eb221f1a66.tar.gz"],
 )
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories", "docker_pull")

--- a/experiment/commenter/BUILD
+++ b/experiment/commenter/BUILD
@@ -2,7 +2,15 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_push")
+load(
+    "@io_bazel_rules_docker//docker:docker.bzl",
+    "docker_build",
+    "docker_bundle",
+)
+load(
+    "@io_bazel_rules_docker//docker/contrib:push-all.bzl",
+    "docker_push",
+)
 
 docker_build(
     name = "image",
@@ -11,12 +19,19 @@ docker_build(
     files = [":commenter"],
 )
 
+docker_bundle(
+    name = "bundle",
+    images = {
+        "{STABLE_DOCKER_REPO}/commenter:{DOCKER_TAG}": ":image",
+        "{STABLE_DOCKER_REPO}/commenter:latest": ":image",
+        "{STABLE_DOCKER_REPO}/commenter:latest-{BUILD_USER}": ":image",
+    },
+    stamp = True,
+)
+
 docker_push(
     name = "push",
-    image = ":image",
-    registry = "gcr.io",
-    repository = "k8s-testimages/commenter",
-    tag = "latest",
+    bundle = ":bundle",
 )
 
 load(

--- a/print-workspace-status.sh
+++ b/print-workspace-status.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+git_commit="$(git describe --tags --always --dirty)"
+build_date="$(date -u '+%Y%m%d')"
+docker_tag="v${build_date}-${git_commit}"
+cat <<EOF
+STABLE_DOCKER_REPO ${DOCKER_REPO_OVERRIDE:-gcr.io/k8s-testimages}
+STABLE_BUILD_GIT_COMMIT ${git_commit}
+DOCKER_TAG ${docker_tag}
+EOF


### PR DESCRIPTION
/assign @ixdy 

`bazel run //experiment/commenter:push` will build and push `gcr.io/k8s-testimages/commenter:v20170807-cbcd2e51` (assuming git is at cbcd2e51)

Update `io_bazel_rules_docker` to include new `bundle` option included with `io_bazel_rules_docker//docker/contrib:push-all.bzl`