### PR TITLE
Run pull-bazel on release-1.{6,7} branches and only run affected tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9953,6 +9953,7 @@
   },
   "pull-kubernetes-bazel": {
     "args": [
+      "--affected",
       "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/...",
       "--release=//build/release-tars",
       "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -67,8 +67,9 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-kubernetes-bazel"
     trigger: "(?m)^/test( all| pull-kubernetes-bazel),?(\\s+|$)"
-    branches:
-    - master
+    skip_branches:
+    - release-1.4
+    - release-1.5
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
@@ -342,8 +343,9 @@ presubmits:
     always_run: true
     rerun_command: "/test pull-security-kubernetes-bazel"
     trigger: "(?m)^/test( all| pull-security-kubernetes-bazel),?(\\s+|$)"
-    branches:
-    - master
+    skip_branches:
+    - release-1.4
+    - release-1.5
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4


### PR DESCRIPTION
The periodic bazel jobs (mostly) work on the recent release branches, so I don't see why we can't run the pull variants:
* https://prow.k8s.io/?job=periodic-kubernetes-bazel-build-1-6
* https://prow.k8s.io/?job=periodic-kubernetes-bazel-build-1-7
* https://prow.k8s.io/?job=periodic-kubernetes-bazel-test-1-6
* https://prow.k8s.io/?job=periodic-kubernetes-bazel-test-1-7

Also, seems like as good a time as any to try out `--affected` on kubernetes/kubernetes.