### PR TITLE
Specify ssh key location for node-canary job

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -508,6 +508,11 @@ func nodeTest(testArgs, nodeArgs []string, nodeTestArgs, project, zone string) e
 		log.Printf("cwd : %s", wd)
 	}
 
+	sshKeyPath := os.Getenv("JENKINS_GCE_SSH_PRIVATE_KEY_FILE")
+	if _, err := os.Stat(sshKeyPath); err != nil {
+		return fmt.Errorf("Cannot find ssh key from: %v, err : %v", sshKeyPath, err)
+	}
+
 	// prep node args
 	runner := []string{
 		"run",
@@ -520,6 +525,7 @@ func nodeTest(testArgs, nodeArgs []string, nodeTestArgs, project, zone string) e
 		fmt.Sprintf("--project=%s", project),
 		fmt.Sprintf("--zone=%s", zone),
 		fmt.Sprintf("--ssh-user=%s", os.Getenv("USER")),
+		fmt.Sprintf("--ssh-key=%s", sshKeyPath),
 		fmt.Sprintf("--ginkgo-flags=%s", strings.Join(testArgs, " ")),
 		fmt.Sprintf("--test_args=%s", nodeTestArgs),
 	}


### PR DESCRIPTION
Or else it will use https://github.com/kubernetes/kubernetes/blob/1157b5a116e4ec26b875fd33fcaf9db84cc646a9/test/e2e_node/remote/ssh.go#L47, from the node image that will be `root`.

/assign @yguo0905 