### PR TITLE
Configure kubernetes-misc-mungers deployment to serve prometheus data to Velodrome.

### DIFF
--- a/mungegithub/misc-mungers/deployment.yaml
+++ b/mungegithub/misc-mungers/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         - --alsologtostderr
         - --config-path=/etc/munge-config/config
         image: gcr.io/k8s-testimages/misc-mungers:2016-03-14-7fb1dae
+        ports:
+        - name: status
+          containerPort: 8080
         resources:
           requests:
             cpu: 100m

--- a/mungegithub/misc-mungers/service.yaml
+++ b/mungegithub/misc-mungers/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: misc-mungers
+    target-repo: @@
+  name: @@-mm-status
+spec:
+  ports:
+  - name: status
+    port: 80
+    targetPort: status
+  selector:
+    app: misc-mungers
+    target-repo: @@
+  loadBalancerIP: 146.148.39.225
+  type: LoadBalancer

--- a/velodrome/config.yaml
+++ b/velodrome/config.yaml
@@ -105,6 +105,11 @@ projects:
             static_configs:
               - targets:
                   - 104.197.27.114
+          - job_name: kubernetes-misc-mungers
+            metrics_path: /prometheus
+            static_configs:
+              - targets:
+                  - 146.148.39.225
   istio:
     repositories:
       istio/api: &transform-istio


### PR DESCRIPTION
/cc @krzyzacy 