### PR TITLE
Bump to kubekins-e2e:v20170808-be19c37e, kubekins-e2e-prow:v20170808-562b55b5

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -55,7 +55,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170808-bd529e23
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170808-be19c37e
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -148,7 +148,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -287,7 +287,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -423,7 +423,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -562,7 +562,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1268,7 +1268,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1301,7 +1301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1334,7 +1334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1367,7 +1367,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1399,7 +1399,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1432,7 +1432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1465,7 +1465,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1498,7 +1498,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1531,7 +1531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1564,7 +1564,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1597,7 +1597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1630,7 +1630,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1663,7 +1663,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1696,7 +1696,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1729,7 +1729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1762,7 +1762,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1795,7 +1795,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1828,7 +1828,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1861,7 +1861,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1894,7 +1894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1927,7 +1927,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1960,7 +1960,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1993,7 +1993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2026,7 +2026,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2058,7 +2058,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2091,7 +2091,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2124,7 +2124,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2157,7 +2157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2190,7 +2190,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2223,7 +2223,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2256,7 +2256,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2288,7 +2288,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2352,7 +2352,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2386,7 +2386,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2420,7 +2420,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2454,7 +2454,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2488,7 +2488,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2522,7 +2522,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2556,7 +2556,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2590,7 +2590,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2624,7 +2624,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2658,7 +2658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2692,7 +2692,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2726,7 +2726,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2760,7 +2760,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2794,7 +2794,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2828,7 +2828,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2862,7 +2862,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2896,7 +2896,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2930,7 +2930,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2964,7 +2964,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2998,7 +2998,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3032,7 +3032,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3066,7 +3066,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3100,7 +3100,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3134,7 +3134,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3168,7 +3168,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3202,7 +3202,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3236,7 +3236,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3270,7 +3270,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3304,7 +3304,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3338,7 +3338,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3372,7 +3372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3406,7 +3406,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3440,7 +3440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3474,7 +3474,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3508,7 +3508,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3542,7 +3542,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3576,7 +3576,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3610,7 +3610,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3644,7 +3644,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3678,7 +3678,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3712,7 +3712,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3744,7 +3744,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3776,7 +3776,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3809,7 +3809,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3841,7 +3841,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3874,7 +3874,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3907,7 +3907,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3939,7 +3939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3971,7 +3971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4004,7 +4004,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4036,7 +4036,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4068,7 +4068,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4101,7 +4101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4134,7 +4134,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4167,7 +4167,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4200,7 +4200,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4233,7 +4233,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4266,7 +4266,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4299,7 +4299,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4332,7 +4332,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4365,7 +4365,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4398,7 +4398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4431,7 +4431,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4464,7 +4464,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4497,7 +4497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4530,7 +4530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4563,7 +4563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4596,7 +4596,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4629,7 +4629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4662,7 +4662,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4695,7 +4695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4728,7 +4728,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4761,7 +4761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4794,7 +4794,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4827,7 +4827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4860,7 +4860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4893,7 +4893,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4926,7 +4926,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4959,7 +4959,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4992,7 +4992,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5025,7 +5025,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5057,7 +5057,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5089,7 +5089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5122,7 +5122,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5155,7 +5155,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5188,7 +5188,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5221,7 +5221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5254,7 +5254,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5287,7 +5287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5320,7 +5320,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5353,7 +5353,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5386,7 +5386,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5419,7 +5419,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5451,7 +5451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5483,7 +5483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5516,7 +5516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5549,7 +5549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5582,7 +5582,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5615,7 +5615,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5648,7 +5648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5681,7 +5681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5714,7 +5714,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5747,7 +5747,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5811,7 +5811,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5843,7 +5843,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5875,7 +5875,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5908,7 +5908,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5941,7 +5941,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5974,7 +5974,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6007,7 +6007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6039,7 +6039,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6072,7 +6072,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6105,7 +6105,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6138,7 +6138,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6171,7 +6171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6203,7 +6203,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6235,7 +6235,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6269,7 +6269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6303,7 +6303,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6337,7 +6337,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6371,7 +6371,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6405,7 +6405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6439,7 +6439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6473,7 +6473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6507,7 +6507,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6541,7 +6541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6575,7 +6575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6609,7 +6609,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6643,7 +6643,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6677,7 +6677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6711,7 +6711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6745,7 +6745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6779,7 +6779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6813,7 +6813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6847,7 +6847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6879,7 +6879,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6911,7 +6911,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6943,7 +6943,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6976,7 +6976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7009,7 +7009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7042,7 +7042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7075,7 +7075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7108,7 +7108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7141,7 +7141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7173,7 +7173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7205,7 +7205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7237,7 +7237,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7269,7 +7269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7301,7 +7301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7333,7 +7333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7365,7 +7365,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7397,7 +7397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7430,7 +7430,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7463,7 +7463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7496,7 +7496,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7529,7 +7529,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7561,7 +7561,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7593,7 +7593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7625,7 +7625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7658,7 +7658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7691,7 +7691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7724,7 +7724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7757,7 +7757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7790,7 +7790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7823,7 +7823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7856,7 +7856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7889,7 +7889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7921,7 +7921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7953,7 +7953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7985,7 +7985,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8018,7 +8018,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8051,7 +8051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8084,7 +8084,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8117,7 +8117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8149,7 +8149,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8182,7 +8182,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8215,7 +8215,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8248,7 +8248,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8281,7 +8281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8313,7 +8313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8345,7 +8345,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8377,7 +8377,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8409,7 +8409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8441,7 +8441,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8473,7 +8473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8506,7 +8506,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8539,7 +8539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8572,7 +8572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8604,7 +8604,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8636,7 +8636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8668,7 +8668,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8701,7 +8701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8733,7 +8733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8766,7 +8766,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8799,7 +8799,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8832,7 +8832,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8865,7 +8865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8898,7 +8898,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8931,7 +8931,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8963,7 +8963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8996,7 +8996,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9029,7 +9029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9062,7 +9062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9094,7 +9094,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9127,7 +9127,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9160,7 +9160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9193,7 +9193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9225,7 +9225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9257,7 +9257,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9289,7 +9289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9321,7 +9321,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9353,7 +9353,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9385,7 +9385,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9418,7 +9418,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9451,7 +9451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9484,7 +9484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9517,7 +9517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9550,7 +9550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9583,7 +9583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9616,7 +9616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9649,7 +9649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9682,7 +9682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9715,7 +9715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9748,7 +9748,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9781,7 +9781,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9813,7 +9813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9846,7 +9846,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9879,7 +9879,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9912,7 +9912,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9976,7 +9976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10009,7 +10009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10042,7 +10042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10075,7 +10075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10108,7 +10108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10141,7 +10141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10174,7 +10174,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10207,7 +10207,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10240,7 +10240,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10273,7 +10273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10306,7 +10306,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10339,7 +10339,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10372,7 +10372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10405,7 +10405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10438,7 +10438,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10471,7 +10471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10504,7 +10504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10537,7 +10537,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10570,7 +10570,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10603,7 +10603,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10636,7 +10636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10669,7 +10669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10702,7 +10702,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10735,7 +10735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10768,7 +10768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10801,7 +10801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10834,7 +10834,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10866,7 +10866,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10899,7 +10899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10932,7 +10932,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10965,7 +10965,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10998,7 +10998,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11031,7 +11031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11064,7 +11064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11097,7 +11097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11130,7 +11130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11163,7 +11163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11196,7 +11196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11229,7 +11229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11262,7 +11262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11295,7 +11295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11328,7 +11328,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11361,7 +11361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11394,7 +11394,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11427,7 +11427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11460,7 +11460,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11493,7 +11493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11527,7 +11527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11560,7 +11560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11593,7 +11593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11626,7 +11626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11659,7 +11659,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11692,7 +11692,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11725,7 +11725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11758,7 +11758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11791,7 +11791,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11824,7 +11824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11857,7 +11857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11890,7 +11890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11922,7 +11922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11955,7 +11955,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11988,7 +11988,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12021,7 +12021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12054,7 +12054,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12087,7 +12087,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12120,7 +12120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12153,7 +12153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12186,7 +12186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12219,7 +12219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12251,7 +12251,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12283,7 +12283,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12316,7 +12316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12349,7 +12349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12382,7 +12382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12415,7 +12415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12448,7 +12448,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12481,7 +12481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12514,7 +12514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12546,7 +12546,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12579,7 +12579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12612,7 +12612,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12645,7 +12645,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12677,7 +12677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12710,7 +12710,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12743,7 +12743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12776,7 +12776,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12808,7 +12808,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12840,7 +12840,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12872,7 +12872,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12904,7 +12904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12939,7 +12939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12973,7 +12973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13007,7 +13007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13041,7 +13041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13075,7 +13075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13109,7 +13109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13143,7 +13143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13177,7 +13177,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13211,7 +13211,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13245,7 +13245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13279,7 +13279,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13313,7 +13313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13348,7 +13348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13382,7 +13382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13416,7 +13416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13450,7 +13450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13484,7 +13484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13518,7 +13518,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13552,7 +13552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13586,7 +13586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13620,7 +13620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13654,7 +13654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13688,7 +13688,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13722,7 +13722,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13756,7 +13756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13790,7 +13790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13824,7 +13824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13856,7 +13856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13930,7 +13930,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13999,7 +13999,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14031,7 +14031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14052,7 +14052,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -14087,7 +14087,7 @@ periodics:
   interval: 2h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-8dda933a
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170808-562b55b5
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -34,7 +34,7 @@ import traceback
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20170808-bd529e23'
+DEFAULT_KUBEKINS_TAG = 'v20170808-be19c37e'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
Mostly to pick up #4003, then I'll migrate jobs to `--env`.