### PR TITLE
Separate out execute and janitor args

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10206,6 +10206,7 @@
   "maintenance-ci-aws-janitor": {
     "args": [
       "/aws-janitor",
+      "--",
       "--tty=2h30m",
       "--path=s3://janitor-jenkins/objs.json"
     ],


### PR DESCRIPTION
whoops

```
I0905 21:11:05.923] Call:  /workspace/./test-infra/jenkins/../scenarios/execute.py /aws-janitor --tty=2h30m --path=s3://janitor-jenkins/objs.json
W0905 21:11:05.960] usage: execute.py [-h] [--env ENV] cmd [args [args ...]]
W0905 21:11:05.960] execute.py: error: unrecognized arguments: --tty=2h30m --path=s3://janitor-jenkins/objs.json
```

/assign @zmerlynn 