### PR TITLE
Query for the GitHub bot name as needed.

### DIFF
--- a/experiment/commenter/main.go
+++ b/experiment/commenter/main.go
@@ -39,7 +39,6 @@ import (
 )
 
 const (
-	ClientUser   = "commenter-client"
 	TemplateHelp = `--comment is a golang text/template if set.
 	Valid placeholders:
 		.Org - github org
@@ -152,9 +151,9 @@ func main() {
 	var c client
 	tok := strings.TrimSpace(string(b))
 	if o.confirm {
-		c = github.NewClient(ClientUser, tok, o.endpoint)
+		c = github.NewClient(tok, o.endpoint)
 	} else {
-		c = github.NewDryRunClient(ClientUser, tok, o.endpoint)
+		c = github.NewDryRunClient(tok, o.endpoint)
 	}
 
 	query, err := makeQuery(o.query, o.includeClosed, o.updated)

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,15 +15,15 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.144
+HOOK_VERSION       ?= 0.145
 SINKER_VERSION     ?= 0.16
 DECK_VERSION       ?= 0.43
 SPLICE_VERSION     ?= 0.27
 TOT_VERSION        ?= 0.5
 HOROLOGIUM_VERSION ?= 0.8
-PLANK_VERSION      ?= 0.39
-JENKINS_VERSION    ?= 0.38
-TIDE_VERSION       ?= 0.0
+PLANK_VERSION      ?= 0.40
+JENKINS_VERSION    ?= 0.39
+TIDE_VERSION       ?= 0.1
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,11 +33,10 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.144
+        image: gcr.io/k8s-prow/hook:0.145
         imagePullPolicy: Always
         args:
         - --dry-run=false
-        - --github-bot-name=k8s-ci-robot
         ports:
           - name: http
             containerPort: 8888

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,10 +25,9 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.38
+        image: gcr.io/k8s-prow/jenkins-operator:0.39
         args:
         - --dry-run=false
-        - --github-bot-name=k8s-ci-robot
         volumeMounts:
         - mountPath: /etc/jenkins
           name: jenkins

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,12 +27,11 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.39
+        image: gcr.io/k8s-prow/plank:0.40
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster
         - --dry-run=false
-        - --github-bot-name=k8s-ci-robot
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,9 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.0
-        args:
-        - --github-bot-name=k8s-ci-robot
+        image: gcr.io/k8s-prow/tide:0.1
         volumeMounts:
         - name: oauth
           mountPath: /etc/github

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -60,7 +60,7 @@ var (
 	local  = flag.Bool("local", false, "Run locally for testing purposes only. Does not require secret files.")
 	dryRun = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 
-	githubBotName   = flag.String("github-bot-name", "", "Name of the GitHub bot.")
+	_               = flag.String("github-bot-name", "", "Deprecated.")
 	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 
@@ -87,10 +87,7 @@ func main() {
 		logrus.Print("HMAC Secret: abcde12345")
 		webhookSecret = []byte("abcde12345")
 
-		if *githubBotName == "" {
-			*githubBotName = "fake-robot"
-		}
-		githubClient = github.NewFakeClient(*githubBotName)
+		githubClient = github.NewFakeClient()
 		kubeClient = kube.NewFakeClient()
 	} else {
 		logrus.SetFormatter(&logrus.JSONFormatter{})
@@ -121,19 +118,15 @@ func main() {
 			teamToken = string(bytes.TrimSpace(teamTokenRaw))
 		}
 
-		if *githubBotName == "" {
-			logrus.Fatal("Must specify --github-bot-name.")
-		}
-
 		_, err = url.Parse(*githubEndpoint)
 		if err != nil {
 			logrus.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
 		}
 
 		if *dryRun {
-			githubClient = github.NewDryRunClient(*githubBotName, oauthSecret, *githubEndpoint)
+			githubClient = github.NewDryRunClient(oauthSecret, *githubEndpoint)
 		} else {
-			githubClient = github.NewClient(*githubBotName, oauthSecret, *githubEndpoint)
+			githubClient = github.NewClient(oauthSecret, *githubEndpoint)
 		}
 
 		kubeClient, err = kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -38,7 +38,7 @@ var (
 	jenkinsUserName  = flag.String("jenkins-user", "jenkins-trigger", "Jenkins username")
 	jenkinsTokenFile = flag.String("jenkins-token-file", "/etc/jenkins/jenkins", "Path to the file containing the Jenkins API token.")
 
-	githubBotName   = flag.String("github-bot-name", "", "Name of the GitHub bot.")
+	_               = flag.String("github-bot-name", "", "Deprecated.")
 	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
 	dryRun          = flag.Bool("dry-run", true, "Whether or not to make mutating API calls to GitHub.")
@@ -78,9 +78,9 @@ func main() {
 
 	var ghc *github.Client
 	if *dryRun {
-		ghc = github.NewDryRunClient(*githubBotName, oauthSecret, *githubEndpoint)
+		ghc = github.NewDryRunClient(oauthSecret, *githubEndpoint)
 	} else {
-		ghc = github.NewClient(*githubBotName, oauthSecret, *githubEndpoint)
+		ghc = github.NewClient(oauthSecret, *githubEndpoint)
 	}
 
 	c, err := jenkins.NewController(kc, jc, ghc, configAgent)

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -37,7 +37,7 @@ var (
 	configPath   = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
 	buildCluster = flag.String("build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 
-	githubBotName   = flag.String("github-bot-name", "", "Name of the GitHub bot.")
+	_               = flag.String("github-bot-name", "", "Deprecated.")
 	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
 	dryRun          = flag.Bool("dry-run", true, "Whether or not to make mutating API calls to GitHub.")
@@ -80,9 +80,9 @@ func main() {
 
 	var ghc *github.Client
 	if *dryRun {
-		ghc = github.NewDryRunClient(*githubBotName, oauthSecret, *githubEndpoint)
+		ghc = github.NewDryRunClient(oauthSecret, *githubEndpoint)
 	} else {
-		ghc = github.NewClient(*githubBotName, oauthSecret, *githubEndpoint)
+		ghc = github.NewClient(oauthSecret, *githubEndpoint)
 	}
 
 	c, err := plank.NewController(kc, pkc, ghc, configAgent, *totURL)

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -34,7 +34,7 @@ import (
 var (
 	configPath = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
 
-	githubBotName   = flag.String("github-bot-name", "", "Name of the GitHub bot.")
+	_               = flag.String("github-bot-name", "", "Deprecated.")
 	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
 )
@@ -59,7 +59,7 @@ func main() {
 		logrus.WithError(err).Fatalf("Must specify a valid --github-endpoint URL.")
 	}
 
-	ghc := github.NewClient(*githubBotName, oauthSecret, *githubEndpoint)
+	ghc := github.NewClient(oauthSecret, *githubEndpoint)
 	ghc.Logger = logrus.WithField("client", "github")
 
 	kc, err := kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -83,6 +83,32 @@ func TestRetry404(t *testing.T) {
 	}
 }
 
+func TestBotName(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/user" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, "{\"login\": \"wowza\"}")
+	}))
+	c := getClient(ts.URL)
+	botName, err := c.BotName()
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	} else if botName != "wowza" {
+		t.Errorf("Wrong bot name. Got %s, expected wowza.", botName)
+	}
+	ts.Close()
+	botName, err = c.BotName()
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	} else if botName != "wowza" {
+		t.Errorf("Wrong bot name. Got %s, expected wowza.", botName)
+	}
+}
+
 func TestIsMember(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -50,8 +50,8 @@ type FakeClient struct {
 	RemoteFiles map[string]map[string]string
 }
 
-func (f *FakeClient) BotName() string {
-	return "k8s-ci-robot"
+func (f *FakeClient) BotName() (string, error) {
+	return "k8s-ci-robot", nil
 }
 
 func (f *FakeClient) IsMember(org, user string) (bool, error) {

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -53,7 +53,7 @@ type jenkinsClient interface {
 }
 
 type githubClient interface {
-	BotName() string
+	BotName() (string, error)
 	CreateStatus(org, repo, ref string, s github.Status) error
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 	CreateComment(org, repo string, number int, comment string) error

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -55,7 +55,7 @@ type kubeClient interface {
 }
 
 type githubClient interface {
-	BotName() string
+	BotName() (string, error)
 	CreateStatus(org, repo, ref string, s github.Status) error
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 	CreateComment(org, repo string, number int, comment string) error

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -66,7 +66,7 @@ type githubClient interface {
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
 	GetRepoLabels(owner, repo string) ([]github.Label, error)
-	BotName() string
+	BotName() (string, error)
 }
 
 type slackClient interface {
@@ -148,7 +148,12 @@ func (ae assignEvent) getRepeats(sigMatches [][]string, existingLabels map[strin
 }
 
 func handle(gc githubClient, log *logrus.Entry, ae assignEvent, sc slackClient) error {
-	if ae.login == gc.BotName() {
+	// only parse newly created comments/issues/PRs and if non bot author
+	botName, err := gc.BotName()
+	if err != nil {
+		return err
+	}
+	if ae.login == botName {
 		return nil
 	}
 

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -46,7 +46,11 @@ func handleIC(c client, ic github.IssueCommentEvent) error {
 		return nil
 	}
 	// Skip bot comments.
-	if commentAuthor == c.GitHubClient.BotName() {
+	botName, err := c.GitHubClient.BotName()
+	if err != nil {
+		return err
+	}
+	if commentAuthor == botName {
 		return nil
 	}
 	var trustedOrg string

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -131,7 +131,11 @@ func trustedPullRequest(ghc githubClient, pr github.PullRequest, trustedOrg stri
 			continue
 		}
 		// Skip bot comments.
-		if commentAuthor == ghc.BotName() {
+		botName, err := ghc.BotName()
+		if err != nil {
+			return false, err
+		}
+		if commentAuthor == botName {
 			continue
 		}
 		// Look for "ok to test"

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -40,7 +40,7 @@ func init() {
 
 type githubClient interface {
 	AddLabel(org, repo string, number int, label string) error
-	BotName() string
+	BotName() (string, error)
 	IsMember(org, user string) (bool, error)
 	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
 	GetRef(org, repo, ref string) (string, error)


### PR DESCRIPTION
Rather than using --github-bot-name, we can learn this value by just asking the GitHub /user endpoint. Lets only do so once and cache the result, though.

/assign @kargakis @cjwagner 
/area prow
#4140