### PR TITLE
Node test is not part of k8s tarball, so switch back to --repo instead

### DIFF
--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -2265,13 +2265,14 @@ class JobTest(unittest.TestCase):
 
                     extracts = [a for a in args if '--extract=' in a]
                     shared_builds = [a for a in args if '--use-shared-build' in a]
+                    node_e2e = [a for a in args if '--deployment=node' in a]
                     if shared_builds and extracts:
                         self.fail(('e2e jobs cannot have --use-shared-build'
                                    ' and --extract: %s %s') % (job, args))
-                    elif not extracts and not shared_builds:
+                    elif not extracts and not shared_builds and not node_e2e:
                         self.fail(('e2e job needs --extract or'
                                    ' --use-shared-build: %s %s') % (job, args))
-                    if shared_builds:
+                    if shared_builds or node_e2e:
                         expected = 0
                     elif any(s in job for s in [
                             'upgrade', 'skew', 'downgrade', 'rollback',

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8454,7 +8454,6 @@
   "ci-kubernetes-e2e-node-canary": {
     "args": [
       "--deployment=node",
-      "--extract=ci/latest",
       "--gcp-project=sen-lu-test",
       "--gcp-zone=us-central1-f",
       "--node-args=--images=cos-stable-60-9592-76-0 --image-project=cos-cloud",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14585,9 +14585,9 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
       args:
-      - --bare
+      - --repo=k8s.io/kubernetes=master
       - --timeout=80
-      - --root=/go/src/k8s.io
+      - --root=/go/src
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
@@ -14597,6 +14597,8 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
+      - name: GOPATH
+        value: /go
       volumeMounts:
       - name: service
         mountPath: /etc/service-account


### PR DESCRIPTION
```
W0828 22:19:45.260] 2017/08/28 22:19:45 e2e.go:508: cwd : /go/src/k8s.io/kubernetes
W0828 22:19:47.110] stat /go/src/k8s.io/kubernetes/test/e2e_node/runner/remote/run_remote.go: no such file or directory
```

/assign @yguo0905 