### PR TITLE
Bump kubetest image to v20170808-5d58fc35

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -568,7 +568,7 @@ def create_parser():
     parser.add_argument(
         '--kubeadm', choices=['ci', 'periodic', 'pull'])
     parser.add_argument(
-        '--tag', default='v20170728-faff708c', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default='v20170808-5d58fc35', help='Use a specific kubekins-e2e tag if set')
     parser.add_argument(
         '--test', default='true', help='If we need to run any actual test within kubetest')
     parser.add_argument(


### PR DESCRIPTION
Fixes #3950 

This includes the change avoiding double cluster-logdump.