### PR TITLE
Always chdir to root

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -810,6 +810,9 @@ def setup_root(call, root, repos, ssh, git_cache, clean):
         os.makedirs(root)
     root_dir = os.path.realpath(root)
     logging.info('Root: %s', root_dir)
+    os.chdir(root_dir)
+    logging.info('cd to %s', root_dir)
+
     with choose_ssh_key(ssh):
         for repo, (branch, pull) in repos.items():
             os.chdir(root_dir)

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -1126,7 +1126,7 @@ class BootstrapTest(unittest.TestCase):
 
         with Stub(bootstrap, 'ci_paths', Bomb):
             with Stub(bootstrap, 'pr_paths', FakePath()) as path:
-                test_bootstrap(branch=None, pull=PULL)
+                test_bootstrap(branch=None, pull=PULL, root='.')
             self.assertEquals(PULL, path.arg[1][REPO][1], (PULL, path.arg))
 
     def test_ci_paths(self):


### PR DESCRIPTION
So if I don't have `--repo` set, and want to work under, `--root=/go/src`, it's not really going to work.

/assign @fejta 

cc @yguo0905 