### PR TITLE
Don't specify status context url if url is empty string.

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -1484,9 +1484,11 @@ func (obj *MungeObject) SetStatus(state, url, description, statusContext string)
 	config := obj.config
 	status := &github.RepoStatus{
 		State:       &state,
-		TargetURL:   &url,
 		Description: &description,
 		Context:     &statusContext,
+	}
+	if len(url) > 0 {
+		status.URL = &url
 	}
 	pr, ok := obj.GetPR()
 	if !ok {


### PR DESCRIPTION
This should allow the `context-url` option to be the empty string while still allowing the "Submit Queue" status context to be set.
/cc @yutongz 