### PR TITLE
mungebot: Configure milestone munger for kubectl repo to test

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubectl/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubectl/configmap.yaml
@@ -1,0 +1,15 @@
+# basic config options.
+http-cache-dir: /cache/httpcache
+organization: kubernetes
+project: kubectl
+pr-mungers: milestone-maintainer
+state: open
+token-file: /etc/secret-volume/token
+period: 2m
+repo-dir: /gitrepos
+github-key-file: /etc/hook-secret-volume/secret
+
+# milestone-maintainer options
+active-milestone: v1.8
+milestone-grace-period: 2
+milestone-warning-interval: 1


### PR DESCRIPTION
The goal of this PR is configuring the milestone munger as per https://github.com/kubernetes/test-infra/pull/4052#issuecomment-324453135 against https://github.com/kubernetes/kubectl to allow munger behavior to be validated.

It will be necessary to add the following labels to the kubectl repo before this merges:

 - milestone-removed
 - milestone-labels-incomplete
 - milestone-labels-complete