### PR TITLE
Temporarily use a different GCS bucket for gke-regional job logs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -12913,6 +12913,7 @@ periodics:
     - args:
       - --timeout=170
       - --bare
+      - --upload=gs://shyamjvs-test/logs
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json


### PR DESCRIPTION
/cc @wojtek-t 