### PR TITLE
Fix kube-proxy downgrade job: use test_args instead of upgrade_args

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4104,9 +4104,8 @@
       "--extract=ci/latest",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=Networking --ginkgo.skip=Networking-Performance --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
-      "--timeout=90m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetDowngrade\\] --upgrade-target=ci/latest-1.7"
+      "--test_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetDowngrade\\] --upgrade-target=ci/latest-1.7 --minStartupPods=8",
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/pull/4281

kube-proxy downgrade test is only available on master branch, modified job config to pick that up.

@krzyzacy 