### PR TITLE
Try to run kops-aws with latest kubetest image and e2e scenario

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8235,14 +8235,18 @@
   },
   "ci-kubernetes-e2e-kops-aws": {
     "args": [
+      "--aws",
       "--cluster=e2e-kops-aws.test-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
+      "--extract=ci/latest",
+      "--mode=docker",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
     ],
-    "scenario": "kubernetes_kops_aws",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-aws"
     ]
   },
   "ci-kubernetes-e2e-kops-aws-canary": {


### PR DESCRIPTION
So I made the canary job runs successfully on Jenkins from e2e scenario already - (that's currently failing because some ssh/credential issue from prow, separately, while the other aws jobs are still running on Jenkins)

I'd take a ci job and convert it to be sync with the latest kubetest image, make sure that works, and we can move over the pr-kops-aws job, to resolve the dump log issue.

cc @zmerlynn 
/assign @pipejakob 