### PR TITLE
Bump e2e-prow to v20170808-0a00d3e7 (using generate_tests and manual)

### DIFF
--- a/experiment/bump_e2e_image.sh
+++ b/experiment/bump_e2e_image.sh
@@ -34,8 +34,9 @@ pushd "${TREE}/jenkins/e2e-image"
 make push TAG="${TAG}"
 popd
 
+sed -i "s/DEFAULT_KUBEKINS_TAG = '.*'/DEFAULT_KUBEKINS_TAG = '${TAG}'/" "${TREE}/scenarios/kubernetes_e2e.py"
 sed -i "s/\/kubekins-e2e:.*$/\/kubekins-e2e:${TAG}/" "${TREE}/images/e2e-prow/Dockerfile"
-git commit -am "Bump e2e-prow base image to ${TAG}"
+git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e:${TAG}"
 
 TAG="${DATE}-$(git describe --tags --always --dirty)"
 pushd "${TREE}/images/e2e-prow"
@@ -49,8 +50,9 @@ bazel run //experiment:generate_tests -- \
   --json-config-path=jobs/config.json \
   --prow-config-path=prow/config.yaml
 bazel run //jobs:config_sort
+popd
 
 # Scan for kubekins-e2e-prow:v.* as a rudimentary way to avoid
 # replacing :latest.
 sed -i "s/\/kubekins-e2e-prow:v.*$/\/kubekins-e2e-prow:${TAG}/" "${TREE}/prow/config.yaml"
-git commit -am "Bump e2e-prow to ${TAG} (using generate_tests and manual)"
+git commit -am "Bump to gcr.io/k8s-testimages/kubekins-e2e-prow:${TAG} (using generate_tests and manual)"

--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -55,7 +55,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170807-c980addf
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170808-bd529e23
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -148,7 +148,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -287,7 +287,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -423,7 +423,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -562,7 +562,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1310,7 +1310,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1343,7 +1343,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1376,7 +1376,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1409,7 +1409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1441,7 +1441,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1474,7 +1474,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1507,7 +1507,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1540,7 +1540,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1573,7 +1573,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1606,7 +1606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1639,7 +1639,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1672,7 +1672,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1705,7 +1705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1738,7 +1738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1771,7 +1771,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1804,7 +1804,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1837,7 +1837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1870,7 +1870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1903,7 +1903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1936,7 +1936,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1969,7 +1969,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2002,7 +2002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2035,7 +2035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2068,7 +2068,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2100,7 +2100,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2133,7 +2133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2166,7 +2166,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2199,7 +2199,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2232,7 +2232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2265,7 +2265,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2298,7 +2298,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2330,7 +2330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2394,7 +2394,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2428,7 +2428,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2462,7 +2462,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2496,7 +2496,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2530,7 +2530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2564,7 +2564,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2598,7 +2598,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2632,7 +2632,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2666,7 +2666,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2700,7 +2700,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2734,7 +2734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2768,7 +2768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2802,7 +2802,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2836,7 +2836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2870,7 +2870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2904,7 +2904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2938,7 +2938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2972,7 +2972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3006,7 +3006,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3040,7 +3040,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3074,7 +3074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3108,7 +3108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3142,7 +3142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3176,7 +3176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3210,7 +3210,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3244,7 +3244,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3278,7 +3278,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3312,7 +3312,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3346,7 +3346,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3380,7 +3380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3414,7 +3414,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3448,7 +3448,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3482,7 +3482,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3516,7 +3516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3550,7 +3550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3584,7 +3584,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3618,7 +3618,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3652,7 +3652,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3686,7 +3686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3720,7 +3720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3754,7 +3754,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3786,7 +3786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3818,7 +3818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3851,7 +3851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3883,7 +3883,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3916,7 +3916,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3949,7 +3949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3981,7 +3981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4013,7 +4013,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4046,7 +4046,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4078,7 +4078,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4110,7 +4110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4143,7 +4143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4176,7 +4176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4209,7 +4209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4242,7 +4242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4275,7 +4275,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4308,7 +4308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4341,7 +4341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4374,7 +4374,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4407,7 +4407,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4440,7 +4440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4473,7 +4473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4506,7 +4506,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4539,7 +4539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4572,7 +4572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4605,7 +4605,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4638,7 +4638,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4671,7 +4671,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4704,7 +4704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4737,7 +4737,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4770,7 +4770,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4803,7 +4803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4836,7 +4836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4869,7 +4869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4902,7 +4902,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4935,7 +4935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4968,7 +4968,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5001,7 +5001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5034,7 +5034,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5067,7 +5067,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5099,7 +5099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5131,7 +5131,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5164,7 +5164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5197,7 +5197,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5230,7 +5230,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5263,7 +5263,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5296,7 +5296,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5329,7 +5329,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5362,7 +5362,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5395,7 +5395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5428,7 +5428,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5461,7 +5461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5493,7 +5493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5525,7 +5525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5558,7 +5558,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5591,7 +5591,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5624,7 +5624,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5657,7 +5657,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5690,7 +5690,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5723,7 +5723,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5756,7 +5756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5789,7 +5789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5853,7 +5853,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5885,7 +5885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5917,7 +5917,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5950,7 +5950,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5983,7 +5983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6016,7 +6016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6049,7 +6049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6081,7 +6081,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6114,7 +6114,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6147,7 +6147,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6180,7 +6180,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6213,7 +6213,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6245,7 +6245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6277,7 +6277,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6314,7 +6314,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6348,7 +6348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6382,7 +6382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6416,7 +6416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6450,7 +6450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6484,7 +6484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6518,7 +6518,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6552,7 +6552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6586,7 +6586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6620,7 +6620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6654,7 +6654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6688,7 +6688,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6722,7 +6722,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6756,7 +6756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6790,7 +6790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6824,7 +6824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6858,7 +6858,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6892,7 +6892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6926,7 +6926,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6958,7 +6958,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6990,7 +6990,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7022,7 +7022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7055,7 +7055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7088,7 +7088,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7121,7 +7121,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7154,7 +7154,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7187,7 +7187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7220,7 +7220,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7252,7 +7252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7284,7 +7284,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7316,7 +7316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7348,7 +7348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7380,7 +7380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7412,7 +7412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7444,7 +7444,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7476,7 +7476,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7509,7 +7509,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7542,7 +7542,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7575,7 +7575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7608,7 +7608,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7640,7 +7640,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7672,7 +7672,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7704,7 +7704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7737,7 +7737,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7770,7 +7770,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7803,7 +7803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7836,7 +7836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7869,7 +7869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7902,7 +7902,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7935,7 +7935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7968,7 +7968,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8000,7 +8000,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8032,7 +8032,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8064,7 +8064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8097,7 +8097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8130,7 +8130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8163,7 +8163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8196,7 +8196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8228,7 +8228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8261,7 +8261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8294,7 +8294,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8327,7 +8327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8360,7 +8360,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8392,7 +8392,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8424,7 +8424,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8456,7 +8456,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8488,7 +8488,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8520,7 +8520,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8552,7 +8552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8585,7 +8585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8618,7 +8618,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8651,7 +8651,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8683,7 +8683,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8715,7 +8715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8747,7 +8747,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8780,7 +8780,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8812,7 +8812,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8845,7 +8845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8878,7 +8878,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8911,7 +8911,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8944,7 +8944,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8977,7 +8977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9010,7 +9010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9042,7 +9042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9075,7 +9075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9108,7 +9108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9141,7 +9141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9173,7 +9173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9206,7 +9206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9239,7 +9239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9272,7 +9272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9304,7 +9304,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9336,7 +9336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9368,7 +9368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9400,7 +9400,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9432,7 +9432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9464,7 +9464,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9497,7 +9497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9530,7 +9530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9563,7 +9563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9596,7 +9596,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9629,7 +9629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9662,7 +9662,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9695,7 +9695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9728,7 +9728,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9761,7 +9761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9794,7 +9794,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9827,7 +9827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9860,7 +9860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9892,7 +9892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9925,7 +9925,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9958,7 +9958,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9991,7 +9991,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10055,7 +10055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10088,7 +10088,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10121,7 +10121,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10154,7 +10154,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10187,7 +10187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10220,7 +10220,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10253,7 +10253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10286,7 +10286,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10319,7 +10319,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10352,7 +10352,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10385,7 +10385,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10418,7 +10418,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10451,7 +10451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10484,7 +10484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10517,7 +10517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10550,7 +10550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10583,7 +10583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10616,7 +10616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10649,7 +10649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10682,7 +10682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10715,7 +10715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10748,7 +10748,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10781,7 +10781,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10814,7 +10814,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10847,7 +10847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10880,7 +10880,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10913,7 +10913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10945,7 +10945,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10978,7 +10978,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11011,7 +11011,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11044,7 +11044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11077,7 +11077,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11110,7 +11110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11143,7 +11143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11176,7 +11176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11209,7 +11209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11242,7 +11242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11275,7 +11275,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11308,7 +11308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11341,7 +11341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11374,7 +11374,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11407,7 +11407,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11440,7 +11440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11473,7 +11473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11506,7 +11506,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11539,7 +11539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11572,7 +11572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11606,7 +11606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11639,7 +11639,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11672,7 +11672,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11705,7 +11705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11738,7 +11738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11771,7 +11771,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11804,7 +11804,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170801-7b8e5ef2
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11837,7 +11837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11870,7 +11870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11903,7 +11903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11936,7 +11936,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11969,7 +11969,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12001,7 +12001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12034,7 +12034,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12067,7 +12067,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12100,7 +12100,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12133,7 +12133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12166,7 +12166,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12199,7 +12199,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12232,7 +12232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12265,7 +12265,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12298,7 +12298,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12330,7 +12330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12362,7 +12362,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12395,7 +12395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12428,7 +12428,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12461,7 +12461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12494,7 +12494,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12527,7 +12527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12560,7 +12560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12593,7 +12593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12625,7 +12625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12658,7 +12658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12691,7 +12691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12724,7 +12724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12756,7 +12756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12789,7 +12789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12822,7 +12822,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12855,7 +12855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12887,7 +12887,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12919,7 +12919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12951,7 +12951,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12983,7 +12983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13018,7 +13018,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13052,7 +13052,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13086,7 +13086,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13120,7 +13120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13154,7 +13154,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13188,7 +13188,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13222,7 +13222,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13256,7 +13256,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13290,7 +13290,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13324,7 +13324,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13358,7 +13358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13392,7 +13392,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13427,7 +13427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13461,7 +13461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13495,7 +13495,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13529,7 +13529,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13563,7 +13563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13597,7 +13597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13631,7 +13631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13665,7 +13665,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13699,7 +13699,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13733,7 +13733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13767,7 +13767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13801,7 +13801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13835,7 +13835,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13869,7 +13869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13903,7 +13903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13935,7 +13935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13967,7 +13967,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14038,7 +14038,7 @@ periodics:
         value: /go
       - name: GCE_USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14070,7 +14070,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14091,7 +14091,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -14126,7 +14126,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170807-80aef0ad
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -34,7 +34,7 @@ import traceback
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20170808-5d58fc35'
+DEFAULT_KUBEKINS_TAG = 'v20170808-bd529e23'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -33,6 +33,9 @@ import traceback
 
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
+# Note: This variable is managed by experiment/bump_e2e_image.sh.
+DEFAULT_KUBEKINS_TAG = 'v20170808-5d58fc35'
+
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""
     return os.path.join(ORIG_CWD, os.path.dirname(__file__), '..', *paths)
@@ -568,7 +571,7 @@ def create_parser():
     parser.add_argument(
         '--kubeadm', choices=['ci', 'periodic', 'pull'])
     parser.add_argument(
-        '--tag', default='v20170808-5d58fc35', help='Use a specific kubekins-e2e tag if set')
+        '--tag', default=DEFAULT_KUBEKINS_TAG, help='Use a specific kubekins-e2e tag if set')
     parser.add_argument(
         '--test', default='true', help='If we need to run any actual test within kubetest')
     parser.add_argument(


### PR DESCRIPTION
Along the way: Bump the docker tag used in `scenarios/kubernetes_e2e.py` as well.

This is primarily to pick up #3967 for #3983 

Canaries have been running since 9:45-ish with this code. 