### PR TITLE
don't use shared builds for GPU jobs until patched kubetest rolls out

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10467,17 +10467,19 @@
   },
   "pull-kubernetes-e2e-gce-gpu": {
     "args": [
+      "--build",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
       "--env-file=jobs/env/pull-kubernetes-e2e-gce-gpu.env",
+      "--extract=local",
       "--gcp-project=k8s-jkns-pr-gce-gpus",
       "--gcp-zone=us-west1-b",
       "--mode=docker",
       "--provider=gce",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gpu",
       "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
-      "--timeout=60m",
-      "--use-shared-build=bazel"
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -112,14 +112,6 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-    run_after_success:
-    - name: pull-kubernetes-e2e-gce-gpu
-      agent: jenkins
-      always_run: true
-      context: pull-kubernetes-e2e-gce-gpu
-      rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
-      trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
-
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
     context: pull-kubernetes-bazel-test
@@ -250,6 +242,12 @@ presubmits:
     context: pull-kubernetes-e2e-gce-gci
     rerun_command: "/test pull-kubernetes-e2e-gce-gci"
     trigger: "(?m)^/test pull-kubernetes-e2e-gce-gci,?(\\s+|$)"
+  - name: pull-kubernetes-e2e-gce-gpu
+    agent: jenkins
+    always_run: true
+    context: pull-kubernetes-e2e-gce-gpu
+    rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
   - name: pull-kubernetes-e2e-gke
     agent: jenkins
     context: pull-kubernetes-e2e-gke
@@ -456,13 +454,6 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-    run_after_success:
-    - name: pull-security-kubernetes-e2e-gce-gpu
-      agent: jenkins
-      always_run: true
-      context: pull-security-kubernetes-e2e-gce-gpu
-      rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
-      trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"
   - name: pull-security-kubernetes-bazel-test
     agent: kubernetes
     context: pull-security-kubernetes-bazel-test
@@ -593,6 +584,12 @@ presubmits:
     context: pull-security-kubernetes-e2e-gce-gci
     rerun_command: "/test pull-security-kubernetes-e2e-gce-gci"
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gce-gci,?(\\s+|$)"
+  - name: pull-security-kubernetes-e2e-gce-gpu
+    agent: jenkins
+    always_run: true
+    context: pull-security-kubernetes-e2e-gce-gpu
+    rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"
   - name: pull-security-kubernetes-e2e-gke
     agent: jenkins
     context: pull-security-kubernetes-e2e-gke


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/51481
Once something like https://github.com/kubernetes/test-infra/pull/4218 goes in with updated kubetest then we should be able to revert this.