### PR TITLE
Temporarily make kops-aws presubmit non-blocking until it's made useful

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -19,7 +19,6 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce-etcd3,\
-  pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-federation-e2e-gce,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -16,7 +16,6 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce-etcd3,\
-  pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-federation-e2e-gce,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\


### PR DESCRIPTION
To alleviate https://github.com/kubernetes/kubernetes/issues/51692 for now, until the job is made to run against PR builds (instead of CI ones).

cc @justinsb @kubernetes/test-infra-maintainers @kubernetes/sig-aws-misc 