### PR TITLE
Move aws-janitor image to the same image project

### DIFF
--- a/jenkins/aws-janitor/Makefile
+++ b/jenkins/aws-janitor/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE ?= gcr.io/k8s-test-infra-aws/aws-janitor
+IMAGE ?= gcr.io/k8s-testimages/aws-janitor
 VERSION ?= 0.3
 
 image:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16052,7 +16052,7 @@ periodics:
         value: /etc/service-account/service-account.json
       - name: JENKINS_AWS_CREDENTIALS_FILE
         value: /etc/aws-cred/aws-cred
-      image: gcr.io/k8s-test-infra-aws/aws-janitor:0.3
+      image: gcr.io/k8s-testimages/aws-janitor:0.3
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
It probably should live with all other test-infra images.

Fixing acl does not fixing the image pulling which is ???

/assign @zmerlynn @justinsb 