### PR TITLE
Make Gubernator handle non-kubernetes/kubernetes repos better.

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -23,8 +23,8 @@ import urllib
 import jinja2
 
 
-GITHUB_VIEW_TEMPLATE = 'https://github.com/kubernetes/kubernetes/blob/%s/%s#L%s'
-GITHUB_COMMIT_TEMPLATE = 'https://github.com/kubernetes/kubernetes/commit/%s'
+GITHUB_VIEW_TEMPLATE = 'https://github.com/%s/blob/%s/%s#L%s'
+GITHUB_COMMIT_TEMPLATE = 'https://github.com/%s/commit/%s'
 LINKIFY_RE = re.compile(
     r'(^\s*/\S*/)(kubernetes/(\S+):(\d+)(?: \+0x[0-9a-f]+)?)$',
     flags=re.MULTILINE)
@@ -67,7 +67,7 @@ def do_slugify(inp):
     return re.sub(r'\s+', '-', inp).lower()
 
 
-def do_linkify_stacktrace(inp, commit):
+def do_linkify_stacktrace(inp, commit, repo):
     """Add links to a source code viewer for every mentioned source line."""
     inp = unicode(jinja2.escape(inp))
     if not commit:
@@ -76,13 +76,13 @@ def do_linkify_stacktrace(inp, commit):
         prefix, full, path, line = m.groups()
         return '%s<a href="%s">%s</a>' % (
             prefix,
-            GITHUB_VIEW_TEMPLATE % (commit, path, line),
+            GITHUB_VIEW_TEMPLATE % (repo, commit, path, line),
             full)
     return jinja2.Markup(LINKIFY_RE.sub(rep, inp))
 
 
-def do_github_commit_link(commit):
-    commit_url = jinja2.escape(GITHUB_COMMIT_TEMPLATE % commit)
+def do_github_commit_link(commit, repo):
+    commit_url = jinja2.escape(GITHUB_COMMIT_TEMPLATE % (repo, commit))
     return jinja2.Markup('<a href="%s">%s</a>' % (commit_url, commit[:8]))
 
 

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -21,6 +21,11 @@ import urllib
 import filters
 
 
+def linkify(inp, commit):
+    return str(filters.do_linkify_stacktrace(
+        inp, commit, 'kubernetes/kubernetes'))
+
+
 class HelperTest(unittest.TestCase):
     def test_timestamp(self):
         self.assertEqual(
@@ -39,22 +44,22 @@ class HelperTest(unittest.TestCase):
 
     def test_linkify_safe(self):
         self.assertEqual('&lt;a&gt;',
-                         str(filters.do_linkify_stacktrace('<a>', '3')))
+                         linkify('<a>', '3'))
 
     def test_linkify(self):
-        linked = str(filters.do_linkify_stacktrace(
-            "/go/src/k8s.io/kubernetes/test/example.go:123", 'VERSION'))
+        linked = linkify(
+            "/go/src/k8s.io/kubernetes/test/example.go:123", 'VERSION')
         self.assertIn('<a href="https://github.com/kubernetes/kubernetes/blob/'
                       'VERSION/test/example.go#L123">', linked)
 
     def test_linkify_trailing(self):
-        linked = str(filters.do_linkify_stacktrace(
-            "    /go/src/k8s.io/kubernetes/test/example.go:123 +0x1ad", 'VERSION'))
+        linked = linkify(
+            "    /go/src/k8s.io/kubernetes/test/example.go:123 +0x1ad", 'VERSION')
         self.assertIn('github.com', linked)
 
     def test_linkify_unicode(self):
         # Check that Unicode characters pass through cleanly.
-        linked = filters.do_linkify_stacktrace(u'\u883c', 'VERSION')
+        linked = filters.do_linkify_stacktrace(u'\u883c', 'VERSION', '')
         self.assertEqual(linked, u'\u883c')
 
     def test_slugify(self):

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -7,7 +7,7 @@
 % endif
 % endblock
 % block header
-<h1>{% if pr %}<a href="/pr/{{pr_path}}{{pr}}">{% if repo != "kubernetes/kubernetes" %}{{repo}} {% endif %}PR #{{pr}}</a> {% endif %}
+<h1>{% if pr and pr != "batch"  %}<a href="/pr/{{pr_path}}{{pr}}">{% if repo != "kubernetes/kubernetes"%}{{repo}} {% endif %}PR #{{pr}}</a> {% endif %}
 	% if testgrid_query
 		<a href="{{testgrid_query|tg_url}}">{{job}}</a>
 	% else
@@ -37,15 +37,19 @@
 		% endif
 		<tr><td>Started<td>{{started['timestamp']|timestamp}}
 		{% if finished %}<tr><td>Elapsed<td>{{(finished['timestamp']-started['timestamp'])|duration}}{% endif %}
-		<tr><td>Version<td><a href="https://github.com/kubernetes/kubernetes/commit/{{commit}}">{{started['version'] or finished['version']}}</a>
+		<tr><td>Version<td><a href="https://github.com/{{repo}}/commit/{{commit}}">{{started['version'] or finished['version']}}</a>
 		% if 'jenkins-node' in started
 			<tr><td>Builder<td>{{started['jenkins-node']}}
 		% endif
-		% if 'pull' in started
+		% if refs
 			<tr><td>Refs<td>
-			{% for x in started['pull'].split(',') -%}
-				{% set x=x.split(':', 1) %}
-				{{x[0]}}{% if x|length == 2 %}{% set commit=x[1] %}:{{x[1]|github_commit_link}}{% endif %}<br>
+			% for name, sha in refs
+				{%- if name.isdigit() -%}
+					<a href="https://github.com/{{repo}}/pull/{{name}}">{{name}}</a>
+				{%- else -%}
+					{{name}}
+				{%- endif -%}
+				{%- if sha %}:{{sha|github_commit_link}}{% endif %}<br>
 			{%- endfor %}
 		% endif
 		% if 'metadata' in started

--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -49,7 +49,7 @@
 				{%- else -%}
 					{{name}}
 				{%- endif -%}
-				{%- if sha %}:{{sha|github_commit_link}}{% endif %}<br>
+				{%- if sha %}:{{sha|github_commit_link(repo)}}{% endif %}<br>
 			{%- endfor %}
 		% endif
 		% if 'metadata' in started
@@ -88,9 +88,9 @@
 				<pre class="cmd" onclick="select(this)">{{name | testcmd}}</pre>
 			% endif
 			% if text
-				<pre class="error">{{text|linkify_stacktrace(commit)}}
+				<pre class="error">{{text|linkify_stacktrace(commit, repo)}}
 				% if output
-				<div class="hidden"><hr>{{output|linkify_stacktrace(commit)}}</div>
+				<div class="hidden"><hr>{{output|linkify_stacktrace(commit, repo)}}</div>
 				<span class="expand inset-expand">Click to see stdout/stderr</span><span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span></pre>
 				% else
 				<span class="inset-filename">from <a href="https://storage.googleapis.com{{filename}}">{{filename|basename}}</a></span></pre>

--- a/gubernator/templates/pr.html
+++ b/gubernator/templates/pr.html
@@ -17,7 +17,7 @@
     <tr><th>Job</th><th colspan="{{max_builds}}">Build</th></tr>
     <tr class="pr-version"><td></td>
     {%- for version, width, started in header -%}
-      <th{% if width != 1 %} colspan="{{width}}"{% endif %}>{{version|github_commit_link}}<br>{{started|shorttimestamp}}</th>
+      <th{% if width != 1 %} colspan="{{width}}"{% endif %}>{{version|github_commit_link("%s/%s" % (org, repo))}}<br>{{started|shorttimestamp}}</th>
     {% endfor %}
   </thead>
   % for job, results in rows

--- a/gubernator/view_base.py
+++ b/gubernator/view_base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import functools
 import logging
 import os
@@ -50,7 +51,12 @@ DEFAULT_JOBS = {
     },
 }
 
-PR_PREFIX = 'kubernetes-jenkins/pr-logs/pull'
+# Maps github organizations/owners to GCS paths for presubmit results
+PR_PREFIX = collections.OrderedDict([
+    ('kubernetes', 'kubernetes-jenkins/pr-logs/pull'),
+    ('google', 'kubernetes-jenkins/pr-logs/pull'),  # for cadvisor
+    ('istio', 'istio-prow/pull'),
+])
 
 JINJA_ENVIRONMENT = jinja2.Environment(
     loader=jinja2.FileSystemLoader(os.path.dirname(__file__) + '/templates'),

--- a/gubernator/view_base.py
+++ b/gubernator/view_base.py
@@ -58,6 +58,11 @@ PR_PREFIX = collections.OrderedDict([
     ('istio', 'istio-prow/pull'),
 ])
 
+PROW_INSTANCES = {
+    'istio': 'prow.istio.io',
+    'DEFAULT': 'prow.k8s.io',
+}
+
 JINJA_ENVIRONMENT = jinja2.Environment(
     loader=jinja2.FileSystemLoader(os.path.dirname(__file__) + '/templates'),
     extensions=['jinja2.ext.autoescape', 'jinja2.ext.loopcontrols'],

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -142,13 +142,22 @@ def build_details(build_dir):
 
 
 def parse_pr_path(prefix):
-    if not prefix.startswith(view_base.PR_PREFIX):
-        return None, None, None
-    pr = os.path.basename(prefix)
-    repo = os.path.basename(os.path.dirname(prefix))
-    if repo == 'pull':
-        return pr, '', 'kubernetes/kubernetes'
-    return pr, repo + '/', 'kubernetes/' + repo
+    for org, path in view_base.PR_PREFIX.items():
+        if not prefix.startswith(path):
+            continue
+        pr = os.path.basename(prefix)
+        repo = os.path.basename(os.path.dirname(prefix))
+        if '_' in repo and not repo.startswith(org):
+            continue
+        if org == 'kubernetes' and repo == 'pull':
+            return pr, '', 'kubernetes/kubernetes'
+        pr_path = repo.replace('_', '/')
+        if '_' not in repo:
+            repo = '%s/%s' % (org, repo)
+        else:
+            repo = pr_path
+        return pr, pr_path + '/', repo
+    return None, None, None
 
 
 class BuildHandler(view_base.BaseHandler):

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -198,12 +198,21 @@ class BuildHandler(view_base.BaseHandler):
         if pr:
             pr_digest = models.GHIssueDigest.get(repo, pr)
 
+        refs = []
+        if started and 'pull' in started:
+            for ref in started['pull'].split(','):
+                x = ref.split(':', 1)
+                if len(x) == 2:
+                    refs.append((x[0], x[1]))
+                else:
+                    refs.append((x[1], ''))
+
         self.render('build.html', dict(
             job_dir=job_dir, build_dir=build_dir, job=job, build=build,
             commit=commit, started=started, finished=finished,
-            res=results,
+            res=results, refs=refs,
             build_log=build_log, build_log_src=build_log_src,
-            issues=issues,
+            issues=issues, repo=repo,
             pr_path=pr_path, pr=pr, pr_digest=pr_digest,
             testgrid_query=testgrid_query))
 

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -240,23 +240,27 @@ class BuildTest(main_test.TestBase):
         self.assertIn('No Test Failures', response)
 
     def test_parse_pr_path(self):
-        for prefix, expected in [
-            ('kubernetes-jenkins/logs/e2e', (None, None, None)),
-            ('kubernetes-jenkins/pr-logs/pull/123', ('123', '', 'kubernetes/kubernetes')),
-            ('kubernetes-jenkins/pr-logs/pull/charts/123', ('123', 'charts/', 'kubernetes/charts')),
-        ]:
+        def check(prefix, expected):
             self.assertEqual(view_build.parse_pr_path(prefix), expected)
+
+        check('kubernetes-jenkins/logs/e2e', (None, None, None))
+        check('kubernetes-jenkins/pr-logs/pull/123', ('123', '', 'kubernetes/kubernetes'))
+        check('kubernetes-jenkins/pr-logs/pull/charts/123', ('123', 'charts/', 'kubernetes/charts'))
+        check('istio-prow/pull/istio_istio/517', ('517', 'istio/istio/', 'istio/istio'))
+        check(
+            'kubernetes-jenkins/pr-logs/pull/google_cadvisor/296',
+            ('296', 'google/cadvisor/', 'google/cadvisor'))
 
     def test_build_pr_link(self):
         ''' The build page for a PR build links to the PR results.'''
-        build_dir = '/%s/123/e2e/567/' % view_pr.PR_PREFIX
+        build_dir = '/%s/123/e2e/567/' % view_pr.PR_PREFIX['kubernetes']
         init_build(build_dir)
         response = app.get('/build' + build_dir)
         self.assertIn('PR #123', response)
         self.assertIn('href="/pr/123"', response)
 
     def test_build_pr_link_other(self):
-        build_dir = '/%s/charts/123/e2e/567/' % view_pr.PR_PREFIX
+        build_dir = '/%s/charts/123/e2e/567/' % view_pr.PR_PREFIX['kubernetes']
         init_build(build_dir)
         response = app.get('/build' + build_dir)
         self.assertIn('PR #123', response)

--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -67,10 +67,10 @@ def pr_path(org, repo, pr):
     """Builds the correct gs://prefix/maybe_kubernetes/maybe_repo_org/pr."""
     # TODO(fejta): make this less specific to kubernetes.
     if org == repo == 'kubernetes':
-        return '%s/%s' % (PR_PREFIX, pr)
+        return '%s/%s' % (PR_PREFIX['kubernetes'], pr)
     if org == 'kubernetes':
-        return '%s/%s/%s' % (PR_PREFIX, repo, pr)
-    return '%s/%s_%s/%s' % (PR_PREFIX, org, repo, pr)
+        return '%s/%s/%s' % (PR_PREFIX['kubernetes'], repo, pr)
+    return '%s/%s_%s/%s' % (PR_PREFIX[org], org, repo, pr)
 
 
 def org_repo(path):

--- a/gubernator/view_pr_test.py
+++ b/gubernator/view_pr_test.py
@@ -30,6 +30,7 @@ from webapp2_extras import securecookie
 
 app = main_test.app
 write = gcs_async_test.write
+PR_PREFIX = view_base.PR_PREFIX['kubernetes']
 
 
 class PathTest(unittest.TestCase):
@@ -49,7 +50,7 @@ class PathTest(unittest.TestCase):
     def test_pr_path(self):
         def check(org, repo, pr, path):
             actual_path = view_pr.pr_path(org, repo, pr)
-            self.assertEquals(actual_path, '%s/%s' % (view_base.PR_PREFIX, path))
+            self.assertEquals(actual_path, '%s/%s' % (PR_PREFIX, path))
 
         check('kubernetes', 'kubernetes', 1234, 1234)
         check('kubernetes', 'kubernetes', 'batch', 'batch')
@@ -79,7 +80,7 @@ class PRTest(main_test.TestBase):
 
         for job, builds in self.BUILDS.iteritems():
             for build, started, finished in builds:
-                path = '/%s/123/%s/%s/' % (view_pr.PR_PREFIX, job, build)
+                path = '/%s/123/%s/%s/' % (PR_PREFIX, job, build)
                 if started:
                     write(path + 'started.json', started)
                 if finished:
@@ -189,7 +190,7 @@ class TestDashboard(main_test.TestBase):
     def test_build_links_user(self):
         "Build pages show PR information"
         make_pr(12345, ['human'], {'title': 'huge pr!'})
-        build_dir = '/%s/12345/e2e/5/' % view_base.PR_PREFIX
+        build_dir = '/%s/12345/e2e/5/' % PR_PREFIX
         write(build_dir + 'started.json', '{}')
         resp = app.get('/build' + build_dir)
         self.assertIn('href="/pr/human"', resp)


### PR DESCRIPTION
This should fix Github links and internal references for results from other repositories, including Istio.

cc @sebastienvas 