### PR TITLE
Configure Gubernator using a static, external file

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -1,0 +1,35 @@
+---
+default_org: kubernetes
+default_repo: kubernetes
+external_services:
+  istio:
+    gcs_pull_prefix: istio-prow/pull
+    prow_url: prow.istio.io
+  kubernetes:
+    gcs_pull_prefix: kubernetes-jenkins/pr-logs/pull
+    prow_url: prow.k8s.io
+jobs:
+  kubernetes-jenkins/logs/:
+  - ci-kubernetes-e2e-gce-etcd3
+  - ci-kubernetes-e2e-gci-gce
+  - ci-kubernetes-e2e-gci-gce-slow
+  - ci-kubernetes-e2e-gci-gke
+  - ci-kubernetes-e2e-gci-gke-slow
+  - ci-kubernetes-kubemark-500-gce
+  - ci-kubernetes-node-kubelet
+  - ci-kubernetes-test-go
+  - ci-kubernetes-verify-master
+  - kubernetes-build
+  - kubernetes-e2e-kops-aws
+  kubernetes-jenkins/pr-logs/directory/:
+  - pull-kubernetes-bazel-build
+  - pull-kubernetes-bazel-test
+  - pull-kubernetes-e2e-gce-bazel
+  - pull-kubernetes-e2e-gce-etcd3
+  - pull-kubernetes-e2e-gce-gpu
+  - pull-kubernetes-e2e-kops-aws
+  - pull-kubernetes-federation-e2e-gce
+  - pull-kubernetes-kubemark-e2e-gce
+  - pull-kubernetes-node-e2e
+  - pull-kubernetes-unit
+  - pull-kubernetes-verify

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 
+import yaml
 import webapp2
 from webapp2_extras import security
 
@@ -64,6 +65,10 @@ def get_github_client():
         return None
 
 
+def get_app_config():
+    with open('config.yaml') as config_file:
+        return yaml.load(config_file)
+
 config = {
     'webapp2_extras.sessions': {
         'secret_key': get_session_secret(),
@@ -75,6 +80,8 @@ config = {
     },
     'github_client': get_github_client(),
 }
+
+config.update(get_app_config())
 
 class Warmup(webapp2.RequestHandler):
     """Warms up gubernator."""

--- a/gubernator/main_test.py
+++ b/gubernator/main_test.py
@@ -35,7 +35,6 @@ write = gcs_async_test.write
 
 app = webtest.TestApp(main.app)
 
-
 JUNIT_SUITE = '''<testsuite tests="8" failures="0" time="1000.24">
     <testcase name="First" classname="Example e2e suite" time="0">
         <skipped/>

--- a/gubernator/prow_jobs.yaml
+++ b/gubernator/prow_jobs.yaml
@@ -1,1 +1,0 @@
-../prow/config.yaml

--- a/gubernator/update_config.py
+++ b/gubernator/update_config.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Updates the Gubernator configuration from the Prow configuration."""
+
+import argparse
+import yaml
+
+def main(prow_config, gubernator_config):
+    with open(prow_config) as prow_file:
+        prow_data = yaml.load(prow_file)
+
+    default_presubmits = []
+    for job in prow_data['presubmits']['kubernetes/kubernetes']:
+        if job.get('always_run'):
+            default_presubmits.append(job['name'])
+
+    with open(gubernator_config) as gubernator_file:
+        gubernator_data = yaml.load(gubernator_file)
+
+    gubernator_data['jobs']['kubernetes-jenkins/pr-logs/directory/'] = default_presubmits
+
+    with open(gubernator_config, 'w+') as gubernator_file:
+        yaml.dump(gubernator_data, gubernator_file, default_flow_style=False, explicit_start=True)
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    PARSER.add_argument('prow_config', help="Path to Prow configuration YAML.")
+    PARSER.add_argument('gubernator_config', help="Path to Gubernator configuration YAML.")
+    ARGS = PARSER.parse_args()
+    main(ARGS.prow_config, ARGS.gubernator_config)

--- a/gubernator/update_config.sh
+++ b/gubernator/update_config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o xtrace
+# This script updates the Gubernator configuration
+# file to keep it in sync with Prow.
 
-cd "$(dirname "$0")"
-pip install -r test_requirements.txt
-./test.sh --nologcapture
-./lint.sh
-mocha static/build_test.js
-./verify_config.sh
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+./update_config.py ./../prow/config.yaml ./config.yaml

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -23,12 +23,10 @@ import main_test
 import gcs_async_test
 import github.models
 import testgrid_test
-import view_pr
 
 app = main_test.app
 init_build = main_test.init_build
 write = gcs_async_test.write
-
 
 class ParseJunitTest(unittest.TestCase):
     @staticmethod
@@ -263,26 +261,30 @@ class BuildTest(main_test.TestBase):
 
     def test_parse_pr_path(self):
         def check(prefix, expected):
-            self.assertEqual(view_build.parse_pr_path(prefix), expected)
+            self.assertEqual(
+                view_build.parse_pr_path(gcs_path=prefix,
+                    default_org='kubernetes',
+                    default_repo='kubernetes',
+                ),
+                expected
+            )
 
-        check('kubernetes-jenkins/logs/e2e', (None, None, None))
         check('kubernetes-jenkins/pr-logs/pull/123', ('123', '', 'kubernetes/kubernetes'))
         check('kubernetes-jenkins/pr-logs/pull/charts/123', ('123', 'charts/', 'kubernetes/charts'))
-        check('istio-prow/pull/istio_istio/517', ('517', 'istio/istio/', 'istio/istio'))
         check(
             'kubernetes-jenkins/pr-logs/pull/google_cadvisor/296',
             ('296', 'google/cadvisor/', 'google/cadvisor'))
 
     def test_build_pr_link(self):
         ''' The build page for a PR build links to the PR results.'''
-        build_dir = '/%s/123/e2e/567/' % view_pr.PR_PREFIX['kubernetes']
+        build_dir = '/kubernetes-jenkins/pr-logs/pull/123/e2e/567/'
         init_build(build_dir)
         response = app.get('/build' + build_dir)
         self.assertIn('PR #123', response)
         self.assertIn('href="/pr/123"', response)
 
     def test_build_pr_link_other(self):
-        build_dir = '/%s/charts/123/e2e/567/' % view_pr.PR_PREFIX['kubernetes']
+        build_dir = '/kubernetes-jenkins/pr-logs/pull/charts/123/e2e/567/'
         init_build(build_dir)
         response = app.get('/build' + build_dir)
         self.assertIn('PR #123', response)

--- a/gubernator/view_pr.py
+++ b/gubernator/view_pr.py
@@ -18,15 +18,11 @@ import logging
 import os
 import time
 
-import webapp2
-
 import filters
 import gcs_async
 import github.models as ghm
 import pull_request
 import view_base
-
-PR_PREFIX = view_base.PR_PREFIX
 
 
 @view_base.memcache_memoize('pr-details://', expires=60 * 3)
@@ -63,27 +59,26 @@ def pr_builds(path):
     return jobs
 
 
-def pr_path(org, repo, pr):
+def pr_path(org, repo, pr, default_org, default_repo, pull_prefix):
     """Builds the correct gs://prefix/maybe_kubernetes/maybe_repo_org/pr."""
-    # TODO(fejta): make this less specific to kubernetes.
-    if org == repo == 'kubernetes':
-        return '%s/%s' % (PR_PREFIX['kubernetes'], pr)
-    if org == 'kubernetes':
-        return '%s/%s/%s' % (PR_PREFIX['kubernetes'], repo, pr)
-    return '%s/%s_%s/%s' % (PR_PREFIX[org], org, repo, pr)
+    if org == default_org and repo == default_repo:
+        return '%s/%s' % (pull_prefix, pr)
+    if org == default_org:
+        return '%s/%s/%s' % (pull_prefix, repo, pr)
+    return '%s/%s_%s/%s' % (pull_prefix, org, repo, pr)
 
 
-def org_repo(path):
+def org_repo(path, default_org, default_repo):
     """Converts /maybe_org/maybe_repo into (org, repo)."""
-    # TODO(fejta): make this less specific to kubernetes.
     parts = path.split('/')[1:]
     if len(parts) == 2:
         org, repo = parts
     elif len(parts) == 1:
-        org = 'kubernetes'
+        org = default_org
         repo = parts[0]
     else:
-        org = repo = 'kubernetes'
+        org = default_org
+        repo = default_repo
     return org, repo
 
 
@@ -91,8 +86,15 @@ class PRHandler(view_base.BaseHandler):
     """Show a list of test runs for a PR."""
     def get(self, path, pr):
         # pylint: disable=too-many-locals
-        org, repo = org_repo(path)
-        path = pr_path(org, repo, pr)
+        org, repo = org_repo(path=path,
+            default_org=self.app.config['default_org'],
+            default_repo=self.app.config['default_repo'],
+        )
+        path = pr_path(org=org, repo=repo, pr=pr,
+            pull_prefix=self.app.config['external_services'][org]['gcs_pull_prefix'],
+            default_org=self.app.config['default_org'],
+            default_repo=self.app.config['default_repo'],
+        )
         builds = pr_builds(path)
         # TODO(fejta): assume all builds are monotonically increasing.
         for bs in builds.itervalues():
@@ -222,6 +224,12 @@ class PRDashboard(view_base.BaseHandler):
             self.abort(400)
 
 
-class PRBuildLogHandler(webapp2.RequestHandler):
+class PRBuildLogHandler(view_base.BaseHandler):
     def get(self, path):
-        self.redirect('https://storage.googleapis.com/%s/%s' % (PR_PREFIX, path))
+        org, _ = org_repo(path=path,
+            default_org=self.app.config['default_org'],
+            default_repo=self.app.config['default_repo'],
+        )
+        self.redirect('https://storage.googleapis.com/%s/%s' % (
+            self.app.config['external_services'][org]['gcs_pull_prefix'], path
+        ))


### PR DESCRIPTION
As other organizations begin to use Gubernator, the need to configure
links, paths and defaults becomes greater. This patch introduces a
static configuration file where this configuration can live.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @kargakis
/assign @rmmh @fejta 

~~I still need to figure out how to thread through the fake config into the test app, but~~ this is ready for a preliminary look.