### PR TITLE
bump golang images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
     - master
 language: go
 go:
-    - 1.8.x
+    - 1.9.x
 go_import_path: k8s.io/test-infra
 services:
     - docker

--- a/gcsweb/Makefile
+++ b/gcsweb/Makefile
@@ -25,7 +25,7 @@ REGISTRY ?= gcr.io/google_containers
 ARCH ?= amd64
 
 # The version string.
-VERSION := v1.0.4
+VERSION := v1.0.5
 
 ###
 ### These variables should not need tweaking.
@@ -54,7 +54,7 @@ endif
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
 
-BUILD_IMAGE ?= golang:1.7-alpine
+BUILD_IMAGE ?= golang:1.9-alpine
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.

--- a/testgrid/jenkins_verify/verify.sh
+++ b/testgrid/jenkins_verify/verify.sh
@@ -29,5 +29,5 @@ docker run --rm=true \
 docker run --rm=true \
   -w "/go/src/k8s.io/test-infra" \
   -v "${GOPATH}/src/k8s.io/test-infra:/go/src/k8s.io/test-infra" \
-  'golang:1.7.1' \
+  'golang:1.9' \
   go run testgrid/jenkins_verify/jenkins_validate.go testgrid/output prow testgrid/config/config.yaml


### PR DESCRIPTION
Noticed in https://travis-ci.org/kubernetes/test-infra/builds/269368838 that travis is using an old go1.7.1 image. Searched and bumping two images that were found with old go1.7 versions.