### PR TITLE
Bumping kubeadm image.

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170817-eb8ff765
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170823-263f7cf6
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -235,7 +235,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -532,7 +532,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -921,7 +921,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1036,7 +1036,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1155,7 +1155,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1198,7 +1198,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -15742,7 +15742,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
           args:
           - "--repo=k8s.io/kubernetes=release-1.6"
           - "--clean"
@@ -15862,7 +15862,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170817-95c7a07f
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170823-231baa6b
           args:
           - "--repo=k8s.io/kubernetes=release-1.7"
           - "--clean"


### PR DESCRIPTION
This is to pick up the kubetest [change](
https://github.com/kubernetes/test-infra/pull/4164) to disable cluster log dumping for kubernetes-anywhere deployments.