### PR TITLE
Enforces code freeze for 1.8

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -91,7 +91,7 @@ nonblocking-jobs: "\
   ci-kubernetes-soak-gke-test,\
   ci-kubernetes-test-go,\
   ci-kubernetes-verify-master"
-do-not-merge-milestones: ""
+do-not-merge-milestones: "v1.9,v1.10,next-candidate,"
 admin-port: 9999
 chart-url: https://storage.googleapis.com/kubernetes-test-history/k8s-queue-health.svg
 history-url: https://storage.googleapis.com/kubernetes-test-history/static/index.html


### PR DESCRIPTION
1.8 code freeze should go into effect at 6pm PST on 1 September 2017.
Instructs submit queue to not merge PRs after the 1.8 milestone.

**cc: @kubernetes/kubernetes-release-managers**