### PR TITLE
Try to set --num-nodes flag in kubetest

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -89,7 +89,7 @@ type ig struct {
 
 var _ deployer = &gkeDeployer{}
 
-func newGKE(provider, project, zone, region, network, image, cluster string) (*gkeDeployer, error) {
+func newGKE(provider, project, zone, region, network, image, cluster string, testArgs *string) (*gkeDeployer, error) {
 	if provider != "gke" {
 		return nil, fmt.Errorf("--provider must be 'gke' for GKE deployment, found %q", provider)
 	}
@@ -220,6 +220,9 @@ func newGKE(provider, project, zone, region, network, image, cluster string) (*g
 	if err := os.Setenv("KUBE_GCE_INSTANCE_PREFIX", "gke-"+g.cluster); err != nil {
 		return nil, err
 	}
+
+	// set --num-nodes flag for ginkgo, since NUM_NODES is not set for gke deployer.
+	*testArgs = strings.Join(setFieldDefault(strings.Fields(*testArgs), "--num-nodes", strconv.Itoa(g.shape[defaultPool].Nodes)), " ")
 
 	return g, nil
 }

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -217,7 +217,7 @@ func getDeployer(o *options) (deployer, error) {
 	case "bash":
 		return bash{&o.clusterIPRange}, nil
 	case "gke":
-		return newGKE(o.provider, o.gcpProject, o.gcpZone, o.gcpRegion, o.gcpNetwork, o.gcpNodeImage, o.cluster)
+		return newGKE(o.provider, o.gcpProject, o.gcpZone, o.gcpRegion, o.gcpNetwork, o.gcpNodeImage, o.cluster, &o.testArgs)
 	case "kops":
 		return newKops()
 	case "kubernetes-anywhere":


### PR DESCRIPTION
Context: to fix https://k8s-testgrid.appspot.com/google-gke#gci-gke-serial-1.7, and also all other gke-serial jobs.

So we have tests depend on --num-nodes - https://github.com/kubernetes/kubernetes/blob/4d5c823d7870be/test/e2e/network_partition.go#L296,

which is passed from https://github.com/kubernetes/kubernetes/blob/401985bf6cb0af5699e6d47f29028d317889ec03/hack/ginkgo-e2e.sh#L105

which, previously, as a bash deployer, is set either from the env file, or https://github.com/kubernetes/kubernetes/blob/55160e7cc10d759a5a342e46545290838b7ff1b5/cluster/gce/config-default.sh#L31, or other config places (that's my understanding). To me we'd probably have to backfill this NUM_NODES env in gke deployer so that it can pass through to ginkgo.

/assign @wojtek-t @fejta @zmerlynn 