### PR TITLE
Add a new job ci-kubernetes-e2e-gce-alpha-api

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -613,6 +613,23 @@
       "sig-cli"
     ]
   },
+  "ci-kubernetes-e2e-gce-alpha-api": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gce-alpha-api.env",
+      "--extract=ci/latest",
+      "--gcp-project=k8s-e2e-gce-alpha-api-access",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:GCEAlphaFeature:\\] --minStartupPods=8",
+      "--timeout=60m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "ci-kubernetes-e2e-gce-alpha-features": {
     "args": [
       "--check-leaked-resources",

--- a/jobs/env/ci-kubernetes-e2e-gce-alpha-api.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-alpha-api.env
@@ -1,0 +1,13 @@
+### job-env
+GINKGO_PARALLEL=y
+KUBE_OS_DISTRIBUTION=gci
+NUM_NODES=4
+GINKGO_PARALLEL_NODES=30
+
+# For now explicitly test etcd v2 mode in this suite.
+STORAGE_BACKEND=etcd2
+TEST_ETCD_IMAGE=2.2.1
+TEST_ETCD_VERSION=2.2.1
+
+# List GCE Alpha features we want to enable, separated by commas.
+GCE_ALPHA_FEATURES=network-tiers

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2206,6 +2206,40 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
+  name: ci-kubernetes-e2e-gce-alpha-api
+  spec:
+    containers:
+    - args:
+      - --timeout=80
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170828-7e980d14
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 30m
+  agent: kubernetes
   name: ci-kubernetes-e2e-gce-alpha-features
   spec:
     containers:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -242,6 +242,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability
 - name: ci-kubernetes-e2e-gci-gce-ip-alias
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ip-alias
+- name: ci-kubernetes-e2e-gce-alpha-api
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-api
 - name: ci-kubernetes-e2e-gci-gce-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial
 - name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
@@ -1965,6 +1967,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-release-1-6
   - name: gci-gce-ip-alias
     test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
+  - name: gce-alpha-api
+    test_group_name: ci-kubernetes-e2e-gce-alpha-api
   - name: gce-serial
     test_group_name: ci-kubernetes-e2e-gce-serial
   - name: gci-gce-serial
@@ -3750,6 +3754,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress-release-1-7
   - name: gci-gce-ip-alias
     test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
+  - name: gce-alpha-api
+    test_group_name: ci-kubernetes-e2e-gce-alpha-api
   - name: gci-gke-ingress
     test_group_name: ci-kubernetes-e2e-gci-gke-ingress
   - name: gci-gke-ingress-release-1-5


### PR DESCRIPTION
This job requires a dedicated project which is whitelisted to access
compute Alpha API.

/cc @krzyzacy 
/cc @bowei @freehan 