### PR TITLE
Add route to velodrome's influxdb instance through a different port.

### DIFF
--- a/velodrome/grafana-stack/datasource.sh
+++ b/velodrome/grafana-stack/datasource.sh
@@ -32,7 +32,7 @@ env - server_hostname="${server_hostname}" envsubst <<EOF |
   "name": "github",
   "type": "influxdb",
   "access": "proxy",
-  "url": "http://${server_hostname}/influxdb/",
+  "url": "http://${server_hostname}:8181/",
   "user": "grafana",
   "password": "password",
   "database": "github",

--- a/velodrome/grafana-stack/nginx.yaml
+++ b/velodrome/grafana-stack/nginx.yaml
@@ -23,6 +23,8 @@ spec:
         ports:
         - name: nginx-port
           containerPort: 8080
+        - name: influxdb-port
+          containerPort: 8181
         volumeMounts:
         - mountPath: /etc/nginx
           name: nginx-config
@@ -46,6 +48,9 @@ spec:
   - name: nginx
     port: 80
     targetPort: nginx-port
+  - name: influxdb
+    port: 8181
+    targetPort: influxdb-port
   selector:
     app: nginx
     project: ${PROJECT}
@@ -88,6 +93,14 @@ data:
                 proxy_set_header X-Real-IP $remote_addr;
             }
             location /influxdb/ {
+                proxy_pass http://influxdb-${PROJECT}:8086/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+            }
+        }
+        server {
+            listen 8181;
+            location / {
                 proxy_pass http://influxdb-${PROJECT}:8086/;
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This avoids using a URI path like http://velodrome.k8s.io/influxdb/
Such a path is undesirable because it is not supported by the influxdb
python client which I want to use in the metrics-bigquery job instead of my own client.

The old route has been left in place to avoid breaking existing data flows. The influxdb grafana datasources on http://velodrome.k8s.io have been updated to use the new route.

/cc @apelisse 