### PR TITLE
Re-enable mungegithub on docs repo.

### DIFF
--- a/mungegithub/cherrypick/secret.yaml
+++ b/mungegithub/cherrypick/secret.yaml
@@ -4,7 +4,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: cherrypick
     target-repo: @@
   name: @@-github-token
 type: Opaque

--- a/mungegithub/misc-mungers/deployment/docs/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/docs/configmap.yaml
@@ -1,0 +1,15 @@
+# basic config options.
+http-cache-dir: /cache/httpcache
+organization: kubernetes
+project: kubernetes.github.io
+pr-mungers: blunderbuss
+state: open
+token-file: /etc/secret-volume/token
+period: 2m
+repo-dir: /gitrepos
+github-key-file: /etc/hook-secret-volume/secret
+enable-md-yaml: true
+use-reviewers: true
+
+# munger specific options.
+label-file: "/gitrepos/kubernetes.github.io/labels.yaml"

--- a/mungegithub/misc-mungers/secret.yaml
+++ b/mungegithub/misc-mungers/secret.yaml
@@ -4,7 +4,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: submit-queue
     target-repo: @@
   name: @@-github-token
 type: Opaque
@@ -15,7 +14,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: submit-queue
     target-repo: @@
   name: @@-github-secret
 type: Opaque

--- a/mungegithub/publisher/secret.yaml
+++ b/mungegithub/publisher/secret.yaml
@@ -4,7 +4,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: publisher
     target-repo: @@
   name: @@-github-token
 type: Opaque

--- a/mungegithub/submit-queue/secret.yaml
+++ b/mungegithub/submit-queue/secret.yaml
@@ -5,7 +5,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: submit-queue
     target-repo: @@
   name: @@-github-token
 type: Opaque
@@ -16,7 +15,6 @@ data:
 kind: Secret
 metadata:
   labels:
-    app: submit-queue
     target-repo: @@
   name: @@-github-secret
 type: Opaque


### PR DESCRIPTION
I also removed the `app` label from all of the secrets so that different apps can share the github token for the repo as intended.
/cc @rmmh 
@chenopis @zacharysarah