### PR TITLE
Revert "Set the provider to 'kubemark' for kubemark jobs"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9071,7 +9071,7 @@
       "--kubemark-master-size=n1-standard-4",
       "--kubemark-nodes=100",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--tag=latest",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
@@ -9095,7 +9095,7 @@
       "--kubemark-master-size=n1-standard-4",
       "--kubemark-nodes=100",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=240m"
@@ -9118,7 +9118,7 @@
       "--kubemark-master-size=n1-standard-1",
       "--kubemark-nodes=5",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=60m"
@@ -9141,7 +9141,7 @@
       "--kubemark-master-size=n1-standard-1",
       "--kubemark-nodes=5",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=60m"
@@ -9164,7 +9164,7 @@
       "--kubemark-master-size=n1-standard-16",
       "--kubemark-nodes=500",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=120m"
@@ -9187,7 +9187,7 @@
       "--kubemark-master-size=n1-standard-64",
       "--kubemark-nodes=5000",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=1080m"
@@ -9210,7 +9210,7 @@
       "--kubemark-master-size=n1-standard-32",
       "--kubemark-nodes=600",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:HighDensityPerformance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=280m"
@@ -10666,7 +10666,7 @@
       "--kubemark-master-size=n1-standard-1",
       "--kubemark-nodes=5",
       "--mode=docker",
-      "--provider=kubemark",
+      "--provider=gce",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --garbage-collector-enabled=true",


### PR DESCRIPTION
Reverts kubernetes/test-infra#4256

This seems to have broken kubemark jobs - as of now I've no idea why

/cc @krzyzacy 

