### PR TITLE
Set JENKINS_USE_LOCAL_BINARIES=y for pull-kubernetes-e2e-kops-aws job

### DIFF
--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -880,6 +880,7 @@ class JobTest(unittest.TestCase):
         for env, fix in black:
             if 'kops' in job and env in [
                     'JENKINS_PUBLISHED_VERSION=',
+                    'JENKINS_USE_LOCAL_BINARIES=',
                     'GINKGO_TEST_ARGS=',
                     'KUBERNETES_PROVIDER=',
             ]:

--- a/jobs/env/pull-kubernetes-e2e-kops-aws.env
+++ b/jobs/env/pull-kubernetes-e2e-kops-aws.env
@@ -2,3 +2,6 @@ KOPS_LATEST=latest-ci-green.txt
 CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 KUBE_GCS_UPDATE_LATEST=n
 KUBE_FASTBUILD=true
+# kops-aws is using an old version of the kubekins-e2e image which requires
+# this environment variable
+JENKINS_USE_LOCAL_BINARIES=y


### PR DESCRIPTION
See explanation in https://github.com/kubernetes/test-infra/issues/4315#issuecomment-326660428.

Should fix #4315.

/assign @krzyzacy 