### PR TITLE
prow: Add team and team membership support to github client

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -893,3 +893,47 @@ func (c *Client) Query(ctx context.Context, q interface{}, vars map[string]inter
 	c.log("Query", q, vars)
 	return c.gqlc.Query(ctx, q, vars)
 }
+
+// ListTeams gets a list of teams for the given org
+func (c *Client) ListTeams(org string) ([]Team, error) {
+	c.log("ListTeams", org)
+	if c.fake {
+		return nil, nil
+	}
+	path := fmt.Sprintf("/orgs/%s/teams", org)
+	var teams []Team
+	err := c.readPaginatedResults(path,
+		func() interface{} {
+			return &[]Team{}
+		},
+		func(obj interface{}) {
+			teams = append(teams, *(obj.(*[]Team))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return teams, nil
+}
+
+// ListTeamMembers gets a list of team members for the given team id
+func (c *Client) ListTeamMembers(id int) ([]TeamMember, error) {
+	c.log("ListTeamMembers", id)
+	if c.fake {
+		return nil, nil
+	}
+	path := fmt.Sprintf("/teams/%d/members", id)
+	var teamMembers []TeamMember
+	err := c.readPaginatedResults(path,
+		func() interface{} {
+			return &[]TeamMember{}
+		},
+		func(obj interface{}) {
+			teamMembers = append(teamMembers, *(obj.(*[]TeamMember))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return teamMembers, nil
+}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -336,6 +336,41 @@ func (c *Client) CreateIssueReaction(org, repo string, ID int, reaction string) 
 	return err
 }
 
+// readPaginatedResults iterates over all objects in the paginated
+// result indicated by the given url.  The newObj function should
+// return a new slice of the expected type, and the accumulate
+// function should accept that populated slice for each page of
+// results.  An error is returned if encountered in making calls to
+// github or marshalling objects.
+func (c *Client) readPaginatedResults(path string, newObj func() interface{}, accumulate func(interface{})) error {
+	url := fmt.Sprintf("%s%s?per_page=100", c.base, path)
+	for url != "" {
+		resp, err := c.requestRetry(http.MethodGet, url, "", nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			return fmt.Errorf("return code not 2XX: %s", resp.Status)
+		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		obj := newObj()
+		if err := json.Unmarshal(b, obj); err != nil {
+			return err
+		}
+
+		accumulate(obj)
+
+		url = parseLinks(resp.Header.Get("Link"))["next"]
+	}
+	return nil
+}
+
 // ListIssueComments returns all comments on an issue. This may use more than
 // one API token.
 func (c *Client) ListIssueComments(org, repo string, number int) ([]IssueComment, error) {
@@ -343,29 +378,18 @@ func (c *Client) ListIssueComments(org, repo string, number int) ([]IssueComment
 	if c.fake {
 		return nil, nil
 	}
-	nextURL := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments?per_page=100", c.base, org, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", org, repo, number)
 	var comments []IssueComment
-	for nextURL != "" {
-		resp, err := c.requestRetry(http.MethodGet, nextURL, "", nil)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			return nil, fmt.Errorf("return code not 2XX: %s", resp.Status)
-		}
-
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		var ics []IssueComment
-		if err := json.Unmarshal(b, &ics); err != nil {
-			return nil, err
-		}
-		comments = append(comments, ics...)
-		nextURL = parseLinks(resp.Header.Get("Link"))["next"]
+	err := c.readPaginatedResults(path,
+		func() interface{} {
+			return &[]IssueComment{}
+		},
+		func(obj interface{}) {
+			comments = append(comments, *(obj.(*[]IssueComment))...)
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 	return comments, nil
 }
@@ -388,29 +412,18 @@ func (c *Client) GetPullRequestChanges(org, repo string, number int) ([]PullRequ
 	if c.fake {
 		return []PullRequestChange{}, nil
 	}
-	nextURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files?per_page=100", c.base, org, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/files", org, repo, number)
 	var changes []PullRequestChange
-	for nextURL != "" {
-		resp, err := c.requestRetry(http.MethodGet, nextURL, "", nil)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			return nil, fmt.Errorf("return code not 2XX: %s", resp.Status)
-		}
-
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		var newChanges []PullRequestChange
-		if err := json.Unmarshal(b, &newChanges); err != nil {
-			return nil, err
-		}
-		changes = append(changes, newChanges...)
-		nextURL = parseLinks(resp.Header.Get("Link"))["next"]
+	err := c.readPaginatedResults(path,
+		func() interface{} {
+			return &[]PullRequestChange{}
+		},
+		func(obj interface{}) {
+			changes = append(changes, *(obj.(*[]PullRequestChange))...)
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 	return changes, nil
 }
@@ -422,29 +435,18 @@ func (c *Client) ListPullRequestComments(org, repo string, number int) ([]Review
 	if c.fake {
 		return nil, nil
 	}
-	nextURL := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/comments?per_page=100", c.base, org, repo, number)
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/comments", org, repo, number)
 	var comments []ReviewComment
-	for nextURL != "" {
-		resp, err := c.requestRetry(http.MethodGet, nextURL, "", nil)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			return nil, fmt.Errorf("return code not 2XX: %s", resp.Status)
-		}
-
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		var cs []ReviewComment
-		if err := json.Unmarshal(b, &cs); err != nil {
-			return nil, err
-		}
-		comments = append(comments, cs...)
-		nextURL = parseLinks(resp.Header.Get("Link"))["next"]
+	err := c.readPaginatedResults(path,
+		func() interface{} {
+			return &[]ReviewComment{}
+		},
+		func(obj interface{}) {
+			comments = append(comments, *(obj.(*[]ReviewComment))...)
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 	return comments, nil
 }
@@ -542,28 +544,16 @@ func (c *Client) getLabels(path string) ([]Label, error) {
 	if c.fake {
 		return labels, nil
 	}
-	nextURL := strings.Join([]string{c.base, path}, "")
-	for nextURL != "" {
-		resp, err := c.requestRetry(http.MethodGet, nextURL, "", nil)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			return nil, fmt.Errorf("return code not 2XX: %s", resp.Status)
-		}
-
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		var labs []Label
-		if err := json.Unmarshal(b, &labs); err != nil {
-			return nil, err
-		}
-		labels = append(labels, labs...)
-		nextURL = parseLinks(resp.Header.Get("Link"))["next"]
+	err := c.readPaginatedResults(path,
+		func() interface{} {
+			return &[]Label{}
+		},
+		func(obj interface{}) {
+			labels = append(labels, *(obj.(*[]Label))...)
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 	return labels, nil
 }

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -477,6 +477,51 @@ func TestUnassignIssue(t *testing.T) {
 	}
 }
 
+func TestReadPaginatedResults(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path == "/label/foo" {
+			objects := []Label{{Name: "foo"}}
+			b, err := json.Marshal(objects)
+			if err != nil {
+				t.Fatalf("Didn't expect error: %v", err)
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<blorp>; rel="first", <https://%s/label/bar>; rel="next"`, r.Host))
+			fmt.Fprint(w, string(b))
+		} else if r.URL.Path == "/label/bar" {
+			objects := []Label{{Name: "bar"}}
+			b, err := json.Marshal(objects)
+			if err != nil {
+				t.Fatalf("Didn't expect error: %v", err)
+			}
+			fmt.Fprint(w, string(b))
+		} else {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	path := "/label/foo"
+	var labels []Label
+	err := c.readPaginatedResults(path,
+		func() interface{} {
+			return &[]Label{}
+		},
+		func(obj interface{}) {
+			labels = append(labels, *(obj.(*[]Label))...)
+		},
+	)
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	} else if len(labels) != 2 {
+		t.Errorf("Expected two labels, found %d: %v", len(labels), labels)
+	} else if labels[0].Name != "foo" || labels[1].Name != "bar" {
+		t.Errorf("Wrong label names: %v", labels)
+	}
+}
+
 func TestListPullRequestComments(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -367,3 +367,14 @@ type Content struct {
 	Content string `json:"content"`
 	SHA     string `json:"sha"`
 }
+
+// Team is a github organizational team
+type Team struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// TeamMember is a member of an organizational team
+type TeamMember struct {
+	Login string `json:"login"`
+}


### PR DESCRIPTION
This is required by a plugin that will restrict addition of the ``approved-for-milestone`` label to members of the @kubernetes-milestone-maintainers team.