### PR TITLE
Prow: move punctuation out of respond format string and into reply strings

### DIFF
--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -209,7 +209,7 @@ type handler struct {
 
 func newAssignHandler(e *event, gc githubClient, log *logrus.Entry) *handler {
 	addFailureResponse := func(mu github.MissingUsers) string {
-		return fmt.Sprintf("GitHub didn't allow me to assign the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) can be assigned", strings.Join(mu.Users, ", "), e.org, e.org)
+		return fmt.Sprintf("GitHub didn't allow me to assign the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) can be assigned.", strings.Join(mu.Users, ", "), e.org, e.org)
 	}
 
 	return &handler{
@@ -226,7 +226,7 @@ func newAssignHandler(e *event, gc githubClient, log *logrus.Entry) *handler {
 
 func newReviewHandler(e *event, gc githubClient, log *logrus.Entry) *handler {
 	addFailureResponse := func(mu github.MissingUsers) string {
-		return fmt.Sprintf("GitHub didn't allow me to request PR reviews from the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) can review this PR, and authors cannot review their own PRs", strings.Join(mu.Users, ", "), e.org, e.repo)
+		return fmt.Sprintf("GitHub didn't allow me to request PR reviews from the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) can review this PR, and authors cannot review their own PRs.", strings.Join(mu.Users, ", "), e.org, e.repo)
 	}
 
 	return &handler{

--- a/prow/plugins/close/close.go
+++ b/prow/plugins/close/close.go
@@ -74,7 +74,7 @@ func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) err
 			} else {
 				log.WithError(err).Errorf("Failed AssignIssue(%s, %s, %d, %s)", org, repo, number, commentAuthor)
 			}
-			resp := fmt.Sprintf("you can't close an issue unless you authored it or you are assigned to it, %s", msg)
+			resp := fmt.Sprintf("you can't close an issue unless you authored it or you are assigned to it, %s.", msg)
 			log.Infof("Commenting \"%s\".", resp)
 			return gc.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
 		}

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -211,7 +211,7 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, ic github.Issue
 	if totalProblems == 1 {
 		s = ""
 	}
-	response := fmt.Sprintf("%d warning%s", totalProblems, s)
+	response := fmt.Sprintf("%d warning%s.", totalProblems, s)
 
 	return ghc.CreateReview(org, repo, ic.Issue.Number, github.DraftReview{
 		Body:     plugins.FormatICResponse(ic.Comment, response),

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -45,8 +45,8 @@ var (
 	labelRegex              = regexp.MustCompile(`(?m)^/(area|priority|kind|sig)\s*(.*)$`)
 	removeLabelRegex        = regexp.MustCompile(`(?m)^/remove-(area|priority|kind|sig)\s*(.*)$`)
 	sigMatcher              = regexp.MustCompile(`(?m)@kubernetes/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)`)
-	chatBack                = "Reiterating the mentions to trigger a notification: \n%v"
-	nonExistentLabelOnIssue = "Those labels are not set on the issue: `%v`"
+	chatBack                = "Reiterating the mentions to trigger a notification: \n%v."
+	nonExistentLabelOnIssue = "Those labels are not set on the issue: `%v`."
 	kindMap                 = map[string]string{
 		"bugs":             "kind/bug",
 		"feature-requests": "kind/feature",
@@ -246,7 +246,7 @@ func handle(gc githubClient, log *logrus.Entry, ae assignEvent, sc slackClient) 
 
 		// If sig matches then send a notification on slack.
 		for _, sig := range sigMatches {
-			msg := fmt.Sprintf("Message: ```%s```\nIssue: %d, %s\nUrl: %s", ae.body, ae.issue.Number, ae.issue.Title, ae.issue.HTMLURL)
+			msg := fmt.Sprintf("Message: ```%s```\nIssue: %d, %s\nUrl: %s.", ae.body, ae.issue.Number, ae.issue.Title, ae.issue.HTMLURL)
 			if err := sc.WriteMessage(plugins.FormatResponseRaw(ae.body, ae.url, ae.login, msg), "sig-"+sig[1]); err != nil {
 				log.WithError(err).Error("Failed to send message on slack channel: ", "sig-"+sig[1], " with message ", msg)
 			}

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -170,7 +170,7 @@ func handle(gc githubClient, log *logrus.Entry, e *event) error {
 	}
 	isAuthor := e.commentAuthor == e.prAuthor
 	if isAuthor && wantLGTM {
-		resp := "you cannot LGTM your own PR"
+		resp := "you cannot LGTM your own PR."
 		log.Infof("Commenting with \"%s\".", resp)
 		return gc.CreateComment(e.org, e.repo, e.number, plugins.FormatResponseRaw(e.body, e.htmlurl, e.commentAuthor, resp))
 	} else if !isAuthor && !isAssignee {
@@ -184,7 +184,7 @@ func handle(gc githubClient, log *logrus.Entry, e *event) error {
 			} else {
 				log.WithError(err).Errorf("Failed AssignIssue(%s, %s, %d, %s)", e.org, e.repo, e.number, e.commentAuthor)
 			}
-			resp := "changing LGTM is restricted to assignees, and " + msg
+			resp := "changing LGTM is restricted to assignees, and " + msg + "."
 			log.Infof("Reply to assign via /lgtm request with comment: \"%s\"", resp)
 			return gc.CreateComment(e.org, e.repo, e.number, plugins.FormatResponseRaw(e.body, e.htmlurl, e.commentAuthor, resp))
 		}

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -91,7 +91,7 @@ func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) err
 	isAuthor := ic.Issue.IsAuthor(ic.Comment.User.Login)
 
 	if !isMember && !isAuthor {
-		resp := "you can only set release notes if you are the author or an org member"
+		resp := "you can only set release notes if you are the author or an org member."
 		log.Infof("Commenting with \"%s\".", resp)
 		return gc.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
 	}

--- a/prow/plugins/reopen/reopen.go
+++ b/prow/plugins/reopen/reopen.go
@@ -61,7 +61,7 @@ func handle(gc githubClient, log *logrus.Entry, ic github.IssueCommentEvent) err
 
 	// Allow assignees and authors to re-open issues.
 	if !ic.Issue.IsAuthor(commentAuthor) && !ic.Issue.IsAssignee(commentAuthor) {
-		resp := "you can't re-open an issue/PR unless you authored it or you are assigned to it"
+		resp := "you can't re-open an issue/PR unless you authored it or you are assigned to it."
 		log.Infof("Commenting \"%s\".", resp)
 		return gc.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
 	}

--- a/prow/plugins/respond.go
+++ b/prow/plugins/respond.go
@@ -34,7 +34,7 @@ func FormatICResponse(ic github.IssueComment, s string) string {
 
 // FormatResponseRaw nicely formats a response for one does not have an issue comment
 func FormatResponseRaw(body, bodyURL, login, reply string) string {
-	format := `@%s: %s.
+	format := `@%s: %s
 
 <details>
 

--- a/prow/plugins/respond_test.go
+++ b/prow/plugins/respond_test.go
@@ -29,7 +29,7 @@ func TestFormatICResponse(t *testing.T) {
 		User:    github.User{Login: "ca"},
 		HTMLURL: "happygoodsite.com",
 	}
-	s := "you are a nice person"
+	s := "you are a nice person."
 	out := FormatICResponse(ic, s)
 	if !strings.HasPrefix(out, "@ca: you are a nice person.") {
 		t.Errorf("Expected compliments to the comment author, got:\n%s", out)
@@ -44,7 +44,7 @@ func TestFormatResponseRaw(t *testing.T) {
 	body := "Looks neat.\r\nI like it.\r\n"
 	user := "ca"
 	htmlURL := "happygoodsite.com"
-	comment := "you are a nice person"
+	comment := "you are a nice person."
 
 	out := FormatResponseRaw(body, htmlURL, user, comment)
 	if !strings.HasPrefix(out, "@ca: you are a nice person.") {

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -102,7 +102,7 @@ func handleIC(c client, ic github.IssueCommentEvent) error {
 			return err
 		}
 		if !trusted {
-			resp := fmt.Sprintf("you can't request testing unless you are a [%s](https://github.com/orgs/%s/people) member", trustedOrg, trustedOrg)
+			resp := fmt.Sprintf("you can't request testing unless you are a [%s](https://github.com/orgs/%s/people) member.", trustedOrg, trustedOrg)
 			c.Logger.Infof("Commenting \"%s\".", resp)
 			return c.GitHubClient.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
 		}


### PR DESCRIPTION
This fixes comments like: https://github.com/kubernetes/test-infra/pull/3767#issuecomment-318716059 (`I updated Prow config for you!.` should be `I updated Prow config for you!`)