### PR TITLE
Explicitly set cluster name for ci-kubernetes-e2e-gce-federation

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1917,6 +1917,7 @@
   "ci-kubernetes-e2e-gce-federation": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=prow-us-central1-f",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation.env",
       "--extract=ci/latest",


### PR DESCRIPTION
We are NOT setting cluster name in `ci-kubernetes-e2e-gce-federation` job and default cluster name `bootstrap-e2e` is picked up for cluster, which is then set to INSTANCE_PREFIX and KUBE_GCE_INSTANCE_PREFIX [here](https://github.com/kubernetes/test-infra/blob/master/scenarios/kubernetes_e2e.py#L537) . But in federation scripts we do set instance prefix by setting KUBE_GCE_INSTANCE_PREFIX like [here](https://github.com/kubernetes/kubernetes/blob/master/cluster/kube-util.sh#L75). This causes inconsistencies in some scripts. so passing cluster name explicitly should fix the inconsistencies.

Just updating one job for now. once it is successful, shall update other jobs.

/assign @madhusudancs 
/cc @shyamjvs 