### PR TITLE
List node names instead of IPs for log-dump in GKE

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -299,7 +299,7 @@ function log_dump_custom_get_instances() {
     return 0
   fi
 
-  gcloud compute instances list '--project=%[1]s' '--filter=%[2]s' '--format=get(networkInterfaces.accessConfigs[0][natIP])'
+  gcloud compute instances list '--project=%[1]s' '--filter=%[2]s' '--format=get(name)'
 }
 export -f log_dump_custom_get_instances
 export LOG_DUMP_SSH_USER="${USER}"


### PR DESCRIPTION
Ref https://github.com/kubernetes/test-infra/issues/4046

We're dumping node logs using their IPs (instead of names) - http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke/13541/artifacts/
This seems weird and different than our gce setup.
Also it's breaking logexporter (which matches those node names against those that are used in k8s).

/cc @krzyzacy 

