### PR TITLE
Dynamically configure verbose logging

### DIFF
--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -65,7 +65,6 @@ func main() {
 	if err := configAgent.Start(*configPath); err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
-	logger := logrus.StandardLogger()
 
 	var webhookSecret []byte
 	var githubClient *github.Client
@@ -139,9 +138,11 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting git client.")
 	}
 
+	logger := logrus.StandardLogger()
 	githubClient.Logger = logger.WithField("client", "github")
 	kubeClient.Logger = logger.WithField("client", "kube")
 	gitClient.Logger = logger.WithField("client", "git")
+	slackClient.Logger = logger.WithField("client", "slack")
 
 	pluginAgent := &plugins.PluginAgent{
 		PluginClient: plugins.PluginClient{

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -44,6 +44,9 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting kube client.")
 	}
 
+	logger := logrus.StandardLogger()
+	kc.Logger = logger.WithField("client", "kube")
+
 	for now := range time.Tick(1 * time.Minute) {
 		start := time.Now()
 		if err := sync(kc, configAgent.Config(), now); err != nil {

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -100,6 +100,11 @@ func main() {
 		ghc = github.NewClient(oauthSecret, *githubEndpoint)
 	}
 
+	logger := logrus.StandardLogger()
+	kc.Logger = logger.WithField("client", "kube")
+	jc.Logger = logger.WithField("client", "jenkins")
+	ghc.Logger = logger.WithField("client", "github")
+
 	c := jenkins.NewController(kc, jc, ghc, configAgent)
 
 	for range time.Tick(30 * time.Second) {

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -85,6 +85,11 @@ func main() {
 		ghc = github.NewClient(oauthSecret, *githubEndpoint)
 	}
 
+	logger := logrus.StandardLogger()
+	kc.Logger = logger.WithField("client", "kube")
+	pkc.Logger = logger.WithField("client", "kube")
+	ghc.Logger = logger.WithField("client", "github")
+
 	c, err := plank.NewController(kc, pkc, ghc, configAgent, *totURL)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating plank controller.")

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -70,8 +70,9 @@ func main() {
 		}
 	}
 
-	kc.Logger = logrus.WithField("client", "kube")
-	pkc.Logger = logrus.WithField("client", "kube")
+	logger := logrus.StandardLogger()
+	kc.Logger = logger.WithField("client", "kube")
+	pkc.Logger = logger.WithField("client", "kube")
 
 	// Clean now and regularly from now on.
 	for {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9,6 +9,7 @@ sinker:
 
 prowjob_namespace: default
 pod_namespace: test-pods
+log_level: info
 
 tide:
   queries:

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/kube"
 )
@@ -52,6 +53,16 @@ type Config struct {
 	// The namespace needs to exist and will not be created by prow.
 	// Defaults to "default".
 	PodNamespace string `json:"pod_namespace,omitempty"`
+
+	// LogLevel enables dynamically updating the log level of the
+	// standard logger that is used by all prow components.
+	//
+	// Valid values:
+	//
+	// "debug", "info", "warn", "warning", "error", "fatal", "panic"
+	//
+	// Defaults to "info".
+	LogLevel string `json:"log_level,omitempty"`
 
 	// PushGateway is a prometheus push gateway.
 	PushGateway PushGateway `json:"push_gateway,omitempty"`
@@ -224,6 +235,16 @@ func parseConfig(c *Config) error {
 	if c.PodNamespace == "" {
 		c.PodNamespace = "default"
 	}
+
+	if c.LogLevel == "" {
+		c.LogLevel = "info"
+	}
+	lvl, err := logrus.ParseLevel(c.LogLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(lvl)
+
 	return nil
 }
 

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -36,7 +36,7 @@ import (
 )
 
 type Logger interface {
-	Printf(s string, v ...interface{})
+	Debugf(s string, v ...interface{})
 }
 
 type Client struct {
@@ -101,7 +101,7 @@ func (c *Client) log(methodName string, args ...interface{}) {
 	for _, arg := range args {
 		as = append(as, fmt.Sprintf("%v", arg))
 	}
-	c.Logger.Printf("%s(%s)", methodName, strings.Join(as, ", "))
+	c.Logger.Debugf("%s(%s)", methodName, strings.Join(as, ", "))
 }
 
 var timeSleep = time.Sleep

--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -39,7 +39,7 @@ const (
 )
 
 type Logger interface {
-	Printf(s string, v ...interface{})
+	Debugf(s string, v ...interface{})
 }
 
 // Client interacts with the Kubernetes api-server.
@@ -69,7 +69,7 @@ func (c *Client) log(methodName string, args ...interface{}) {
 	for _, arg := range args {
 		as = append(as, fmt.Sprintf("%v", arg))
 	}
-	c.Logger.Printf("%s(%s)", methodName, strings.Join(as, ", "))
+	c.Logger.Debugf("%s(%s)", methodName, strings.Join(as, ", "))
 }
 
 type ConflictError error

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -71,7 +71,6 @@ func (c *Controller) Sync() error {
 	var pjs []kube.ProwJob
 	var err error
 	if len(pool) > 0 {
-		c.log.Info("Listing ProwJobs.")
 		pjs, err = c.kc.ListProwJobs(nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
Unify enabling verbose logging across the main prow
workhorses and add missing logging calls in Jenkins
and Slack clients.

Tested this with tide and it works like a charm.

/assign spxtr