### PR TITLE
Add "planter" for local bazel development in docker

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@ boskos/** @krzyzacy
 gubernator/** @rmmh
 kettle/** @rmmh
 logexporter/** @shyamjvs
+planter/** @bentheelder
 prow/** @spxtr
 prow/config.yaml @krzyzacy
 testgrid/** @krzyzacy @michelle192837

--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -1,0 +1,55 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:jessie
+LABEL maintainer="Benjamin Elder <bentheelder@google.com>"
+
+# Includes everything needed to build and test github.com/kubernetes/kubernetes
+# and github.com/kubernetes/test-infra with bazel and run bazel as the host UID
+
+ENV BAZEL_VERSION 0.5.4
+
+WORKDIR "/workspace"
+RUN mkdir -p "/workspace"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    python \
+    python-pip \
+    unzip \
+    wget \
+    zip \
+    zlib1g-dev \
+    && apt-get clean && \
+    # TODO(bentheelder): we should probably have these as bazel dependencies,
+    # remove these from the container if kettle is fixed.
+    pip install pylint pyyaml
+
+RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
+    wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}" && \
+    chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"
+
+# It turns out git and bazel pkg_tar and a bunch of other things fail if we
+# don't have a /etc/passwd with the user in it, so let's solve that.
+# We're making a fake world-writable one *inside* the container so that the
+# entrypoint can write an entry to it with the user matching the host user
+# this means we don't need to run the container as root! :-)
+# We care about not running as root because it means build files are owned by
+# the host users, not root (and logs, etc).
+RUN touch /etc/passwd && chmod a+rw /etc/passwd
+
+COPY ./entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/planter/Makefile
+++ b/planter/Makefile
@@ -1,0 +1,26 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# note: sync this with planter.sh!
+# this should be bazel version - planter sub version
+VERSION = 0.5.4-1
+IMAGE_NAME = "gcr.io/k8s-testimages/planter"
+
+image:
+	docker build -t "$(IMAGE_NAME):$(VERSION)" . --pull
+
+push: image
+	gcloud docker -- push "$(IMAGE_NAME):$(VERSION)"
+
+.PHONY: image push

--- a/planter/README.md
+++ b/planter/README.md
@@ -1,0 +1,16 @@
+# Planter
+
+Planter is a container + wrapper script for your bazel builds.
+It will run a docker container as the current user that can run bazel builds
+in your `$PWD`. It has been tested on macOS and Linux against 
+`kubernetes/test-infra` and `kubernetes/kubernetes`.
+
+To build kubernetes set up your `$GOPATH/src` to contain:
+```
+$GOPATH/src/k8s.io/kubernetes/ ... <kubernetes/kubernetes checkout>
+$GOPATH/src/k8s.io/test-infra/ ... <kubernetes/test-infra checkout>
+```
+Then from `$GOPATH/src/k8s.io/kubernetes/` run:
+ `./../planter/planter.sh make bazel-build`.
+
+ For `test-infra` you can run eg `./planter/planter.sh bazel test //...`.

--- a/planter/entrypoint.sh
+++ b/planter/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+# write a fake user entry with settings matching the host user possible
+echo "${USER}:!:${UID}:${GID}:${HOME}:/bin/bash" >> /etc/passwd
+exec "$@"

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: use like: ./planter.sh bazel build //cmd/...
+# NOTE: build kubernetes with: <path to test-infra>/planter.sh make bazel-build
+
+set -o errexit
+set -o nounset
+IMAGE_NAME="gcr.io/k8s-testimages/planter"
+VERSION="0.5.4-1"
+IMAGE="${IMAGE_NAME}:${VERSION}"
+# run our docker image as the host user with bazel cache and current repo dir
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
+REPO=${REPO:-${PWD}}
+VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --tmpfs /tmp:exec,mode=777"
+GID="$(id -g ${USER})"
+ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
+docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${IMAGE} ${@}


### PR DESCRIPTION
This adds tooling to allow using bazel in docker for building `kubernetes/kubernetes` and `kubernetes/test-infra`, possibly others. This container is run unprivileged as the host user and uses the same directories as normal local bazel usage.

TODO:
 - [x] Create minimal docker image and wrapper script for local bazel development
 - [x] remove sandbox disabling for go_genrule once https://github.com/kubernetes/kubernetes/pull/51219 is in
 - [x] Set up image publishing
 - [ ] Fix test-infra `test //jenkins:bootstrap_test ` failure
 - [x] Better name(s) ?
 - [x] Document usage
