### PR TITLE
kubetest: Migrate KUBE_OS_DISTRIBUTION and NUM_NODES

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2287,8 +2287,12 @@ class JobTest(unittest.TestCase):
                     else:
                         self.assertIn('--mode=docker', args, job)
                     if '--provider=gke' in args:
-                        self.assertTrue(any('--deployment=gke' in a for a in args),
+                        self.assertTrue('--deployment=gke' in args,
                                         '%s must use --deployment=gke' % job)
+                        self.assertFalse(any('--gcp-master-image' in a for a in args),
+                                         '%s cannot use --gcp-master-image on GKE' % job)
+                        self.assertFalse(any('--gcp-nodes' in a for a in args),
+                                         '%s cannot use --gcp-nodes on GKE' % job)
                     if '--deployment=gke' in args:
                         self.assertTrue(any('--gcp-node-image' in a for a in args), job)
                     self.assertNotIn('--charts-tests', args)  # Use --charts


### PR DESCRIPTION
I'm headed towards more cleanup of the .json for flags, these are some
low hanging fruit.

Along the way: Unconditionally set
CLOUDSDK_CORE_PRINT_UNHANDLED_TRACEBACKS, it's used in every GCE job
(and might as well be used in GKE as well).