### PR TITLE
fix kubetest for gs:// paths

### DIFF
--- a/kubetest/extract.go
+++ b/kubetest/extract.go
@@ -393,7 +393,8 @@ func (e extractStrategy) Extract(project, zone string) error {
 		}
 		return getKube(url, release)
 	case gcs:
-		return getKube(path.Dir(e.option), path.Base(e.option))
+		url := strings.Replace(path.Dir(e.option), "gs:/", "https://storage.googleapis.com/", 1)
+		return getKube(url, path.Base(e.option))
 	case load:
 		return loadState(e.option)
 	case bazel:

--- a/kubetest/extract.go
+++ b/kubetest/extract.go
@@ -393,8 +393,10 @@ func (e extractStrategy) Extract(project, zone string) error {
 		}
 		return getKube(url, release)
 	case gcs:
-		url := strings.Replace(path.Dir(e.option), "gs:/", "https://storage.googleapis.com/", 1)
-		return getKube(url, path.Base(e.option))
+		// strip gs://foo -> /foo
+		withoutGS := e.option[3:]
+		url := "https://storage.googleapis.com" + path.Dir(withoutGS)
+		return getKube(url, path.Base(withoutGS))
 	case load:
 		return loadState(e.option)
 	case bazel:

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -100,6 +100,11 @@ func TestExtractStrategies(t *testing.T) {
 			"",
 			"bazel/49747/master:b341939d6d3666b119028400a4311cc66da9a542,49747:c4656c3d029e47d03b3d7d9915d79cab72a80852",
 		},
+		{
+			"gs://kubernetes-release-dev/bazel/v1.8.0-alpha.3.389+eab2f8f6c19fcb",
+			"https://storage.googleapis.com/kubernetes-release-dev/bazel",
+			"v1.8.0-alpha.3.389+eab2f8f6c19fcb",
+		},
 	}
 
 	var gotURL string


### PR DESCRIPTION
`path.Dir` alone still gives you a `gs://` path (actually it munges `gs://` to `gs:/` too), whereas we want something we can `GET` in get-kube: this makes sure we form a base URL instead of a base path.

This also adds a unit test for this strategy.