### PR TITLE
Bringup multiple clusters from k8s-anywhere

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -42,10 +42,12 @@ var (
 		"(kubernetes-anywhere only) Cluster name. Must be set for kubernetes-anywhere.")
 	kubernetesAnywhereUpTimeout = flag.Duration("kubernetes-anywhere-up-timeout", 20*time.Minute,
 		"(kubernetes-anywhere only) Time limit between starting a cluster and making a successful call to the Kubernetes API.")
+	kubernetesAnywhereNumNodes = flag.Int("kubernetes-anywhere-num-nodes", 4,
+		"(kubernetes-anywhere only) Number of nodes to be deployed in the cluster.")
 )
 
 const kubernetesAnywhereConfigTemplate = `
-.phase1.num_nodes=4
+.phase1.num_nodes={{.NumNodes}}
 .phase1.cluster_name="{{.Cluster}}"
 .phase1.ssh_user=""
 .phase1.cloud_provider="gce"
@@ -78,6 +80,7 @@ type kubernetesAnywhere struct {
 	Phase2Provider    string
 	KubeadmVersion    string
 	KubernetesVersion string
+	NumNodes          int
 	Project           string
 	Cluster           string
 	Zone              string
@@ -114,6 +117,7 @@ func newKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, error) {
 		Phase2Provider:    *kubernetesAnywherePhase2Provider,
 		KubeadmVersion:    *kubernetesAnywhereKubeadmVersion,
 		KubernetesVersion: *kubernetesAnywhereKubernetesVersion,
+		NumNodes:          *kubernetesAnywhereNumNodes,
 		Project:           project,
 		Cluster:           *kubernetesAnywhereCluster,
 		Zone:              zone,
@@ -163,7 +167,7 @@ func (k kubernetesAnywhere) Up() error {
 		return err
 	}
 
-	nodes := 4 // For now, this is hardcoded in the config
+	nodes := k.NumNodes
 	return waitForNodes(k, nodes+1, *kubernetesAnywhereUpTimeout)
 }
 

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -55,7 +56,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase1.gce.os_image="ubuntu-1604-xenial-v20160420c"
 .phase1.gce.instance_type="n1-standard-1"
 .phase1.gce.project="{{.Project}}"
-.phase1.gce.region="us-central1"
+.phase1.gce.region="{{.Region}}"
 .phase1.gce.zone="{{.Zone}}"
 .phase1.gce.network="default"
 
@@ -84,6 +85,7 @@ type kubernetesAnywhere struct {
 	Project           string
 	Cluster           string
 	Zone              string
+	Region            string
 	KubeContext       string
 }
 
@@ -121,6 +123,7 @@ func newKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, error) {
 		Project:           project,
 		Cluster:           *kubernetesAnywhereCluster,
 		Zone:              zone,
+		Region:            regexp.MustCompile(`-[^-]+$`).ReplaceAllString(zone, ""),
 	}
 
 	if err := k.writeConfig(); err != nil {

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -47,6 +47,7 @@ var (
 const kubernetesAnywhereConfigTemplate = `
 .phase1.num_nodes=4
 .phase1.cluster_name="{{.Cluster}}"
+.phase1.ssh_user=""
 .phase1.cloud_provider="gce"
 
 .phase1.gce.os_image="ubuntu-1604-xenial-v20160420c"
@@ -61,6 +62,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase2.kubernetes_version="{{.KubernetesVersion}}"
 .phase2.provider="{{.Phase2Provider}}"
 .phase2.kubeadm.version="{{.KubeadmVersion}}"
+.phase2.kube_context_name="{{.KubeContext}}"
 
 .phase3.run_addons=y
 .phase3.weave_net={{if eq .Phase2Provider "kubeadm" -}} y {{- else -}} n {{- end}}
@@ -79,6 +81,7 @@ type kubernetesAnywhere struct {
 	Project           string
 	Cluster           string
 	Zone              string
+	KubeContext       string
 }
 
 var _ deployer = kubernetesAnywhere{}

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -89,9 +90,7 @@ type kubernetesAnywhere struct {
 	KubeContext       string
 }
 
-var _ deployer = kubernetesAnywhere{}
-
-func newKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, error) {
+func newKubernetesAnywhere(project, zone string) (deployer, error) {
 	if *kubernetesAnywherePath == "" {
 		return nil, fmt.Errorf("--kubernetes-anywhere-path is required")
 	}
@@ -132,39 +131,30 @@ func newKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, error) {
 	return k, nil
 }
 
-func (k kubernetesAnywhere) getConfig() (string, error) {
+func (k *kubernetesAnywhere) getConfig() ([]byte, error) {
 	// As needed, plumb through more CLI options to replace these defaults
 	tmpl, err := template.New("kubernetes-anywhere-config").Parse(kubernetesAnywhereConfigTemplate)
-
 	if err != nil {
-		return "", fmt.Errorf("Error creating template for KubernetesAnywhere config: %v", err)
+		return nil, fmt.Errorf("Error creating template for KubernetesAnywhere config: %v", err)
 	}
 
 	var buf bytes.Buffer
 	if err = tmpl.Execute(&buf, k); err != nil {
-		return "", fmt.Errorf("Error executing template for KubernetesAnywhere config: %v", err)
+		return nil, fmt.Errorf("Error executing template for KubernetesAnywhere config: %v", err)
 	}
 
-	return buf.String(), nil
+	return buf.Bytes(), nil
 }
 
-func (k kubernetesAnywhere) writeConfig() error {
+func (k *kubernetesAnywhere) writeConfig() error {
 	config, err := k.getConfig()
 	if err != nil {
 		return fmt.Errorf("Could not generate config: %v", err)
 	}
-
-	f, err := os.Create(k.path + "/.config")
-	if err != nil {
-		return fmt.Errorf("Could not create file: %v", err)
-	}
-	defer f.Close()
-
-	fmt.Fprint(f, config)
-	return nil
+	return ioutil.WriteFile(k.path+"/.config", config, 0644)
 }
 
-func (k kubernetesAnywhere) Up() error {
+func (k *kubernetesAnywhere) Up() error {
 	cmd := exec.Command("make", "-C", k.path, "WAIT_FOR_KUBECONFIG=y", "deploy")
 	if err := finishRunning(cmd); err != nil {
 		return err
@@ -174,11 +164,11 @@ func (k kubernetesAnywhere) Up() error {
 	return waitForNodes(k, nodes+1, *kubernetesAnywhereUpTimeout)
 }
 
-func (k kubernetesAnywhere) IsUp() error {
+func (k *kubernetesAnywhere) IsUp() error {
 	return isUp(k)
 }
 
-func (k kubernetesAnywhere) DumpClusterLogs(localPath, gcsPath string) error {
+func (k *kubernetesAnywhere) DumpClusterLogs(localPath, gcsPath string) error {
 	// TODO(pipejakob): the default implementation (log-dump.sh) doesn't work for
 	// kubernetes-anywhere yet, so just skip attempting to dump logs.
 	// https://github.com/kubernetes/kubeadm/issues/256
@@ -188,7 +178,7 @@ func (k kubernetesAnywhere) DumpClusterLogs(localPath, gcsPath string) error {
 	return nil
 }
 
-func (k kubernetesAnywhere) TestSetup() error {
+func (k *kubernetesAnywhere) TestSetup() error {
 	o, err := output(exec.Command("make", "--silent", "-C", k.path, "kubeconfig-path"))
 	if err != nil {
 		return fmt.Errorf("Could not get kubeconfig-path: %v", err)
@@ -201,11 +191,132 @@ func (k kubernetesAnywhere) TestSetup() error {
 	return nil
 }
 
-func (k kubernetesAnywhere) Down() error {
+func (k *kubernetesAnywhere) Down() error {
 	err := finishRunning(exec.Command("make", "-C", k.path, "kubeconfig-path"))
 	if err != nil {
 		// This is expected if the cluster doesn't exist.
 		return nil
 	}
 	return finishRunning(exec.Command("make", "-C", k.path, "FORCE_DESTROY=y", "destroy"))
+}
+
+const defaultConfigFile = ".config"
+
+type kubernetesAnywhereMultiCluster struct {
+	*kubernetesAnywhere
+	multiClusters multiClusterDeployment
+	configFile    map[string]string
+}
+
+// newKubernetesAnywhereMultiCluster returns the deployer based on kubernetes-anywhere
+// which can be used to deploy multiple clusters simultaneously.
+func newKubernetesAnywhereMultiCluster(project, zone string, multiClusters multiClusterDeployment) (deployer, error) {
+	if len(multiClusters.clusters) < 1 {
+		return nil, fmt.Errorf("invalid --multi-clusters flag passed")
+	}
+	k, err := newKubernetesAnywhere(project, zone)
+	if err != nil {
+		return nil, err
+	}
+	mk := &kubernetesAnywhereMultiCluster{k.(*kubernetesAnywhere), multiClusters, make(map[string]string)}
+
+	for _, cluster := range mk.multiClusters.clusters {
+		specificZone, specified := mk.multiClusters.zones[cluster]
+		if specified {
+			mk.Zone = specificZone
+		}
+		mk.Cluster = cluster
+		mk.KubeContext = mk.Zone + "-" + mk.Cluster
+		mk.configFile[cluster] = defaultConfigFile + "-" + mk.Cluster
+		if err := mk.writeConfig(); err != nil {
+			return nil, err
+		}
+	}
+	return mk, nil
+}
+
+// writeConfig writes the kubernetes-anywhere config file to file system after
+// rendering the template file with configuration in deployer.
+func (k *kubernetesAnywhereMultiCluster) writeConfig() error {
+	config, err := k.getConfig()
+	if err != nil {
+		return fmt.Errorf("could not generate config: %v", err)
+	}
+
+	return ioutil.WriteFile(k.path+"/"+k.configFile[k.Cluster], config, 0644)
+}
+
+// Up brings up multiple k8s clusters in parallel.
+func (k *kubernetesAnywhereMultiCluster) Up() error {
+	var cmds []*exec.Cmd
+	for _, cluster := range k.multiClusters.clusters {
+		cmd := exec.Command("make", "-C", k.path, "CONFIG_FILE="+k.configFile[cluster], "deploy")
+		cmds = append(cmds, cmd)
+	}
+
+	if err := finishRunningParallel(cmds...); err != nil {
+		return err
+	}
+
+	return k.TestSetup()
+}
+
+// TestSetup sets up test environment by merging kubeconfig of multiple deployments.
+func (k *kubernetesAnywhereMultiCluster) TestSetup() error {
+	var kubecfg string
+	for _, cluster := range k.multiClusters.clusters {
+		o, err := output(exec.Command("make", "--silent", "-C", k.path, "CONFIG_FILE="+k.configFile[cluster], "kubeconfig-path"))
+		if err != nil {
+			return fmt.Errorf("could not get kubeconfig-path: %v", err)
+		}
+		if len(kubecfg) != 0 {
+			kubecfg += ":"
+		}
+		kubecfg += strings.TrimSuffix(string(o), "\n")
+	}
+
+	if err := os.Setenv("KUBECONFIG", kubecfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// IsUp checks if all the clusters in the deployer are up.
+func (k *kubernetesAnywhereMultiCluster) IsUp() error {
+	if err := k.TestSetup(); err != nil {
+		return err
+	}
+
+	for _, cluster := range k.multiClusters.clusters {
+		zone := k.multiClusters.zones[cluster]
+		kubeContext := zone + "-" + cluster
+		o, err := output(exec.Command("kubectl", "--context="+kubeContext, "get", "nodes", "--no-headers"))
+		if err != nil {
+			log.Printf("kubectl get nodes failed for cluster %s: %s\n%s", cluster, wrapError(err).Error(), string(o))
+			return err
+		}
+		stdout := strings.TrimSpace(string(o))
+		log.Printf("Cluster nodes of cluster %s:\n%s", cluster, stdout)
+
+		n := len(strings.Split(stdout, "\n"))
+		if n < k.NumNodes {
+			return fmt.Errorf("cluster %s found, but %d nodes reported", cluster, n)
+		}
+	}
+	return nil
+}
+
+// Down brings down multiple k8s clusters in parallel.
+func (k *kubernetesAnywhereMultiCluster) Down() error {
+	if err := k.TestSetup(); err != nil {
+		// This is expected if the clusters doesn't exist.
+		return nil
+	}
+
+	var cmds []*exec.Cmd
+	for _, cluster := range k.multiClusters.clusters {
+		cmd := exec.Command("make", "-C", k.path, "CONFIG_FILE="+k.configFile[cluster], "FORCE_DESTROY=y", "destroy")
+		cmds = append(cmds, cmd)
+	}
+	return finishRunningParallel(cmds...)
 }

--- a/kubetest/anywhere_test.go
+++ b/kubetest/anywhere_test.go
@@ -113,3 +113,93 @@ func containsLine(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+func TestNewKubernetesAnywhereMultiCluster(t *testing.T) {
+	tests := map[string]struct {
+		mcFlag      string
+		expectError bool
+	}{
+		"ZeroCluster": {
+			mcFlag:      "",
+			expectError: true,
+		},
+		"SingleCluster": {
+			mcFlag:      "c1",
+			expectError: false,
+		},
+		"MultiClusters": {
+			mcFlag:      "c1,c2,c3",
+			expectError: false,
+		},
+		"MultiClustersWithZonesSpecifiedForAll": {
+			mcFlag:      "z1:c1,z2:c2,z3:c3",
+			expectError: false,
+		},
+		"MultiClustersWithZonesSpecifiedForSome": {
+			mcFlag:      "c1,z2:c2,c3",
+			expectError: false,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			tmpdir, err := ioutil.TempDir("", "kubernetes-anywhere-multi-cluster-test")
+			if err != nil {
+				t.Errorf("couldn't create tempdir: %v", err)
+			}
+			defer os.Remove(tmpdir)
+
+			*kubernetesAnywherePath = tmpdir
+			*kubernetesAnywhereCluster = "test-cluster"
+			*kubernetesAnywherePhase2Provider = "kubeadm"
+			*kubernetesAnywhereKubeadmVersion = "stable"
+			*kubernetesAnywhereKubernetesVersion = ""
+
+			multiClusters := multiClusterDeployment{}
+			multiClusters.Set(test.mcFlag)
+			zone := "fake-zone-a"
+
+			_, err = newKubernetesAnywhereMultiCluster("fake-project", zone, multiClusters)
+			if test.expectError {
+				if err == nil {
+					t.Errorf("expected err but newKubernetesAnywhereMultiCluster(%s) suceeded.", testName)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("newKubernetesAnywhereMultiCluster(%s) failed: %v", testName, err)
+				}
+			}
+
+			for _, cluster := range multiClusters.clusters {
+				config, err := ioutil.ReadFile(tmpdir + "/.config-" + cluster)
+				if err != nil {
+					t.Errorf("newKubernetesAnywhereMultiCluster(%s) failed to create readable config file: %v", testName, err)
+				}
+
+				specificZone, specified := multiClusters.zones[cluster]
+				if specified {
+					zone = specificZone
+				}
+				kubeContext := zone + "-" + cluster
+				expectConfigLines := []string{
+					".phase1.cloud_provider=\"gce\"",
+					".phase2.provider=\"kubeadm\"",
+					".phase2.kubeadm.version=\"stable\"",
+					".phase2.kubernetes_version=\"\"",
+					".phase3.weave_net=y",
+					".phase1.cluster_name=\"" + cluster + "\"",
+					".phase1.gce.zone=\"" + zone + "\"",
+					".phase2.kube_context_name=\"" + kubeContext + "\"",
+				}
+
+				configLines := strings.Split(string(config), "\n")
+
+				for _, line := range expectConfigLines {
+					if !containsLine(configLines, line) {
+						t.Errorf("newKubernetesAnywhereMultiCluster(%s) config got %q, wanted line: %v", testName, config, line)
+					}
+				}
+			}
+		})
+	}
+}

--- a/kubetest/federation.go
+++ b/kubetest/federation.go
@@ -17,8 +17,65 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"os/exec"
+	"strings"
 )
+
+/*
+ multiClusterDeployment type holds the data passed to `--multi-clusters` flag.
+ The format of value that should be passed to the flag is `[Zone1:]Cluster1[,[ZoneN:]ClusterN]]*`.
+ Multiple clusters can be specified as a comma separated list.
+ Zone can be optionally specified along with cluster name as described above in the format.
+ If zone is not specified along with cluster then cluster would be deployed in default zone.
+*/
+type multiClusterDeployment struct {
+	zones    map[string]string
+	clusters []string
+}
+
+func (m *multiClusterDeployment) String() string {
+	var str string
+	for _, cluster := range m.clusters {
+		if len(str) != 0 {
+			str += ","
+		}
+		zone, exist := m.zones[cluster]
+		if exist {
+			str += zone + ":"
+		}
+		str += cluster
+	}
+	return str
+}
+
+func (m *multiClusterDeployment) Set(value string) error {
+	if len(value) == 0 {
+		return errors.New("invalid value passed to --multi-clusters flag, should specify at least one cluster")
+	}
+
+	if m.zones == nil {
+		m.zones = make(map[string]string)
+	}
+	clusterZones := strings.Split(value, ",")
+	for _, czTuple := range clusterZones {
+		czSlice := strings.SplitN(czTuple, ":", 2)
+		if len(czSlice[0]) == 0 || (len(czSlice) == 2 && len(czSlice[1]) == 0) {
+			return errors.New("invalid value passed to --multi-clusters flag")
+		}
+		if len(czSlice) == 2 {
+			m.zones[czSlice[1]] = czSlice[0]
+			m.clusters = append(m.clusters, czSlice[1])
+		} else {
+			m.clusters = append(m.clusters, czSlice[0])
+		}
+	}
+	return nil
+}
+
+func (m *multiClusterDeployment) Enabled() bool {
+	return len(m.clusters) > 0
+}
 
 func fedUp() error {
 	return finishRunning(exec.Command("./federation/cluster/federation-up.sh"))

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -230,6 +230,9 @@ func getDeployer(o *options) (deployer, error) {
 	case "kops":
 		return newKops()
 	case "kubernetes-anywhere":
+		if o.multiClusters.Enabled() {
+			return newKubernetesAnywhereMultiCluster(o.gcpProject, o.gcpZone, o.multiClusters)
+		}
 		return newKubernetesAnywhere(o.gcpProject, o.gcpZone)
 	case "node":
 		return nodeDeploy{}, nil

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -86,6 +86,7 @@ type options struct {
 	kubemarkNodes       string // TODO(fejta): switch to int after migration
 	logexporterGCSPath  string
 	metadataSources     string
+	multiClusters       multiClusterDeployment
 	multipleFederations bool
 	nodeArgs            string
 	nodeTestArgs        string
@@ -131,6 +132,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.kubemarkNodes, "kubemark-nodes", "5", "Number of kubemark nodes to start (only relevant if --kubemark=true).")
 	flag.StringVar(&o.logexporterGCSPath, "logexporter-gcs-path", "", "Path to the GCS artifacts directory to dump logs from nodes. Logexporter gets enabled if this is non-empty")
 	flag.StringVar(&o.metadataSources, "metadata-sources", "images.json", "Comma-separated list of files inside ./artifacts to merge into metadata.json")
+	flag.Var(&o.multiClusters, "multi-clusters", "If set, bring up/down multiple clusters specified. Format is [Zone1:]Cluster1[,[ZoneN:]ClusterN]]*. Zone is optional and default zone is used if zone is not specified")
 	flag.BoolVar(&o.multipleFederations, "multiple-federations", false, "If true, enable running multiple federation control planes in parallel")
 	flag.StringVar(&o.nodeArgs, "node-args", "", "Args for node e2e tests.")
 	flag.StringVar(&o.nodeTestArgs, "node-test-args", "", "Test args specifically for node e2e tests.")

--- a/kubetest/util_test.go
+++ b/kubetest/util_test.go
@@ -326,6 +326,99 @@ func TestOutput(t *testing.T) {
 	}
 }
 
+func TestFinishRunningParallel(t *testing.T) {
+	cases := []struct {
+		name              string
+		terminated        bool
+		interrupted       bool
+		causeTermination  bool
+		causeInterruption bool
+		cmds              []*exec.Cmd
+		shouldError       bool
+		shouldInterrupt   bool
+		shouldTerminate   bool
+	}{
+		{
+			name: "finishRunningParallel with single command can pass",
+			cmds: []*exec.Cmd{exec.Command("true")},
+		},
+		{
+			name: "finishRunningParallel with multiple commands can pass",
+			cmds: []*exec.Cmd{exec.Command("true"), exec.Command("true")},
+		},
+		{
+			name:        "finishRunningParallel with single command can fail",
+			cmds:        []*exec.Cmd{exec.Command("false")},
+			shouldError: true,
+		},
+		{
+			name:        "finishRunningParallel with multiple commands can fail",
+			cmds:        []*exec.Cmd{exec.Command("true"), exec.Command("false")},
+			shouldError: true,
+		},
+		{
+			name:        "finishRunningParallel should error when terminated",
+			cmds:        []*exec.Cmd{exec.Command("true"), exec.Command("true")},
+			terminated:  true,
+			shouldError: true,
+		},
+		{
+			name:              "finishRunningParallel should interrupt when interrupted",
+			cmds:              []*exec.Cmd{exec.Command("true"), exec.Command("sleep", "60"), exec.Command("sleep", "30")},
+			causeInterruption: true,
+			shouldError:       true,
+		},
+		{
+			name:             "finishRunningParallel should terminate when terminated",
+			cmds:             []*exec.Cmd{exec.Command("true"), exec.Command("sleep", "60"), exec.Command("sleep", "30")},
+			causeTermination: true,
+			shouldError:      true,
+		},
+	}
+
+	clearTimers := func() {
+		if !terminate.Stop() {
+			<-terminate.C
+		}
+		if !interrupt.Stop() {
+			<-interrupt.C
+		}
+	}
+
+	for _, tc := range cases {
+		log.Println(tc.name)
+		terminated = tc.terminated
+		interrupted = tc.interrupted
+		interrupt = time.NewTimer(time.Duration(0))
+		terminate = time.NewTimer(time.Duration(0))
+		clearTimers()
+		if tc.causeInterruption {
+			interrupt.Reset(1 * time.Second)
+		}
+		if tc.causeTermination {
+			terminate.Reset(1 * time.Second)
+		}
+
+		err := finishRunningParallel(tc.cmds...)
+		if err == nil == tc.shouldError {
+			t.Errorf("TC %s shouldError=%v error: %v", tc.name, tc.shouldError, err)
+		}
+		if tc.causeInterruption && !interrupted {
+			t.Errorf("TC %s did not interrupt, err: %v", tc.name, err)
+		} else if tc.causeInterruption && !terminate.Reset(0) {
+			t.Errorf("TC %s did not reset the terminate timer: %v", tc.name, err)
+		}
+		if tc.causeTermination && !terminated {
+			t.Errorf("TC %s did not terminate, err: %v", tc.name, err)
+		}
+	}
+	terminated = false
+	interrupted = false
+	if !terminate.Stop() {
+		<-terminate.C
+	}
+}
+
 func TestOutputOutputs(t *testing.T) {
 	b, err := output(exec.Command("echo", "hello world"))
 	txt := string(b)

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -103,6 +103,12 @@ def kubeadm_version(mode):
         # Add bin/linux/amd64 yet to that path so it points to the dir with the debs
         return '%s/bin/linux/amd64/' % os.environ['SHARED_BUILD_GCS_PATH']
 
+    elif mode == 'stable':
+        # This job need not run against the kubernetes repo and uses the stable version
+        # of kubeadm packages. This mode may be desired when kubeadm itself is not the
+        # SUT (System Under Test).
+        return 'stable'
+
     else:
         raise ValueError("Unknown kubeadm mode given: %s" % mode)
 
@@ -649,7 +655,7 @@ def create_parser():
     parser.add_argument(
         '--docker-in-docker', action='store_true', help='Enable run docker within docker')
     parser.add_argument(
-        '--kubeadm', choices=['ci', 'periodic', 'pull'])
+        '--kubeadm', choices=['ci', 'periodic', 'pull', 'stable'])
     parser.add_argument(
         '--stage', default=None, help='Stage release to GCS path provided')
     parser.add_argument(


### PR DESCRIPTION
Ref #3858. This is the 4th subtask in the list described in the issue.
`Bringup multiple clusters in single invocation of kubetest deploy Up(). Bringing up all clusters in parallel is desirable.`

Introduced a new flag called `--multi-clusters`, to specify multi-cluster deployment. The value is of the format `Cluster-1:Zone1[,Cluster2:Zone2][,Cluster3:Zone3]`. The first cluster is the primary cluster which will host the federation control plane.

Federation control plane bring-up is not yet implemented into k8s-anywhere deployer, which is the  subsequent work to this PR.

/assign @madhusudancs 
/assign @pipejakob 
/cc @luxas @kubernetes/sig-federation-pr-reviews 