### PR TITLE
Create build/verify/unittest/bazel jobs for release 1.8

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -83,14 +83,6 @@
         repo-name: k8s.io/kubernetes
         timeout: 120
 
-    - kubernetes-build-1.4:
-        branch: release-1.4
-        commit-frequency: 'H/5 * * * *'
-        giturl: 'https://github.com/kubernetes/kubernetes'
-        job-name: ci-kubernetes-build-1.4
-        repo-name: k8s.io/kubernetes
-        timeout: 50
-
     - kubernetes-build-1.5:
         branch: release-1.5
         commit-frequency: 'H/5 * * * *'
@@ -112,6 +104,14 @@
         commit-frequency: 'H/5 * * * *'
         giturl: 'https://github.com/kubernetes/kubernetes'
         job-name: ci-kubernetes-build-1.7
+        repo-name: k8s.io/kubernetes
+        timeout: 100
+
+    - kubernetes-build-1.8:
+        branch: release-1.8
+        commit-frequency: 'H/5 * * * *'
+        giturl: 'https://github.com/kubernetes/kubernetes'
+        job-name: ci-kubernetes-build-1.8
         repo-name: k8s.io/kubernetes
         timeout: 100
 

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -59,6 +59,12 @@
         job-name: ci-kubernetes-verify-master
         repo-name: k8s.io/kubernetes
         timeout: 80
+    - kubernetes-verify-release-1.8:
+        branch: release-1.8
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-verify-release-1.8
+        repo-name: k8s.io/kubernetes
+        timeout: 80
     - kubernetes-verify-release-1.7:
         branch: release-1.7
         frequency: 'H/5 * * * *'
@@ -67,7 +73,7 @@
         timeout: 80
     - kubernetes-verify-release-1.6:
         branch: release-1.6
-        frequency: 'H/5 * * * *'
+        frequency: 'H H/3 * * *'
         job-name: ci-kubernetes-verify-release-1.6
         repo-name: k8s.io/kubernetes
         timeout: 80
@@ -77,17 +83,18 @@
         job-name: ci-kubernetes-verify-release-1.5
         repo-name: k8s.io/kubernetes
         timeout: 80
-    - kubernetes-verify-release-1.4:
-        branch: release-1.4
-        frequency: 'H H/3 * * *'
-        job-name: ci-kubernetes-verify-release-1.4
-        repo-name: k8s.io/kubernetes
-        timeout: 80
+
 
     - kubernetes-test-go:
         branch: master
         frequency: 'H/5 * * * *'
         job-name: ci-kubernetes-test-go
+        repo-name: k8s.io/kubernetes
+        timeout: 100
+    - kubernetes-test-go-release-1.8:
+        branch: release-1.8
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-test-go-release-1.8
         repo-name: k8s.io/kubernetes
         timeout: 100
     - kubernetes-test-go-release-1.7:
@@ -98,7 +105,7 @@
         timeout: 100
     - kubernetes-test-go-release-1.6:
         branch: release-1.6
-        frequency: 'H/5 * * * *'
+        frequency: 'H H/3 * * *'
         job-name: ci-kubernetes-test-go-release-1.6
         repo-name: k8s.io/kubernetes
         timeout: 100
@@ -108,12 +115,7 @@
         job-name: ci-kubernetes-test-go-release-1.5
         repo-name: k8s.io/kubernetes
         timeout: 100
-    - kubernetes-test-go-release-1.4:
-        branch: release-1.4
-        frequency: 'H H/3 * * *'
-        job-name: ci-kubernetes-test-go-release-1.4
-        repo-name: k8s.io/kubernetes
-        timeout: 100
+
 
     - kubernetes-node-kubelet:  # dawnchen
         branch: master

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -60,6 +60,16 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-bazel-build-1-8": {
+    "args": [
+      "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/...",
+      "--release=//build/release-tars"
+    ],
+    "scenario": "kubernetes_bazel",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "ci-kubernetes-bazel-test": {
     "args": [
       "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",
@@ -92,6 +102,17 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-bazel-test-1-8": {
+    "args": [
+      "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",
+      "--test-args=--test_tag_filters=-integration",
+      "--test-args=--flaky_test_attempts=3"
+    ],
+    "scenario": "kubernetes_bazel",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "ci-kubernetes-build": {
     "args": [
       "--fast"
@@ -101,7 +122,7 @@
       "sig-release"
     ]
   },
-  "ci-kubernetes-build-1.4": {
+  "ci-kubernetes-build-1.5": {
     "args": [
       "--extra-publish-file=k8s-stable4"
     ],
@@ -110,7 +131,7 @@
       "sig-release"
     ]
   },
-  "ci-kubernetes-build-1.5": {
+  "ci-kubernetes-build-1.6": {
     "args": [
       "--extra-publish-file=k8s-stable3"
     ],
@@ -119,7 +140,7 @@
       "sig-release"
     ]
   },
-  "ci-kubernetes-build-1.6": {
+  "ci-kubernetes-build-1.7": {
     "args": [
       "--extra-publish-file=k8s-stable2"
     ],
@@ -128,7 +149,7 @@
       "sig-release"
     ]
   },
-  "ci-kubernetes-build-1.7": {
+  "ci-kubernetes-build-1.8": {
     "args": [
       "--extra-publish-file=k8s-stable1"
     ],
@@ -10033,16 +10054,6 @@
       "UNKNOWN"
     ]
   },
-  "ci-kubernetes-test-go-release-1.4": {
-    "args": [
-      "--branch=release-1.4",
-      "--force"
-    ],
-    "scenario": "kubernetes_verify",
-    "sigOwners": [
-      "UNKNOWN"
-    ]
-  },
   "ci-kubernetes-test-go-release-1.5": {
     "args": [
       "--branch=release-1.5",
@@ -10073,20 +10084,19 @@
       "UNKNOWN"
     ]
   },
-  "ci-kubernetes-verify-master": {
+  "ci-kubernetes-test-go-release-1.8": {
     "args": [
-      "--branch=master",
-      "--force",
-      "--script=./hack/jenkins/verify-dockerized.sh"
+      "--branch=release-1.8",
+      "--force"
     ],
     "scenario": "kubernetes_verify",
     "sigOwners": [
       "UNKNOWN"
     ]
   },
-  "ci-kubernetes-verify-release-1.4": {
+  "ci-kubernetes-verify-master": {
     "args": [
-      "--branch=release-1.4",
+      "--branch=master",
       "--force",
       "--script=./hack/jenkins/verify-dockerized.sh"
     ],
@@ -10120,6 +10130,17 @@
   "ci-kubernetes-verify-release-1.7": {
     "args": [
       "--branch=release-1.7",
+      "--force",
+      "--script=./hack/jenkins/verify-dockerized.sh"
+    ],
+    "scenario": "kubernetes_verify",
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  },
+  "ci-kubernetes-verify-release-1.8": {
+    "args": [
+      "--branch=release-1.8",
       "--force",
       "--script=./hack/jenkins/verify-dockerized.sh"
     ],
@@ -10282,6 +10303,16 @@
       "sig-testing"
     ]
   },
+  "periodic-kubernetes-bazel-build-1-8": {
+    "args": [
+      "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/...",
+      "--release=//build/release-tars"
+    ],
+    "scenario": "kubernetes_bazel",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "periodic-kubernetes-bazel-test-1-6": {
     "args": [
       "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all",
@@ -10293,6 +10324,17 @@
     ]
   },
   "periodic-kubernetes-bazel-test-1-7": {
+    "args": [
+      "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",
+      "--test-args=--test_tag_filters=-integration",
+      "--test-args=--flaky_test_attempts=3"
+    ],
+    "scenario": "kubernetes_bazel",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
+  "periodic-kubernetes-bazel-test-1-8": {
     "args": [
       "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",
       "--test-args=--test_tag_filters=-integration",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1413,6 +1413,81 @@ postsubmits:
             hostPath:
               path: /mnt/disks/ssd0
 
+  - name: ci-kubernetes-bazel-build-1-8
+    agent: kubernetes
+    branches:
+    - release-1.8
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        # Make Bazel use shared cache for its root
+        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: ci-kubernetes-bazel-test-1-8
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+          args:
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--job=$(JOB_NAME)"
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--service-account=/etc/service-account/service-account.json"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          securityContext:
+            privileged: true
+          env:
+          # Make Bazel use shared cache for its root
+          # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
+          - name: TEST_TMPDIR
+            value: /root/.cache/bazel
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+
   kubernetes/test-infra:
   - name: ci-test-infra-bazel
     agent: kubernetes
@@ -16376,6 +16451,80 @@ periodics:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+
+- name: periodic-kubernetes-bazel-build-1-8
+  interval: 2h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+      args:
+      - "--clean"
+      - "--git-cache=/root/.cache/git"
+      - "--job=$(JOB_NAME)"
+      - "--repo=k8s.io/kubernetes=release-1.8"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      # Bazel needs privileged mode in order to sandbox builds.
+      securityContext:
+        privileged: true
+      env:
+      # Make Bazel use shared cache for its root
+      # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
+      - name: TEST_TMPDIR
+        value: /root/.cache/bazel
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: cache-ssd
+        mountPath: /root/.cache
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: cache-ssd
+      hostPath:
+        path: /mnt/disks/ssd0
+  run_after_success:
+  - name: periodic-kubernetes-bazel-test-1-8
+    agent: kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/kubernetes=release-1.8"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        securityContext:
+          privileged: true
+        env:
+        # Make Bazel use shared cache for its root
+        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
 
 - name: periodic-test-infra-retester
   interval: 20m  # Retest at most 1 PR per 20m, which should not DOS the queue.

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -78,8 +78,8 @@ test_groups:
     name_format: '%s [%s]'
 - name: ci-kubernetes-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
-- name: ci-kubernetes-build-1.4
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.4
+- name: ci-kubernetes-build-1.8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.8
 - name: ci-kubernetes-build-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.5
 - name: ci-kubernetes-build-1.6
@@ -478,8 +478,8 @@ test_groups:
 - name: ci-kubernetes-test-go
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-test-go
   days_of_results: 4
-- name: ci-kubernetes-test-go-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-test-go-release-1.4
+- name: ci-kubernetes-test-go-release-1.8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-test-go-release-1.8
   days_of_results: 4
 - name: ci-kubernetes-test-go-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-test-go-release-1.5
@@ -498,8 +498,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.6
 - name: ci-kubernetes-verify-release-1.5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.5
-- name: ci-kubernetes-verify-release-1.4
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.4
+- name: ci-kubernetes-verify-release-1.8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.8
 - name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
 - name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
@@ -749,12 +749,16 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-build-1-6
 - name: ci-kubernetes-bazel-build-1-7
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-build-1-7
+- name: ci-kubernetes-bazel-build-1-8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-build-1-8
 - name: ci-kubernetes-bazel-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test
 - name: ci-kubernetes-bazel-test-1-6
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test-1-6
 - name: ci-kubernetes-bazel-test-1-7
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test-1-7
+- name: ci-kubernetes-bazel-test-1-8
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-bazel-test-1-8
 - name: ci-test-infra-bazel
   gcs_prefix: kubernetes-jenkins/logs/ci-test-infra-bazel
 # rktnetes
@@ -1170,10 +1174,14 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-1-6
 - name: periodic-kubernetes-bazel-test-1-7
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-1-7
+- name: periodic-kubernetes-bazel-test-1-8
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-test-1-8
 - name: periodic-kubernetes-bazel-build-1-6
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-1-6
 - name: periodic-kubernetes-bazel-build-1-7
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-1-7
+- name: periodic-kubernetes-bazel-build-1-8
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-1-8
 - name: periodic-test-infra-retester
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-retester
 - name: metrics-bigquery
@@ -2364,46 +2372,50 @@ dashboards:
   dashboard_tab:
   - name: build
     test_group_name: ci-kubernetes-build
-  - name: build-1.4
-    test_group_name: ci-kubernetes-build-1.4
   - name: build-1.5
     test_group_name: ci-kubernetes-build-1.5
   - name: build-1.6
     test_group_name: ci-kubernetes-build-1.6
   - name: build-1.7
     test_group_name: ci-kubernetes-build-1.7
+  - name: build-1.8
+    test_group_name: ci-kubernetes-build-1.8
   - name: bazel-build
     test_group_name: ci-kubernetes-bazel-build
   - name: bazel-build-1.6
     test_group_name: ci-kubernetes-bazel-build-1-6
   - name: bazel-build-1.7
     test_group_name: ci-kubernetes-bazel-build-1-7
+  - name: bazel-build-1.8
+    test_group_name: ci-kubernetes-bazel-build-1-8
   - name: bazel-test
     test_group_name: ci-kubernetes-bazel-test
   - name: bazel-test-1.6
     test_group_name: ci-kubernetes-bazel-test-1-6
   - name: bazel-test-1.7
     test_group_name: ci-kubernetes-bazel-test-1-7
+  - name: bazel-test-1.8
+    test_group_name: ci-kubernetes-bazel-test-1-8
   - name: test-go
     test_group_name: ci-kubernetes-test-go
-  - name: test-go-1.4
-    test_group_name: ci-kubernetes-test-go-release-1.4
   - name: test-go-1.5
     test_group_name: ci-kubernetes-test-go-release-1.5
   - name: test-go-1.6
     test_group_name: ci-kubernetes-test-go-release-1.6
   - name: test-go-1.7
     test_group_name: ci-kubernetes-test-go-release-1.7
+  - name: test-go-1.8
+    test_group_name: ci-kubernetes-test-go-release-1.8
   - name: verify-master
     test_group_name: ci-kubernetes-verify-master
-  - name: verify-1.7
-    test_group_name: ci-kubernetes-verify-release-1.7
-  - name: verify-1.6
-    test_group_name: ci-kubernetes-verify-release-1.6
   - name: verify-1.5
     test_group_name: ci-kubernetes-verify-release-1.5
-  - name: verify-1.4
-    test_group_name: ci-kubernetes-verify-release-1.4
+  - name: verify-1.6
+    test_group_name: ci-kubernetes-verify-release-1.6
+  - name: verify-1.7
+    test_group_name: ci-kubernetes-verify-release-1.7
+  - name: verify-1.8
+    test_group_name: ci-kubernetes-verify-release-1.8
 
 - name: master-kubectl-skew
   dashboard_tab:
@@ -2930,14 +2942,10 @@ dashboards:
 
 - name: release-1.4-all
   dashboard_tab:
-  - name: build-1.4
-    test_group_name: ci-kubernetes-build-1.4
   - name: gce-alpha-features-1.4
     test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1-4
   - name: gci-gce-alpha-features-1.4
     test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features-release-1-4
-  - name: test-go-1.4
-    test_group_name: ci-kubernetes-test-go-release-1.4
   - name: gce-slow-1.4
     test_group_name: ci-kubernetes-e2e-gce-slow-release-1-4
   - name: gce-serial-1.4
@@ -2973,12 +2981,8 @@ dashboards:
 
 - name: release-1.4-blocking
   dashboard_tab:
-  - name: build-1.4
-    test_group_name: ci-kubernetes-build-1.4
   - name: kubelet-1.4
     test_group_name: ci-kubernetes-node-kubelet-1.4
-  - name: verify-1.4
-    test_group_name: ci-kubernetes-verify-release-1.4
   - name: gce-1.4
     test_group_name: ci-kubernetes-e2e-gce-release-1-4
   - name: gce-serial-1.4
@@ -2987,8 +2991,28 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-slow-release-1-4
   - name: gce-reboot-1.4
     test_group_name: ci-kubernetes-e2e-gce-reboot-release-1-4
-  - name: test-go-1.4
-    test_group_name: ci-kubernetes-test-go-release-1.4
+
+- name: release-1.8-all
+  dashboard_tab:
+  - name: build-1.8
+    test_group_name: ci-kubernetes-build-1.8
+  - name: verify-1.8
+    test_group_name: ci-kubernetes-verify-release-1.8
+  - name: test-go-1.8
+    test_group_name: ci-kubernetes-test-go-release-1.8
+  - name: bazel-build-1.8
+    test_group_name: periodic-kubernetes-bazel-build-1-8
+  - name: bazel-test-1.8
+    test_group_name: periodic-kubernetes-bazel-test-1-8
+
+- name: release-1.8-blocking
+  dashboard_tab:
+  - name: build-1.8
+    test_group_name: ci-kubernetes-build-1.8
+  - name: verify-1.8
+    test_group_name: ci-kubernetes-verify-release-1.8
+  - name: test-go-1.8
+    test_group_name: ci-kubernetes-test-go-release-1.8
 
 - name: misc
   dashboard_tab:


### PR DESCRIPTION
Seems still better naming those build jobs as there release version for now.

Updated alias ci/stable-x file and I'll try to use them in the ci jobs.

/assign @BenTheElder @ixdy 
cc @jdumars @abgworrall 
cc @luxas I did not add kubeadm jobs, but feel free to send a PR to chain your jobs to the bazel jobs :-)