### PR TITLE
Add `--downgrade_args` to kubetest to make downgrade test easier

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4098,6 +4098,7 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--downgrade_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetDowngrade\\] --upgrade-target=ci/latest-1.7",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env",
       "--extract=ci/latest-1.7",
@@ -4105,8 +4106,7 @@
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--test_args=--ginkgo.focus=Networking --ginkgo.skip=Networking-Performance --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
-      "--timeout=90m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetDowngrade\\] --upgrade-target=ci/latest-1.7"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -163,6 +163,10 @@ func run(deploy deployer, o options) error {
 		errs = appendError(errs, xmlWrap("UpgradeTest", func() error {
 			return skewTest(argFields(o.upgradeArgs, dump, o.clusterIPRange), "upgrade", o.checkSkew)
 		}))
+	} else if o.downgradeArgs != "" {
+		errs = appendError(errs, xmlWrap("DowngradeTest", func() error {
+			return test(argFields(o.downgradeArgs, dump, o.clusterIPRange))
+		}))
 	}
 
 	testArgs := argFields(o.testArgs, dump, o.clusterIPRange)

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -101,6 +101,7 @@ type options struct {
 	testArgs            string
 	up                  bool
 	upgradeArgs         string
+	downgradeArgs       string
 }
 
 func defineFlags() *options {
@@ -148,7 +149,8 @@ func defineFlags() *options {
 	flag.StringVar(&o.testArgs, "test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
 	flag.DurationVar(&timeout, "timeout", time.Duration(0), "Terminate testing after the timeout duration (s/m/h)")
 	flag.BoolVar(&o.up, "up", false, "If true, start the the e2e cluster. If cluster is already up, recreate it.")
-	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests")
+	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests. This is multually exclusive with --downgrade_args.")
+	flag.StringVar(&o.downgradeArgs, "downgrade_args", "", "If set, run downgrade tests before other tests. This is multually exclusive with --upgrade_args.")
 
 	flag.BoolVar(&verbose, "v", false, "If true, print all command output.")
 	return &o


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/4127 added upgrade/downgrade test for validating kube-proxy migration path. But it turned out the downgrade test did not run in a proper way.

From https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds/2?log#log:
```
W0830 23:05:01.924] 2017/08/30 23:05:01 util.go:131: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=\[Feature:KubeProxyDaemonSetDowngrade\] --upgrade-target=ci/latest-1.7 --report-dir=/workspace/_artifacts --disable-log-dump=true --report-prefix=upgrade
W0830 23:05:01.947] Project: gce-up-c1-3-g1-4-up-mas
W0830 23:05:01.948] Zone: us-central1-f
W0830 23:05:01.948] Trying to find master named 'bootstrap-e2e-master'
W0830 23:05:01.948] Looking for address 'bootstrap-e2e-master-ip'
I0830 23:05:02.048] Setting up for KUBERNETES_PROVIDER="gce".
W0830 23:05:02.514] Using master: bootstrap-e2e-master (external IP: 35.192.21.170)
I0830 23:05:05.965] Aug 30 23:05:05.965: INFO: Overriding default scale value of zero to 1
I0830 23:05:05.965] Aug 30 23:05:05.965: INFO: Overriding default milliseconds value of zero to 5000
I0830 23:05:06.002] I0830 23:05:06.002523    7278 e2e.go:344] Starting e2e run "a96b760f-8dd7-11e7-9f84-0a580a3c4c08" on Ginkgo node 1
I0830 23:05:06.030] Running Suite: Kubernetes e2e suite
I0830 23:05:06.030] ===================================
I0830 23:05:06.030] Random Seed: 1504134302 - Will randomize all specs
I0830 23:05:06.031] Will run 0 of 652 specs
```

To make the context clearer, below are the args for kube-proxy downgrade test:
https://github.com/kubernetes/test-infra/blob/a47452699f70f67cd5e84cfd8898f322db01f1ad/jobs/config.json#L4097-L4116

We are passing in `--upgrade_args` to kubetest and expect it to run [kube-proxy downgrade test](https://github.com/kubernetes/kubernetes/blob/5dc0845e3625a99028bef39d6dcd648d48e2e61e/test/e2e/lifecycle/cluster_upgrade.go#L255-L279), but in fact it runs nothing because by design it will bring up cluster in `latest` and run skew test in `latest-1.7` while the downgrade test is only available on `latest`:
https://github.com/kubernetes/test-infra/blob/d76830ba7e464a4669b08d94ebcf34da89bb169c/kubetest/e2e.go#L162-L166

Run skew test make sense in the upgrade case, because we are bringing up cluster in `latest-1.7` and run upgrade test in `latest`.

There is another way to work around, i.e. by passing in the downgrade test directly through `--test_args`. Like what ci-kubernetes-e2e-gke-gci-1-6-gci-1-5-downgrade-cluster does:
https://github.com/kubernetes/test-infra/blob/a47452699f70f67cd5e84cfd8898f322db01f1ad/jobs/config.json#L6478-L6497 

But by using that pattern, there is no ways to include other generic tests --- if we compose those tests within `--test_args` as well, then the downgrade sequence will be messed up.

In short, it seems adding this flag makes downgrade jobs more symmetric with upgrade jobs.

@krzyzacy not sure whom should I send this to?