### PR TITLE
Match no-issue argument with space

### DIFF
--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -33,13 +33,15 @@ import (
 )
 
 const (
-	approveCommand  = "APPROVE"
-	lgtmCommand     = "LGTM"
-	cancelArgument  = "cancel"
-	noIssueArgument = "no-issue"
+	approveCommand = "APPROVE"
+	lgtmCommand    = "LGTM"
+	cancelArgument = "cancel"
 )
 
-var AssociatedIssueRegex = regexp.MustCompile(`(?:kubernetes/[^/]+/issues/|#)(\d+)`)
+var (
+	AssociatedIssueRegex = regexp.MustCompile(`(?:kubernetes/[^/]+/issues/|#)(\d+)`)
+	noIssueRe            = regexp.MustCompile(`no[ -]issue`)
+)
 
 // ApprovalHandler will try to add "approved" label once
 // all files of change has been approved by approvers.
@@ -253,13 +255,13 @@ func addApprovers(approversHandler *approvers.Approvers, approveComments c.Filte
 					approversHandler.AddApprover(
 						*comment.Author,
 						url,
-						cmd.Arguments == noIssueArgument,
+						noIssueRe.MatchString(cmd.Arguments),
 					)
 				} else {
 					approversHandler.AddLGTMer(
 						*comment.Author,
 						url,
-						cmd.Arguments == noIssueArgument,
+						noIssueRe.MatchString(cmd.Arguments),
 					)
 				}
 


### PR DESCRIPTION
I've seen a number of PRs that were approved with "/approve no issue" rather than "/approve no-issue".. the intent is there, but I think auto correct or something removes the space.

I don't know if this will work as there isn't unit tests, but I figured I'd give it a shot anyways.