### PR TITLE
Fix plugin configuration passthrough

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION             ?= 0.154
+HOOK_VERSION             ?= 0.148
 SINKER_VERSION           ?= 0.16
 DECK_VERSION             ?= 0.43
 SPLICE_VERSION           ?= 0.27

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION             ?= 0.148
+HOOK_VERSION             ?= 0.155
 SINKER_VERSION           ?= 0.16
 DECK_VERSION             ?= 0.43
 SPLICE_VERSION           ?= 0.27

--- a/prow/README.md
+++ b/prow/README.md
@@ -4,7 +4,7 @@ Prow is the system that handles GitHub events and commands for Kubernetes. It
 currently comprises several related pieces that live in a Kubernetes cluster.
 See the [GoDoc](https://godoc.org/k8s.io/test-infra/prow) for library docs.
 Please note that these libraries are intended for use by prow only, and we do
-not make any attempt to preserve backwards compatability.
+not make any attempt to preserve backwards compatibility.
 
 * `cmd/hook` is the most important piece. It is a stateless server that listens
   for GitHub webhooks and dispatches them to the appropriate handlers.
@@ -19,6 +19,18 @@ not make any attempt to preserve backwards compatability.
 * `cmd/mkpj` creates `ProwJobs`.
 
 See also: [Life of a Prow Job](https://github.com/kubernetes/test-infra/blob/master/prow/architecture.md).
+
+## Announcements
+
+Breaking changes to external APIs (labels, GitHub interactions, configuration
+or deployment) will be documented in this section. Prow is in a pre-release
+state and no claims of backwards compatibility are made for any external API.
+
+ - *August 29, 2017* Configuration specific to plugins is now held in in the
+   `plugins` `ConfigMap` and serialized in this repo in the `plugins.yaml` file.
+   Cluster administrators upgrading to the newest version of Prow should move
+   plugin configuration from the main `ConfigMap`. For more context, please see
+   [this pull request.](https://github.com/kubernetes/test-infra/pull/4213)
 
 ## How to test prow
 

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.148
+        image: gcr.io/k8s-prow/hook:0.155
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.154
+        image: gcr.io/k8s-prow/hook:0.148
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -14,18 +14,6 @@ tide:
   queries:
   - "type:pr state:open repo:kubernetes/test-infra label:lgtm -label:do-not-merge"
 
-triggers:
-- repos:
-  - kubernetes
-  - kubernetes-incubator
-  - kubernetes-security
-  - google/cadvisor
-  trusted_org: kubernetes
-
-heart:
-  adorees:
-  - k8s-merge-bot
-
 presubmits:
   # PR job triggering definitions.
   # Keys: Full repo name: "org/repo".

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -38,11 +38,9 @@ type Config struct {
 	// Periodics are not associated with any repo.
 	Periodics []Periodic `json:"periodics,omitempty"`
 
-	Tide     Tide      `json:"tide,omitempty"`
-	Plank    Plank     `json:"plank,omitempty"`
-	Sinker   Sinker    `json:"sinker,omitempty"`
-	Triggers []Trigger `json:"triggers,omitempty"`
-	Heart    Heart     `json:"heart,omitempty"`
+	Tide   Tide   `json:"tide,omitempty"`
+	Plank  Plank  `json:"plank,omitempty"`
+	Sinker Sinker `json:"sinker,omitempty"`
 
 	// ProwJobNamespace is the namespace in the cluster that prow
 	// components will use for looking up ProwJobs. The namespace
@@ -51,8 +49,7 @@ type Config struct {
 	// PodNamespace is the namespace in the cluster that prow
 	// components will use for looking up Pods owned by ProwJobs.
 	// The namespace needs to exist and will not be created by prow.
-	PodNamespace string       `json:"pod_namespace,omitempty"`
-	SlackEvents  []SlackEvent `json:"slackevents,omitempty"`
+	PodNamespace string `json:"pod_namespace,omitempty"`
 }
 
 // Tide is config for the tide pool.
@@ -94,34 +91,6 @@ type Sinker struct {
 	MaxPodAgeString string `json:"max_pod_age,omitempty"`
 	// MaxPodAge is how old a Pod can be before it is garbage-collected.
 	MaxPodAge time.Duration `json:"-"`
-}
-
-// Trigger is config for the trigger plugin.
-type Trigger struct {
-	// Repos is either of the form org/repos or just org.
-	Repos []string `json:"repos,omitempty"`
-	// TrustedOrg is the org whose members' PRs will be automatically built
-	// for PRs to the above repos.
-	TrustedOrg string `json:"trusted_org,omitempty"`
-}
-
-// Heart is config for the heart plugin
-type Heart struct {
-	// Adorees is a list of GitHub logins for members
-	// for whom we will add emojis to comments
-	Adorees []string `json:"adorees,omitempty"`
-}
-
-// SlackEvent is config for the slackevents plugin.
-// If a PR is pushed to any of the repos listed in the config
-// then sent message to the all the  slack channels listed if pusher is NOT in the whitelist.
-type SlackEvent struct {
-	// Repos is either of the form org/repos or just org.
-	Repos []string `json:"repos,omitempty"`
-	// List of channels on which a event is published.
-	Channels []string `json:"channels,omitempty"`
-	// A slack event is published if the user is not part of the WhiteList.
-	WhiteList []string `json:"whitelist,omitempty"`
 }
 
 // Load loads and parses the config at path.

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -38,6 +38,7 @@ func (s *Server) handleReviewEvent(re github.ReviewEvent) {
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
+			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, re); err != nil {
 				pc.Logger.WithError(err).Error("Error handling ReviewEvent.")
 			}
@@ -60,6 +61,7 @@ func (s *Server) handleReviewCommentEvent(rce github.ReviewCommentEvent) {
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
+			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, rce); err != nil {
 				pc.Logger.WithError(err).Error("Error handling ReviewCommentEvent.")
 			}
@@ -81,6 +83,7 @@ func (s *Server) handlePullRequestEvent(pr github.PullRequestEvent) {
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
+			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, pr); err != nil {
 				pc.Logger.WithError(err).Error("Error handling PullRequestEvent.")
 			}
@@ -101,6 +104,7 @@ func (s *Server) handlePushEvent(pe github.PushEvent) {
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
+			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, pe); err != nil {
 				pc.Logger.WithError(err).Error("Error handling PushEvent.")
 			}
@@ -122,6 +126,7 @@ func (s *Server) handleIssueEvent(i github.IssueEvent) {
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
+			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, i); err != nil {
 				pc.Logger.WithError(err).Error("Error handleing IssueEvent.")
 			}
@@ -143,6 +148,7 @@ func (s *Server) handleIssueCommentEvent(ic github.IssueCommentEvent) {
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
+			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, ic); err != nil {
 				pc.Logger.WithError(err).Error("Error handling IssueCommentEvent.")
 			}
@@ -165,6 +171,7 @@ func (s *Server) handleStatusEvent(se github.StatusEvent) {
 			pc := s.Plugins.PluginClient
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
+			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, se); err != nil {
 				pc.Logger.WithError(err).Error("Error handling StatusEvent.")
 			}

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -53,7 +53,7 @@ func TestHook(t *testing.T) {
 		return nil
 	})
 	pa := &plugins.PluginAgent{}
-	pa.Set(plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
+	pa.Set(&plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}
 	s := httptest.NewServer(&Server{
 		Plugins:     pa,

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -53,9 +53,7 @@ func TestHook(t *testing.T) {
 		return nil
 	})
 	pa := &plugins.PluginAgent{}
-	if err := pa.Set(map[string][]string{"foo/bar": {"baz"}}); err != nil {
-		t.Fatalf("Setting plugins: %v", err)
-	}
+	pa.Set(plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}
 	s := httptest.NewServer(&Server{
 		Plugins:     pa,

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -2,54 +2,67 @@
 # Keys: Full repo name: "org/repo".
 # Values: List of plugins to run against the repo.
 ---
-google/cadvisor:
-- trigger
+triggers:
+- repos:
+  - kubernetes
+  - kubernetes-incubator
+  - kubernetes-security
+  - google/cadvisor
+  trusted_org: kubernetes
 
-kubernetes/charts:
-- trigger
+heart:
+  adorees:
+  - k8s-merge-bot
 
-kubernetes/heapster:
-- trigger
+plugins:
+  google/cadvisor:
+  - trigger
 
-kubernetes/kops:
-- trigger
+  kubernetes/charts:
+  - trigger
 
-kubernetes/kubernetes:
-- trigger
-- release-note
+  kubernetes/heapster:
+  - trigger
 
-kubernetes/test-infra:
-- trigger
-- config-updater
+  kubernetes/kops:
+  - trigger
 
-kubernetes:
-- assign
-- cla
-- close
-- reopen
-- golint
-- heart
-- hold
-- label
-- lgtm
-- size
-- yuks
-- shrug
+  kubernetes/kubernetes:
+  - trigger
+  - release-note
 
-kubernetes-incubator:
-- cla
-- assign
-- size
+  kubernetes/test-infra:
+  - trigger
+  - config-updater
 
-kubernetes-incubator/kube-aws:
-- lgtm
+  kubernetes:
+  - assign
+  - cla
+  - close
+  - reopen
+  - golint
+  - heart
+  - hold
+  - label
+  - lgtm
+  - size
+  - yuks
+  - shrug
 
-kubernetes-security/kubernetes:
-- trigger
+  kubernetes-incubator:
+  - cla
+  - assign
+  - size
 
-spxtr/envoy:
-- assign
-- close
-- reopen
-- lgtm
-- trigger
+  kubernetes-incubator/kube-aws:
+  - lgtm
+
+  kubernetes-security/kubernetes:
+  - trigger
+
+  spxtr/envoy:
+  - assign
+  - close
+  - reopen
+  - lgtm
+  - trigger

--- a/prow/plugins/heart/BUILD
+++ b/prow/plugins/heart/BUILD
@@ -10,7 +10,6 @@ go_library(
     name = "go_default_library",
     srcs = ["heart.go"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/github.com/Sirupsen/logrus:go_default_library",
@@ -35,7 +34,6 @@ go_test(
     srcs = ["heart_test.go"],
     library = ":go_default_library",
     deps = [
-        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//vendor/github.com/Sirupsen/logrus:go_default_library",

--- a/prow/plugins/heart/heart_test.go
+++ b/prow/plugins/heart/heart_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 )
@@ -109,12 +108,7 @@ func TestHandlePR(t *testing.T) {
 		}
 		fakeClient := client{
 			GitHubClient: fakeGitHubClient,
-			Config: &config.Heart{
-				Adorees: []string{
-					"kubernetes",
-				},
-			},
-			Logger: logrus.WithField("plugin", pluginName),
+			Logger:       logrus.WithField("plugin", pluginName),
 		}
 
 		err := handlePR(fakeClient, event)

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -99,16 +99,78 @@ type PluginClient struct {
 	KubeClient   *kube.Client
 	GitClient    *git.Client
 	SlackClient  *slack.Client
-	Config       *config.Config
-	Logger       *logrus.Entry
+
+	// Config provides information about the jobs
+	// that we know how to run for repos.
+	Config *config.Config
+	// PluginConfig provides plugin-specific options
+	PluginConfig *Configuration
+
+	Logger *logrus.Entry
 }
 
 type PluginAgent struct {
 	PluginClient
 
-	mut sync.Mutex
+	mut           sync.Mutex
+	configuration Configuration
+}
+
+// Configuration is the top-level serialization
+// target for plugin Configuration
+type Configuration struct {
 	// Repo (eg "k/k") -> list of handler names.
-	ps map[string][]string
+	Plugins     map[string][]string `json:"plugins,omitempty"`
+	Triggers    []Trigger           `json:"trigger,omitempty"`
+	Heart       Heart               `json:"heart,omitempty"`
+	Label       Label               `json:"label,omitempty"`
+	SlackEvents []SlackEvent        `json:"slackevents,omitempty"`
+}
+
+type Trigger struct {
+	// Repos is either of the form org/repos or just org.
+	Repos []string `json:"repos,omitempty"`
+	// TrustedOrg is the org whose members' PRs will be automatically built
+	// for PRs to the above repos.
+	TrustedOrg string `json:"trusted_org,omitempty"`
+}
+
+type Heart struct {
+	// Adorees is a list of GitHub logins for members
+	// for whom we will add emojis to comments
+	Adorees []string `json:"adorees,omitempty"`
+}
+
+type Label struct {
+	// SigOrg is the organization that owns the
+	// special interest groups tagged in this repo
+	SigOrg string `json:"sig_org,omitempty"`
+}
+
+// SlackEvent is config for the slackevents plugin.
+// If a PR is pushed to any of the repos listed in the config
+// then sent message to the all the  slack channels listed if pusher is NOT in the whitelist.
+type SlackEvent struct {
+	// Repos is either of the form org/repos or just org.
+	Repos []string `json:"repos,omitempty"`
+	// List of channels on which a event is published.
+	Channels []string `json:"channels,omitempty"`
+	// A slack event is published if the user is not part of the WhiteList.
+	WhiteList []string `json:"whitelist,omitempty"`
+}
+
+// TriggerFor finds the Trigger for a repo, if one exists
+// a trigger can be listed for the repo itself or for the
+// owning organization
+func (c *Configuration) TriggerFor(org, repo string) *Trigger {
+	for _, tr := range c.Triggers {
+		for _, r := range tr.Repos {
+			if r == org || r == fmt.Sprintf("%s/%s", org, repo) {
+				return &tr
+			}
+		}
+	}
+	return nil
 }
 
 // Load attempts to load config from the path. It returns an error if either
@@ -118,44 +180,65 @@ func (pa *PluginAgent) Load(path string) error {
 	if err != nil {
 		return err
 	}
-	np := map[string][]string{}
+	np := Configuration{}
 	if err := yaml.Unmarshal(b, &np); err != nil {
 		return err
 	}
-	return pa.Set(np)
+
+	if err := validatePlugins(np.Plugins); err != nil {
+		return err
+	}
+	pa.Set(np)
+	return nil
 }
 
-// Set attempts to set the plugins that are enabled on repos. The input is a
-// map from repositories to the list of plugins that are enabled on them.
+// validatePlugins will return error if
+// there are unknown or duplicated plugins.
+func validatePlugins(plugins map[string][]string) error {
+	errors := []string{}
+	for _, configuration := range plugins {
+		for _, plugin := range configuration {
+			if _, ok := allPlugins[plugin]; !ok {
+				errors = append(errors, fmt.Sprintf("unknown plugin: %s", plugin))
+			}
+		}
+	}
+	for repo, repoConfig := range plugins {
+		if strings.Contains(repo, "/") {
+			org := strings.Split(repo, "/")[0]
+			if dupes := findDuplicatedPluginConfig(repoConfig, plugins[org]); len(dupes) > 0 {
+				errors = append(errors, fmt.Sprintf("plugins %v are duplicated for %s and %s", dupes, repo, org))
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("invalid plugin configuration:\n\t%v", strings.Join(errors, "\n\t"))
+	}
+	return nil
+}
+
+func findDuplicatedPluginConfig(repoConfig, orgConfig []string) []string {
+	dupes := []string{}
+	for _, repoPlugin := range repoConfig {
+		for _, orgPlugin := range orgConfig {
+			if repoPlugin == orgPlugin {
+				dupes = append(dupes, repoPlugin)
+			}
+		}
+	}
+
+	return dupes
+}
+
+// Set attempts to set the plugins that are enabled on repos. Plugins are listed
+// as a map from repositories to the list of plugins that are enabled on them.
 // Specifying simply an org name will also work, and will enable the plugin on
-// all repos in the org. It will return error if there are unknown or duplicated
-// plugins.
-func (pa *PluginAgent) Set(np map[string][]string) error {
-	// Check that there are no plugins that we don't know about.
-	for _, v := range np {
-		for _, p := range v {
-			if _, ok := allPlugins[p]; !ok {
-				return fmt.Errorf("unknown plugin: %s", p)
-			}
-		}
-	}
-	// Check that there are no duplicates.
-	for k, v := range np {
-		if strings.Contains(k, "/") {
-			org := strings.Split(k, "/")[0]
-			for _, p1 := range v {
-				for _, p2 := range np[org] {
-					if p1 == p2 {
-						return fmt.Errorf("plugin %s is duplicated for %s and %s", p1, k, org)
-					}
-				}
-			}
-		}
-	}
+// all repos in the org.
+func (pa *PluginAgent) Set(pc Configuration) {
 	pa.mut.Lock()
 	defer pa.mut.Unlock()
-	pa.ps = np
-	return nil
+	pa.configuration = pc
 }
 
 // Start starts polling path for plugin config. If the first attempt fails,
@@ -284,8 +367,8 @@ func (pa *PluginAgent) getPlugins(owner, repo string) []string {
 	var plugins []string
 
 	fullName := fmt.Sprintf("%s/%s", owner, repo)
-	plugins = append(plugins, pa.ps[owner]...)
-	plugins = append(plugins, pa.ps[fullName]...)
+	plugins = append(plugins, pa.configuration.Plugins[owner]...)
+	plugins = append(plugins, pa.configuration.Plugins[fullName]...)
 
 	return plugins
 }

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -70,7 +70,7 @@ func TestGetPlugins(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		pa := PluginAgent{}
-		pa.ps = tc.pluginMap
+		pa.configuration.Plugins = tc.pluginMap
 
 		plugins := pa.getPlugins(tc.owner, tc.repo)
 		if len(plugins) != len(tc.expectedPlugins) {

--- a/prow/plugins/plugins_test.go
+++ b/prow/plugins/plugins_test.go
@@ -69,8 +69,7 @@ func TestGetPlugins(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		pa := PluginAgent{}
-		pa.configuration.Plugins = tc.pluginMap
+		pa := PluginAgent{configuration: &Configuration{Plugins: tc.pluginMap}}
 
 		plugins := pa.getPlugins(tc.owner, tc.repo)
 		if len(plugins) != len(tc.expectedPlugins) {

--- a/prow/plugins/slackevents/BUILD
+++ b/prow/plugins/slackevents/BUILD
@@ -11,8 +11,8 @@ go_test(
     srcs = ["push_test.go"],
     library = ":go_default_library",
     deps = [
-        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
         "//prow/slack:go_default_library",
         "//prow/slack/fakeslack:go_default_library",
     ],
@@ -22,7 +22,6 @@ go_library(
     name = "go_default_library",
     srcs = ["slackevents.go"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
     ],

--- a/prow/plugins/slackevents/push_test.go
+++ b/prow/plugins/slackevents/push_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/slack"
 	"k8s.io/test-infra/prow/slack/fakeslack"
 )
@@ -91,18 +91,14 @@ func TestPush(t *testing.T) {
 		},
 	}
 
-	cnfg := &config.Config{
-		SlackEvents: []config.SlackEvent{
+	pc := client{
+		SlackEvents: []plugins.SlackEvent{
 			{
 				Repos:     []string{"kubernetes/kubernetes"},
 				Channels:  []string{"kubernetes-dev", "sig-contribex"},
 				WhiteList: []string{"k8s-merge-robot"},
 			},
 		},
-	}
-
-	pc := client{
-		Config:      cnfg,
 		SlackClient: slack.NewFakeClient(),
 	}
 

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -19,7 +19,6 @@ package slackevents
 import (
 	"fmt"
 
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -34,7 +33,7 @@ type slackClient interface {
 
 type client struct {
 	SlackClient slackClient
-	Config      *config.Config
+	SlackEvents []plugins.SlackEvent
 }
 
 func init() {
@@ -43,7 +42,7 @@ func init() {
 
 func handlePush(pc plugins.PluginClient, pe github.PushEvent) error {
 	c := client{
-		Config:      pc.Config,
+		SlackEvents: pc.PluginConfig.SlackEvents,
 		SlackClient: pc.SlackClient,
 	}
 	return notifyOnSlackIfManualMerge(c, pe)
@@ -65,8 +64,8 @@ func notifyOnSlackIfManualMerge(pc client, pe github.PushEvent) error {
 	return nil
 }
 
-func getSlackEvent(pc client, org, repo string) *config.SlackEvent {
-	for _, se := range pc.Config.SlackEvents {
+func getSlackEvent(pc client, org, repo string) *plugins.SlackEvent {
+	for _, se := range pc.SlackEvents {
 		if stringInArray(repo, se.Repos) || stringInArray(fmt.Sprintf("%s/%s", org, repo), se.Repos) {
 			return &se
 		}

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -29,7 +29,7 @@ import (
 var okToTest = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 var retest = regexp.MustCompile(`(?m)^/retest\s*$`)
 
-func handleIC(c client, ic github.IssueCommentEvent) error {
+func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 	org := ic.Repo.Owner.Login
 	repo := ic.Repo.Name
 	number := ic.Issue.Number
@@ -52,13 +52,6 @@ func handleIC(c client, ic github.IssueCommentEvent) error {
 	}
 	if commentAuthor == botName {
 		return nil
-	}
-	var trustedOrg string
-	if tr := triggerConfig(c.Config, org, repo); tr != nil && tr.TrustedOrg == "" {
-		c.Logger.Info("Ignoring PR Event, no TrustedOrg set in config.")
-		return nil
-	} else if tr != nil {
-		trustedOrg = tr.TrustedOrg
 	}
 
 	if okToTest.MatchString(ic.Comment.Body) && ic.Issue.HasLabel(needsOkToTest) {

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -229,7 +229,7 @@ func TestHandleIssueComment(t *testing.T) {
 			},
 		}
 
-		if err := handleIC(c, event); err != nil {
+		if err := handleIC(c, "kubernetes", event); err != nil {
 			t.Fatalf("Didn't expect error: %s", err)
 		}
 		if len(kc.started) > 0 && !tc.ShouldBuild {

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -29,17 +29,8 @@ const (
 	needsOkToTest = "needs-ok-to-test"
 )
 
-func handlePR(c client, pr github.PullRequestEvent) error {
-	org := pr.PullRequest.Base.Repo.Owner.Login
-	repo := pr.PullRequest.Base.Repo.Name
+func handlePR(c client, trustedOrg string, pr github.PullRequestEvent) error {
 	author := pr.PullRequest.User.Login
-	var trustedOrg string
-	if tr := triggerConfig(c.Config, org, repo); tr != nil && tr.TrustedOrg == "" {
-		c.Logger.Info("Ignoring PR Event, no TrustedOrg set in config.")
-		return nil
-	} else if tr != nil {
-		trustedOrg = tr.TrustedOrg
-	}
 	switch pr.Action {
 	case github.PullRequestActionOpened:
 		// When a PR is opened, if the author is in the org then build it.

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -17,8 +17,6 @@ limitations under the License.
 package trigger
 
 import (
-	"fmt"
-
 	"github.com/Sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/config"
@@ -63,17 +61,6 @@ type client struct {
 	Logger       *logrus.Entry
 }
 
-func triggerConfig(c *config.Config, org, repo string) *config.Trigger {
-	for _, tr := range c.Triggers {
-		for _, r := range tr.Repos {
-			if r == org || r == fmt.Sprintf("%s/%s", org, repo) {
-				return &tr
-			}
-		}
-	}
-	return nil
-}
-
 func getClient(pc plugins.PluginClient) client {
 	return client{
 		GitHubClient: pc.GitHubClient,
@@ -84,11 +71,23 @@ func getClient(pc plugins.PluginClient) client {
 }
 
 func handlePullRequest(pc plugins.PluginClient, pr github.PullRequestEvent) error {
-	return handlePR(getClient(pc), pr)
+	org, repo := pr.PullRequest.Base.Repo.Owner.Login, pr.PullRequest.Base.Repo.Name
+	config := pc.PluginConfig.TriggerFor(org, repo)
+	if config == nil || config.TrustedOrg == "" {
+		pc.Logger.Infof("Ignoring pull request event, triggers not configured for %s/%s.", org, repo)
+		return nil
+	}
+	return handlePR(getClient(pc), config.TrustedOrg, pr)
 }
 
 func handleIssueComment(pc plugins.PluginClient, ic github.IssueCommentEvent) error {
-	return handleIC(getClient(pc), ic)
+	org, repo := ic.Repo.Owner.Login, ic.Repo.Name
+	config := pc.PluginConfig.TriggerFor(org, repo)
+	if config == nil || config.TrustedOrg == "" {
+		pc.Logger.Infof("Ignoring issue comment event, triggers not configured for %s/%s.", org, repo)
+		return nil
+	}
+	return handleIC(getClient(pc), config.TrustedOrg, ic)
 }
 
 func handlePush(pc plugins.PluginClient, pe github.PushEvent) error {


### PR DESCRIPTION
Revert "Merge pull request #4267 from kubernetes/revert-4213-skuznets/separate-prow-plugin-config"

This reverts commit 8682faf2f9e6fca190fd588d5ef55f6b004f3bd9, reversing
changes made to 2d41ad02ff1654c15f0e2a597c5f84ad1a8565fe.

---

Add a thread-safe plugin configuration accessor

We need to give the plugins the latest read-only copy of the plugin
configuration, which we must access in a thread-safe way from the plugin
agent.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/area prow
/assign @spxtr 