### PR TITLE
Bump boskos janitor concurrent goroutines count

### DIFF
--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20170803-856c615d
+        image: gcr.io/k8s-testimages/janitor:v20170830-c0d24857
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gce-project,gke-project

--- a/boskos/janitor/janitor.go
+++ b/boskos/janitor/janitor.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	poolSize       = 30 // Maximum concurrent janitor goroutines
+	poolSize       = 50 // Maximum concurrent janitor goroutines
 	bufferSize     = 1  // Maximum holding resources
 	serviceAccount = flag.String("service-account", "", "Path to projects service account")
 )


### PR DESCRIPTION
so we are adding more jobs and when [bad thing happens](http://velodrome.k8s.io/dashboard/db/boskos-dashboard?orgId=1) janitor does not clean the mess up fast enough - bump to 50 goroutines (they are shared between gce and gke jobs though)

/assign @cjwagner 