### PR TITLE
Add support for bearer token auth in Prow Jenkins controller

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -17,12 +17,12 @@ all: build test
 
 HOOK_VERSION             ?= 0.155
 SINKER_VERSION           ?= 0.17
-DECK_VERSION             ?= 0.43
+DECK_VERSION             ?= 0.44
 SPLICE_VERSION           ?= 0.27
 TOT_VERSION              ?= 0.5
 HOROLOGIUM_VERSION       ?= 0.8
 PLANK_VERSION            ?= 0.42
-JENKINS-OPERATOR_VERSION ?= 0.40
+JENKINS-OPERATOR_VERSION ?= 0.41
 TIDE_VERSION             ?= 0.2
 
 # These are the usual GKE variables.

--- a/prow/README.md
+++ b/prow/README.md
@@ -35,9 +35,15 @@ state and no claims of backwards compatibility are made for any external API.
    ```
    kubectl label pods --all -n pod_namespace created-by-prow=true
    ```
+ - *September 1, 2017* `deck` version 0.44 and `jenkins-operator` version 0.41
+   controllers no longer provide a default value for the `--jenkins-token-file` flag.
+   Cluster administrators should provide `--jenkins-token-file=/etc/jenkins/jenkins`
+   explicitly when upgrading to a new version of these components if they were
+   previously relying on the default. For more context, please see
+   [this pull request.](https://github.com/kubernetes/test-infra/pull/4210)
  - *August 29, 2017* Configuration specific to plugins is now held in in the
    `plugins` `ConfigMap` and serialized in this repo in the `plugins.yaml` file.
-   Cluster administrators upgrading to the newest version of Prow should move
+   Cluster administrators upgrading to `hook` version 0.148 or newer should move
    plugin configuration from the main `ConfigMap`. For more context, please see
    [this pull request.](https://github.com/kubernetes/test-infra/pull/4213)
 

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,12 +33,13 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.43
+        image: gcr.io/k8s-prow/deck:0.44
         ports:
           - name: http
             containerPort: 8080
         args:
         - --jenkins-url=$(JENKINS_URL)
+        - --jenkins-token-file=/etc/jenkins/jenkins
         - --build-cluster=/etc/cluster/cluster
         env:
         - name: JENKINS_URL

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,9 +25,10 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.39
+        image: gcr.io/k8s-prow/jenkins-operator:0.41
         args:
         - --dry-run=false
+        - --jenkins-token-file=/etc/jenkins/jenkins
         volumeMounts:
         - mountPath: /etc/jenkins
           name: jenkins


### PR DESCRIPTION
Not all Jenkins masters allow for basic auth. This patch adds support
for bearer token auth in the Prow Jenkins client.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @spxtr @kargakis @csrwng 