### PR TITLE
Add JUnit result summaries to the build summary page

### DIFF
--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -26,6 +26,15 @@
 		% set result = finished['result'] if finished else 'Not Finished'
 		<tr><td>Result<td><span class="build-{{result | slugify}}">{{result}}</span>
 	% if started
+		% if finished
+			<tr><td>Tests<td>
+			% if stats['failures'] > 0
+				<span class="text-failure">{{stats['failures']}} failed</span>
+			% else
+				{{stats['failures']}} failed
+			% endif
+			/ {{stats['successes']}} succeeded / {{stats['skipped']}} skipped / {{stats['testcases']}} total
+		% endif
 		<tr><td>Started<td>{{started['timestamp']|timestamp}}
 		{% if finished %}<tr><td>Elapsed<td>{{(finished['timestamp']-started['timestamp'])|duration}}{% endif %}
 		<tr><td>Version<td><a href="https://github.com/kubernetes/kubernetes/commit/{{commit}}">{{started['version'] or finished['version']}}</a>

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -32,13 +32,17 @@ write = gcs_async_test.write
 
 class ParseJunitTest(unittest.TestCase):
     @staticmethod
-    def parse(xml):
-        return list(view_build.parse_junit(xml, "fp"))
+    def parse(xml, stats=None):
+        if stats is None:
+            stats = {'testcases':0, 'successes':0, 'failures':0, 'skipped':0}
+        return list(view_build.parse_junit(xml, "fp", stats))
 
     def test_normal(self):
-        failures = self.parse(main_test.JUNIT_SUITE)
+        stats = {'testcases':0, 'successes':0, 'failures':0, 'skipped':0}
+        failures = self.parse(main_test.JUNIT_SUITE, stats)
         stack = '/go/src/k8s.io/kubernetes/test.go:123\nError Goes Here'
         self.assertEqual(failures, [('Third', 96.49, stack, "fp", "")])
+        self.assertEqual(stats, {'testcases':3, 'successes':1, 'failures':1, 'skipped':1})
 
     def test_testsuites(self):
         failures = self.parse('''


### PR DESCRIPTION
Fixes #172

Built on top of #1981 because signature of parse junit changes