### PR TITLE
Turn off bazel --affected

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9989,7 +9989,6 @@
   },
   "pull-kubernetes-bazel": {
     "args": [
-      "--affected",
       "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/...",
       "--release=//build/release-tars",
       "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",
@@ -10310,9 +10309,10 @@
   },
   "pull-test-infra-bazel": {
     "args": [
-      "--affected",
+      "--build=//...",
       "--install=gubernator/test_requirements.txt",
-      "--install=verify/test_requirements.txt"
+      "--test=//... //verify:verify-all",
+      "--test-args=--test_output=errors"
     ],
     "scenario": "kubernetes_bazel",
     "sigOwners": [


### PR DESCRIPTION
`gazelle` doesn't currently delete empty rules (https://github.com/bazelbuild/rules_go/issues/332), and because we filter out deletions when computing the `git diff`, we're now failing to detect bazel build breakages in PR tests.

Until we get a better fix, let's turn off testing only affected packages. It's not a great contributor experience (the bazel build will be broken and require manual fixing, since `update-bazel.sh` won't do the right thing), but it's better than unknowingly breaking the build.

x-ref #4083 

/assign @krzyzacy 
cc @apelisse 