### PR TITLE
sig-notifier recognizes wg labels.

### DIFF
--- a/mungegithub/mungers/sig-mention-handler.go
+++ b/mungegithub/mungers/sig-mention-handler.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/test-infra/mungegithub/options"
 )
 
+var labelPrefixes = []string{"sig/", "committee/", "wg/"}
+
 type SigMentionHandler struct{}
 
 func init() {
@@ -57,11 +59,13 @@ func (*SigMentionHandler) HasSigLabel(obj *github.MungeObject) bool {
 	labels := obj.Issue.Labels
 
 	for i := range labels {
-		if labels[i].Name != nil && strings.HasPrefix(*labels[i].Name, "sig/") {
-			return true
+		if labels[i].Name == nil {
+			continue
 		}
-		if labels[i].Name != nil && strings.HasPrefix(*labels[i].Name, "committee/") {
-			return true
+		for j := range labelPrefixes {
+			if strings.HasPrefix(*labels[i].Name, labelPrefixes[j]) {
+				return true
+			}
 		}
 	}
 

--- a/mungegithub/mungers/sig-mention-handler_test.go
+++ b/mungegithub/mungers/sig-mention-handler_test.go
@@ -29,12 +29,13 @@ import (
 )
 
 const (
-	helpWanted        = "help-wanted"
-	open              = "open"
-	sigApps           = "sig/apps"
-	committeeSteering = "committee/steering"
-	username          = "Ali"
-	needsSigLabel     = "needs-sig"
+	helpWanted          = "help-wanted"
+	open                = "open"
+	sigApps             = "sig/apps"
+	committeeSteering   = "committee/steering"
+	wgContainerIdentity = "wg/container-identity"
+	username            = "Ali"
+	needsSigLabel       = "needs-sig"
 )
 
 func TestSigMentionHandler(t *testing.T) {
@@ -161,6 +162,33 @@ func TestSigMentionHandler(t *testing.T) {
 			},
 			expected: []githubapi.Label{{Name: githubapi.String(helpWanted)},
 				{Name: githubapi.String(committeeSteering)}},
+		},
+		{
+			name: "issue has wg/foo label, no needs-sig label",
+			issue: &githubapi.Issue{
+				State: githubapi.String(open),
+				Labels: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+					{Name: githubapi.String(wgContainerIdentity)}},
+				PullRequestLinks: nil,
+				Assignee:         &githubapi.User{Login: githubapi.String(username)},
+				Number:           intPtr(1),
+			},
+			expected: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+				{Name: githubapi.String(wgContainerIdentity)}},
+		},
+		{
+			name: "issue has both needs-sig label and wg/foo label",
+			issue: &githubapi.Issue{
+				State: githubapi.String(open),
+				Labels: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+					{Name: githubapi.String(needsSigLabel)},
+					{Name: githubapi.String(wgContainerIdentity)}},
+				PullRequestLinks: nil,
+				Assignee:         &githubapi.User{Login: githubapi.String(username)},
+				Number:           intPtr(1),
+			},
+			expected: []githubapi.Label{{Name: githubapi.String(helpWanted)},
+				{Name: githubapi.String(wgContainerIdentity)}},
 		},
 	}
 


### PR DESCRIPTION
fixes: #4356

Note that we haven't had `wg/*` labels yet in any of our projects. We should add these labels first.

/cc @luxas @cblecker 