### PR TITLE
Use boskos for pull-kubernetes-e2e-gce-bazel

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10004,7 +10004,6 @@
       "--env-file=jobs/pull-kubernetes-e2e.env",
       "--env-file=jobs/pull-kubernetes-e2e-gce-bazel.env",
       "--extract=local",
-      "--gcp-project=k8s-jkns-pr-gce-bazel",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-bazel",


### PR DESCRIPTION
Is boskos ready for general use?
We keep running out of quota in the `k8s-jkns-pr-gce-bazel` project, I'm guessing because we're running too many simultaneous gce-bazel jobs.

/assign @krzyzacy 