### PR TITLE
Add anchors to PR dashboard

### DIFF
--- a/gubernator/templates/pr_dashboard.html
+++ b/gubernator/templates/pr_dashboard.html
@@ -22,6 +22,7 @@ View
 		% continue
 	% endif
 	<h3 class="pr-section">
+	<a id="section-{{title|slugify}}"></a>
 	% if search
 	<a href="https://github.com/pulls?q={{search|quote_plus}}">{{title}}</a>
 	% else


### PR DESCRIPTION
Small PR to add anchors that can be linked to, to the PR dashboard.

/area gubernator