### PR TITLE
Update images to bazel 0.5.4

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/e2e-prow/Dockerfile
+++ b/images/e2e-prow/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170829-9b422e21
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170829-1d33d34c
 MAINTAINER  Sen Lu <senlu@google.com>
 
 ADD runner /

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170829-9b422e21
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170829-1d33d34c
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/images/pull_kubernetes_bazel/Dockerfile
+++ b/images/pull_kubernetes_bazel/Dockerfile
@@ -30,12 +30,12 @@ RUN apt-get update && apt-get install -y \
     python-pip && \
     apt-get clean
 
-ENV BAZEL_VERSION 0.5.2
+ENV BAZEL_VERSION 0.5.4
 RUN wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb" && \
     rm "bazel_${BAZEL_VERSION}-linux-x86_64.deb"
 
-ENV GCLOUD_VERSION 156.0.0
+ENV GCLOUD_VERSION 163.0.0
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     tar xf google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
     rm google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-openssl \
     && apt-get clean
 
-ENV BAZEL_VERSION 0.5.2
+ENV BAZEL_VERSION 0.5.4
 RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
     wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}" && \
     chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -82,7 +82,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -124,7 +124,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -424,7 +424,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -466,7 +466,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -764,7 +764,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-test-infra-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -942,7 +942,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -977,7 +977,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -1057,7 +1057,7 @@ postsubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1092,7 +1092,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -1172,7 +1172,7 @@ postsubmits:
     - release-1.7
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1209,7 +1209,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -1335,7 +1335,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1398,7 +1398,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -15765,7 +15765,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -15915,7 +15915,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -15950,7 +15950,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -16031,7 +16031,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -16068,7 +16068,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -201,7 +201,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -280,7 +280,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -360,7 +360,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -543,7 +543,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -622,7 +622,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -702,7 +702,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1011,7 +1011,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1126,7 +1126,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1245,7 +1245,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1288,7 +1288,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1439,7 +1439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1473,7 +1473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1507,7 +1507,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1541,7 +1541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1575,7 +1575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1609,7 +1609,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1643,7 +1643,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1677,7 +1677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1711,7 +1711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1745,7 +1745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1779,7 +1779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1813,7 +1813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1847,7 +1847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1881,7 +1881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1915,7 +1915,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1949,7 +1949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -1983,7 +1983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2017,7 +2017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2051,7 +2051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2085,7 +2085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2119,7 +2119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2153,7 +2153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2187,7 +2187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2221,7 +2221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2255,7 +2255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2289,7 +2289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2323,7 +2323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2357,7 +2357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2391,7 +2391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2425,7 +2425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2459,7 +2459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2493,7 +2493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2561,7 +2561,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2597,7 +2597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2633,7 +2633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2669,7 +2669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2705,7 +2705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2741,7 +2741,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2777,7 +2777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2813,7 +2813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2849,7 +2849,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2885,7 +2885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2921,7 +2921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2957,7 +2957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2993,7 +2993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3029,7 +3029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3065,7 +3065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3101,7 +3101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3137,7 +3137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3173,7 +3173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3209,7 +3209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3245,7 +3245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3281,7 +3281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3317,7 +3317,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3353,7 +3353,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3389,7 +3389,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3425,7 +3425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3461,7 +3461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3497,7 +3497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3533,7 +3533,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3569,7 +3569,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3605,7 +3605,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3641,7 +3641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3677,7 +3677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3713,7 +3713,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3749,7 +3749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3785,7 +3785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3821,7 +3821,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3857,7 +3857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3893,7 +3893,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3929,7 +3929,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3965,7 +3965,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4001,7 +4001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4035,7 +4035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4069,7 +4069,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4103,7 +4103,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4137,7 +4137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4171,7 +4171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4205,7 +4205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4239,7 +4239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4273,7 +4273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4307,7 +4307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4341,7 +4341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4375,7 +4375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4409,7 +4409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4443,7 +4443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4477,7 +4477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4511,7 +4511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4545,7 +4545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4579,7 +4579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4613,7 +4613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4647,7 +4647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4681,7 +4681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4715,7 +4715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4749,7 +4749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4783,7 +4783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4817,7 +4817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4851,7 +4851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4885,7 +4885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4919,7 +4919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4953,7 +4953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4987,7 +4987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5021,7 +5021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5055,7 +5055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5089,7 +5089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5123,7 +5123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5157,7 +5157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5191,7 +5191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5225,7 +5225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5259,7 +5259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5293,7 +5293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5327,7 +5327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5361,7 +5361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5395,7 +5395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5429,7 +5429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5463,7 +5463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5497,7 +5497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5531,7 +5531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5565,7 +5565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5599,7 +5599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5633,7 +5633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5667,7 +5667,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5701,7 +5701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5735,7 +5735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5769,7 +5769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5803,7 +5803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5837,7 +5837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5871,7 +5871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5905,7 +5905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5939,7 +5939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5973,7 +5973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6007,7 +6007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6041,7 +6041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6075,7 +6075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6109,7 +6109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6177,7 +6177,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6211,7 +6211,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6245,7 +6245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6279,7 +6279,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6313,7 +6313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6347,7 +6347,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6381,7 +6381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6415,7 +6415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6449,7 +6449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6483,7 +6483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6517,7 +6517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6551,7 +6551,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6585,7 +6585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6619,7 +6619,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6655,7 +6655,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6691,7 +6691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6727,7 +6727,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6763,7 +6763,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6799,7 +6799,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6835,7 +6835,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6871,7 +6871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6907,7 +6907,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6943,7 +6943,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6979,7 +6979,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7015,7 +7015,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7051,7 +7051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7087,7 +7087,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7123,7 +7123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7159,7 +7159,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7195,7 +7195,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7231,7 +7231,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7267,7 +7267,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7301,7 +7301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7335,7 +7335,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7369,7 +7369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7403,7 +7403,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7437,7 +7437,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7471,7 +7471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7505,7 +7505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7539,7 +7539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7573,7 +7573,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7607,7 +7607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7641,7 +7641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7675,7 +7675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7709,7 +7709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7743,7 +7743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7777,7 +7777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7811,7 +7811,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7845,7 +7845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7879,7 +7879,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7913,7 +7913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7947,7 +7947,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7981,7 +7981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8015,7 +8015,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8049,7 +8049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8083,7 +8083,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8117,7 +8117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8151,7 +8151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8185,7 +8185,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8219,7 +8219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8253,7 +8253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8287,7 +8287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8321,7 +8321,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8355,7 +8355,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8389,7 +8389,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8423,7 +8423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8457,7 +8457,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8491,7 +8491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8525,7 +8525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8559,7 +8559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8593,7 +8593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8627,7 +8627,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8661,7 +8661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8695,7 +8695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8729,7 +8729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8763,7 +8763,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8797,7 +8797,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8831,7 +8831,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8865,7 +8865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8899,7 +8899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8933,7 +8933,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8967,7 +8967,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9001,7 +9001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9035,7 +9035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9069,7 +9069,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9103,7 +9103,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9137,7 +9137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9171,7 +9171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9205,7 +9205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9239,7 +9239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9273,7 +9273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9307,7 +9307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9341,7 +9341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9375,7 +9375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9409,7 +9409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9443,7 +9443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9477,7 +9477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9511,7 +9511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9545,7 +9545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9579,7 +9579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9613,7 +9613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9647,7 +9647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9681,7 +9681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9715,7 +9715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9749,7 +9749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9783,7 +9783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9817,7 +9817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9851,7 +9851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9885,7 +9885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9919,7 +9919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9953,7 +9953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9987,7 +9987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10021,7 +10021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10055,7 +10055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10089,7 +10089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10123,7 +10123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10157,7 +10157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10191,7 +10191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10225,7 +10225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10259,7 +10259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10293,7 +10293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10327,7 +10327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10361,7 +10361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10395,7 +10395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10429,7 +10429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10463,7 +10463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10531,7 +10531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10565,7 +10565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10599,7 +10599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10633,7 +10633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10667,7 +10667,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10701,7 +10701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10735,7 +10735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10769,7 +10769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10803,7 +10803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10837,7 +10837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10871,7 +10871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10905,7 +10905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10939,7 +10939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10973,7 +10973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11007,7 +11007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11041,7 +11041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11075,7 +11075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11109,7 +11109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11143,7 +11143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11177,7 +11177,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11211,7 +11211,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11245,7 +11245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11279,7 +11279,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11313,7 +11313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11347,7 +11347,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11381,7 +11381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11415,7 +11415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11449,7 +11449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11483,7 +11483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11517,7 +11517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11551,7 +11551,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11585,7 +11585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11619,7 +11619,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11653,7 +11653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11687,7 +11687,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11721,7 +11721,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11755,7 +11755,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11789,7 +11789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11823,7 +11823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11857,7 +11857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11891,7 +11891,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11925,7 +11925,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11959,7 +11959,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11993,7 +11993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12027,7 +12027,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12061,7 +12061,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12095,7 +12095,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12130,7 +12130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12164,7 +12164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12198,7 +12198,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12232,7 +12232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12266,7 +12266,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12300,7 +12300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12334,7 +12334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12368,7 +12368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12402,7 +12402,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12436,7 +12436,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12470,7 +12470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12504,7 +12504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12538,7 +12538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12572,7 +12572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12606,7 +12606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12640,7 +12640,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12674,7 +12674,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12708,7 +12708,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12742,7 +12742,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12776,7 +12776,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12810,7 +12810,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12844,7 +12844,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12878,7 +12878,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12912,7 +12912,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12946,7 +12946,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12980,7 +12980,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13014,7 +13014,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13048,7 +13048,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13082,7 +13082,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13116,7 +13116,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13150,7 +13150,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13184,7 +13184,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13218,7 +13218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13252,7 +13252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13286,7 +13286,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13320,7 +13320,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13354,7 +13354,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13388,7 +13388,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13422,7 +13422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13456,7 +13456,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13490,7 +13490,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13524,7 +13524,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13558,7 +13558,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13594,7 +13594,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13630,7 +13630,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13666,7 +13666,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13702,7 +13702,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13738,7 +13738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13774,7 +13774,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13810,7 +13810,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13846,7 +13846,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13882,7 +13882,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13918,7 +13918,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13954,7 +13954,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13990,7 +13990,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14027,7 +14027,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14063,7 +14063,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14099,7 +14099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14135,7 +14135,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14171,7 +14171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14207,7 +14207,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14243,7 +14243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14279,7 +14279,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14315,7 +14315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14351,7 +14351,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14387,7 +14387,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14423,7 +14423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14459,7 +14459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14495,7 +14495,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14531,7 +14531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14565,7 +14565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14642,7 +14642,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14752,7 +14752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14791,7 +14791,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14830,7 +14830,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14869,7 +14869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14908,7 +14908,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14947,7 +14947,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14986,7 +14986,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15025,7 +15025,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15064,7 +15064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15103,7 +15103,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15142,7 +15142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15181,7 +15181,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15220,7 +15220,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15259,7 +15259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15298,7 +15298,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15337,7 +15337,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15376,7 +15376,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15415,7 +15415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15454,7 +15454,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15493,7 +15493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15532,7 +15532,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15571,7 +15571,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15610,7 +15610,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15649,7 +15649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15683,7 +15683,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15705,7 +15705,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -15741,7 +15741,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-ad5123fb
+    - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"
@@ -15984,7 +15984,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
           args:
           - "--repo=k8s.io/kubernetes=release-1.6"
           - "--clean"
@@ -16104,7 +16104,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-ad5123fb
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170829-89d24535
           args:
           - "--repo=k8s.io/kubernetes=release-1.7"
           - "--clean"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -35,7 +35,7 @@ import urllib2
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20170829-9b422e21'
+DEFAULT_KUBEKINS_TAG = 'v20170829-1d33d34c'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
Everything should have a new enough `rules_go` for this to be safe. I have bazel 0.5.4 installed on my workstation and everything still builds/passes tests.

I haven't pushed any of these images yet.

@spxtr @krzyzacy @BenTheElder 