### PR TITLE
Only add release note label and comment if they aren't present

### DIFF
--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -142,14 +142,18 @@ func (r *ReleaseNoteLabel) Munge(obj *github.MungeObject) {
 
 	labelToAdd := determineReleaseNoteLabel(obj)
 	if labelToAdd == releaseNoteLabelNeeded {
-		obj.WriteComment(releaseNoteBody)
+		if !obj.HasLabel(releaseNoteLabelNeeded) {
+			obj.WriteComment(releaseNoteBody)
+		}
 	} else {
 		//going to apply some other release-note-label
 		if obj.HasLabel(releaseNoteLabelNeeded) {
 			obj.RemoveLabel(releaseNoteLabelNeeded)
 		}
 	}
-	obj.AddLabel(labelToAdd)
+	if !obj.HasLabel(labelToAdd) {
+		obj.AddLabel(labelToAdd)
+	}
 	return
 }
 


### PR DESCRIPTION
We should not add a release note label if it already exists. Similarly,
if the label indicating that a release note is necessary already exists,
we should not add another comment about why the label has been added.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

The revert is a lot hairier than this ....

/cc @spxtr @BenTheElder 
/assign @fejta 
/area mungegithub