### PR TITLE
Configure organization for SIG labels

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION             ?= 0.157
+HOOK_VERSION             ?= 0.158
 SINKER_VERSION           ?= 0.17
 DECK_VERSION             ?= 0.44
 SPLICE_VERSION           ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.157
+        image: gcr.io/k8s-prow/hook:0.158
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -14,6 +14,9 @@ heart:
   adorees:
   - k8s-merge-bot
 
+label:
+  sig_org: kubernetes
+
 plugins:
   google/cadvisor:
   - trigger

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -533,7 +533,7 @@ func TestLabel(t *testing.T) {
 			fakeSlackClient := &fakeslack.FakeClient{
 				SentMessages: make(map[string][]string),
 			}
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), ae, fakeSlackClient); err != nil {
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), "kubernetes", ae, fakeSlackClient); err != nil {
 				t.Errorf("For case %s, didn't expect error from label test: %v", tc.name, err)
 				return
 			}
@@ -665,7 +665,7 @@ func TestRepeat(t *testing.T) {
 			member, _ := fakeClient.IsMember(ae.org, ae.login)
 			toRepeat := []string{}
 			if !member {
-				toRepeat = ae.getRepeats(sigMatcher.FindAllStringSubmatch(tc.body, -1), m)
+				toRepeat = ae.getRepeats(sigMatcher("kubernetes").FindAllStringSubmatch(tc.body, -1), m)
 			}
 
 			sort.Strings(toRepeat)
@@ -748,7 +748,7 @@ func TestSlackMessages(t *testing.T) {
 				SentMessages: make(map[string][]string),
 			}
 
-			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), ae, fakeSlackClient); err != nil {
+			if err := handle(fakeClient, logrus.WithField("plugin", pluginName), "kubernetes", ae, fakeSlackClient); err != nil {
 				t.Fatalf("For case %s, didn't expect error from label test: %v", tc.name, err)
 			}
 			if len(tc.expectedMessages) != len(fakeSlackClient.SentMessages) {


### PR DESCRIPTION
Supporting SIG labels for SIGs in other organizations requires that the
label-matching regular expression be configurable with the name of the
organization that owns SIGs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/assign @spxtr 