### PR TITLE
Autocalculate clusterIPrange in kubetest if not provided (based on #nodes)

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -110,7 +110,7 @@ func defineFlags() *options {
 	flag.BoolVar(&o.checkSkew, "check-version-skew", true, "Verify client and server versions match")
 	flag.BoolVar(&o.checkLeaks, "check-leaked-resources", false, "Ensure project ends with the same resources")
 	flag.StringVar(&o.cluster, "cluster", "", "Cluster name. Must be set for --deployment=gke (TODO: other deployments).")
-	flag.StringVar(&o.clusterIPRange, "cluster-ip-range", "", "Specify CLUSTER_IP_RANGE during --up and --test")
+	flag.StringVar(&o.clusterIPRange, "cluster-ip-range", "", "Specifies CLUSTER_IP_RANGE value during --up and --test (only relevant for --deployment=bash). Auto-calculated if empty.")
 	flag.StringVar(&o.deployment, "deployment", "bash", "Choices: none/bash/gke/kops/kubernetes-anywhere/node")
 	flag.BoolVar(&o.down, "down", false, "If true, tear down the cluster before exiting.")
 	flag.StringVar(&o.dump, "dump", "", "If set, dump cluster logs to this location on test or cluster-up failure")


### PR DESCRIPTION
Follows from PR https://github.com/kubernetes/kubernetes/pull/50947
Helps https://github.com/kubernetes/test-infra/issues/3375

/cc @fejta @krzyzacy 