### PR TITLE
Shouldn't remove "needs-ok-to-test" when a non org member asks for "/ok-to-test"

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION             ?= 0.155
+HOOK_VERSION             ?= 0.156
 SINKER_VERSION           ?= 0.17
 DECK_VERSION             ?= 0.43
 SPLICE_VERSION           ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.155
+        image: gcr.io/k8s-prow/hook:0.156
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -54,11 +54,6 @@ func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 		return nil
 	}
 
-	if okToTest.MatchString(ic.Comment.Body) && ic.Issue.HasLabel(needsOkToTest) {
-		if err := c.GitHubClient.RemoveLabel(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, needsOkToTest); err != nil {
-			c.Logger.WithError(err).Errorf("Failed at removing %s label", needsOkToTest)
-		}
-	}
 	// Which jobs does the comment want us to run?
 	shouldRetestFailed := retest.MatchString(ic.Comment.Body)
 	requestedJobs := c.Config.MatchingPresubmits(ic.Repo.FullName, ic.Comment.Body, okToTest)
@@ -102,6 +97,12 @@ func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 			resp := fmt.Sprintf("you can't request testing unless you are a [%s](https://github.com/orgs/%s/people) member.", trustedOrg, trustedOrg)
 			c.Logger.Infof("Commenting \"%s\".", resp)
 			return c.GitHubClient.CreateComment(org, repo, number, plugins.FormatICResponse(ic.Comment, resp))
+		}
+	}
+
+	if okToTest.MatchString(ic.Comment.Body) && ic.Issue.HasLabel(needsOkToTest) {
+		if err := c.GitHubClient.RemoveLabel(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, needsOkToTest); err != nil {
+			c.Logger.WithError(err).Errorf("Failed at removing %s label", needsOkToTest)
 		}
 	}
 

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -79,7 +79,7 @@ func TestHandleIssueComment(t *testing.T) {
 			IsPR:        true,
 			ShouldBuild: false,
 		},
-		// Non-trusted member after "ok to test".
+		// Non-trusted member after "/ok-to-test".
 		{
 			Author:      "u",
 			Body:        "/test all",

--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -34,8 +34,8 @@ func handlePR(c client, trustedOrg string, pr github.PullRequestEvent) error {
 	switch pr.Action {
 	case github.PullRequestActionOpened:
 		// When a PR is opened, if the author is in the org then build it.
-		// Otherwise, ask for "ok to test". There's no need to look for previous
-		// "ok to test" comments since the PR was just opened!
+		// Otherwise, ask for "/ok-to-test". There's no need to look for previous
+		// "/ok-to-test" comments since the PR was just opened!
 		member, err := c.GitHubClient.IsMember(trustedOrg, author)
 		if err != nil {
 			return fmt.Errorf("could not check membership: %s", err)
@@ -50,8 +50,8 @@ func handlePR(c client, trustedOrg string, pr github.PullRequestEvent) error {
 		}
 	case github.PullRequestActionReopened, github.PullRequestActionSynchronize:
 		// When a PR is updated, check that the user is in the org or that an org
-		// member has said "ok to test" before building. There's no need to ask
-		// for "ok to test" because we do that once when the PR is created.
+		// member has said "/ok-to-test" before building. There's no need to ask
+		// for "/ok-to-test" because we do that once when the PR is created.
 		trusted, err := trustedPullRequest(c.GitHubClient, pr.PullRequest, trustedOrg)
 		if err != nil {
 			return fmt.Errorf("could not validate PR: %s", err)
@@ -99,7 +99,7 @@ I understand the commands that are listed [here](https://github.com/kubernetes/t
 }
 
 // trustedPullRequest returns whether or not the given PR should be tested.
-// It first checks if the author is in the org, then looks for "ok to test
+// It first checks if the author is in the org, then looks for "/ok-to-test"
 // comments by org members.
 func trustedPullRequest(ghc githubClient, pr github.PullRequest, trustedOrg string) (bool, error) {
 	author := pr.User.Login
@@ -110,7 +110,7 @@ func trustedPullRequest(ghc githubClient, pr github.PullRequest, trustedOrg stri
 	} else if orgMember {
 		return true, nil
 	}
-	// Next look for "ok to test" comments on the PR.
+	// Next look for "/ok-to-test" comments on the PR.
 	comments, err := ghc.ListIssueComments(pr.Base.Repo.Owner.Login, pr.Base.Repo.Name, pr.Number)
 	if err != nil {
 		return false, err
@@ -129,7 +129,7 @@ func trustedPullRequest(ghc githubClient, pr github.PullRequest, trustedOrg stri
 		if commentAuthor == botName {
 			continue
 		}
-		// Look for "ok to test"
+		// Look for "/ok-to-test"
 		if !okToTest.MatchString(comment.Body) {
 			continue
 		}


### PR DESCRIPTION
See in: https://github.com/kubernetes/kubernetes/pull/47584#issuecomment-327075108

When a non org member asks for a `/ok-to-test`, the bot removes `needs-ok-to-test` and comments `you can't request testing unless you are a kubernetes member`. It should only comment but not remove the label `needs-ok-to-test`.

Also fix some nits.

/cc @cjwagner 