### PR TITLE
Expand the do-not-merge label into a class of labels

### DIFF
--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -32,13 +32,14 @@ import (
 )
 
 const (
-	blockPathFormat = `Adding label:%s because PR changes docs prohibited to auto merge
+	blockedPathsLabel = doNotMergePrefix + "/blocked-paths"
+	blockPathFormat   = `Adding label:%s because PR changes docs prohibited to auto merge
 See http://kubernetes.io/editdocs/ for information about editing docs`
 )
 
 var (
 	_             = fmt.Print
-	blockPathBody = fmt.Sprintf(blockPathFormat, doNotMergeLabel)
+	blockPathBody = fmt.Sprintf(blockPathFormat, blockedPathsLabel)
 )
 
 type configBlockPath struct {
@@ -140,7 +141,7 @@ func (b *BlockPath) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if obj.HasLabel(doNotMergeLabel) {
+	if obj.HasLabel(blockedPathsLabel) {
 		return
 	}
 
@@ -155,7 +156,7 @@ func (b *BlockPath) Munge(obj *github.MungeObject) {
 				continue
 			}
 			obj.WriteComment(blockPathBody)
-			obj.AddLabels([]string{doNotMergeLabel})
+			obj.AddLabels([]string{blockedPathsLabel})
 			return
 		}
 	}
@@ -168,7 +169,7 @@ func (b *BlockPath) isStaleIssueComment(obj *github.MungeObject, comment *github
 	if *comment.Body != blockPathBody {
 		return false
 	}
-	stale := !obj.HasLabel(doNotMergeLabel)
+	stale := !obj.HasLabel(blockedPathsLabel)
 	if stale {
 		glog.V(6).Infof("Found stale BlockPath comment")
 	}

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	blockedPathsLabel = doNotMergePrefix + "/blocked-paths"
+	blockedPathsLabel = "do-not-merge/blocked-paths"
 	blockPathFormat   = `Adding label:%s because PR changes docs prohibited to auto merge
 See http://kubernetes.io/editdocs/ for information about editing docs`
 )

--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	cherrypickUnapprovedLabel = doNotMergePrefix + "/cherry-pick-not-approved"
+	cherrypickUnapprovedLabel = "do-not-merge/cherry-pick-not-approved"
 	labelUnapprovedPicksName  = "label-unapproved-picks"
 	labelUnapprovedFormat     = "This PR is not for the master branch but does not have the `%s` label. Adding the `%s` label."
 )

--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -29,12 +29,13 @@ import (
 )
 
 const (
-	labelUnapprovedPicksName = "label-unapproved-picks"
-	labelUnapprovedFormat    = "This PR is not for the master branch but does not have the `%s` label. Adding the `%s` label."
+	cherrypickUnapprovedLabel = doNotMergePrefix + "/cherry-pick-not-approved"
+	labelUnapprovedPicksName  = "label-unapproved-picks"
+	labelUnapprovedFormat     = "This PR is not for the master branch but does not have the `%s` label. Adding the `%s` label."
 )
 
 var (
-	labelUnapprovedBody = fmt.Sprintf(labelUnapprovedFormat, cpApprovedLabel, doNotMergeLabel)
+	labelUnapprovedBody = fmt.Sprintf(labelUnapprovedFormat, cpApprovedLabel, cherrypickUnapprovedLabel)
 )
 
 // LabelUnapprovedPicks will add `do-not-merge` to PRs against a release branch which
@@ -79,11 +80,11 @@ func (LabelUnapprovedPicks) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if obj.HasLabel(doNotMergeLabel) {
+	if obj.HasLabel(cherrypickUnapprovedLabel) {
 		return
 	}
 
-	obj.AddLabel(doNotMergeLabel)
+	obj.AddLabel(cherrypickUnapprovedLabel)
 
 	obj.WriteComment(labelUnapprovedBody)
 }

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -34,7 +34,7 @@ import (
 const (
 	releaseNoteLabeler = "release-note-label"
 
-	releaseNoteLabelNeeded    = doNotMergePrefix + "/release-note-label-needed"
+	releaseNoteLabelNeeded    = "do-not-merge/release-note-label-needed"
 	releaseNote               = "release-note"
 	releaseNoteNone           = "release-note-none"
 	releaseNoteActionRequired = "release-note-action-required"

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -40,7 +40,8 @@ const (
 	releaseNoteActionRequired = "release-note-action-required"
 	releaseNoteExperimental   = "release-note-experimental"
 
-	releaseNoteFormat = `Adding ` + doNotMergeLabel + ` because the release note process has not been followed.
+	releaseNoteMissingLabel = doNotMergePrefix + "/release-note-label-missing"
+	releaseNoteFormat       = `Adding ` + releaseNoteMissingLabel + ` because the release note process has not been followed.
 One of the following labels is required %q, %q, %q or %q.
 Please see: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed.`
 	parentReleaseNoteFormat = `The 'parent' PR of a cherry-pick PR must have one of the %q or %q labels, or this PR must follow the standard/parent release note labeling requirement. (release-note-experimental must be explicit for cherry-picks)`
@@ -55,7 +56,7 @@ var (
 	noteMatcherRE         = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
 )
 
-// ReleaseNoteLabel will add the doNotMergeLabel to a PR which has not
+// ReleaseNoteLabel will add the releaseNoteMissingLabel to a PR which has not
 // set one of the appropriete 'release-note-*' labels but has LGTM
 type ReleaseNoteLabel struct {
 	config *github.Config
@@ -153,12 +154,12 @@ func (r *ReleaseNoteLabel) Munge(obj *github.MungeObject) {
 		return
 	}
 
-	if obj.HasLabel(doNotMergeLabel) {
+	if obj.HasLabel(releaseNoteMissingLabel) {
 		return
 	}
 
 	obj.WriteComment(releaseNoteBody)
-	obj.AddLabel(doNotMergeLabel)
+	obj.AddLabel(releaseNoteMissingLabel)
 }
 
 // determineReleaseNoteLabel returns the label to be added if

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -34,6 +34,11 @@ import (
 const (
 	releaseNoteLabeler = "release-note-label"
 
+	// deprecatedReleaseNoteLabelNeeded is the previous version of the
+	// releaseNotLabelNeeded label, which we continue to honor for the
+	// time being
+	deprecatedReleaseNoteLabelNeeded = "release-note-label-needed"
+
 	releaseNoteLabelNeeded    = "do-not-merge/release-note-label-needed"
 	releaseNote               = "release-note"
 	releaseNoteNone           = "release-note-none"

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -75,13 +75,13 @@ func TestReleaseNoteLabel(t *testing.T) {
 		{
 			name:        "LGTM with release-note-label-needed",
 			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel, releaseNoteLabelNeeded}, true),
-			mustHave:    []string{lgtmLabel, doNotMergeLabel, releaseNoteLabelNeeded},
+			mustHave:    []string{lgtmLabel, releaseNoteMissingLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 		{
 			name:        "LGTM only",
 			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel}, true),
-			mustHave:    []string{lgtmLabel, doNotMergeLabel, releaseNoteLabelNeeded},
+			mustHave:    []string{lgtmLabel, releaseNoteMissingLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 		{
@@ -159,12 +159,12 @@ func TestReleaseNoteLabel(t *testing.T) {
 			mustHave:    []string{releaseNoteLabelNeeded},
 		},
 		{
-			name:        "add doNotMergeLabel on non-master when parent PR has releaseNoteNone label",
+			name:        "add releaseNoteMissingLabel on non-master when parent PR has releaseNoteNone label",
 			branch:      "release-1.2",
 			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
 			secondIssue: github_test.Issue(testBotName, 2, []string{releaseNoteNone}, true),
-			mustHave:    []string{doNotMergeLabel, releaseNoteLabelNeeded},
+			mustHave:    []string{releaseNoteMissingLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 	}

--- a/mungegithub/mungers/release-note-label_test.go
+++ b/mungegithub/mungers/release-note-label_test.go
@@ -75,13 +75,13 @@ func TestReleaseNoteLabel(t *testing.T) {
 		{
 			name:        "LGTM with release-note-label-needed",
 			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel, releaseNoteLabelNeeded}, true),
-			mustHave:    []string{lgtmLabel, releaseNoteMissingLabel, releaseNoteLabelNeeded},
+			mustHave:    []string{lgtmLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 		{
 			name:        "LGTM only",
 			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel}, true),
-			mustHave:    []string{lgtmLabel, releaseNoteMissingLabel, releaseNoteLabelNeeded},
+			mustHave:    []string{lgtmLabel, releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 		{
@@ -164,7 +164,7 @@ func TestReleaseNoteLabel(t *testing.T) {
 			issue:       github_test.Issue(testBotName, 1, []string{lgtmLabel}, true),
 			body:        "Cherry pick of #2 on release-1.2.",
 			secondIssue: github_test.Issue(testBotName, 2, []string{releaseNoteNone}, true),
-			mustHave:    []string{releaseNoteMissingLabel, releaseNoteLabelNeeded},
+			mustHave:    []string{releaseNoteLabelNeeded},
 			mustNotHave: []string{},
 		},
 	}

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -1081,7 +1081,7 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 	}
 
 	// PR cannot have any labels which prevent merging.
-	for _, label := range []string{cherrypickUnapprovedLabel, blockedPathsLabel, releaseNoteLabelNeeded, doNotMergeLabel} {
+	for _, label := range []string{cherrypickUnapprovedLabel, blockedPathsLabel, deprecatedReleaseNoteLabelNeeded, releaseNoteLabelNeeded, doNotMergeLabel} {
 		if obj.HasLabel(label) {
 			sq.SetMergeStatus(obj, noMergeMessage(label))
 			return false

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -55,7 +55,7 @@ const (
 	lgtmLabel                      = "lgtm"
 	retestNotRequiredLabel         = "retest-not-required"
 	retestNotRequiredDocsOnlyLabel = "retest-not-required-docs-only"
-	doNotMergePrefix               = "do-not-merge"
+	doNotMergeLabel                = "do-not-merge"
 	claYesLabel                    = "cla: yes"
 	claNoLabel                     = "cla: no"
 	cncfClaYesLabel                = "cncf-cla: yes"
@@ -1081,8 +1081,8 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 	}
 
 	// PR cannot have any labels which prevent merging.
-	for _, label := range obj.LabelSet().List() {
-		if strings.HasPrefix(label, doNotMergePrefix) {
+	for _, label := range []string{cherrypickUnapprovedLabel, blockedPathsLabel, releaseNoteLabelNeeded, doNotMergeLabel} {
+		if obj.HasLabel(label) {
 			sq.SetMergeStatus(obj, noMergeMessage(label))
 			return false
 		}
@@ -1587,7 +1587,7 @@ func (sq *SubmitQueue) serveMergeInfo(res http.ResponseWriter, req *http.Request
 	if gateApproved {
 		out.WriteString(fmt.Sprintf(`<li>The PR must have the %q label</li>`, approvedLabel))
 	}
-	out.WriteString(fmt.Sprintf("<li>The PR must not have the any labels starting with %q</li>", doNotMergePrefix))
+	out.WriteString(`<li>The PR must not have the any labels starting with "do-not-merge"</li>`)
 	out.WriteString(`</ol><br>`)
 	out.WriteString("The PR can then be queued to re-test before merge. Once it reaches the top of the queue all of the above conditions must be true but so must the following:")
 	out.WriteString("<ol>")

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -114,6 +114,10 @@ func BlockedPathsIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, blockedPathsLabel}, true)
 }
 
+func DeprecatedMissingReleaseNoteIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, deprecatedReleaseNoteLabelNeeded}, true)
+}
+
 func MissingReleaseNoteIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, releaseNoteLabelNeeded}, true)
 }
@@ -796,6 +800,20 @@ func TestSubmitQueue(t *testing.T) {
 			retest1Pass:     true,
 			retest2Pass:     true,
 			reason:          noMergeMessage(releaseNoteLabelNeeded),
+			state:           "pending",
+		},
+		{
+			name:            "Fail because deprecated missing release note label is present",
+			pr:              ValidPR(),
+			issue:           DeprecatedMissingReleaseNoteIssue(),
+			events:          NewLGTMEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			retest1Pass:     true,
+			retest2Pass:     true,
+			reason:          noMergeMessage(deprecatedReleaseNoteLabelNeeded),
 			state:           "pending",
 		},
 		{

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -102,12 +102,20 @@ func OnlyApprovedIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, approvedLabel}, true)
 }
 
-func DoNotMergeIssue() *github.Issue {
-	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, doNotMergeLabel}, true)
+func CherrypickUnapprovedIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, cherrypickUnapprovedLabel}, true)
+}
+
+func BlockedPathsIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, blockedPathsLabel}, true)
+}
+
+func MissingReleaseNoteIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, releaseNoteMissingLabel}, true)
 }
 
 func DoNotMergeMilestoneIssue() *github.Issue {
-	issue := github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, doNotMergeLabel}, true)
+	issue := github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel}, true)
 	milestone := &github.Milestone{
 		Title: stringPtr(doNotMergeMilestone),
 	}
@@ -773,9 +781,9 @@ func TestSubmitQueue(t *testing.T) {
 			state:           "pending",
 		},
 		{
-			name:            "Fail because doNotMerge label is present",
+			name:            "Fail because missing release note label is present",
 			pr:              ValidPR(),
-			issue:           DoNotMergeIssue(),
+			issue:           MissingReleaseNoteIssue(),
 			events:          NewLGTMEvents(),
 			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
 			ciStatus:        SuccessStatus(),
@@ -783,7 +791,35 @@ func TestSubmitQueue(t *testing.T) {
 			gcsResult:       SuccessGCS(),
 			retest1Pass:     true,
 			retest2Pass:     true,
-			reason:          noMerge,
+			reason:          noMergeMessage(releaseNoteMissingLabel),
+			state:           "pending",
+		},
+		{
+			name:            "Fail because cherrypick unapproved label is present",
+			pr:              ValidPR(),
+			issue:           CherrypickUnapprovedIssue(),
+			events:          NewLGTMEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			retest1Pass:     true,
+			retest2Pass:     true,
+			reason:          noMergeMessage(cherrypickUnapprovedLabel),
+			state:           "pending",
+		},
+		{
+			name:            "Fail because blocked paths label is present",
+			pr:              ValidPR(),
+			issue:           BlockedPathsIssue(),
+			events:          NewLGTMEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			retest1Pass:     true,
+			retest2Pass:     true,
+			reason:          noMergeMessage(blockedPathsLabel),
 			state:           "pending",
 		},
 		// Should fail because the 'do-not-merge-milestone' is set.

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -111,7 +111,7 @@ func BlockedPathsIssue() *github.Issue {
 }
 
 func MissingReleaseNoteIssue() *github.Issue {
-	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, releaseNoteMissingLabel}, true)
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, releaseNoteLabelNeeded}, true)
 }
 
 func DoNotMergeMilestoneIssue() *github.Issue {
@@ -791,7 +791,7 @@ func TestSubmitQueue(t *testing.T) {
 			gcsResult:       SuccessGCS(),
 			retest1Pass:     true,
 			retest2Pass:     true,
-			reason:          noMergeMessage(releaseNoteMissingLabel),
+			reason:          noMergeMessage(releaseNoteLabelNeeded),
 			state:           "pending",
 		},
 		{

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -102,6 +102,10 @@ func OnlyApprovedIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, approvedLabel}, true)
 }
 
+func DoNotMergeIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, doNotMergeLabel}, true)
+}
+
 func CherrypickUnapprovedIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, cherrypickUnapprovedLabel}, true)
 }
@@ -792,6 +796,20 @@ func TestSubmitQueue(t *testing.T) {
 			retest1Pass:     true,
 			retest2Pass:     true,
 			reason:          noMergeMessage(releaseNoteLabelNeeded),
+			state:           "pending",
+		},
+		{
+			name:            "Fail because do not merge label is present",
+			pr:              ValidPR(),
+			issue:           DoNotMergeIssue(),
+			events:          NewLGTMEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			retest1Pass:     true,
+			retest2Pass:     true,
+			reason:          noMergeMessage(doNotMergeLabel),
 			state:           "pending",
 		},
 		{


### PR DESCRIPTION
In order to support a larger set of reasons why a developer or the
system may wish to stop a pull request from merging and in order to do
so in a way that is clearly communicated, the `do-not-merge` label is
broken into a `do-not-merge/X` label class. The submit-queue will not
merge a PR if any label with the prefix exists. This change is
backwards-compatible as the original `do-not-merge` label matches the
prefix and no munger was removing the `do-not-merge` labels they added.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area mungegithub
/cc @spxtr @fejta @cjwagner 
/assign @fejta 