### PR TITLE
Set KUBERNETES_PROVIDER=gce in case of 'kubernetes-anywhere' provider

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -715,10 +715,15 @@ func chmodArtifacts() error {
 }
 
 func prepare(o *options) error {
+	k8sProviderEnvVar := o.provider
+	if o.provider == "kubernetes-anywhere" {
+		// To make gce-related setup scripts in k8s to get sourced.
+		k8sProviderEnvVar = "gce"
+	}
 	if err := migrateOptions([]migratedOption{
 		{
 			env:    "KUBERNETES_PROVIDER",
-			option: &o.provider,
+			option: &k8sProviderEnvVar,
 			name:   "--provider",
 		},
 		{


### PR DESCRIPTION
- as it seems to be used only inside k8s repo (which doesn't understand the kubernetes-anywhere provider)

Ref https://github.com/kubernetes/kubernetes/issues/50760

cc @pipejakob @krzyzacy 