### PR TITLE
Have sig label munger support committee/ label

### DIFF
--- a/mungegithub/mungers/sig-mention-handler.go
+++ b/mungegithub/mungers/sig-mention-handler.go
@@ -60,6 +60,9 @@ func (*SigMentionHandler) HasSigLabel(obj *github.MungeObject) bool {
 		if labels[i].Name != nil && strings.HasPrefix(*labels[i].Name, "sig/") {
 			return true
 		}
+		if labels[i].Name != nil && strings.HasPrefix(*labels[i].Name, "committee/") {
+			return true
+		}
 	}
 
 	return false
@@ -106,7 +109,7 @@ func (s *SigMentionHandler) Munge(obj *github.MungeObject) {
 
 		msg := fmt.Sprintf(`@%s
 There are no sig labels on this issue. Please [add a sig label](https://github.com/kubernetes/test-infra/blob/master/commands.md) by:
-	
+
 1. mentioning a sig: `+"`@kubernetes/sig-<group-name>-<group-suffix>`"+`
     e.g., `+"`@kubernetes/sig-contributor-experience-<group-suffix>`"+` to notify the contributor experience sig, OR
 

--- a/mungegithub/mungers/sig-mention-handler_test.go
+++ b/mungegithub/mungers/sig-mention-handler_test.go
@@ -29,11 +29,12 @@ import (
 )
 
 const (
-	helpWanted    = "help-wanted"
-	open          = "open"
-	sigApps       = "sig/apps"
-	username      = "Ali"
-	needsSigLabel = "needs-sig"
+	helpWanted        = "help-wanted"
+	open              = "open"
+	sigApps           = "sig/apps"
+	committeeSteering = "committee/steering"
+	username          = "Ali"
+	needsSigLabel     = "needs-sig"
 )
 
 func TestSigMentionHandler(t *testing.T) {
@@ -133,6 +134,33 @@ func TestSigMentionHandler(t *testing.T) {
 			},
 			expected: []githubapi.Label{{Name: githubapi.String(helpWanted)},
 				{Name: githubapi.String(sigApps)}},
+		},
+		{
+			name: "issue has committee/foo label, no needs-sig label",
+			issue: &githubapi.Issue{
+				State: githubapi.String(open),
+				Labels: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+					{Name: githubapi.String(committeeSteering)}},
+				PullRequestLinks: nil,
+				Assignee:         &githubapi.User{Login: githubapi.String(username)},
+				Number:           intPtr(1),
+			},
+			expected: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+				{Name: githubapi.String(committeeSteering)}},
+		},
+		{
+			name: "issue has both needs-sig label and committee/foo label",
+			issue: &githubapi.Issue{
+				State: githubapi.String(open),
+				Labels: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+					{Name: githubapi.String(needsSigLabel)},
+					{Name: githubapi.String(committeeSteering)}},
+				PullRequestLinks: nil,
+				Assignee:         &githubapi.User{Login: githubapi.String(username)},
+				Number:           intPtr(1),
+			},
+			expected: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+				{Name: githubapi.String(committeeSteering)}},
 		},
 	}
 


### PR DESCRIPTION
Ref: https://github.com/kubernetes/community/issues/921

Adds support for the munger to treat `committee/` labels as satisfying the `needs-sig` requirement