### PR TITLE
Set cluster name explicitly to few more federation jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1936,6 +1936,7 @@
   "ci-kubernetes-e2e-gce-federation-release-1-6": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=prow-us-central1-f",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-release-1-6.env",
       "--extract=ci/latest",
@@ -1954,6 +1955,7 @@
   "ci-kubernetes-e2e-gce-federation-release-1-7": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=prow-us-central1-f",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-release-1-7.env",
       "--extract=ci/latest-1.7",
@@ -1972,6 +1974,7 @@
   "ci-kubernetes-e2e-gce-federation-serial": {
     "args": [
       "--check-leaked-resources",
+      "--cluster=prow-us-central1-f",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/ci-kubernetes-e2e-gce-federation-serial.env",
       "--extract=ci/latest",


### PR DESCRIPTION
This is in continuation of #4033
The federation job is fixed with that PR. So extending the fix to few more federation jobs.

federation Soak jobs is not affected by this DumpClusterLogs issue.
fix for federation PR jobs need to be worked out. For PR jobs currently cluster name is dynamically generated.

/assign @madhusudancs 
/cc @shyamjvs 