### PR TITLE
prow: add custom GitHub API endpoint configuration

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,14 +15,14 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.143
+HOOK_VERSION       ?= 0.144
 SINKER_VERSION     ?= 0.16
 DECK_VERSION       ?= 0.42
 SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.8
-PLANK_VERSION      ?= 0.37
-JENKINS_VERSION    ?= 0.37
+PLANK_VERSION      ?= 0.38
+JENKINS_VERSION    ?= 0.38
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.143
+        image: gcr.io/k8s-prow/hook:0.144
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.37
+        image: gcr.io/k8s-prow/jenkins-operator:0.38
         args:
         - --dry-run=false
         - --github-bot-name=k8s-ci-robot

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.37
+        image: gcr.io/k8s-prow/plank:0.38
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -47,7 +47,6 @@ type Client struct {
 }
 
 const (
-	githubBase    = "https://api.github.com"
 	maxRetries    = 8
 	max404Retries = 2
 	maxSleepTime  = 2 * time.Minute
@@ -55,12 +54,12 @@ const (
 )
 
 // NewClient creates a new fully operational GitHub client.
-func NewClient(botName, token string) *Client {
+func NewClient(botName, token, base string) *Client {
 	return &Client{
 		client:  &http.Client{},
 		botName: botName,
 		token:   token,
-		base:    githubBase,
+		base:    base,
 		dry:     false,
 	}
 }
@@ -68,12 +67,12 @@ func NewClient(botName, token string) *Client {
 // NewDryRunClient creates a new client that will not perform mutating actions
 // such as setting statuses or commenting, but it will still query GitHub and
 // use up API tokens.
-func NewDryRunClient(botName, token string) *Client {
+func NewDryRunClient(botName, token, base string) *Client {
 	return &Client{
 		client:  &http.Client{},
 		botName: botName,
 		token:   token,
-		base:    githubBase,
+		base:    base,
 		dry:     true,
 	}
 }


### PR DESCRIPTION
New CLI flag `--github-endpoint` is added to `hook` and `plank`.
Default value points to the public GitHub API endpoint.

fixes #3805 