### PR TITLE
Add a prow plugin for PR authors to hold PR merges

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -18,6 +18,8 @@ Command | Implemented By | Who can run it | Description
 `/remove-sig [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | removes a sig/<> label(s) if it exists
 `/lgtm` | prow [lgtm](./prow/plugins/lgtm) | assignees | adds the `lgtm` label
 `/lgtm cancel` | prow [lgtm](./prow/plugins/lgtm) | authors and assignees | removes the `lgtm` label
+`/hold` | prow [hold](./prow/plugins/hold) | anyone | adds the `hold` label
+`/hold cancel` | prow [hold](./prow/plugins/hold) | anyone | removes the `hold` label
 `/approve` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | approve all the files for which you are an approver
 `/approve no-issue` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | approve when a PR doesn't have an associated issue
 `/approve cancel` | mungegithub [approvers](./mungegithub/mungers/approvers) | owners | removes your approval on this pull-request

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -57,6 +57,7 @@ const (
 	retestNotRequiredDocsOnlyLabel = "retest-not-required-docs-only"
 	doNotMergeLabel                = "do-not-merge"
 	wipLabel                       = "do-not-merge/work-in-progress"
+	holdLabel                      = "do-not-merge/hold"
 	claYesLabel                    = "cla: yes"
 	claNoLabel                     = "cla: no"
 	cncfClaYesLabel                = "cncf-cla: yes"
@@ -1082,7 +1083,15 @@ func (sq *SubmitQueue) validForMergeExt(obj *github.MungeObject, checkStatus boo
 	}
 
 	// PR cannot have any labels which prevent merging.
-	for _, label := range []string{cherrypickUnapprovedLabel, blockedPathsLabel, deprecatedReleaseNoteLabelNeeded, releaseNoteLabelNeeded, doNotMergeLabel, wipLabel} {
+	for _, label := range []string{
+		cherrypickUnapprovedLabel,
+		blockedPathsLabel,
+		deprecatedReleaseNoteLabelNeeded,
+		releaseNoteLabelNeeded,
+		doNotMergeLabel,
+		wipLabel,
+		holdLabel,
+	} {
 		if obj.HasLabel(label) {
 			sq.SetMergeStatus(obj, noMergeMessage(label))
 			return false

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -126,6 +126,10 @@ func WorkInProgressIssue() *github.Issue {
 	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, wipLabel}, true)
 }
 
+func HoldLabelIssue() *github.Issue {
+	return github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel, approvedLabel, holdLabel}, true)
+}
+
 func DoNotMergeMilestoneIssue() *github.Issue {
 	issue := github_test.Issue(someUserName, 1, []string{claYesLabel, lgtmLabel}, true)
 	milestone := &github.Milestone{
@@ -804,6 +808,20 @@ func TestSubmitQueue(t *testing.T) {
 			retest1Pass:     true,
 			retest2Pass:     true,
 			reason:          noMergeMessage(releaseNoteLabelNeeded),
+			state:           "pending",
+		},
+		{
+			name:            "Fail because hold label is present",
+			pr:              ValidPR(),
+			issue:           HoldLabelIssue(),
+			events:          NewLGTMEvents(),
+			commits:         Commits(), // Modified at time.Unix(7), 8, and 9
+			ciStatus:        SuccessStatus(),
+			lastBuildNumber: LastBuildNumber(),
+			gcsResult:       SuccessGCS(),
+			retest1Pass:     true,
+			retest2Pass:     true,
+			reason:          noMergeMessage(holdLabel),
 			state:           "pending",
 		},
 		{

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION             ?= 0.151
+HOOK_VERSION             ?= 0.152
 SINKER_VERSION           ?= 0.16
 DECK_VERSION             ?= 0.43
 SPLICE_VERSION           ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.151
+        image: gcr.io/k8s-prow/hook:0.152
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//prow/plugins/close:go_default_library",
         "//prow/plugins/golint:go_default_library",
         "//prow/plugins/heart:go_default_library",
+        "//prow/plugins/hold:go_default_library",
         "//prow/plugins/label:go_default_library",
         "//prow/plugins/lgtm:go_default_library",
         "//prow/plugins/releasenote:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -41,6 +41,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/close"
 	_ "k8s.io/test-infra/prow/plugins/golint"
 	_ "k8s.io/test-infra/prow/plugins/heart"
+	_ "k8s.io/test-infra/prow/plugins/hold"
 	_ "k8s.io/test-infra/prow/plugins/label"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"
 	_ "k8s.io/test-infra/prow/plugins/releasenote"

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -49,6 +49,7 @@ filegroup(
         "//prow/plugins/close:all-srcs",
         "//prow/plugins/golint:all-srcs",
         "//prow/plugins/heart:all-srcs",
+        "//prow/plugins/hold:all-srcs",
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/releasenote:all-srcs",

--- a/prow/plugins/hold/BUILD
+++ b/prow/plugins/hold/BUILD
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hold.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/Sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["hold_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/Sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hold contains a plugin which will allow users to label their
+// own pull requests as not ready or ready for merge. The submit queue
+// will honor the label to ensure pull requests do not merge when it is
+// applied.
+package hold
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "hold"
+
+var (
+	label         = "do-not-merge/hold"
+	labelRe       = regexp.MustCompile(`(?mi)^/hold\s*$`)
+	labelCancelRe = regexp.MustCompile(`(?mi)^/hold cancel\s*$`)
+)
+
+type event struct {
+	org      string
+	repo     string
+	number   int
+	body     string
+	htmlurl  string
+	hasLabel func() (bool, error)
+}
+
+func init() {
+	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
+	plugins.RegisterReviewEventHandler(pluginName, handleReview)
+	plugins.RegisterReviewCommentEventHandler(pluginName, handleReviewComment)
+}
+
+type githubClient interface {
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
+	// Only consider open PRs.
+	if !ic.Issue.IsPullRequest() || ic.Issue.State != "open" || ic.Action != github.IssueCommentActionCreated {
+		return nil
+	}
+
+	e := &event{
+		org:    ic.Repo.Owner.Login,
+		repo:   ic.Repo.Name,
+		number: ic.Issue.Number,
+		body:   ic.Comment.Body,
+		hasLabel: func() (bool, error) {
+			return ic.Issue.HasLabel(label), nil
+		},
+		htmlurl: ic.Comment.HTMLURL,
+	}
+	return handle(pc.GitHubClient, pc.Logger, e)
+}
+
+func handleReview(pc plugins.PluginClient, re github.ReviewEvent) error {
+	if re.Action != github.ReviewActionSubmitted {
+		return nil
+	}
+
+	e := &event{
+		org:    re.Repo.Owner.Login,
+		repo:   re.Repo.Name,
+		number: re.PullRequest.Number,
+		body:   re.Review.Body,
+		hasLabel: func() (bool, error) {
+			return hasLabel(pc.GitHubClient, re.Repo.Owner.Login, re.Repo.Name, re.PullRequest.Number, label)
+		},
+		htmlurl: re.Review.HTMLURL,
+	}
+	return handle(pc.GitHubClient, pc.Logger, e)
+}
+
+func handleReviewComment(pc plugins.PluginClient, rce github.ReviewCommentEvent) error {
+	if rce.Action != github.ReviewCommentActionCreated {
+		return nil
+	}
+
+	e := &event{
+		org:    rce.Repo.Owner.Login,
+		repo:   rce.Repo.Name,
+		number: rce.PullRequest.Number,
+		body:   rce.Comment.Body,
+		hasLabel: func() (bool, error) {
+			return hasLabel(pc.GitHubClient, rce.Repo.Owner.Login, rce.Repo.Name, rce.PullRequest.Number, label)
+		},
+		htmlurl: rce.Comment.HTMLURL,
+	}
+	return handle(pc.GitHubClient, pc.Logger, e)
+}
+
+// handle drives the pull request to the desired state. If any user adds
+// a /hold directive, we want to add a label if one does not already exist.
+// If they add /hold cancel, we want to remove the label if it exists.
+func handle(gc githubClient, log *logrus.Entry, e *event) error {
+	needsLabel := false
+	if labelRe.MatchString(e.body) {
+		needsLabel = true
+	} else if labelCancelRe.MatchString(e.body) {
+		needsLabel = false
+	} else {
+		return nil
+	}
+
+	hasLabel, err := e.hasLabel()
+	if err != nil {
+		return err
+	}
+
+	if hasLabel && !needsLabel {
+		log.Info("Removing %q label for %s/%s#%d", label, e.org, e.repo, e.number)
+		return gc.RemoveLabel(e.org, e.repo, e.number, label)
+	} else if !hasLabel && needsLabel {
+		log.Info("Adding %q label for %s/%s#%d", label, e.org, e.repo, e.number)
+		return gc.AddLabel(e.org, e.repo, e.number, label)
+	}
+	return nil
+}
+
+// hasLabel checks if a label is applied to a pr.
+func hasLabel(c githubClient, org, repo string, num int, label string) (bool, error) {
+	labels, err := c.GetIssueLabels(org, repo, num)
+	if err != nil {
+		return false, fmt.Errorf("failed to get the labels on %s/%s#%d: %v", org, repo, num, err)
+	}
+	for _, candidate := range labels {
+		if candidate.Name == label {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/prow/plugins/hold/hold_test.go
+++ b/prow/plugins/hold/hold_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hold
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestHandle(t *testing.T) {
+	var tests = []struct {
+		name          string
+		body          string
+		hasLabel      bool
+		shouldLabel   bool
+		shouldUnlabel bool
+	}{
+		{
+			name:          "nothing to do",
+			body:          "noise",
+			hasLabel:      false,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+		},
+		{
+			name:          "requested hold",
+			body:          "/hold",
+			hasLabel:      false,
+			shouldLabel:   true,
+			shouldUnlabel: false,
+		},
+		{
+			name:          "requested hold, label already exists",
+			body:          "/hold",
+			hasLabel:      true,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+		},
+		{
+			name:          "requested hold cancel",
+			body:          "/hold cancel",
+			hasLabel:      true,
+			shouldLabel:   false,
+			shouldUnlabel: true,
+		},
+		{
+			name:          "requested hold cancel, label already gone",
+			body:          "/hold cancel",
+			hasLabel:      false,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+		},
+	}
+
+	for _, tc := range tests {
+		fc := &fakegithub.FakeClient{
+			IssueComments: make(map[int][]github.IssueComment),
+		}
+
+		org, repo, number, htmlurl := "org", "repo", 1, "url"
+		e := &event{
+			org:    org,
+			repo:   repo,
+			number: number,
+			body:   tc.body,
+			hasLabel: func() (bool, error) {
+				return tc.hasLabel, nil
+			},
+			htmlurl: htmlurl,
+		}
+
+		if err := handle(fc, logrus.WithField("plugin", pluginName), e); err != nil {
+			t.Errorf("For case %s, didn't expect error from hold: %v", tc.name, err)
+			continue
+		}
+
+		fakeLabel := fmt.Sprintf("%s/%s#%d:%s", org, repo, number, label)
+		if tc.shouldLabel {
+			if len(fc.LabelsAdded) != 1 || fc.LabelsAdded[0] != fakeLabel {
+				t.Errorf("For case %s: expected to add %q label but instead added: %v", tc.name, label, fc.LabelsAdded)
+			}
+		} else if len(fc.LabelsAdded) > 0 {
+			t.Errorf("For case %s, expected to not add %q label but added: %v", tc.name, label, fc.LabelsAdded)
+		}
+		if tc.shouldUnlabel {
+			if len(fc.LabelsRemoved) != 1 || fc.LabelsRemoved[0] != fakeLabel {
+				t.Errorf("For case %s: expected to remove %q label but instead removed: %v", tc.name, label, fc.LabelsRemoved)
+			}
+		} else if len(fc.LabelsRemoved) > 0 {
+			t.Errorf("For case %s, expected to not remove %q label but removed: %v", tc.name, label, fc.LabelsRemoved)
+		}
+	}
+}


### PR DESCRIPTION
Pull request authors need a means by which they can communicate to the
submit queue that their pull request should not be considered for
merges. This plugin adds that functionality with the `/hold` command.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/area mungegithub

/cc @fejta @spxtr 