### PR TITLE
Add --root for node-canary job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14588,6 +14588,7 @@ periodics:
       args:
       - --bare
       - --timeout=80
+      - --root=/go/src/k8s.io
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json


### PR DESCRIPTION
`GOPATH` comes from the base go image which should be `/go` already

`e2e.go:508: cwd : /workspace/kubernetes`
seems that:
`--repo` checks out k8s.io/kubernetes
`--extract` extract to ./kubernetes without k8s.io

I think this might be able to fix the path.

/assign @yguo0905 
