### PR TITLE
Disable kubemark presubmit for release-1.4

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -317,6 +317,8 @@ presubmits:
     context: pull-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    skip_branches:
+    - release-1.4
   - name: pull-kubernetes-kubemark-e2e-gce-gci
     context: pull-kubernetes-kubemark-e2e-gce-gci
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-gci"
@@ -592,6 +594,8 @@ presubmits:
     context: pull-security-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    skip_branches:
+    - release-1.4
   - name: pull-security-kubernetes-kubemark-e2e-gce-gci
     context: pull-security-kubernetes-kubemark-e2e-gce-gci
     rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-gci"


### PR DESCRIPTION
We no longer support kubemark for 1.4. There are multiple issues (mostly related to compatibility). For e.g:

```
Error: Status 405 trying to pull repository google_containers/etcd: "v1 Registry API is disabled. If you are not explicitly using the v1 Registry API, it is possible your v2 image could not be found. Verify that your image is available, or retry with `dockerd --disable-legacy-registry`. See https://cloud.google.com/container-registry/docs/support/deprecation-notices"
```

```
W0810 19:46:50.669] 2017/08/10 19:46:50 e2e.go:544: Failed to dump logs from kubemark master: error starting ./test/kubemark/master-log-dump.sh /workspace/_artifacts: fork/exec ./test/kubemark/master-log-dump.sh: no such file or directory
```

```
W0810 19:50:55.072] WARNING: Flag zones is deprecated.
W0810 19:50:55.072] WARNING: Flag regexp is deprecated.
W0810 19:50:56.680] WARNING: Flag regexp is deprecated.
W0810 19:50:58.407] ERROR: (gcloud.compute.ssh) could not parse resource []
```

etc..

cc @gmarek 