### PR TITLE
Fix jenkins version variable

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,15 +15,15 @@
 all: build test
 
 
-HOOK_VERSION       ?= 0.151
-SINKER_VERSION     ?= 0.16
-DECK_VERSION       ?= 0.43
-SPLICE_VERSION     ?= 0.27
-TOT_VERSION        ?= 0.5
-HOROLOGIUM_VERSION ?= 0.8
-PLANK_VERSION      ?= 0.41
-JENKINS_VERSION    ?= 0.40
-TIDE_VERSION       ?= 0.2
+HOOK_VERSION             ?= 0.151
+SINKER_VERSION           ?= 0.16
+DECK_VERSION             ?= 0.43
+SPLICE_VERSION           ?= 0.27
+TOT_VERSION              ?= 0.5
+HOROLOGIUM_VERSION       ?= 0.8
+PLANK_VERSION            ?= 0.41
+JENKINS-OPERATOR_VERSION ?= 0.40
+TIDE_VERSION             ?= 0.2
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow


### PR DESCRIPTION
The bump script was broken because the name of the
Jenkins operator inside the Makefile didn't match
with the correct name of the controller.

Signed-off-by: Michail Kargakis <mkargaki@redhat.com>

/cc @stevekuznetsov @spxtr 

@stevekuznetsov the rogue bump you observed a couple of days ago