### PR TITLE
Use `ci/latest` instead of `latest` in the kubeadm e2e job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8363,7 +8363,7 @@
       "--extract=ci/latest",
       "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
-      "--kubernetes-anywhere-kubernetes-version=latest",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest",
       "--provider=kubernetes-anywhere",
       "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
       "--timeout=300m"


### PR DESCRIPTION
As it will use control plane images from HEAD instead of the latest alpha version.

Fixes https://github.com/kubernetes/kubeadm/issues/238
Works thanks to PR https://github.com/kubernetes/kubernetes/pull/49119

/assign @krzyzacy @pipejakob @roberthbailey @ixdy 

cc @kad 