### PR TITLE
kubetest kops should wait for Ready nodes

### DIFF
--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -25,6 +25,7 @@ go_library(
         "federation.go",
         "gke.go",
         "kops.go",
+        "kubernetes.go",
         "main.go",
         "node.go",
         "none.go",

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -54,9 +54,11 @@ filegroup(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "anywhere_test.go",
         "extract_test.go",
+        "kubernetes_test.go",
         "main_test.go",
         "util_test.go",
     ],

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -245,8 +245,7 @@ func (k *kubernetesAnywhere) Up() error {
 		return err
 	}
 
-	nodes := k.NumNodes
-	return waitForNodes(k, nodes+1, *kubernetesAnywhereUpTimeout)
+	return waitForReadyNodes(k.NumNodes+1, *kubernetesAnywhereUpTimeout)
 }
 
 func (k *kubernetesAnywhere) IsUp() error {

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -446,22 +446,6 @@ func isUp(d deployer) error {
 	return nil
 }
 
-func waitForNodes(d deployer, nodes int, timeout time.Duration) error {
-	for stop := time.Now().Add(timeout); time.Now().Before(stop); time.Sleep(30 * time.Second) {
-		n, err := clusterSize(d)
-		if err != nil {
-			log.Printf("Can't get cluster size, sleeping: %v", err)
-			continue
-		}
-		if n < nodes {
-			log.Printf("%d (current nodes) < %d (requested instances), sleeping", n, nodes)
-			continue
-		}
-		return nil
-	}
-	return fmt.Errorf("waiting for nodes timed out")
-}
-
 func defaultDumpClusterLogs(localArtifactsDir, logexporterGCSPath string) error {
 	logDumpPath := "./cluster/log-dump/log-dump.sh"
 	// cluster/log-dump/log-dump.sh only exists in the Kubernetes tree

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -294,7 +294,7 @@ func (k kops) Up() error {
 	// TODO(zmerlynn): More cluster validation. This should perhaps be
 	// added to kops and not here, but this is a fine place to loop
 	// for now.
-	return waitForNodes(k, k.nodes+1, *kopsUpTimeout)
+	return waitForReadyNodes(k.nodes+1, *kopsUpTimeout)
 }
 
 func (k kops) IsUp() error {

--- a/kubetest/kubernetes.go
+++ b/kubetest/kubernetes.go
@@ -58,20 +58,26 @@ func waitForReadyNodes(desiredCount int, timeout time.Duration) error {
 			log.Printf("kubectl get nodes failed, sleeping: %v", err)
 			continue
 		}
-		var ready []*node
-		for i := range nodes.Items {
-			node := &nodes.Items[i]
-			if isReady(node) {
-				ready = append(ready, node)
-			}
+		readyNodes := countReadyNodes(nodes)
+		if readyNodes >= desiredCount {
+			return nil
 		}
-		if len(ready) < desiredCount {
-			log.Printf("%d (ready nodes) < %d (requested instances), sleeping", len(ready), desiredCount)
-			continue
-		}
-		return nil
+
+		log.Printf("%d (ready nodes) < %d (requested instances), sleeping", readyNodes, desiredCount)
 	}
 	return fmt.Errorf("waiting for ready nodes timed out")
+}
+
+// countReadyNodes returns the number of nodes that have isReady == true
+func countReadyNodes(nodes *nodeList) int {
+	var ready []*node
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if isReady(node) {
+			ready = append(ready, node)
+		}
+	}
+	return len(ready)
 }
 
 // nodeList is a simplified version of the v1.NodeList API type

--- a/kubetest/kubernetes.go
+++ b/kubetest/kubernetes.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"time"
+)
+
+// kubectlGetNodes lists nodes by executing kubectl get nodes, parsing the output into a nodeList object
+func kubectlGetNodes() (*nodeList, error) {
+	o, err := output(exec.Command("kubectl", "get", "nodes", "-ojson"))
+	if err != nil {
+		log.Printf("kubectl get nodes failed: %s\n%s", wrapError(err).Error(), string(o))
+		return nil, err
+	}
+
+	nodes := &nodeList{}
+	if err := json.Unmarshal(o, nodes); err != nil {
+		return nil, fmt.Errorf("error parsing kubectl get nodes output: %v", err)
+	}
+
+	return nodes, nil
+}
+
+// isReady checks if the node has a Ready Condition that is True
+func isReady(node *node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == "Ready" {
+			return c.Status == "True"
+		}
+	}
+	return false
+}
+
+// waitForReadyNodes polls the nodes until we see at least desiredCount that are Ready
+func waitForReadyNodes(desiredCount int, timeout time.Duration) error {
+	for stop := time.Now().Add(timeout); time.Now().Before(stop); time.Sleep(30 * time.Second) {
+		nodes, err := kubectlGetNodes()
+		if err != nil {
+			log.Printf("kubectl get nodes failed, sleeping: %v", err)
+			continue
+		}
+		var ready []*node
+		for i := range nodes.Items {
+			node := &nodes.Items[i]
+			if isReady(node) {
+				ready = append(ready, node)
+			}
+		}
+		if len(ready) < desiredCount {
+			log.Printf("%d (ready nodes) < %d (requested instances), sleeping", len(ready), desiredCount)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("waiting for ready nodes timed out")
+}
+
+// nodeList is a simplified version of the v1.NodeList API type
+type nodeList struct {
+	Items []node `json:"items"`
+}
+
+// node is a simplified version of the v1.Node API type
+type node struct {
+	Metadata metadata   `json:"metadata"`
+	Status   nodeStatus `json:"status"`
+}
+
+// nodeStatus is a simplified version of the v1.NodeStatus API type
+type nodeStatus struct {
+	Addresses  []nodeAddress   `json:"addresses"`
+	Conditions []nodeCondition `json:"conditions"`
+}
+
+// nodeAddress is a simplified version of the v1.NodeAddress API type
+type nodeAddress struct {
+	Address string `json:"address"`
+	Type    string `json:"type"`
+}
+
+// nodeCondition is a simplified version of the v1.NodeCondition API type
+type nodeCondition struct {
+	Message string `json:"message"`
+	Reason  string `json:"reason"`
+	Status  string `json:"status"`
+	Type    string `json:"type"`
+}
+
+// metadata is a simplified version of the kubernetes metadata types
+type metadata struct {
+	Name string `json:"name"`
+}

--- a/kubetest/kubernetes_test.go
+++ b/kubetest/kubernetes_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func Test_isReady(t *testing.T) {
+	grid := []struct {
+		node     *node
+		expected bool
+	}{
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{},
+				},
+			},
+			expected: false,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{
+						{Type: "Ready", Status: "True"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{
+						{Type: "Ready", Status: "False"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{
+						{Type: "Ready", Status: "Unknown"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{
+						{Type: "Ready", Status: "not-a-known-value"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{
+						{Type: "Random", Status: "True"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{
+						{Type: "Random", Status: "Unknown"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{
+						{Type: "Random", Status: "True"},
+						{Type: "Ready", Status: "True"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{
+					Conditions: []nodeCondition{},
+				},
+			},
+			expected: false,
+		},
+		{
+			node: &node{
+				Status: nodeStatus{},
+			},
+			expected: false,
+		},
+		{
+			node:     &node{},
+			expected: false,
+		},
+	}
+
+	for _, g := range grid {
+		actual := isReady(g.node)
+
+		if actual != g.expected {
+			t.Errorf("unexpected isReady.  actual=%v, expected=%v", actual, g.expected)
+			continue
+		}
+	}
+}
+
+func Test_countReadyNodes(t *testing.T) {
+	readyNode := node{
+		Status: nodeStatus{
+			Conditions: []nodeCondition{
+				{Type: "Ready", Status: "True"},
+			},
+		},
+	}
+	notReadyNode := node{
+		Status: nodeStatus{
+			Conditions: []nodeCondition{
+				{Type: "Ready", Status: "False"},
+			},
+		},
+	}
+
+	grid := []struct {
+		nodes    []node
+		expected int
+	}{
+		{
+			nodes:    []node{readyNode, readyNode, readyNode},
+			expected: 3,
+		},
+		{
+			nodes:    []node{notReadyNode, notReadyNode, notReadyNode},
+			expected: 0,
+		},
+		{
+			nodes:    []node{},
+			expected: 0,
+		},
+		{
+			nodes:    nil,
+			expected: 0,
+		},
+		{
+			nodes:    []node{readyNode, notReadyNode, readyNode},
+			expected: 2,
+		},
+		{
+			nodes:    []node{notReadyNode, readyNode},
+			expected: 1,
+		},
+	}
+
+	for _, g := range grid {
+		actual := countReadyNodes(&nodeList{Items: g.nodes})
+		if actual != g.expected {
+			t.Errorf("unexpected countReadyNodes.  actual=%v, expected=%v", actual, g.expected)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
At least for kops, we don't consider a cluster to be ready until the
nodes are actually Ready.