### PR TITLE
Write test results to _artifacts in the current working dir

### DIFF
--- a/scenarios/kubernetes_kubelet.py
+++ b/scenarios/kubernetes_kubelet.py
@@ -141,7 +141,7 @@ def run_local_mode(run_args, private_key, public_key):
         '--logtostderr',
         '--vmodule=*=4',
         '--ssh-env=gce',
-        '--results-dir=/tmp/_artifacts',
+        '--results-dir=%s/_artifacts' % k8s,
         *run_args)
 
 


### PR DESCRIPTION
The node e2e tests triggered from Prow does not have artifacts uploaded. E.g., http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2enode-cosstable1-k8sdev-default/12/.

This is because bootstrap.py tries to upload the data in the _artifacts of the current working directory to GCS, but the test currently outputs to the results to /tmp/_artifacts and the current working directory is the k8s dir.

@krzyzacy 
Let me know if this is not the correct way to fix the issue.