### PR TITLE
bazel scenario: fall back to HEAD if $PULL_PULL_SHA is not set

### DIFF
--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -113,9 +113,9 @@ def main(args):
         affected = None
         if args.affected:
             base = os.getenv('PULL_BASE_SHA', '')
-            pull = os.getenv('PULL_PULL_SHA', '')
-            if not base or not pull:
-                raise ValueError('PULL_BASE_SHA and PULL_PULL_SHA must be set!')
+            pull = os.getenv('PULL_PULL_SHA', 'HEAD')
+            if not base:
+                raise ValueError('PULL_BASE_SHA must be set!')
             affected = get_changed(base, pull)
 
         build_pkgs = None


### PR DESCRIPTION
The batch presubmit job doesn't set `$PULL_PULL_SHA` (since there are multiple commits), so the bazel job has been repeatedly failing:
```
W0811 05:44:06.563] Traceback (most recent call last):
W0811 05:44:06.563]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_bazel.py", line 204, in <module>
W0811 05:44:06.564]     main(parse_args())
W0811 05:44:06.564]   File "/workspace/./test-infra/jenkins/../scenarios/kubernetes_bazel.py", line 118, in main
W0811 05:44:06.564]     raise ValueError('PULL_BASE_SHA and PULL_PULL_SHA must be set!')
W0811 05:44:06.565] ValueError: PULL_BASE_SHA and PULL_PULL_SHA must be set!
```

Since bootstrap merges everything into the local branch, we should just be able to compare `$PULL_BASE_SHA` against `HEAD` and get the desired result.

/assign @krzyzacy 