### PR TITLE
Don't use ci/latest kubernetes binaries in pull-kubernetes-e2e-kops-aws

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10620,7 +10620,6 @@
       "--check-leaked-resources=false",
       "--cluster=",
       "--env-file=jobs/platform/kops_aws.env",
-      "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/env/pull-kubernetes-e2e-kops-aws.env",
       "--extract=local",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws",

--- a/jobs/env/pull-kubernetes-e2e-kops-aws.env
+++ b/jobs/env/pull-kubernetes-e2e-kops-aws.env
@@ -5,3 +5,15 @@ KUBE_FASTBUILD=true
 # kops-aws is using an old version of the kubekins-e2e image which requires
 # this environment variable
 JENKINS_USE_LOCAL_BINARIES=y
+
+# See https://github.com/kubernetes/kubernetes/issues/30312 for why HPA is disabled.
+# See https://github.com/kubernetes/kops/issues/774 for why the Dashboard is disabled
+# See https://github.com/kubernetes/kops/issues/775 for why NodePort is disabled
+GINKGO_TEST_ARGS=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+
+# Ignore version-we-pass vs version-kops-expects
+KOPS_RUN_OBSOLETE_VERSION=true
+
+KOPS_DEPLOY_LATEST_KUBE=n
+GINKGO_PARALLEL=y
+GINKGO_TOLERATE_FLAKES=y


### PR DESCRIPTION
This is so much fun.

We want to disable this branch in `kops-e2e-runner.sh`.
https://github.com/kubernetes/test-infra/blob/328200516af12570fccfdde709c1fa9de4b73f53/jenkins/e2e-image/kops-e2e-runner.sh#L50-L60

`KOPS_DEPLOY_LATEST_KUBE` is set to `y` in `ci-kubernetes-e2e-kops-aws.env`; we include this in the pull job for reasons I don't really understand.

I've copied (what I think is) the relevant env to `pull-kubernetes-e2e-kops-aws.env`. This way we have less magical behavior in the future.

Maybe fixes #4315.

/assign @krzyzacy 