### PR TITLE
Add upgrade CIs for kube-proxy daemonset migration path

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4094,6 +4094,46 @@
       "sig-network"
     ]
   },
+  "ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=Networking --ginkgo.skip=Networking-Performance --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=90m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetDowngrade\\] --upgrade-target=ci/latest-1.7"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network",
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds": {
+    "args": [
+      "--check-leaked-resources",
+      "--check-version-skew=false",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds.env",
+      "--extract=ci/latest",
+      "--extract=ci/latest-1.7",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=Networking --ginkgo.skip=Networking-Performance --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--timeout=90m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetUpgrade\\] --upgrade-target=ci/latest"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network",
+      "sig-cluster-lifecycle"
+    ]
+  },
   "ci-kubernetes-e2e-gci-gce-proto": {
     "args": [
       "--check-leaked-resources",

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env
@@ -1,0 +1,5 @@
+### job-env
+
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+KUBE_NODE_OS_DISTRIBUTION=gci
+KUBE_PROXY_DAEMONSET=true

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds.env
@@ -1,0 +1,5 @@
+### job-env
+
+STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+KUBE_NODE_OS_DISTRIBUTION=gci
+KUBE_PROXY_DAEMONSET=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7998,6 +7998,74 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
+- interval: 2h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
+  spec:
+    containers:
+    - args:
+      - --timeout=110
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170818-da12177a
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds
+  spec:
+    containers:
+    - args:
+      - --timeout=110
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170818-da12177a
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-proto

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1658,6 +1658,11 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
 - name: ci-kubernetes-e2e-mlkube-gke
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-mlkube-gke
+# kube-proxy daemonset migration jobs
+- name: ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
+- name: ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds
 #ibm ppc64le test results
 - name: ppc64le-conformance
   gcs_prefix: ppc64le-kubernetes/logs/ci-conformance-kubernetes
@@ -3817,6 +3822,12 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gke-serial
     base_options: 'include-filter-by-regex=\[sig-network\]'
     description: 'network gci-gke serial e2e tests for master branch'
+  - name: gci-gce-latest-upgrade-kube-proxy-ds
+    test_group_name: ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds
+    description: 'upgrade cluster and migrate kube-proxy from static pods to a daemonset'
+  - name: gci-gce-latest-downgrade-kube-proxy-ds
+    test_group_name: ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
+    description: 'downgrade cluster and migrate kube-proxy from a daemonset to static pods'
 
 - name: sig-node
   dashboard_tab:


### PR DESCRIPTION
From kubernetes/kubernetes#23225, we are adding the option for GCE to run kube-proxy as a DaemonSet in 1.8. The plan is to have this option enabled by default in a future release. Adding upgrade CIs to evaluate kube-proxy's migration path (static pods -> daemonset and reverse).

This is not ready until https://github.com/kubernetes/kubernetes/pull/50705 and https://github.com/kubernetes/kubernetes/pull/50940 are merged.

cc @krzyzacy 