### PR TITLE
Correct default cluster-ip-range subnet

### DIFF
--- a/kubetest/bash.go
+++ b/kubetest/bash.go
@@ -66,15 +66,15 @@ func (b bash) Down() error {
 // Calculates the cluster IP range based on the no. of nodes in the cluster.
 // Note: This mimics the function get-cluster-ip-range used by kube-up script.
 func getClusterIPRange(numNodes int) string {
-	suggestedRange := "10.100.0.0/14"
+	suggestedRange := "10.160.0.0/14"
 	if numNodes > 1000 {
-		suggestedRange = "10.100.0.0/13"
+		suggestedRange = "10.160.0.0/13"
 	}
 	if numNodes > 2000 {
-		suggestedRange = "10.100.0.0/12"
+		suggestedRange = "10.160.0.0/12"
 	}
 	if numNodes > 4000 {
-		suggestedRange = "10.100.0.0/11"
+		suggestedRange = "10.160.0.0/11"
 	}
 	return suggestedRange
 }


### PR DESCRIPTION
Inspired from https://github.com/kubernetes/kubernetes/pull/51343