### PR TITLE
Revert "unpin gcloud version"

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -68,6 +68,8 @@ RUN tar xzf /workspace/google-cloud-sdk.tar.gz -C / && \
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
+# TODO(krzyzacy): Remove once https://github.com/kubernetes/kubernetes/issues/49673 is resolved
+RUN gcloud components update --version=163.0.0
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
     "kubetest", \


### PR DESCRIPTION
:-( pin it back to 163.0.0 for now

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd3-pr-validate/2268/

Reverts kubernetes/test-infra#4009

/assign @rmmh @fejta @cjwagner 