### PR TITLE
Expose the same environment variables in Jenkins and Kube jobs

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,8 +21,8 @@ DECK_VERSION       ?= 0.43
 SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.8
-PLANK_VERSION      ?= 0.40
-JENKINS_VERSION    ?= 0.39
+PLANK_VERSION      ?= 0.41
+JENKINS_VERSION    ?= 0.40
 TIDE_VERSION       ?= 0.1
 
 # These are the usual GKE variables.

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.40
+        image: gcr.io/k8s-prow/plank:0.41
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -232,11 +232,6 @@ func (c *Controller) syncJenkinsJob(pj kube.ProwJob, reports chan<- kube.ProwJob
 		pj.Status.State = kube.PendingState
 		c.incrementNumPendingJobs(pj.Spec.Job)
 		env := npj.EnvForSpec(pj.Spec)
-		// These two are provided for backwards-compatibility with scripts that
-		// used the ghprb plugin.
-		// TODO(spxtr): Remove these.
-		env["ghprbPullId"] = pj.Spec.Refs.String()
-		env["ghprbTargetBranch"] = pj.Spec.Refs.BaseRef
 
 		br := BuildRequest{
 			JobName:     pj.Spec.Job,

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -143,6 +143,9 @@ func TestSyncJenkinsJob(t *testing.T) {
 		{
 			name: "start new job",
 			pj: kube.ProwJob{
+				Spec: kube.ProwJobSpec{
+					Type: kube.PostsubmitJob,
+				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
 				},
@@ -157,6 +160,12 @@ func TestSyncJenkinsJob(t *testing.T) {
 			pj: kube.ProwJob{
 				Spec: kube.ProwJobSpec{
 					Type: kube.PresubmitJob,
+					Refs: kube.Refs{
+						Pulls: []kube.Pull{{
+							Number: 1,
+							SHA:    "fake-sha",
+						}},
+					},
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,
@@ -199,7 +208,10 @@ func TestSyncJenkinsJob(t *testing.T) {
 					Type:   kube.PresubmitJob,
 					Report: true,
 					Refs: kube.Refs{
-						Pulls: []kube.Pull{{}},
+						Pulls: []kube.Pull{{
+							Number: 1,
+							SHA:    "fake-sha",
+						}},
 					},
 				},
 
@@ -232,6 +244,12 @@ func TestSyncJenkinsJob(t *testing.T) {
 			pj: kube.ProwJob{
 				Spec: kube.ProwJobSpec{
 					Type: kube.PresubmitJob,
+					Refs: kube.Refs{
+						Pulls: []kube.Pull{{
+							Number: 1,
+							SHA:    "fake-sha",
+						}},
+					},
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.PendingState,

--- a/prow/npj/BUILD
+++ b/prow/npj/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -29,4 +30,12 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["npj_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//prow/kube:go_default_library"],
 )

--- a/prow/npj/npj_test.go
+++ b/prow/npj/npj_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package npj
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/test-infra/prow/kube"
+)
+
+func TestEnvironmentForSpec(t *testing.T) {
+	var tests = []struct {
+		name     string
+		spec     kube.ProwJobSpec
+		expected map[string]string
+	}{
+		{
+			name: "periodic job",
+			spec: kube.ProwJobSpec{
+				Type: kube.PeriodicJob,
+				Job:  "job-name",
+			},
+			expected: map[string]string{
+				"JOB_NAME": "job-name",
+			},
+		},
+		{
+			name: "postsubmit job",
+			spec: kube.ProwJobSpec{
+				Type: kube.PostsubmitJob,
+				Job:  "job-name",
+				Refs: kube.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+				},
+			},
+			expected: map[string]string{
+				"JOB_NAME":      "job-name",
+				"REPO_OWNER":    "org-name",
+				"REPO_NAME":     "repo-name",
+				"PULL_BASE_REF": "base-ref",
+				"PULL_BASE_SHA": "base-sha",
+				"PULL_REFS":     "base-ref:base-sha",
+			},
+		},
+		{
+			name: "batch job",
+			spec: kube.ProwJobSpec{
+				Type: kube.BatchJob,
+				Job:  "job-name",
+				Refs: kube.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []kube.Pull{{
+						Number: 1,
+						Author: "author-name",
+						SHA:    "pull-sha",
+					}, {
+						Number: 2,
+						Author: "other-author-name",
+						SHA:    "second-pull-sha",
+					}},
+				},
+			},
+			expected: map[string]string{
+				"JOB_NAME":      "job-name",
+				"REPO_OWNER":    "org-name",
+				"REPO_NAME":     "repo-name",
+				"PULL_BASE_REF": "base-ref",
+				"PULL_BASE_SHA": "base-sha",
+				"PULL_REFS":     "base-ref:base-sha,1:pull-sha,2:second-pull-sha",
+			},
+		},
+		{
+			name: "presubmit job",
+			spec: kube.ProwJobSpec{
+				Type: kube.PresubmitJob,
+				Job:  "job-name",
+				Refs: kube.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []kube.Pull{{
+						Number: 1,
+						Author: "author-name",
+						SHA:    "pull-sha",
+					}},
+				},
+			},
+			expected: map[string]string{
+				"JOB_NAME":      "job-name",
+				"REPO_OWNER":    "org-name",
+				"REPO_NAME":     "repo-name",
+				"PULL_BASE_REF": "base-ref",
+				"PULL_BASE_SHA": "base-sha",
+				"PULL_REFS":     "base-ref:base-sha,1:pull-sha",
+				"PULL_NUMBER":   "1",
+				"PULL_PULL_SHA": "pull-sha",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if actual, expected := EnvForSpec(test.spec), test.expected; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: got environment:\n\t%v\n\tbut expected:\n\t%v", test.name, actual, expected)
+		}
+	}
+}

--- a/prow/plank/plank_test.go
+++ b/prow/plank/plank_test.go
@@ -264,7 +264,8 @@ func TestSyncKubernetesJob(t *testing.T) {
 			name: "start new pod",
 			pj: kube.ProwJob{
 				Spec: kube.ProwJobSpec{
-					Job: "boop",
+					Job:  "boop",
+					Type: kube.PeriodicJob,
 				},
 				Status: kube.ProwJobStatus{
 					State: kube.TriggeredState,

--- a/verify/go_install_from_commit.sh
+++ b/verify/go_install_from_commit.sh
@@ -21,7 +21,7 @@ PKG=$1
 COMMIT=$2
 export GOPATH=$3
 
-go get -d -u "${PKG}" 2>/dev/null
+go get -d -u "${PKG}"
 cd "${GOPATH}/src/${PKG}"
 git checkout -q "${COMMIT}"
 go install "${PKG}"


### PR DESCRIPTION
This patch DRYs out the way that we determine which environment
variables to expose to the job in order to ensure that we have the same
API for Jenkins jobs as we do for Kubernetes jobs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes #4112 
/area prow
/cc @spxtr @kargakis 