### PR TITLE
Update boskos README to display more cleanly using Markdown

### DIFF
--- a/boskos/README.md
+++ b/boskos/README.md
@@ -27,79 +27,101 @@ State is a string that tells the current status of the resource.
 
 ## API
 
-1. 	URL: /acquire
-	Desc: Use /acquire when you want to get hold of some resource.
-	Method: POST
-	URL Params: 
-		Required: type=[string]  : type of requested resource
-		Required: state=[string] : current state of the requested resource
-		Required: dest=[string] : destination state of the requested resource
-		Required: owner=[string] : requester of the resource
-	Return: error code or 200 with a valid Resource JSON object
-	Example: /acquire?type=gce-project&state=free&dest=busy&owner=user
+###	`POST /acquire`
 
-2.	URL: /release
-	Desc: use /release when you finish use some resource. Owner need to match current owner.
-	Method: POST
-	URL Params:
-		Required: name=[string]  : name of finished resource
-		Required: owner=[string] : owner of the resource
-		Required: dest=[string]  : destination state of the released resource
-	Return: status code
-	Example: /release?name=k8s-jkns-foo&dest=dirty&owner=user
+Use `/acquire` when you want to get hold of some resource.
 
-3.	URL: /update
-	Desc: Update resource last-update timestamp. Owner need to match current owner.
-	Method: POST
-	URL Params:
-		Required: name=[string]  : name of target resource
-		Required: owner=[string] : owner of the resource
-		Required: state=[string] : current state of the resource
-	Return: status code
-	Example: /update?name=k8s-jkns-foo&state=free&owner=user
+#### Required Parameters
 
-4.	URL: /reset
-	Desc: Reset a group of expired resource to certain state.
-	Method: POST
-	URL Params:
-		Required: type=[string] : type of resource in interest
-		Required: state=[string] : current state of the expired resource
-		Required: dest=[string] : destination state of the expired resource
-		Required: expire=[durationStr*] resource has not been updated since before {expire}. 
-			*durationStr is any string can be parsed by [time.ParseDuration()](https://golang.org/pkg/time/#ParseDuration)
-	Return: status code with a list of [Owner:Resource] pairs, which can be unmarshal into map[string]string
-	Example: /reset?type=gce-project&state=busy&dest=dirty&expire=20m
+| Name    | Type     | Description                                 |
+| ------- | -------- | ------------------------------------------- |
+| `type`  | `string` | type of requested resource                  |
+| `state` | `string` | current state of the requested resource     |
+| `dest`  | `string` | destination state of the requested resource |
+| `owner` | `string` | requester of the resource                   |
 
-5.	URL: /metric
-	Method: GET
-	URL Params: 
-		Required: type=[string] : type of requested resource
+Example: `/acquire?type=gce-project&state=free&dest=busy&owner=user`.
 
-	Return: error code or JSON object with: 
-			Count of projects in each state
-			Count of projects with each owner (or without an owner)
-			Sum of state moved to after /done (Todo)
-			A sample object will look like:
+On a successful request, `/acquire` will return HTTP 200 and a valid Resource JSON object.
+
+###	`POST /release`
+
+Use `/release` when you finish use some resource. Owner need to match current owner.
+
+#### Required Parameters
+
+| Name    | Type     | Description                                |
+| ------- | -------- | ------------------------------------------ |
+| `name`  | `string` | name of finished resource                  |
+| `owner` | `string` | owner of the resource                      |
+| `dest`  | `string` | destination state of the released resource |
+
+Example: `/release?name=k8s-jkns-foo&dest=dirty&owner=user`
+
+###	`POST /update`
+
+Use `/update` to update resource last-update timestamp. Owner need to match current owner.
+
+#### Required Parameters
+
+| Name    | Type     | Description                    |
+| ------- | -------- | ------------------------------ |
+| `name`  | `string` | name of target resource        |
+| `owner` | `string` | owner of the resource          |
+| `state` | `string` | current state of the resource  |
+
+Example: `/update?name=k8s-jkns-foo&state=free&owner=user`
+
+###	`POST /reset`
+
+Use `/reset` to reset a group of expired resource to certain state.
+
+#### Required Parameters
+
+| Name     | Type          | Description                                         |
+| -------- | ------------- | --------------------------------------------------- |
+| `type`   | `string`      | type of resource in interest                        |
+| `state`  | `string`      | current state of the expired resource               |
+| `dest`   | `string`      | destination state of the expired resource           |
+| `expire` | `durationStr` | resource has not been updated since before `expire` |
+
+Note: `durationStr` is any string can be parsed by [`time.ParseDuration()`](https://golang.org/pkg/time/#ParseDuration)
+
+On a successful request, `/reset` will return HTTP 200 and a list of [Owner:Resource] pairs, which can be unmarshalled into `map[string]string{}`
+
+Example: `/reset?type=gce-project&state=busy&dest=dirty&expire=20m`
+
+###	`GET /metric`
+
+Use `/metric` to retrieve a metric.
+
+#### Required Parameters
+
+| Name   | Type     | Description                |
+| ------ | -------- | -------------------------- |
+| `type` | `string` | type of requested resource |
+
+On a successful request, `/metric` will return HTTP 200 and a JSON object containing the count of projects in each state, the count of projects with each owner (or without an owner), and the sum of state moved to after `/done` (Todo). A sample object will look like:
+
 ```json
-			{
-				"type" : "project",
-				"Current": 
-				{
-					"total"   : 35,
-					"free"    : 20,
-					"dirty"   : 10,
-					"injured" : 5
-				},
-				"Owners":
-				{
-					"fejta" : 1,
-					"Senlu" : 1,
-					"sig-testing" : 20,
-					"Janitor" : 10,
-					"None" : 20
-				}
-			}
-
+{
+	"type" : "project",
+	"Current":
+	{
+		"total"   : 35,
+		"free"    : 20,
+		"dirty"   : 10,
+		"injured" : 5
+	},
+	"Owners":
+	{
+		"fejta" : 1,
+		"Senlu" : 1,
+		"sig-testing" : 20,
+		"Janitor" : 10,
+		"None" : 20
+	}
+}
 ```
 
 ## Config update:
@@ -110,7 +132,7 @@ State is a string that tells the current status of the resource.
 1. run `make update-config` to update the configmap.
 
 1. Boskos updates its config every 10min. Newly added resources will be available after next update cycle.
-Newly deleted resource will be removed in a future update cycle if the resource is not owned by any user. 
+Newly deleted resource will be removed in a future update cycle if the resource is not owned by any user.
 
 ## Local test:
 1. Start boskos with a fake resources.json, with `go run boskos.go -config=/path/to/resources.json`


### PR DESCRIPTION
@krzyzacy I was reading through this and thought it might display a little better in the GitHub markdown render if tables were used to separate the information. What do you think?

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>