### PR TITLE
Add a prow plugin to label WIP pull requests

### DIFF
--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -56,6 +56,7 @@ const (
 	retestNotRequiredLabel         = "retest-not-required"
 	retestNotRequiredDocsOnlyLabel = "retest-not-required-docs-only"
 	doNotMergeLabel                = "do-not-merge"
+	wipLabel                       = "do-not-merge/work-in-progress"
 	claYesLabel                    = "cla: yes"
 	claNoLabel                     = "cla: no"
 	cncfClaYesLabel                = "cncf-cla: yes"
@@ -1081,7 +1082,7 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 	}
 
 	// PR cannot have any labels which prevent merging.
-	for _, label := range []string{cherrypickUnapprovedLabel, blockedPathsLabel, deprecatedReleaseNoteLabelNeeded, releaseNoteLabelNeeded, doNotMergeLabel} {
+	for _, label := range []string{cherrypickUnapprovedLabel, blockedPathsLabel, deprecatedReleaseNoteLabelNeeded, releaseNoteLabelNeeded, doNotMergeLabel, wipLabel} {
 		if obj.HasLabel(label) {
 			sq.SetMergeStatus(obj, noMergeMessage(label))
 			return false

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -122,6 +122,10 @@ func MissingReleaseNoteIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, releaseNoteLabelNeeded}, true)
 }
 
+func WorkInProgressIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, wipLabel}, true)
+}
+
 func DoNotMergeMilestoneIssue() *github.Issue {
 	issue := github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel}, true)
 	milestone := &github.Milestone{
@@ -856,6 +860,20 @@ func TestSubmitQueue(t *testing.T) {
 			retest1Pass:     true,
 			retest2Pass:     true,
 			reason:          noMergeMessage(blockedPathsLabel),
+			state:           "pending",
+		},
+		{
+			name:            "Fail because work-in-progress label is present",
+			pr:              ValidPR(),
+			issue:           WorkInProgressIssue(),
+			events:          NewLGTMEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			retest1Pass:     true,
+			retest2Pass:     true,
+			reason:          noMergeMessage(wipLabel),
 			state:           "pending",
 		},
 		// Should fail because the 'do-not-merge-milestone' is set.

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.145
+HOOK_VERSION       ?= 0.146
 SINKER_VERSION     ?= 0.16
 DECK_VERSION       ?= 0.43
 SPLICE_VERSION     ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.145
+        image: gcr.io/k8s-prow/hook:0.146
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -38,6 +38,11 @@ type FakeClient struct {
 	LabelsAdded   []string
 	LabelsRemoved []string
 
+	// org/repo#number:body
+	IssueCommentsAdded []string
+	// org/repo#issuecommentid
+	IssueCommentsDeleted []string
+
 	// org/repo#issuecommentid:reaction
 	IssueReactionsAdded   []string
 	CommentReactionsAdded []string
@@ -68,6 +73,7 @@ func (f *FakeClient) ListIssueComments(owner, repo string, number int) ([]github
 }
 
 func (f *FakeClient) CreateComment(owner, repo string, number int, comment string) error {
+	f.IssueCommentsAdded = append(f.IssueCommentsAdded, fmt.Sprintf("%s/%s#%d:%s", owner, repo, number, comment))
 	f.IssueComments[number] = append(f.IssueComments[number], github.IssueComment{
 		ID:   f.IssueCommentID,
 		Body: comment,
@@ -87,6 +93,7 @@ func (f *FakeClient) CreateIssueReaction(org, repo string, ID int, reaction stri
 }
 
 func (f *FakeClient) DeleteComment(owner, repo string, ID int) error {
+	f.IssueCommentsDeleted = append(f.IssueCommentsDeleted, fmt.Sprintf("%s/%s#%d", owner, repo, ID))
 	for num, ics := range f.IssueComments {
 		for i, ic := range ics {
 			if ic.ID == ID {

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -57,6 +57,7 @@ filegroup(
         "//prow/plugins/slackevents:all-srcs",
         "//prow/plugins/trigger:all-srcs",
         "//prow/plugins/updateconfig:all-srcs",
+        "//prow/plugins/wip:all-srcs",
         "//prow/plugins/yuks:all-srcs",
     ],
     tags = ["automanaged"],

--- a/prow/plugins/respond.go
+++ b/prow/plugins/respond.go
@@ -27,6 +27,20 @@ const AboutThisBotWithoutCommands = "Instructions for interacting with me using 
 const AboutThisBotCommands = "I understand the commands that are listed [here](https://github.com/kubernetes/test-infra/blob/master/commands.md)."
 const AboutThisBot = AboutThisBotWithoutCommands + " " + AboutThisBotCommands
 
+// FormatResponse nicely formats a response to a generic reason.
+func FormatResponse(to, message, reason string) string {
+	format := `@%s: %s
+
+<details>
+
+%s
+
+%s
+</details>`
+
+	return fmt.Sprintf(format, to, message, reason, AboutThisBotWithoutCommands)
+}
+
 // FormatICResponse nicely formats a response to an issue comment.
 func FormatICResponse(ic github.IssueComment, s string) string {
 	return FormatResponseRaw(ic.Body, ic.HTMLURL, ic.User.Login, s)
@@ -34,21 +48,14 @@ func FormatICResponse(ic github.IssueComment, s string) string {
 
 // FormatResponseRaw nicely formats a response for one does not have an issue comment
 func FormatResponseRaw(body, bodyURL, login, reply string) string {
-	format := `@%s: %s
-
-<details>
-
-In response to [this](%s):
+	format := `In response to [this](%s):
 
 %s
-
-%s
-</details>
 `
 	// Quote the user's comment by prepending ">" to each line.
 	var quoted []string
 	for _, l := range strings.Split(body, "\n") {
 		quoted = append(quoted, ">"+l)
 	}
-	return fmt.Sprintf(format, login, reply, bodyURL, strings.Join(quoted, "\n"), AboutThisBotWithoutCommands)
+	return FormatResponse(login, reply, fmt.Sprintf(format, bodyURL, strings.Join(quoted, "\n")))
 }

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -113,7 +113,7 @@ func handlePR(gc githubClient, le *logrus.Entry, pe github.PullRequestEvent) err
 	}
 
 	if err := gc.AddLabel(owner, repo, num, newLabel); err != nil {
-		return fmt.Errorf("can add label to %s/%s PR #%d: %v", owner, repo, num, err)
+		return fmt.Errorf("error adding label to %s/%s PR #%d: %v", owner, repo, num, err)
 	}
 
 	return nil

--- a/prow/plugins/wip/BUILD
+++ b/prow/plugins/wip/BUILD
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["wip-label.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/Sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["wip-label_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/Sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package wip will label a PR a work-in-progress if the author provides
+// a prefix to their pull request title to the same effect. The submit-
+// queue will not merge pull requests with the work-in-progress label.
+// The label will be removed when the title changes to no longer begin
+// with the prefix.
+package wip
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const (
+	label      = "do-not-merge/work-in-progress"
+	pluginName = "wip"
+)
+
+var (
+	titleRegex = regexp.MustCompile(`(?i)^(\[WIP\]|WIP)`)
+)
+
+type event struct {
+	org         string
+	repo        string
+	number      int
+	hasLabel    bool
+	needsLabel  bool
+	commentBody string
+}
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+}
+
+// Strict subset of *github.Client methods.
+type githubClient interface {
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	CreateComment(org, repo string, number int, comment string) error
+}
+
+func handlePullRequest(pc plugins.PluginClient, pe github.PullRequestEvent) error {
+	// These are the only actions indicating the PR title may have changed.
+	if pe.Action != github.PullRequestActionOpened && pe.Action != github.PullRequestActionEdited {
+		return nil
+	}
+
+	var (
+		org    = pe.PullRequest.Base.Repo.Owner.Login
+		repo   = pe.PullRequest.Base.Repo.Name
+		number = pe.PullRequest.Number
+		author = pe.PullRequest.User.Login
+		title  = pe.PullRequest.Title
+	)
+
+	currentLabels, err := pc.GitHubClient.GetIssueLabels(org, repo, number)
+	if err != nil {
+		return fmt.Errorf("could not get labels for PR %s/%s:%d in WIP plugin: %v", org, repo, number, err)
+	}
+	hasLabel := false
+	for _, l := range currentLabels {
+		if l.Name == label {
+			hasLabel = true
+		}
+	}
+
+	needsLabel := titleRegex.MatchString(title)
+
+	commentBody := plugins.FormatResponse(
+		author,
+		fmt.Sprintf(`Your pull request title starts with %q, so the %s label will be added.`, titleRegex.FindString(title), label),
+		`This label will ensure that your pull request will not be merged. Remove the prefix from your pull request title to trigger the removal of the label and allow for your pull request to be merged.`,
+	)
+	e := &event{
+		org:         org,
+		repo:        repo,
+		number:      number,
+		hasLabel:    hasLabel,
+		needsLabel:  needsLabel,
+		commentBody: commentBody,
+	}
+	return handle(pc.GitHubClient, pc.Logger, e)
+}
+
+// handle interacts with GitHub to drive the pull request to the
+// proper state by adding and removing comments and labels. If a
+// PR has a WIP prefix, it needs an explanatory comment and label.
+// Otherwise, neither should be present.
+func handle(gc githubClient, le *logrus.Entry, e *event) error {
+	if e.needsLabel && !e.hasLabel {
+		if err := gc.AddLabel(e.org, e.repo, e.number, label); err != nil {
+			le.Warnf("error while adding label %q: %v", label, err)
+			return err
+		}
+		if err := gc.CreateComment(e.org, e.repo, e.number, e.commentBody); err != nil {
+			le.Warnf("error while adding comment %q: %v", e.commentBody, err)
+			return err
+		}
+	} else if !e.needsLabel && e.hasLabel {
+		if err := gc.RemoveLabel(e.org, e.repo, e.number, label); err != nil {
+			le.Warnf("error while removing label %q: %v", label, err)
+			return err
+		}
+	}
+	return nil
+}

--- a/prow/plugins/wip/wip-label_test.go
+++ b/prow/plugins/wip/wip-label_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestWipLabel(t *testing.T) {
+	var testcases = []struct {
+		name          string
+		hasLabel      bool
+		needsLabel    bool
+		shouldLabel   bool
+		shouldUnlabel bool
+		shouldComment bool
+	}{
+		{
+			name:          "nothing to do, need nothing",
+			hasLabel:      false,
+			needsLabel:    false,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+			shouldComment: false,
+		},
+		{
+			name:          "needs label and comment",
+			hasLabel:      false,
+			needsLabel:    true,
+			shouldLabel:   true,
+			shouldUnlabel: false,
+			shouldComment: true,
+		},
+		{
+			name:          "unnecessary label should be removed",
+			hasLabel:      true,
+			needsLabel:    false,
+			shouldLabel:   false,
+			shouldUnlabel: true,
+			shouldComment: false,
+		},
+		{
+			name:          "nothing to do, have everything",
+			hasLabel:      true,
+			needsLabel:    true,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+			shouldComment: false,
+		},
+	}
+	for _, tc := range testcases {
+		fc := &fakegithub.FakeClient{
+			PullRequests:  make(map[int]*github.PullRequest),
+			IssueComments: make(map[int][]github.IssueComment),
+		}
+		org, repo, number, body := "org", "repo", 5, "comment"
+		e := &event{
+			org:         org,
+			repo:        repo,
+			number:      number,
+			hasLabel:    tc.hasLabel,
+			needsLabel:  tc.needsLabel,
+			commentBody: body,
+		}
+
+		if err := handle(fc, logrus.WithField("plugin", pluginName), e); err != nil {
+			t.Errorf("For case %s, didn't expect error from wip: %v", tc.name, err)
+			continue
+		}
+
+		fakeLabel := fmt.Sprintf("%s/%s#%d:%s", org, repo, number, label)
+		if tc.shouldLabel {
+			if len(fc.LabelsAdded) != 1 || fc.LabelsAdded[0] != fakeLabel {
+				t.Errorf("For case %s: expected to add %q label but instead added: %v", tc.name, label, fc.LabelsAdded)
+			}
+		} else if len(fc.LabelsAdded) > 0 {
+			t.Errorf("For case %s, expected to not add %q label but added: %v", tc.name, label, fc.LabelsAdded)
+		}
+		if tc.shouldUnlabel {
+			if len(fc.LabelsRemoved) != 1 || fc.LabelsRemoved[0] != fakeLabel {
+				t.Errorf("For case %s: expected to remove %q label but instead removed: %v", tc.name, label, fc.LabelsRemoved)
+			}
+		} else if len(fc.LabelsRemoved) > 0 {
+			t.Errorf("For case %s, expected to not remove %q label but removed: %v", tc.name, label, fc.LabelsRemoved)
+		}
+
+		if tc.shouldComment {
+			if len(fc.IssueCommentsAdded) != 1 || fc.IssueCommentsAdded[0] != fmt.Sprintf("%s/%s#%d:%s", org, repo, number, body) {
+				t.Errorf("For case %s: expected to add comment but instead added: %v", tc.name, fc.IssueCommentsAdded)
+			}
+		} else if len(fc.IssueCommentsAdded) > 0 {
+			t.Errorf("For case %s, expected to not add comment but added: %v", tc.name, fc.IssueCommentsAdded)
+		}
+	}
+}
+
+func TestHasWipPrefix(t *testing.T) {
+	var tests = []struct {
+		title    string
+		expected bool
+	}{
+		{
+			title:    "dummy title",
+			expected: false,
+		},
+		{
+			title:    "WIP dummy title",
+			expected: true,
+		},
+		{
+			title:    "[WIP] dummy title",
+			expected: true,
+		},
+		{
+			title:    "wip dummy title",
+			expected: true,
+		},
+		{
+			title:    "[wip] dummy title",
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		if actual, expected := titleRegex.MatchString(test.title), test.expected; actual != expected {
+			t.Errorf("for title %q, got WIP prefix match %v but got %v", test.title, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
Add a prow plugin to label WIP pull requests

Developers often add prefixes to their pull requests to indicate that
the implementation is still a work in progress. A new WIP plugin will
use that information to add a label to these pull requests that will be
honored by the submit-queue. When the prefix is removed from the title
of the pull request, the plugin will remove the label and the submit
queue will consider the pull request for merging us usual.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/area mungegithub

/cc @thockin @errordeveloper @bgrant0607 @fejta 