### PR TITLE
bump hook

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -15,7 +15,7 @@
 all: build test
 
 
-HOOK_VERSION             ?= 0.156
+HOOK_VERSION             ?= 0.157
 SINKER_VERSION           ?= 0.17
 DECK_VERSION             ?= 0.44
 SPLICE_VERSION           ?= 0.27

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.156
+        image: gcr.io/k8s-prow/hook:0.157
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/4360 vs https://github.com/kubernetes/test-infra/pull/4375

obviously @kargakis lost the fight

/assign @BenTheElder @kargakis 