### PR TITLE
Use shared builds for some e2e jobs

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2296,9 +2296,16 @@ class JobTest(unittest.TestCase):
                         self.fail('--mode=local is default now, drop that for %s' % job)
 
                     extracts = [a for a in args if '--extract=' in a]
-                    if not extracts:
-                        self.fail('e2e job needs --extract flag: %s %s' % (job, args))
-                    if any(s in job for s in [
+                    shared_builds = [a for a in args if '--use-shared-build' in a]
+                    if shared_builds and extracts:
+                        self.fail(('e2e jobs cannot have --use-shared-build'
+                                   ' and --extract: %s %s') % (job, args))
+                    elif not extracts and not shared_builds:
+                        self.fail(('e2e job needs --extract or'
+                                   ' --use-shared-build: %s %s') % (job, args))
+                    if shared_builds:
+                        expected = 0
+                    elif any(s in job for s in [
                             'upgrade', 'skew', 'downgrade', 'rollback',
                             'ci-kubernetes-e2e-gce-canary',
                     ]):

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2230,11 +2230,11 @@ class JobTest(unittest.TestCase):
                 extract_in_args = False
                 build_in_args = False
                 for arg in args:
-                    if arg.startswith("--use-shared-build"):
+                    if arg.startswith('--use-shared-build'):
                         use_shared_build_in_args = True
-                    elif arg.startswith("--build"):
+                    elif arg.startswith('--build'):
                         build_in_args = True
-                    elif arg.startswith("--extract"):
+                    elif arg.startswith('--extract'):
                         extract_in_args = True
                     match = re.match(r'--env-file=([^\"]+)\.env', arg)
                     if match:

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2202,7 +2202,7 @@ class JobTest(unittest.TestCase):
             if bad_vars:
                 self.fail('Job %s contains bad bash variables: %s' % (job, ' '.join(bad_vars)))
 
-    def test_valid_job_envs(self):
+    def test_valid_job_config_json(self):
         """Validate jobs/config.json."""
         self.load_prow_yaml(self.prow_config)
         config = bootstrap.test_infra('jobs/config.json')
@@ -2225,7 +2225,17 @@ class JobTest(unittest.TestCase):
                 scenario = bootstrap.test_infra('scenarios/%s.py' % config[job]['scenario'])
                 self.assertTrue(os.path.isfile(scenario), job)
                 self.assertTrue(os.access(scenario, os.X_OK|os.R_OK), job)
-                for arg in config[job].get('args', []):
+                args = config[job].get('args', [])
+                use_shared_build_in_args = False
+                extract_in_args = False
+                build_in_args = False
+                for arg in args:
+                    if arg.startswith("--use-shared-build"):
+                        use_shared_build_in_args = True
+                    elif arg.startswith("--build"):
+                        build_in_args = True
+                    elif arg.startswith("--extract"):
+                        extract_in_args = True
                     match = re.match(r'--env-file=([^\"]+)\.env', arg)
                     if match:
                         path = bootstrap.test_infra('%s.env' % match.group(1))
@@ -2240,8 +2250,11 @@ class JobTest(unittest.TestCase):
                                 len(cluster), 20,
                                 'Job %r, --cluster should be 20 chars or fewer' % job
                                 )
+                # these args should not be combined:
+                # --use-shared-build and (--build or --extract)
+                self.assertFalse(use_shared_build_in_args and build_in_args)
+                self.assertFalse(use_shared_build_in_args and extract_in_args)
                 if config[job]['scenario'] == 'kubernetes_e2e':
-                    args = config[job]['args']
                     if job in self.prowjobs:
                         for arg in args:
                             # --mode=local is default now

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10300,6 +10300,15 @@
       "sig-testing"
     ]
   },
+  "pull-kubernetes-build": {
+    "args": [
+      "--fast"
+    ],
+    "scenario": "kubernetes_build",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "pull-kubernetes-cross": {
     "args": [
       "--env=KUBE_RELEASE_RUN_TESTS=n",
@@ -10416,19 +10425,18 @@
   },
   "pull-kubernetes-e2e-gce-gpu": {
     "args": [
-      "--build",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
       "--env-file=jobs/env/pull-kubernetes-e2e-gce-gpu.env",
-      "--extract=local",
       "--gcp-project=k8s-jkns-pr-gce-gpus",
       "--gcp-zone=us-west1-b",
       "--mode=docker",
       "--provider=gce",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gpu",
       "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
-      "--timeout=60m"
+      "--timeout=60m",
+      "--use-shared-build"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10300,15 +10300,6 @@
       "sig-testing"
     ]
   },
-  "pull-kubernetes-build": {
-    "args": [
-      "--fast"
-    ],
-    "scenario": "kubernetes_build",
-    "sigOwners": [
-      "sig-testing"
-    ]
-  },
   "pull-kubernetes-cross": {
     "args": [
       "--env=KUBE_RELEASE_RUN_TESTS=n",
@@ -10436,7 +10427,7 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gpu",
       "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
       "--timeout=60m",
-      "--use-shared-build"
+      "--use-shared-build=bazel"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -112,7 +112,6 @@ presubmits:
     - name: pull-kubernetes-e2e-gce-gpu
       agent: jenkins
       always_run: true
-      skip_report: true
       context: pull-kubernetes-e2e-gce-gpu
       rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
       trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
@@ -411,7 +410,6 @@ presubmits:
     - name: pull-security-kubernetes-e2e-gce-gpu
       agent: jenkins
       always_run: true
-      skip_report: true
       context: pull-security-kubernetes-e2e-gce-gpu
       rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
       trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -109,6 +109,21 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+  - name: pull-kubernetes-build
+    agent: jenkins
+    context: pull-kubernetes-build
+    always_run: true
+    rerun_command: "/test pull-kubernetes-build"
+    trigger: "(?m)^/test( all| pull-kubernetes-build),?(\\s+|$)"
+    run_after_success:
+    - name: pull-kubernetes-e2e-gce-gpu
+      agent: jenkins
+      always_run: true
+      skip_report: true
+      context: pull-kubernetes-e2e-gce-gpu
+      rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
+      trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
+
   - name: pull-kubernetes-cross
     agent: jenkins
     context: pull-kubernetes-cross
@@ -198,12 +213,6 @@ presubmits:
     context: pull-kubernetes-e2e-gce-gci
     rerun_command: "/test pull-kubernetes-e2e-gce-gci"
     trigger: "(?m)^/test pull-kubernetes-e2e-gce-gci,?(\\s+|$)"
-  - name: pull-kubernetes-e2e-gce-gpu
-    agent: jenkins
-    always_run: true
-    context: pull-kubernetes-e2e-gce-gpu
-    rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
-    trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
   - name: pull-kubernetes-e2e-gke
     agent: jenkins
     context: pull-kubernetes-e2e-gke
@@ -405,7 +414,20 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-
+  - name: pull-security-kubernetes-build
+    agent: jenkins
+    context: pull-security-kubernetes-build
+    always_run: true
+    rerun_command: "/test pull-security-kubernetes-build"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-build),?(\\s+|$)"
+    run_after_success:
+    - name: pull-security-kubernetes-e2e-gce-gpu
+      agent: jenkins
+      always_run: true
+      skip_report: true
+      context: pull-security-kubernetes-e2e-gce-gpu
+      rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
+      trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"
   - name: pull-security-kubernetes-cross
     agent: jenkins
     context: pull-security-kubernetes-cross
@@ -495,12 +517,6 @@ presubmits:
     context: pull-security-kubernetes-e2e-gce-gci
     rerun_command: "/test pull-security-kubernetes-e2e-gce-gci"
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gce-gci,?(\\s+|$)"
-  - name: pull-security-kubernetes-e2e-gce-gpu
-    agent: jenkins
-    always_run: true
-    context: pull-security-kubernetes-e2e-gce-gpu
-    rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"
   - name: pull-security-kubernetes-e2e-gke
     agent: jenkins
     context: pull-security-kubernetes-e2e-gke

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -108,13 +108,6 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-
-  - name: pull-kubernetes-build
-    agent: jenkins
-    context: pull-kubernetes-build
-    always_run: true
-    rerun_command: "/test pull-kubernetes-build"
-    trigger: "(?m)^/test( all| pull-kubernetes-build),?(\\s+|$)"
     run_after_success:
     - name: pull-kubernetes-e2e-gce-gpu
       agent: jenkins
@@ -414,12 +407,6 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-build
-    agent: jenkins
-    context: pull-security-kubernetes-build
-    always_run: true
-    rerun_command: "/test pull-security-kubernetes-build"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-build),?(\\s+|$)"
     run_after_success:
     - name: pull-security-kubernetes-e2e-gce-gpu
       agent: jenkins

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -170,7 +170,8 @@ def main(args):
                 # (gs://<shared-bucket>/$PULL_REFS/bazel-build-location.txt)
                 pull_refs = os.getenv('PULL_REFS', '')
                 gcs_shared = args.gcs_shared + pull_refs + '/bazel-build-location.txt'
-                upload_string(gcs_shared, gcs_build)
+                if pull_refs:
+                    upload_string(gcs_shared, gcs_build)
             except subprocess.CalledProcessError as exp:
                 res = exp.returncode
 

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -199,7 +199,7 @@ def create_parser():
     parser.add_argument(
         '--gcs-shared',
         default="gs://kubernetes-jenkins/shared-results/",
-        help='If release is set push build location to this bucket')
+        help='If $PULL_REFS is set push build location to this bucket')
     parser.add_argument(
         '--test', help='Bazel test targets, split by one space')
     parser.add_argument(

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -38,7 +38,7 @@ def check_output(*cmd):
     return subprocess.check_output(cmd)
 
 def upload_string(gcs_path, text):
-    """Uploads s to gcs_path"""
+    """Uploads text to gcs_path"""
     cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', '-', gcs_path]
     print >>sys.stderr, 'Run:', cmd, 'stdin=%s'%text
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
@@ -169,7 +169,7 @@ def main(args):
                 # log push-build location to path child jobs can find
                 # (gs://<shared-bucket>/$PULL_REFS/bazel-build-location.txt)
                 pull_refs = os.getenv('PULL_REFS', '')
-                gcs_shared = args.gcs_shared + pull_refs + '/bazel-build-location.txt'
+                gcs_shared = os.path.join(args.gcs_shared, pull_refs, 'bazel-build-location.txt')
                 if pull_refs:
                     upload_string(gcs_shared, gcs_build)
             except subprocess.CalledProcessError as exp:

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -23,7 +23,6 @@ import argparse
 import os
 import subprocess
 import sys
-import tarfile
 
 
 def check(*cmd):
@@ -31,12 +30,6 @@ def check(*cmd):
     print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
-def upload_string(gcs_path, text):
-    """Uploads text to gcs_path"""
-    cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', '-', gcs_path]
-    print >>sys.stderr, 'Run:', cmd, 'stdin=%s'%text
-    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-    proc.communicate(input=text)
 
 def main(args):
     """Build and push kubernetes.
@@ -78,21 +71,6 @@ def main(args):
     else:
         check('make', 'release')
     check('../release/push-build.sh', *push_build_args)
-    pull_refs = os.getenv('PULL_REFS', '')
-    if pull_refs:
-        # log push-build location to path child jobs can find
-        # (gs://<shared-bucket>/$PULL_REFS/bazel-build-location.txt)
-        # first get build location the same way push-build.sh does
-        bucket = args.release or 'kubernetes-release-dev'
-        dest = 'ci'
-        if args.suffix:
-            dest += args.suffix
-        build_tar = tarfile.open("_output/release-tars/kubernetes.tar.gz")
-        latest = build_tar.getmember("kubernetes/version").read().strip()
-        gcs_build = os.path.join('gs://', bucket, dest, latest)
-        # and then write it to GCS
-        gcs_shared = os.path.join(args.gcs_shared, pull_refs, 'build-location.txt')
-        upload_string(gcs_shared, gcs_build)
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(
@@ -100,10 +78,6 @@ if __name__ == '__main__':
     PARSER.add_argument('--fast', action='store_true', help='Build quickly')
     PARSER.add_argument(
         '--release', help='Upload binaries to the specified gs:// path')
-    PARSER.add_argument(
-        '--gcs-shared',
-        default="gs://kubernetes-jenkins/shared-results/",
-        help='If $PULL_REFS is set push build location to this bucket')
     PARSER.add_argument(
         '--suffix', help='Append suffix to the upload path if set')
     PARSER.add_argument(

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--gcs-shared',
         default="gs://kubernetes-jenkins/shared-results/",
-        help='If release is set push build location to this bucket')
+        help='If $PULL_REFS is set push build location to this bucket')
     PARSER.add_argument(
         '--suffix', help='Append suffix to the upload path if set')
     PARSER.add_argument(

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -78,20 +78,20 @@ def main(args):
     else:
         check('make', 'release')
     check('../release/push-build.sh', *push_build_args)
-    # log push-build location to path child jobs can find
-    # (gs://<shared-bucket>/$PULL_REFS/bazel-build-location.txt)
-    # first get build location
-    bucket = args.release or 'kubernetes-release-dev'
-    dest = 'ci'
-    if args.suffix:
-        dest += args.suffix
-    build_tar = tarfile.open("_output/release-tars/kubernetes.tar.gz")
-    latest = build_tar.getmember("kubernetes/version").read().strip()
-    gcs_build = 'gs://'+bucket+dest+latest
-    # and then write it to GCS
     pull_refs = os.getenv('PULL_REFS', '')
-    gcs_shared = args.gcs_shared + pull_refs + '/build-location.txt'
     if pull_refs:
+        # log push-build location to path child jobs can find
+        # (gs://<shared-bucket>/$PULL_REFS/bazel-build-location.txt)
+        # first get build location the same way push-build.sh does
+        bucket = args.release or 'kubernetes-release-dev'
+        dest = 'ci'
+        if args.suffix:
+            dest += args.suffix
+        build_tar = tarfile.open("_output/release-tars/kubernetes.tar.gz")
+        latest = build_tar.getmember("kubernetes/version").read().strip()
+        gcs_build = os.path.join('gs://', bucket, dest, latest)
+        # and then write it to GCS
+        gcs_shared = args.gcs_shared + pull_refs + '/build-location.txt'
         upload_string(gcs_shared, gcs_build)
 
 if __name__ == '__main__':

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -89,9 +89,10 @@ def main(args):
     latest = build_tar.getmember("kubernetes/version").read().strip()
     gcs_build = 'gs://'+bucket+dest+latest
     # and then write it to GCS
-    gcs_shared = args.gcs_shared + os.getenv('PULL_REFS', '') + '/build-location.txt'
-    upload_string(gcs_shared, gcs_build)
-
+    pull_refs = os.getenv('PULL_REFS', '')
+    gcs_shared = args.gcs_shared + pull_refs + '/build-location.txt'
+    if pull_refs:
+        upload_string(gcs_shared, gcs_build)
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -32,7 +32,7 @@ def check(*cmd):
     subprocess.check_call(cmd)
 
 def upload_string(gcs_path, text):
-    """Uploads s to gcs_path"""
+    """Uploads text to gcs_path"""
     cmd = ['gsutil', '-q', '-h', 'Content-Type:text/plain', 'cp', '-', gcs_path]
     print >>sys.stderr, 'Run:', cmd, 'stdin=%s'%text
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
@@ -91,7 +91,7 @@ def main(args):
         latest = build_tar.getmember("kubernetes/version").read().strip()
         gcs_build = os.path.join('gs://', bucket, dest, latest)
         # and then write it to GCS
-        gcs_shared = args.gcs_shared + pull_refs + '/build-location.txt'
+        gcs_shared = os.path.join(args.gcs_shared, pull_refs, 'build-location.txt')
         upload_string(gcs_shared, gcs_build)
 
 if __name__ == '__main__':

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -491,11 +491,11 @@ def main(args):
         try:
             build_loc = read_gcs_path(gcs_path)
             # tell kubetest to extract from this location
-            args.kubetest_args.append("--extract="+build_loc)
+            args.kubetest_args.append('--extract=' + build_loc)
             args.build = None
         except urllib2.URLError as err:
-            print >>sys.stderr, "Failed to get shared build location: %s"%err.reason
-            print >>sys.stderr, "Falling back to local build..."
+            print >>sys.stderr, 'Failed to get shared build location: %s'%err.reason
+            print >>sys.stderr, 'Falling back to local build...'
             # fall back on local build
             args.kubetest_args.append('--extract=local')
             args.build = args.use_shared_build

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -488,7 +488,7 @@ def main(args):
             build_file += args.use_shared_build + '-'
         build_file += 'build-location.txt'
         gcs_path = os.path.join(args.gcs_shared, os.getenv('PULL_REFS', ''), build_file)
-        print >>sys.stderr, "Getting shared build location from: "+gcs_path
+        print >>sys.stderr, 'Getting shared build location from: '+gcs_path
         try:
             # tell kubetest to extract from this location
             args.kubetest_args.append('--extract=' + read_gcs_path(gcs_path))
@@ -606,7 +606,7 @@ def create_parser():
         help='Use prebuilt kubernetes binaries if set, optionally specifying strategy')
     parser.add_argument(
         '--gcs-shared',
-        default="gs://kubernetes-jenkins/shared-results/",
+        default='gs://kubernetes-jenkins/shared-results/',
         help='Get shared build from this bucket')
     parser.add_argument(
         '--cluster', default='bootstrap-e2e', help='Name of the cluster')

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -488,6 +488,7 @@ def main(args):
             build_file += args.use_shared_build + '-'
         build_file += 'build-location.txt'
         gcs_path = os.path.join(args.gcs_shared, os.getenv('PULL_REFS', ''), build_file)
+        print >>sys.stderr, "Getting shared build location from: "+gcs_path
         try:
             # tell kubetest to extract from this location
             args.kubetest_args.append('--extract=' + read_gcs_path(gcs_path))

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -484,11 +484,16 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
 
     def test_use_shared_build(self):
         args = kubernetes_e2e.parse_args([
-            '--use-shared-build'
+            '--use-shared-build=bazel'
         ])
+        def expect_bazel_gcs(path):
+            bazel_default = os.path.join(
+                'gs://kubernetes-jenkins/shared-results', 'bazel-build-location.txt')
+            self.assertEqual(path, bazel_default)
+            return always_kubernetes()
         # normal path
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
-            with Stub(kubernetes_e2e, 'read_gcs_path', always_kubernetes):
+            with Stub(kubernetes_e2e, 'read_gcs_path', expect_bazel_gcs):
                 kubernetes_e2e.main(args)
         lastcall = self.callstack[-1]
         self.assertIn('--extract=kubernetes', lastcall)

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -501,13 +501,13 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         args = kubernetes_e2e.parse_args([
             '--use-shared-build'
         ])
-        def expect_bazel_gcs(path):
+        def expect_normal_gcs(path):
             bazel_default = os.path.join(
                 'gs://kubernetes-jenkins/shared-results', 'build-location.txt')
             self.assertEqual(path, bazel_default)
             return always_kubernetes()
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
-            with Stub(kubernetes_e2e, 'read_gcs_path', expect_bazel_gcs):
+            with Stub(kubernetes_e2e, 'read_gcs_path', expect_normal_gcs):
                 kubernetes_e2e.main(args)
         lastcall = self.callstack[-1]
         self.assertIn('--extract=kubernetes', lastcall)

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -486,16 +486,13 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         args = kubernetes_e2e.parse_args([
             '--use-shared-build'
         ])
+        # normal path
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             with Stub(kubernetes_e2e, 'read_gcs_path', always_kubernetes):
                 kubernetes_e2e.main(args)
         lastcall = self.callstack[-1]
         self.assertIn('--extract=kubernetes', lastcall)
-
-    def test_use_shared_build_fallback(self):
-        args = kubernetes_e2e.parse_args([
-            '--use-shared-build'
-        ])
+        # test failure to read shared path from GCS
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             with Stub(kubernetes_e2e, 'read_gcs_path', raise_urllib2_error):
                 with Stub(os, 'getcwd', always_kubernetes):

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -499,10 +499,11 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         with Stub(kubernetes_e2e, 'check_env', self.fake_check_env):
             with Stub(kubernetes_e2e, 'read_gcs_path', raise_urllib2_error):
                 with Stub(os, 'getcwd', always_kubernetes):
-                    kubernetes_e2e.main(args)
-        lastcall = self.callstack[-1]
-        self.assertIn('--extract=local', lastcall)
-        self.assertIn('--build', lastcall)
+                    try:
+                        kubernetes_e2e.main(args)
+                    except RuntimeError as err:
+                        if not err.message.startswith('Failed to get shared build location'):
+                            raise err
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This will allow some jobs to reuse the same kubernetes build. In particular our PR e2e jobs each do a build and then `kubetest --extract=local ...` instead of one shared build.

TODO:
 - [x] Make `run_after_success` jobs able to find builds
  - This is done by logging the path to a text file in GCS similar to pr-logs/directory since we can't just move all the build locations. This file is at `gs://some-shared-bucket/$PULL_REFS/(bazel-)?build-location.txt`
 - [x] add test(s) to make sure the config does not contain new invalid flag combinations
 - [x] make jobs fall back to local builds
 - [x] Configure PR e2e jobs to use a shared build step

FOLLOW-UP:
 - [ ] verify that this works for the test job, expand to all PR e2e jobs

This is a little ugly but after a lot of discussion on-and-offline (#4047, #4074, ...) it seems to be the best solution for the moment. We may want to revisit the entire `run_after_success` system at some point in the future.