### PR TITLE
Actually map test-infra into the docker container

### DIFF
--- a/jenkins/update-jobs.sh
+++ b/jenkins/update-jobs.sh
@@ -45,7 +45,7 @@ if ! docker inspect job-builder &> /dev/null; then
       --net host \
       --name job-builder \
       --restart always \
-      -v "${WORKSPACE}:/test-infra" \
+      -v "${WORKSPACE}/test-infra:/test-infra" \
       "${IMAGE}"
     docker cp "${config_path}" job-builder:/etc/jenkins_jobs
   else


### PR DESCRIPTION
whoops:
```
+ cd test-infra
+ ./jenkins/update-jobs.sh jenkins/job-configs:jenkins/job-configs/kubernetes-jenkins-pull
INFO:root:Updating jobs in ['jenkins/job-configs', 'jenkins/job-configs/kubernetes-jenkins-pull'] ([])
/usr/local/lib/python2.7/dist-packages/jenkins/__init__.py:644: DeprecationWarning: get_plugins_info() is deprecated, use get_plugins()
  DeprecationWarning)
Traceback (most recent call last):
  File "/usr/local/bin/jenkins-jobs", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/jenkins_jobs/cmd.py", line 191, in main
    execute(options, config)
  File "/usr/local/lib/python2.7/dist-packages/jenkins_jobs/cmd.py", line 372, in execute
    n_workers=options.n_workers)
  File "/usr/local/lib/python2.7/dist-packages/jenkins_jobs/builder.py", line 348, in update_jobs
    self.load_files(input_fn)
  File "/usr/local/lib/python2.7/dist-packages/jenkins_jobs/builder.py", line 293, in load_files
    self.parser.parse(in_file)
  File "/usr/local/lib/python2.7/dist-packages/jenkins_jobs/parser.py", line 127, in parse
    with io.open(fn, 'r', encoding='utf-8') as fp:
IOError: [Errno 2] No such file or directory: '/test-infra/jenkins/job-configs'
```

/assign @fejta @cjwagner 