### PR TITLE
Cleaned up unused env variable FEDERATION_CLUSTERS from federation jobs

### DIFF
--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1-6.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1-6.env
@@ -7,7 +7,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
-FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gce-federation-release-1-7.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-release-1-7.env
@@ -7,7 +7,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
-FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-e2e-gce-federation-serial.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation-serial.env
@@ -7,7 +7,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
-FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
 # Note: this only works if [Feature:Federation] is before all
 # the other labels. It is hard to ANDs in ginkgo regexp because

--- a/jobs/ci-kubernetes-e2e-gce-federation.env
+++ b/jobs/ci-kubernetes-e2e-gce-federation.env
@@ -7,8 +7,6 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
-FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
-
 
 GINKGO_PARALLEL=y
 

--- a/jobs/ci-kubernetes-pull-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-pull-gce-federation-deploy.env
@@ -11,4 +11,3 @@ KUBE_NODE_OS_DISTRIBUTION=gci
 
 # Where the clusters will be created. Federation components are now deployed to the last one.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
-FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f

--- a/jobs/ci-kubernetes-soak-gce-federation-deploy.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-deploy.env
@@ -10,7 +10,6 @@ USE_KUBEFED=true
 
 # Where the clusters will be created.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
-FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
 # TODO: Replace this with FEDERATION_HOST_CLUSTER, but do it in
 # lock steps. First make current the scripts understand the host

--- a/jobs/ci-kubernetes-soak-gce-federation-test.env
+++ b/jobs/ci-kubernetes-soak-gce-federation-test.env
@@ -12,7 +12,6 @@ USE_KUBEFED=true
 
 # Where the clusters will be created.
 E2E_ZONES=us-central1-a us-central1-b us-central1-f
-FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f
 
 # TODO: Replace this with FEDERATION_HOST_CLUSTER, but do it in
 # lock steps. First make current the scripts understand the host

--- a/jobs/pull-kubernetes-federation-e2e-gce.env
+++ b/jobs/pull-kubernetes-federation-e2e-gce.env
@@ -5,14 +5,6 @@ FEDERATION=true
 USE_KUBEFED=true
 KUBE_REGISTRY=gcr.io/k8s-jkns-pr-bldr-e2e-gce-fdrtn
 
-# Recycle control plane.
-# We only recycle federation control plane in each run, we don't
-# want to recycle the clusters, it's too slow.
-# This is accomplished by not setting FEDERATION_CLUSTERS env
-# var or setting it to empty string. We set it to empty string
-# to explicitly call it out.
-FEDERATION_CLUSTERS=
-
 # Federation control plane options.
 FEDERATION_DNS_ZONE_NAME=pr-bldr.test-f8n.k8s.io.
 FEDERATION_HOST_CLUSTER_ZONE=us-central1-f


### PR DESCRIPTION
The PR https://github.com/kubernetes/test-infra/pull/2854 rendered FEDERATION_CLUSTERS variable useless and this PR cleans them up.

/assign @krzyzacy 
/assign @madhusudancs 