### PR TITLE
Revert "Temporarily use a different GCS bucket for gke-regional job logs"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -12913,7 +12913,6 @@ periodics:
     - args:
       - --timeout=170
       - --bare
-      - --upload=gs://shyamjvs-test/logs
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json


### PR DESCRIPTION
Reverts kubernetes/test-infra#4144

Since @krzyzacy updated the service-account permissions to write to the regular gcs bucket. I checked it by creating a file inside the bucket.

/cc @wojtek-t 