### PR TITLE
Make the Prow bump script smarter

### DIFF
--- a/prow/bump.sh
+++ b/prow/bump.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ "$#" -ne 1 ]; then
-  echo "usage: $0 [program]"
+if [ "$#" -ne 0 ]; then
+  echo "usage: $0"
   exit 1
 fi
 
@@ -30,13 +30,59 @@ fi
 
 cd $(dirname $0)
 
-makefile_version_re="^\(${1}_VERSION.*=\s*\)"
-version=$($SED -n "s/$makefile_version_re//Ip" Makefile)
-new_version=$(awk -F. '{print $1 "." $2+1}' <<< $version)
+function bump_component() {
+	local component="$1"
 
-echo "program: $1"
-echo "old version: $version"
-echo "new version: $new_version"
+	makefile_version_re="^\(${1}_VERSION.*=\s*\)"
+	version=$($SED -n "s/$makefile_version_re//Ip" Makefile)
+	new_version=$(awk -F. '{print $1 "." $2+1}' <<< $version)
 
-$SED -i "s/$makefile_version_re.*/\1$new_version/I" Makefile
-$SED -i "s/\(${1}:\)[0-9.]*/\1$new_version/I" cluster/*.yaml
+	echo "program: $1"
+	echo "old version: $version"
+	echo "new version: $new_version"
+
+	$SED -i "s/$makefile_version_re.*/\1$new_version/I" Makefile
+	$SED -i "s/\(${1}:\)[0-9.]*/\1$new_version/I" cluster/*.yaml
+}
+
+commit_prefix="Bumped deployment versions for:"
+last_bump="$( git log --grep="${commit_prefix}" --pretty=%H | head -n 1 )"
+if [[ -z "${last_bump}" ]]; then
+	# we haven't used the script yet, so we need to find the last
+	# commit that changed a VERSION field in the Makefile instead
+	for commit in $( git log --pretty=%H -- ./Makefile ); do
+		if git diff "${commit}~1..${commit}" -- ./Makefile | grep -Eq "[+-].*VERSION"; then
+			last_bump="${commit}"
+			break
+		fi
+	done
+fi
+
+components=( $( find ./cmd/ -mindepth 1 -maxdepth 1 -type d -print0 | xargs --null -L 1 basename ) )
+bumped_components=()
+for component in "${components[@]}"; do
+	if [[ -n "$( git diff "${last_bump}~1..HEAD" -- "./cmd/${component}/" "./${component}/" )" ]]; then
+		bump_component "${component}"
+		bumped_components+=( "${component}" )
+	fi
+done
+
+# if we haven't already bumped hook, check for plugin updates
+hook_bumped=0
+for component in "${bumped_components[@]}"; do
+	if [[ "${component}" == "hook" ]]; then
+		hook_bumped=1
+	fi
+done
+
+if [[ "${hook_bumped}" == 0 ]]; then
+	if [[ -n "$( git diff "${last_bump}~1..HEAD" -- "./plugins/" )" ]]; then
+		bump_component "hook"
+		bumped_components+=( "hook" )
+	fi
+fi
+
+if [[ "${#bumped_components[@]}" -gt 0 ]]; then
+	git add Makefile cluster/*.yaml
+	git commit -m "${commit_prefix} ${bumped_components[*]}"
+fi


### PR DESCRIPTION
The script will now automatically detect which components need to be
bumped and determine the last time they were bumped to ensure that it is
not easy to forget to bump. Furthermore, this allows for a daily bump to
occur that will pick up all the changes that ocurred during that day.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @spxtr @fejta @kargakis @BenTheElder 

What do y'all think about this? I'm consistently failing to bump the right thing -- or to bump at all! This should mean people can either add the bump as a presubmit hook or we can just bump once before deployment and catch all of the interim changes.