### PR TITLE
Do not set STACKDRIVER_API_ENDPOINT_OVERRIDE flag on GKE

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170821-76a9f30a
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170821-2bb09e52
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -162,30 +162,20 @@ func newGKE(provider, project, zone, region, network, image, cluster string, tes
 	}
 
 	var endpoint string
-	var monitoring string
 	switch env := *gkeEnvironment; {
 	case env == "test":
 		endpoint = "https://test-container.sandbox.googleapis.com/"
-		monitoring = "https://test-monitoring.sandbox.googleapis.com/"
 	case env == "staging":
 		endpoint = "https://staging-container.sandbox.googleapis.com/"
-		monitoring = "https://staging-monitoring.sandbox.googleapis.com/"
 	case env == "prod":
 		endpoint = "https://container.googleapis.com/"
 	case urlRe.MatchString(env):
 		endpoint = env
-		// dev jobs point to test monitoring.
-		monitoring = "https://test-container.sandbox.googleapis.com/"
 	default:
 		return nil, fmt.Errorf("--gke-environment must be one of {test,staging,prod} or match %v, found %q", urlRe, env)
 	}
 	if err := os.Setenv("CLOUDSDK_API_ENDPOINT_OVERRIDES_CONTAINER", endpoint); err != nil {
 		return nil, err
-	}
-	if monitoring != "" {
-		if err := os.Setenv("STACKDRIVER_API_ENDPOINT_OVERRIDE", monitoring); err != nil {
-			return nil, err
-		}
 	}
 
 	// Override kubecfg to a temporary file rather than trashing the user's.

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -157,7 +157,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -312,7 +312,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -455,7 +455,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -610,7 +610,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1347,7 +1347,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1381,7 +1381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1415,7 +1415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1449,7 +1449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1483,7 +1483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1517,7 +1517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1551,7 +1551,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1585,7 +1585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1619,7 +1619,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1653,7 +1653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1687,7 +1687,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1721,7 +1721,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1755,7 +1755,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1789,7 +1789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1823,7 +1823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1857,7 +1857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1891,7 +1891,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1925,7 +1925,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1959,7 +1959,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1993,7 +1993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2027,7 +2027,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2061,7 +2061,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2095,7 +2095,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2129,7 +2129,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2163,7 +2163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2197,7 +2197,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2231,7 +2231,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2265,7 +2265,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2299,7 +2299,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2333,7 +2333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2367,7 +2367,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2401,7 +2401,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2469,7 +2469,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2505,7 +2505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2541,7 +2541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2577,7 +2577,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2613,7 +2613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2649,7 +2649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2685,7 +2685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2721,7 +2721,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2757,7 +2757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2793,7 +2793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2829,7 +2829,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2865,7 +2865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2901,7 +2901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2937,7 +2937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2973,7 +2973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3009,7 +3009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3045,7 +3045,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3081,7 +3081,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3117,7 +3117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3153,7 +3153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3189,7 +3189,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3225,7 +3225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3261,7 +3261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3297,7 +3297,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3333,7 +3333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3369,7 +3369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3405,7 +3405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3441,7 +3441,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3477,7 +3477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3513,7 +3513,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3549,7 +3549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3585,7 +3585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3621,7 +3621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3657,7 +3657,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3693,7 +3693,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3729,7 +3729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3765,7 +3765,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3801,7 +3801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3837,7 +3837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3873,7 +3873,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3909,7 +3909,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3943,7 +3943,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3977,7 +3977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4011,7 +4011,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4045,7 +4045,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4079,7 +4079,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4113,7 +4113,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4147,7 +4147,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4181,7 +4181,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4215,7 +4215,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4249,7 +4249,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4283,7 +4283,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4317,7 +4317,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4351,7 +4351,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4385,7 +4385,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4419,7 +4419,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4453,7 +4453,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4487,7 +4487,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4521,7 +4521,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4555,7 +4555,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4589,7 +4589,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4623,7 +4623,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4657,7 +4657,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4691,7 +4691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4725,7 +4725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4759,7 +4759,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4793,7 +4793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4827,7 +4827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4861,7 +4861,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4895,7 +4895,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4929,7 +4929,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4963,7 +4963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4997,7 +4997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5031,7 +5031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5065,7 +5065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5099,7 +5099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5133,7 +5133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5167,7 +5167,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5201,7 +5201,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5235,7 +5235,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5269,7 +5269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5303,7 +5303,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5337,7 +5337,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5371,7 +5371,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5405,7 +5405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5439,7 +5439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5473,7 +5473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5507,7 +5507,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5541,7 +5541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5575,7 +5575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5609,7 +5609,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5643,7 +5643,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5677,7 +5677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5711,7 +5711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5745,7 +5745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5779,7 +5779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5813,7 +5813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5847,7 +5847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5881,7 +5881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5915,7 +5915,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5949,7 +5949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5983,7 +5983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6017,7 +6017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6085,7 +6085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6119,7 +6119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6153,7 +6153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6187,7 +6187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6221,7 +6221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6255,7 +6255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6289,7 +6289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6323,7 +6323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6357,7 +6357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6391,7 +6391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6425,7 +6425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6459,7 +6459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6493,7 +6493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6527,7 +6527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6563,7 +6563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6599,7 +6599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6635,7 +6635,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6671,7 +6671,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6707,7 +6707,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6743,7 +6743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6779,7 +6779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6815,7 +6815,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6851,7 +6851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6887,7 +6887,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6923,7 +6923,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6959,7 +6959,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6995,7 +6995,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7031,7 +7031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7067,7 +7067,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7103,7 +7103,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7139,7 +7139,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7175,7 +7175,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7209,7 +7209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7243,7 +7243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7277,7 +7277,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7311,7 +7311,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7345,7 +7345,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7379,7 +7379,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7413,7 +7413,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7447,7 +7447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7481,7 +7481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7515,7 +7515,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7549,7 +7549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7583,7 +7583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7617,7 +7617,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7651,7 +7651,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7685,7 +7685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7719,7 +7719,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7753,7 +7753,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7787,7 +7787,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7821,7 +7821,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7855,7 +7855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7889,7 +7889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7923,7 +7923,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7957,7 +7957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7991,7 +7991,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8025,7 +8025,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8059,7 +8059,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8093,7 +8093,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8127,7 +8127,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8161,7 +8161,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8195,7 +8195,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8229,7 +8229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8263,7 +8263,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8297,7 +8297,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8331,7 +8331,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8365,7 +8365,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8399,7 +8399,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8433,7 +8433,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8467,7 +8467,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8501,7 +8501,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8535,7 +8535,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8569,7 +8569,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8603,7 +8603,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8637,7 +8637,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8671,7 +8671,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8705,7 +8705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8739,7 +8739,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8773,7 +8773,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8807,7 +8807,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8841,7 +8841,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8875,7 +8875,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8909,7 +8909,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8943,7 +8943,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8977,7 +8977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9011,7 +9011,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9045,7 +9045,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9079,7 +9079,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9113,7 +9113,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9147,7 +9147,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9181,7 +9181,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9215,7 +9215,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9249,7 +9249,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9283,7 +9283,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9317,7 +9317,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9351,7 +9351,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9385,7 +9385,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9419,7 +9419,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9453,7 +9453,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9487,7 +9487,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9521,7 +9521,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9555,7 +9555,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9589,7 +9589,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9623,7 +9623,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9657,7 +9657,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9691,7 +9691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9725,7 +9725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9759,7 +9759,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9793,7 +9793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9827,7 +9827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9861,7 +9861,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9895,7 +9895,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9929,7 +9929,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9963,7 +9963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9997,7 +9997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10031,7 +10031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10065,7 +10065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10099,7 +10099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10133,7 +10133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10167,7 +10167,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10201,7 +10201,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10235,7 +10235,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10269,7 +10269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10303,7 +10303,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10337,7 +10337,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10371,7 +10371,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10439,7 +10439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10473,7 +10473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10507,7 +10507,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10541,7 +10541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10575,7 +10575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10609,7 +10609,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10643,7 +10643,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10677,7 +10677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10711,7 +10711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10745,7 +10745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10779,7 +10779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10813,7 +10813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10847,7 +10847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10881,7 +10881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10915,7 +10915,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10949,7 +10949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10983,7 +10983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11017,7 +11017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11051,7 +11051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11085,7 +11085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11119,7 +11119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11153,7 +11153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11187,7 +11187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11221,7 +11221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11255,7 +11255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11289,7 +11289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11323,7 +11323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11357,7 +11357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11391,7 +11391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11425,7 +11425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11459,7 +11459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11493,7 +11493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11527,7 +11527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11561,7 +11561,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11595,7 +11595,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11629,7 +11629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11663,7 +11663,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11697,7 +11697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11731,7 +11731,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11765,7 +11765,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11799,7 +11799,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11833,7 +11833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11867,7 +11867,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11901,7 +11901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11935,7 +11935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11969,7 +11969,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12003,7 +12003,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12038,7 +12038,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12072,7 +12072,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12106,7 +12106,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12140,7 +12140,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12174,7 +12174,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12208,7 +12208,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12242,7 +12242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12276,7 +12276,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12310,7 +12310,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12344,7 +12344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12378,7 +12378,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12412,7 +12412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12446,7 +12446,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12480,7 +12480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12514,7 +12514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12548,7 +12548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12582,7 +12582,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12616,7 +12616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12650,7 +12650,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12684,7 +12684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12718,7 +12718,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12752,7 +12752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12786,7 +12786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12820,7 +12820,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12854,7 +12854,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12888,7 +12888,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12922,7 +12922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12956,7 +12956,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12990,7 +12990,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13024,7 +13024,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13058,7 +13058,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13092,7 +13092,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13126,7 +13126,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13160,7 +13160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13194,7 +13194,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13228,7 +13228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13262,7 +13262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13296,7 +13296,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13330,7 +13330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13364,7 +13364,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13398,7 +13398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13432,7 +13432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13466,7 +13466,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13502,7 +13502,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13538,7 +13538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13574,7 +13574,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13610,7 +13610,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13646,7 +13646,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13682,7 +13682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13718,7 +13718,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13754,7 +13754,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13790,7 +13790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13826,7 +13826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13862,7 +13862,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13898,7 +13898,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13935,7 +13935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13971,7 +13971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14007,7 +14007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14043,7 +14043,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14079,7 +14079,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14115,7 +14115,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14151,7 +14151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14187,7 +14187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14223,7 +14223,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14259,7 +14259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14295,7 +14295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14331,7 +14331,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14367,7 +14367,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14403,7 +14403,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14439,7 +14439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14473,7 +14473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14550,7 +14550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14621,7 +14621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14660,7 +14660,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14699,7 +14699,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14738,7 +14738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14777,7 +14777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14816,7 +14816,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14855,7 +14855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14894,7 +14894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14933,7 +14933,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14972,7 +14972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15011,7 +15011,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15050,7 +15050,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15089,7 +15089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15128,7 +15128,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15167,7 +15167,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15206,7 +15206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15245,7 +15245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15284,7 +15284,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15323,7 +15323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15362,7 +15362,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15401,7 +15401,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15440,7 +15440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15474,7 +15474,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15496,7 +15496,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -15532,7 +15532,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-6bf72f56
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170821-8474e659
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -34,7 +34,7 @@ import traceback
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20170821-76a9f30a'
+DEFAULT_KUBEKINS_TAG = 'v20170821-2bb09e52'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
fix https://github.com/kubernetes/kubernetes/issues/45998
fix https://github.com/kubernetes/kubernetes/issues/46572

Metrics are exported to prod Stackdriver backend.