### PR TITLE
Allow for author self-approval to be toggled with config

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -32,6 +32,7 @@ test-owners-csv: /gitrepos/kubernetes/test/test_owners.csv
 triage-window: 1
 triage-count: 10
 approval-requires-issue: true
+implicit-self-approval: true
 flakyjob-count: 3
 number-of-old-test-results: 5
 generated-files-config: .generated-files


### PR DESCRIPTION
When a PR is working on a section of code that is not covered by the
default set of blocking jobs, and the author is able to approve their
own PR, today anyone in the organization can drive-by with a `/lgtm` or
otherwise innocently place an `/lgtm` that causes the PR to merge even
if it is not ready, and the only method the author has to stop this is
to add and remove the `do-not-merge` label. Whether or not an author
immediately and implicitly self-approves their PR should be configurable
to allow for organizations to turn this feature off and improve the UX
of the approval manager for developers in these cases.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes https://github.com/kubernetes/test-infra/issues/4043
/area mungegithub

/cc @apelisse @grodrigues3 

This patch does _not_ change the default behavior in Kubernetes. If this patch is accepted, I can ask `kubernetes-dev` to see if the community would like it to be.