### PR TITLE
unpin gcloud version

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -68,8 +68,6 @@ RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
-# TODO(krzyzacy): Remove once https://github.com/kubernetes/kubernetes/issues/49673 is resolved
-RUN gcloud components update --version=163.0.0
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
     "kubetest", \


### PR DESCRIPTION
http://k8s-testgrid.appspot.com/canaries#gce-canary

gce-canary is using head gcloud, which has fixed the wrong deprecated --regex flag in 166.0.0 (released around this noon). The pinned version can be removed now.

We still need to migrate the flag in the near future though.

/assign @fejta @ixdy @rmmh 