### PR TITLE
Add timezone data package

### DIFF
--- a/images/pull_kubernetes_bazel/Dockerfile
+++ b/images/pull_kubernetes_bazel/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
     bash-completion \
     git \
     wget \
+    tzdata \
     python \
     python-pip && \
     apt-get clean


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/pull/47266 to work we need to access to timezone data. 

Go's `LoadLocation` looks in the directory named by the `ZONEINFO` environment variable, if any, then looks in known installation locations and finally looks in `$GOROOT/lib/time/zoneinfo.zip`.
Since none of that is available it eventually fails. This PR adds the `tzdata` package to be able to verify TZ-related tests. 

@ixdy ptal