### PR TITLE
add pr e2e shared build canary job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -60,11 +60,6 @@
     jobs:
     - 'pull-{jsonsuffix}'
     jsonsuffix:  # pull-<repo>-<suffix> is the expected format
-    - kubernetes-e2e-gce-canary:
-        max-total: 12
-        job-name: pull-kubernetes-e2e-gce-canary
-        repo-name: 'k8s.io/kubernetes'
-        timeout: 75
     - kubernetes-e2e-gke:
         max-total: 12
         job-name: pull-kubernetes-e2e-gke

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10467,7 +10467,6 @@
       "--env-file=jobs/env/pull-kubernetes-e2e-gce-canary.env",
       "--gcp-project=k8s-jkns-pr-gce",
       "--gcp-zone=us-central1-f",
-      "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=55m",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -116,6 +116,7 @@ presubmits:
     - name: pull-kubernetes-e2e-gce-canary
       agent: kubernetes
       always_run: true
+      skip_report: true
       context: pull-kubernetes-e2e-gce-canary
       rerun_command: "/test pull-kubernetes-e2e-gce-canary"
       trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-canary),?(\\s+|$)"
@@ -495,6 +496,7 @@ presubmits:
     - name: pull-security-kubernetes-e2e-gce-canary
       agent: kubernetes
       always_run: true
+      skip_report: true
       context: pull-security-kubernetes-e2e-gce-canary
       rerun_command: "/test pull-security-kubernetes-e2e-gce-canary"
       trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-canary),?(\\s+|$)"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -122,7 +122,7 @@ presubmits:
       spec:
         containers:
         - args:
-          - --timeout=75
+          - "--timeout=75"
           - "--clean"
           - "--git-cache=/root/.cache/git"
           - "--job=$(JOB_NAME)"
@@ -501,7 +501,7 @@ presubmits:
       spec:
         containers:
         - args:
-          - --timeout=75
+          - "--timeout=75"
           - "--clean"
           - "--git-cache=/root/.cache/git"
           - "--job=$(JOB_NAME)"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -112,6 +112,48 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+    run_after_success:
+    - name: pull-kubernetes-e2e-gce-canary
+      agent: kubernetes
+      always_run: true
+      context: pull-kubernetes-e2e-gce-canary
+      rerun_command: "/test pull-kubernetes-e2e-gce-canary"
+      trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-canary),?(\\s+|$)"
+      spec:
+        containers:
+        - args:
+          - --timeout=75
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--job=$(JOB_NAME)"
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--service-account=/etc/service-account/service-account.json"
+          - "--upload=gs://kubernetes-jenkins/pr-logs"
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: USER
+            value: prow
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
+          volumeMounts:
+          - mountPath: /etc/service-account
+            name: service
+            readOnly: true
+          - mountPath: /etc/ssh-key-secret
+            name: ssh
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            defaultMode: 256
+            secretName: ssh-key-secret
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
     context: pull-kubernetes-bazel-test
@@ -449,6 +491,48 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+    run_after_success:
+    - name: pull-security-kubernetes-e2e-gce-canary
+      agent: kubernetes
+      always_run: true
+      context: pull-security-kubernetes-e2e-gce-canary
+      rerun_command: "/test pull-security-kubernetes-e2e-gce-canary"
+      trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-canary),?(\\s+|$)"
+      spec:
+        containers:
+        - args:
+          - --timeout=75
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--job=$(JOB_NAME)"
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--service-account=/etc/service-account/service-account.json"
+          - "--upload=gs://kubernetes-jenkins/pr-logs"
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: USER
+            value: prow
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170829-89d24535
+          volumeMounts:
+          - mountPath: /etc/service-account
+            name: service
+            readOnly: true
+          - mountPath: /etc/ssh-key-secret
+            name: ssh
+            readOnly: true
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            defaultMode: 256
+            secretName: ssh-key-secret
   - name: pull-security-kubernetes-bazel-test
     agent: kubernetes
     context: pull-security-kubernetes-bazel-test

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1684,6 +1684,9 @@ test_groups:
 - name: pull-kubernetes-e2e-gce-bazel
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-bazel
   days_of_results: 1
+- name: pull-kubernetes-e2e-gce-canary		
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-canary		
+  days_of_results: 1
 - name: pull-kubernetes-e2e-gce-etcd3
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-etcd3
   days_of_results: 1
@@ -4058,6 +4061,9 @@ dashboards:
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-bazel
     test_group_name: pull-kubernetes-e2e-gce-bazel
+    base_options: 'width=10'
+  - name: pull-kubernetes-e2e-gce-canary		
+    test_group_name: pull-kubernetes-e2e-gce-canary		
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-etcd3
     test_group_name: pull-kubernetes-e2e-gce-etcd3


### PR DESCRIPTION
Adds a PR e2e using a shared bazel build so that we can make sure this works properly before switching the other jobs in the near future.