### PR TITLE
Pin commenter to v20170808-abf66782

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14464,7 +14464,7 @@ periodics:
   interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/commenter:latest
+    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
       args:
       - |-
         --query=is:pr


### PR DESCRIPTION
/assign @ixdy @cjwagner 

`bazel run //experiment/commenter:push` now pushes updates three tags `:latest` `:latest-fejta` and `vYYYYMMDD-commitish`

ref https://github.com/kubernetes/test-infra/pull/3962