### PR TITLE
Fix gcloud-in-go unbounded REPO_NAME, bump gcloud to 163.0.0

### DIFF
--- a/images/gcloud/Dockerfile
+++ b/images/gcloud/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     wget && \
     apt-get clean
 
-ENV GCLOUD_VERSION 138.0.0
+ENV GCLOUD_VERSION 163.0.0
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     tar xf google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz -C / && \
     rm google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \

--- a/images/gcloud/Makefile
+++ b/images/gcloud/Makefile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.2
+VERSION = 0.3
 
 image:
 	docker build -t "gcr.io/k8s-testimages/gcloud-in-go:$(VERSION)" .
 
-push:
+push: image
 	gcloud docker -- push "gcr.io/k8s-testimages/gcloud-in-go:$(VERSION)"
 
 .PHONY: image push

--- a/images/gcloud/runner
+++ b/images/gcloud/runner
@@ -19,7 +19,6 @@ set -o pipefail
 
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
-    --repo=k8s.io/${REPO_NAME} \
     --job=${JOB_NAME} \
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     "$@"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -746,9 +746,9 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:0.2
+      - image: gcr.io/k8s-testimages/gcloud-in-go:0.3
         args:
-        - "--pull=$(PULL_REFS)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
@@ -782,9 +782,9 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:0.2
+      - image: gcr.io/k8s-testimages/gcloud-in-go:0.3
         args:
-        - "--pull=$(PULL_REFS)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
@@ -818,9 +818,9 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:0.2
+      - image: gcr.io/k8s-testimages/gcloud-in-go:0.3
         args:
-        - "--pull=$(PULL_REFS)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
@@ -1282,7 +1282,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:0.2
+      - image: gcr.io/k8s-testimages/gcloud-in-go:0.3
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -15648,14 +15648,14 @@ periodics:
   spec:
     containers:
     - args:
+      - --bare
       - --timeout=30
-      - --repo=k8s.io/test-infra=master
       - --service-account=/etc/service-account/service-account.json
       - --upload=gs://kubernetes-jenkins/logs
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      image: gcr.io/k8s-testimages/gcloud-in-go:0.2
+      image: gcr.io/k8s-testimages/gcloud-in-go:0.3
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15671,14 +15671,14 @@ periodics:
   spec:
     containers:
     - args:
+      - --bare
       - --timeout=600
-      - --repo=k8s.io/test-infra=master
       - --service-account=/etc/service-account/service-account.json
       - --upload=gs://kubernetes-jenkins/logs
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      image: gcr.io/k8s-testimages/gcloud-in-go:0.2
+      image: gcr.io/k8s-testimages/gcloud-in-go:0.3
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15694,14 +15694,14 @@ periodics:
   spec:
     containers:
     - args:
+      - --bare
       - --timeout=30
-      - --repo=k8s.io/test-infra=master
       - --service-account=/etc/service-account/service-account.json
       - --upload=gs://kubernetes-jenkins/logs
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      image: gcr.io/k8s-testimages/gcloud-in-go:0.2
+      image: gcr.io/k8s-testimages/gcloud-in-go:0.3
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
from https://github.com/kubernetes/test-infra/pull/4165

`/runner: line 22: REPO_NAME: unbound variable`

and the janitor jobs should not need an extra test-infra checkout.

¯\\\_(ツ)\_/¯ (so many escapes!)

/assign @ixdy @spxtr 