### PR TITLE
Bump e2e-prow to v20170807-6527be77

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -55,7 +55,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170807-c980addf
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170807-bbaef515
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -147,7 +147,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -286,7 +286,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -421,7 +421,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -560,7 +560,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1264,7 +1264,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1297,7 +1297,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1330,7 +1330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1363,7 +1363,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1395,7 +1395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1428,7 +1428,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1461,7 +1461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1494,7 +1494,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1527,7 +1527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1560,7 +1560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1593,7 +1593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1626,7 +1626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1659,7 +1659,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1692,7 +1692,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1725,7 +1725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1758,7 +1758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1791,7 +1791,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1824,7 +1824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1857,7 +1857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1890,7 +1890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1923,7 +1923,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1956,7 +1956,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1989,7 +1989,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2022,7 +2022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2054,7 +2054,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2087,7 +2087,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2120,7 +2120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2153,7 +2153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2186,7 +2186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2219,7 +2219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2252,7 +2252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2284,7 +2284,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2348,7 +2348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2382,7 +2382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2416,7 +2416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2450,7 +2450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2484,7 +2484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2518,7 +2518,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2552,7 +2552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2586,7 +2586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2620,7 +2620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2654,7 +2654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2688,7 +2688,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2722,7 +2722,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2756,7 +2756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2790,7 +2790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2824,7 +2824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2858,7 +2858,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2892,7 +2892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2926,7 +2926,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2960,7 +2960,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2994,7 +2994,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3028,7 +3028,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3062,7 +3062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3096,7 +3096,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3130,7 +3130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3164,7 +3164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3198,7 +3198,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3232,7 +3232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3266,7 +3266,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3300,7 +3300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3334,7 +3334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3368,7 +3368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3402,7 +3402,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3436,7 +3436,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3470,7 +3470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3504,7 +3504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3538,7 +3538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3572,7 +3572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3606,7 +3606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3640,7 +3640,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3674,7 +3674,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3708,7 +3708,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3740,7 +3740,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3772,7 +3772,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3805,7 +3805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3837,7 +3837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3870,7 +3870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3903,7 +3903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3935,7 +3935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3967,7 +3967,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4000,7 +4000,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4032,7 +4032,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4064,7 +4064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4097,7 +4097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4130,7 +4130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4163,7 +4163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4196,7 +4196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4229,7 +4229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4262,7 +4262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4295,7 +4295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4328,7 +4328,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4361,7 +4361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4394,7 +4394,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4427,7 +4427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4460,7 +4460,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4493,7 +4493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4526,7 +4526,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4559,7 +4559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4592,7 +4592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4625,7 +4625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4658,7 +4658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4691,7 +4691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4724,7 +4724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4757,7 +4757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4790,7 +4790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4823,7 +4823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4856,7 +4856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4889,7 +4889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4922,7 +4922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4955,7 +4955,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4988,7 +4988,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5021,7 +5021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5053,7 +5053,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5085,7 +5085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5118,7 +5118,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5151,7 +5151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5184,7 +5184,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5217,7 +5217,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5250,7 +5250,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5283,7 +5283,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5316,7 +5316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5349,7 +5349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5382,7 +5382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5415,7 +5415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5447,7 +5447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5479,7 +5479,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5512,7 +5512,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5545,7 +5545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5578,7 +5578,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5611,7 +5611,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5644,7 +5644,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5677,7 +5677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5710,7 +5710,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5743,7 +5743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5807,7 +5807,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5839,7 +5839,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5871,7 +5871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5904,7 +5904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5937,7 +5937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5970,7 +5970,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6003,7 +6003,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6035,7 +6035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6068,7 +6068,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6101,7 +6101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6134,7 +6134,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6167,7 +6167,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6199,7 +6199,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6231,7 +6231,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6268,7 +6268,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6302,7 +6302,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6336,7 +6336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6370,7 +6370,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6404,7 +6404,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6438,7 +6438,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6472,7 +6472,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6506,7 +6506,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6540,7 +6540,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6574,7 +6574,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6608,7 +6608,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6642,7 +6642,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6676,7 +6676,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6710,7 +6710,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6744,7 +6744,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6778,7 +6778,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6812,7 +6812,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6846,7 +6846,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6880,7 +6880,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6912,7 +6912,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6944,7 +6944,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6976,7 +6976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7009,7 +7009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7042,7 +7042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7075,7 +7075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7108,7 +7108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7141,7 +7141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7174,7 +7174,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7206,7 +7206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7238,7 +7238,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7270,7 +7270,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7302,7 +7302,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7334,7 +7334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7366,7 +7366,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7398,7 +7398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7430,7 +7430,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7463,7 +7463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7496,7 +7496,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7529,7 +7529,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7562,7 +7562,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7594,7 +7594,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7626,7 +7626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7658,7 +7658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7691,7 +7691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7724,7 +7724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7757,7 +7757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7790,7 +7790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7823,7 +7823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7856,7 +7856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7889,7 +7889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7922,7 +7922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7954,7 +7954,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7986,7 +7986,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8018,7 +8018,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8051,7 +8051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8084,7 +8084,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8117,7 +8117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8150,7 +8150,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8182,7 +8182,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8215,7 +8215,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8248,7 +8248,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8281,7 +8281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8314,7 +8314,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8346,7 +8346,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8378,7 +8378,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8410,7 +8410,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8442,7 +8442,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8474,7 +8474,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8506,7 +8506,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8539,7 +8539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8572,7 +8572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8605,7 +8605,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8637,7 +8637,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8669,7 +8669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8701,7 +8701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8734,7 +8734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8766,7 +8766,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8799,7 +8799,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8832,7 +8832,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8865,7 +8865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8898,7 +8898,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8931,7 +8931,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8964,7 +8964,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8996,7 +8996,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9029,7 +9029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9062,7 +9062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9095,7 +9095,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9127,7 +9127,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9160,7 +9160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9193,7 +9193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9226,7 +9226,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9258,7 +9258,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9290,7 +9290,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9322,7 +9322,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9354,7 +9354,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9386,7 +9386,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9418,7 +9418,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9451,7 +9451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9484,7 +9484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9517,7 +9517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9550,7 +9550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9583,7 +9583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9616,7 +9616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9649,7 +9649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9682,7 +9682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9715,7 +9715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9748,7 +9748,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9781,7 +9781,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9814,7 +9814,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9846,7 +9846,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9879,7 +9879,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9912,7 +9912,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9945,7 +9945,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10009,7 +10009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10042,7 +10042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10075,7 +10075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10108,7 +10108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10141,7 +10141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10174,7 +10174,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10207,7 +10207,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10240,7 +10240,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10273,7 +10273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10306,7 +10306,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10339,7 +10339,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10372,7 +10372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10405,7 +10405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10438,7 +10438,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10471,7 +10471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10504,7 +10504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10537,7 +10537,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10570,7 +10570,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10603,7 +10603,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10636,7 +10636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10669,7 +10669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10702,7 +10702,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10735,7 +10735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10768,7 +10768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10801,7 +10801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10834,7 +10834,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10867,7 +10867,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10899,7 +10899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10932,7 +10932,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10965,7 +10965,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10998,7 +10998,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11031,7 +11031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11064,7 +11064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11097,7 +11097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11130,7 +11130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11163,7 +11163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11196,7 +11196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11229,7 +11229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11262,7 +11262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11295,7 +11295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11328,7 +11328,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11361,7 +11361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11394,7 +11394,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11427,7 +11427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11460,7 +11460,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11493,7 +11493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11526,7 +11526,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11560,7 +11560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11593,7 +11593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11626,7 +11626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11659,7 +11659,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11692,7 +11692,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11725,7 +11725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11758,7 +11758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11791,7 +11791,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11824,7 +11824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11857,7 +11857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11890,7 +11890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11923,7 +11923,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11955,7 +11955,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11988,7 +11988,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12021,7 +12021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12054,7 +12054,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12087,7 +12087,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12120,7 +12120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12153,7 +12153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12186,7 +12186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12219,7 +12219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12252,7 +12252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12284,7 +12284,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12316,7 +12316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12349,7 +12349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12382,7 +12382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12415,7 +12415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12448,7 +12448,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12481,7 +12481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12514,7 +12514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12547,7 +12547,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12579,7 +12579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12612,7 +12612,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12645,7 +12645,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12678,7 +12678,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12710,7 +12710,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12743,7 +12743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12776,7 +12776,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12809,7 +12809,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12841,7 +12841,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12873,7 +12873,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12905,7 +12905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12937,7 +12937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12972,7 +12972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13006,7 +13006,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13040,7 +13040,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13074,7 +13074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13108,7 +13108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13142,7 +13142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13176,7 +13176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13210,7 +13210,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13244,7 +13244,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13278,7 +13278,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13312,7 +13312,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13346,7 +13346,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13381,7 +13381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13415,7 +13415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13449,7 +13449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13483,7 +13483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13517,7 +13517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13551,7 +13551,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13585,7 +13585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13619,7 +13619,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13653,7 +13653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13687,7 +13687,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13721,7 +13721,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13755,7 +13755,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13789,7 +13789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13823,7 +13823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13857,7 +13857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13889,7 +13889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13921,7 +13921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13992,7 +13992,7 @@ periodics:
         value: /go
       - name: GCE_USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14024,7 +14024,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14045,7 +14045,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -14080,7 +14080,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-d89d3d7c
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"


### PR DESCRIPTION
This picks up #3958 and #3961.

Test jobs:
* https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-prow-canary/17155/
* https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-canary/611/