### PR TITLE
Add PodPreset e2e test to ci-kubernetes-e2e-gce-alpha-features

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -636,7 +636,7 @@
       "--extract=ci/latest",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:(DynamicKubeletConfig|Audit|LocalPersistentVolumes|FlexVolume)\\]|Initializers|Networking --ginkgo.skip=Networking-Performance --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:(DynamicKubeletConfig|Audit|LocalPersistentVolumes|FlexVolume|PodPreset)\\]|Initializers|Networking --ginkgo.skip=Networking-Performance --minStartupPods=8",
       "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
Enables test modified by kubernetes/kubernetes#51839 with tag [Feature:PodPreset]. The test requires settings/v1alpha1 which is no longer enabled by default.