### PR TITLE
Skip pull-kubernetes-bazel on release-1.6

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -70,6 +70,7 @@ presubmits:
     skip_branches:
     - release-1.4
     - release-1.5
+    - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
@@ -348,6 +349,7 @@ presubmits:
     skip_branches:
     - release-1.4
     - release-1.5
+    - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4


### PR DESCRIPTION
The release-1.6 branch isn't using multi-vendor, so the bazel query on `//vendor/k8s.io/...` is failing.
There's probably a way to work around this, but we should not be failing cherrypick PRs in the meantime.

/assign @krzyzacy 