### PR TITLE
mungebot: Fix milestone munger spamming

### DIFF
--- a/mungegithub/mungers/matchers/comment/notification.go
+++ b/mungegithub/mungers/matchers/comment/notification.go
@@ -31,13 +31,12 @@ type Notification struct {
 }
 
 var (
-	// Matches a notification: [NOTIFNAME] Arguments
-	notificationRegex = regexp.MustCompile(`^\[([^\]\s]+)\] *?([^\n]*)`)
+	// Matches a notification: [NOTIFNAME] Arguments\n\nContext
+	notificationRegex = regexp.MustCompile(`^\[([^\]\s]+)\] *?([^\n]*)(?:\n\n)?(.*)`)
 )
 
 // ParseNotification attempts to read a notification from a comment
 // Returns nil if the comment doesn't contain a notification
-// Also note that Context is not parsed from the notification
 func ParseNotification(comment *Comment) *Notification {
 	if comment == nil || comment.Body == nil {
 		return nil
@@ -51,6 +50,7 @@ func ParseNotification(comment *Comment) *Notification {
 	return &Notification{
 		Name:      strings.ToUpper(match[1]),
 		Arguments: strings.TrimSpace(match[2]),
+		Context:   strings.TrimSpace(match[3]),
 	}
 }
 

--- a/mungegithub/mungers/matchers/comment/notification_test.go
+++ b/mungegithub/mungers/matchers/comment/notification_test.go
@@ -62,6 +62,10 @@ func TestParseNotification(t *testing.T) {
 			notif:   &Notification{Name: "NOTIF", Arguments: "Arguments is trimmed"},
 			comment: "[notif]     Arguments is trimmed   ",
 		},
+		{
+			notif:   &Notification{Name: "NOTIF", Arguments: "Context is read", Context: "What a lovely context"},
+			comment: "[notif]     Context is read \n\n  What a lovely context    ",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The milestone munger was assuming that ``ParseNotification`` would be reading the context, but that was not the case, and the result was spamming issues with incomplete labels.  This change updates ``ParseNotification`` to read the context.