### PR TITLE
Add error handling of syscall.Kill call

### DIFF
--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -158,7 +158,9 @@ func finishRunning(cmd *exec.Cmd) error {
 		case <-terminate.C:
 			terminated = true
 			terminate.Reset(time.Duration(0)) // Kill subsequent processes immediately.
-			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+				log.Printf("Failed to kill %v: %v", stepName, err)
+			}
 			if err := cmd.Process.Kill(); err != nil {
 				log.Printf("Failed to terminate %s (terminated 15m after interrupt): %v", stepName, err)
 			}


### PR DESCRIPTION
This PR is just follow-up of a7181a161fbebdbb014038067abe914074dc76f5
During the review, we have a consensus to add an error handling of
syscall.Kill. Then this PR adds it to this syscall.Kill.

NOTE: This doesn't cover interrupt.C case because the syscall.Kill
      is used for a retry of kill and the log could be confusable.