### PR TITLE
Clean up deprecated comments and labels

### DIFF
--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -38,8 +38,9 @@ See http://kubernetes.io/editdocs/ for information about editing docs`
 )
 
 var (
-	_             = fmt.Print
-	blockPathBody = fmt.Sprintf(blockPathFormat, blockedPathsLabel)
+	_                       = fmt.Print
+	blockPathBody           = fmt.Sprintf(blockPathFormat, blockedPathsLabel)
+	deprecatedBlockPathBody = fmt.Sprintf(blockPathFormat, doNotMergeLabel)
 )
 
 type configBlockPath struct {
@@ -166,7 +167,7 @@ func (b *BlockPath) isStaleIssueComment(obj *github.MungeObject, comment *github
 	if !obj.IsRobot(comment.User) {
 		return false
 	}
-	if *comment.Body != blockPathBody {
+	if *comment.Body != blockPathBody && *comment.Body != deprecatedBlockPathBody {
 		return false
 	}
 	stale := !obj.HasLabel(blockedPathsLabel)

--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -29,13 +29,15 @@ import (
 )
 
 const (
-	cherrypickUnapprovedLabel = "do-not-merge/cherry-pick-not-approved"
-	labelUnapprovedPicksName  = "label-unapproved-picks"
-	labelUnapprovedFormat     = "This PR is not for the master branch but does not have the `%s` label. Adding the `%s` label."
+	cherrypickUnapprovedLabel           = "do-not-merge/cherry-pick-not-approved"
+	deprecatedCherrypickUnapprovedLabel = "cherry-pick-not-approved"
+	labelUnapprovedPicksName            = "label-unapproved-picks"
+	labelUnapprovedFormat               = "This PR is not for the master branch but does not have the `%s` label. Adding the `%s` label."
 )
 
 var (
-	labelUnapprovedBody = fmt.Sprintf(labelUnapprovedFormat, cpApprovedLabel, cherrypickUnapprovedLabel)
+	labelUnapprovedBody           = fmt.Sprintf(labelUnapprovedFormat, cpApprovedLabel, cherrypickUnapprovedLabel)
+	deprecatedLabelUnapprovedBody = fmt.Sprintf(labelUnapprovedFormat, cpApprovedLabel, deprecatedCherrypickUnapprovedLabel)
 )
 
 // LabelUnapprovedPicks will add `do-not-merge` to PRs against a release branch which
@@ -93,7 +95,7 @@ func (LabelUnapprovedPicks) isStaleIssueComment(obj *github.MungeObject, comment
 	if !obj.IsRobot(comment.User) {
 		return false
 	}
-	if *comment.Body != labelUnapprovedBody {
+	if *comment.Body != labelUnapprovedBody && *comment.Body != deprecatedLabelUnapprovedBody {
 		return false
 	}
 	stale := obj.HasLabel(cpApprovedLabel)

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -124,6 +124,9 @@ func (r *ReleaseNoteLabel) ensureNoRelNoteNeededLabel(obj *github.MungeObject) {
 	if obj.HasLabel(releaseNoteLabelNeeded) {
 		obj.RemoveLabel(releaseNoteLabelNeeded)
 	}
+	if obj.HasLabel(deprecatedReleaseNoteLabelNeeded) {
+		obj.RemoveLabel(deprecatedReleaseNoteLabelNeeded)
+	}
 }
 
 // Munge is the workhorse the will actually make updates to the PR
@@ -149,9 +152,7 @@ func (r *ReleaseNoteLabel) Munge(obj *github.MungeObject) {
 		}
 	} else {
 		//going to apply some other release-note-label
-		if obj.HasLabel(releaseNoteLabelNeeded) {
-			obj.RemoveLabel(releaseNoteLabelNeeded)
-		}
+		r.ensureNoRelNoteNeededLabel(obj)
 	}
 	if !obj.HasLabel(labelToAdd) {
 		obj.AddLabel(labelToAdd)

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -44,8 +44,9 @@ const (
 	releaseNoteNone           = "release-note-none"
 	releaseNoteActionRequired = "release-note-action-required"
 
-	releaseNoteFormat = `Adding ` + releaseNoteLabelNeeded + ` because the release note process has not been followed.
-One of the following labels is required %q, %q or %q.
+	releaseNoteFormat = `Adding %s because the release note process has not been followed.
+%s`
+	releaseNoteSuffixFormat = `One of the following labels is required %q, %q, or %q.
 Please see: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed.`
 	parentReleaseNoteFormat = `The 'parent' PR of a cherry-pick PR must have one of the %q or %q labels, or this PR must follow the standard/parent release note labeling requirement.`
 
@@ -54,9 +55,11 @@ Please see: https://github.com/kubernetes/community/blob/master/contributors/dev
 )
 
 var (
-	releaseNoteBody       = fmt.Sprintf(releaseNoteFormat, releaseNote, releaseNoteActionRequired, releaseNoteNone)
-	parentReleaseNoteBody = fmt.Sprintf(parentReleaseNoteFormat, releaseNote, releaseNoteActionRequired)
-	noteMatcherRE         = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
+	releaseNoteSuffix         = fmt.Sprintf(releaseNoteSuffixFormat, releaseNote, releaseNoteActionRequired, releaseNoteNone)
+	releaseNoteBody           = fmt.Sprintf(releaseNoteFormat, releaseNoteLabelNeeded, releaseNoteSuffix)
+	deprecatedReleaseNoteBody = fmt.Sprintf(releaseNoteFormat, deprecatedReleaseNoteLabelNeeded, releaseNoteSuffix)
+	parentReleaseNoteBody     = fmt.Sprintf(parentReleaseNoteFormat, releaseNote, releaseNoteActionRequired)
+	noteMatcherRE             = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
 )
 
 // ReleaseNoteLabel will add the releaseNoteMissingLabel to a PR which has not
@@ -201,7 +204,7 @@ func (r *ReleaseNoteLabel) isStaleIssueComment(obj *github.MungeObject, comment 
 	if !obj.IsRobot(comment.User) {
 		return false
 	}
-	if *comment.Body != releaseNoteBody && *comment.Body != parentReleaseNoteFormat {
+	if *comment.Body != releaseNoteBody && *comment.Body != parentReleaseNoteFormat && *comment.Body != deprecatedReleaseNoteBody {
 		return false
 	}
 	if !r.prMustFollowRelNoteProcess(obj) {

--- a/mungegithub/mungers/release-note-label.go
+++ b/mungegithub/mungers/release-note-label.go
@@ -204,7 +204,7 @@ func (r *ReleaseNoteLabel) isStaleIssueComment(obj *github.MungeObject, comment 
 	if !obj.IsRobot(comment.User) {
 		return false
 	}
-	if *comment.Body != releaseNoteBody && *comment.Body != parentReleaseNoteFormat && *comment.Body != deprecatedReleaseNoteBody {
+	if *comment.Body != releaseNoteBody && *comment.Body != parentReleaseNoteBody && *comment.Body != deprecatedReleaseNoteBody {
 		return false
 	}
 	if !r.prMustFollowRelNoteProcess(obj) {

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION             ?= 0.153
+HOOK_VERSION             ?= 0.154
 SINKER_VERSION           ?= 0.16
 DECK_VERSION             ?= 0.43
 SPLICE_VERSION           ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.153
+        image: gcr.io/k8s-prow/hook:0.154
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -29,16 +29,18 @@ import (
 const pluginName = "release-note"
 
 const (
-	releaseNoteActionRequired = "release-note-action-required"
-	releaseNoteNone           = "release-note-none"
-	releaseNoteLabelNeeded    = "release-note-label-needed"
-	releaseNote               = "release-note"
+	releaseNoteActionRequired        = "release-note-action-required"
+	releaseNoteNone                  = "release-note-none"
+	deprecatedReleaseNoteLabelNeeded = "release-note-label-needed"
+	releaseNoteLabelNeeded           = "do-not-merge/release-note-label-needed"
+	releaseNote                      = "release-note"
 )
 
 var (
 	allRNLabels = []string{
 		releaseNoteNone,
 		releaseNoteActionRequired,
+		deprecatedReleaseNoteLabelNeeded,
 		releaseNoteLabelNeeded,
 		releaseNote,
 	}

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -57,6 +57,16 @@ func TestReleaseNoteComment(t *testing.T) {
 			addedLabel:    releaseNoteNone,
 		},
 		{
+			name:          "author release-note-none, has deprecated label",
+			action:        github.IssueCommentActionCreated,
+			isAuthor:      true,
+			body:          "/release-note-none",
+			currentLabels: []string{releaseNoteLabelNeeded, deprecatedReleaseNoteLabelNeeded, "other"},
+
+			deletedLabels: []string{releaseNoteLabelNeeded, deprecatedReleaseNoteLabelNeeded},
+			addedLabel:    releaseNoteNone,
+		},
+		{
 			name:          "author release-note-none, trailing space.",
 			action:        github.IssueCommentActionCreated,
 			isAuthor:      true,


### PR DESCRIPTION
Consider comments using deprecated labels stale as well

After bc2bc3c the comments that these mungers add have changed, but when
we encounter a comment with the previous format, we should consider it
stale under the same conditions that we would consider a comment with
the new format stale. This will ensure that all of the comments left
before the change went live get cleaned up as necessary.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Search for parent release note comment bodies, not formats

The previous implementation of this comment cleanup logic wrongly
attempted to compare the GitHub comment body with the comment format.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Update the releasenote Prow plugin with new label

When the plugin is removing other release-note labels it needs to remove
both the new and old `release-note-label-needed` labels.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Remove both release note label needed labels

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---