### PR TITLE
Run update-jenkins-jobs job hourly and don't depend on git plugin

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/kubernetes-update-jenkins-jobs.yaml
@@ -6,20 +6,14 @@
             days-to-keep: 3
     node: master
     triggers:
-        - pollscm:
-            cron: '* * * * *'
-    scm:
-        - git:
-            url: https://github.com/kubernetes/test-infra
-            branches:
-                - master
-            browser: githubweb
-            browser-url: https://github.com/kubernetes/test-infra
-            skip-tag: true
+        - timed: '@hourly'
     builders:
         - shell: |
+            git clone https://github.com/kubernetes/test-infra -b master
+            cd test-infra
             ./jenkins/update-jobs.sh "jenkins/job-configs:jenkins/job-configs/kubernetes-jenkins-pull"
-    publishers:
-      - email-ext:
-          recipients: spxtr@google.com
-
+    wrappers:
+      - workspace-cleanup:
+          dirmatch: true
+          exclude:
+          - 'test-infra/.git/'

--- a/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/kubernetes-update-jenkins-jobs.yaml
@@ -6,20 +6,14 @@
             days-to-keep: 3
     node: master
     triggers:
-        - pollscm:
-            cron: '* * * * *'
-    scm:
-        - git:
-            url: https://github.com/kubernetes/test-infra
-            branches:
-                - master
-            browser: githubweb
-            browser-url: https://github.com/kubernetes/test-infra
-            skip-tag: true
+        - timed: '@hourly'
     builders:
         - shell: |
+            git clone https://github.com/kubernetes/test-infra -b master
+            cd test-infra
             ./jenkins/update-jobs.sh "jenkins/job-configs:jenkins/job-configs/kubernetes-jenkins"
-    publishers:
-      - email-ext:
-          recipients: spxtr@google.com
-
+    wrappers:
+      - workspace-cleanup:
+          dirmatch: true
+          exclude:
+          - 'test-infra/.git/'


### PR DESCRIPTION
PR Jenkins no longer has the git plugin, so the job to update Jenkins jobs was never running (and when manually triggered was never updating configs to test-infra HEAD).

Updating the job to explicitly run once an hour (regardless of test-infra changes) and to do its own `git checkout` should resolve the git plugin dependency.

IMO it's not worth the time to convert this to running under bootstrap.

/assign @cjwagner @fejta 