### PR TITLE
Make kubernetes-anywhere actually call prepareGcp

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170811-46afabc8
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170814-2cd119ae
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -726,7 +726,7 @@ func prepare(o *options) error {
 	}
 
 	switch o.provider {
-	case "gce", "gke", "kubemark":
+	case "gce", "gke", "kubemark", "kubernetes-anywhere":
 		if err := prepareGcp(o); err != nil {
 			return err
 		}

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -226,7 +226,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -520,7 +520,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -919,7 +919,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1037,7 +1037,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1159,7 +1159,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1203,7 +1203,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -15212,7 +15212,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
           args:
           - "--repo=k8s.io/kubernetes=release-1.6"
           - "--clean"
@@ -15335,7 +15335,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170811-3d50ec17
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170814-10d310fd
           args:
           - "--repo=k8s.io/kubernetes=release-1.7"
           - "--clean"


### PR DESCRIPTION
/assign @pipejakob @luxas 

All kubeadm jobs are using gcp project/ssh keys/other stuff, to me prepareGcp is necessary here.

Follow up https://github.com/kubernetes/test-infra/pull/4042