### PR TITLE
Bump kubetest version to v20170817-eb8ff765 for kubeadm

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170814-2cd119ae
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170817-eb8ff765
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -34,7 +34,7 @@ import traceback
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20170814-0fdc97cc'
+DEFAULT_KUBEKINS_TAG = 'v20170817-eb8ff765'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
This includes changes in https://github.com/kubernetes/test-infra/pull/4094.

/cc @krzyzacy 