### PR TITLE
jobs: Fix filegroup to include platform

### DIFF
--- a/jobs/BUILD
+++ b/jobs/BUILD
@@ -38,9 +38,9 @@ py_binary(
 filegroup(
     name = "jobs",
     srcs = glob([
-        "*.sh",
-        "*.env",
-        "*.json",
+        "**/*.sh",
+        "**/*.env",
+        "**/*.json",
     ]),
 )
 


### PR DESCRIPTION
Without the recursive glob, this filegroup doesn't include `platform/`, which means running `//jobs:env_gc` doesn't do the right thing.