### PR TITLE
Have prow inform child jobs about their parent

### DIFF
--- a/prow/kube/prowjob.go
+++ b/prow/kube/prowjob.go
@@ -48,11 +48,13 @@ const (
 )
 
 type ProwJob struct {
-	APIVersion string        `json:"apiVersion,omitempty"`
-	Kind       string        `json:"kind,omitempty"`
-	Metadata   ObjectMeta    `json:"metadata,omitempty"`
-	Spec       ProwJobSpec   `json:"spec,omitempty"`
-	Status     ProwJobStatus `json:"status,omitempty"`
+	APIVersion   string        `json:"apiVersion,omitempty"`
+	Kind         string        `json:"kind,omitempty"`
+	Metadata     ObjectMeta    `json:"metadata,omitempty"`
+	Spec         ProwJobSpec   `json:"spec,omitempty"`
+	Status       ProwJobStatus `json:"status,omitempty"`
+	ParentStatus ProwJobStatus `json:"parent_status,omitempty"`
+	ParentJob    string        `json:"parent_job,omitempty"`
 }
 
 type ProwJobSpec struct {


### PR DESCRIPTION
Right now `run_after_success` jobs know nothing about their parent job, this PR allows child jobs to know the name and build ID of their parent job.

Why do we need this?
 - This will allow child jobs to find their parent job's output. We can use this do have one job do builds and the child jobs use the parent job's build.