### PR TITLE
kubetest: Call deployer TestSetup on upgrade test, too

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -160,9 +160,13 @@ func run(deploy deployer, o options) error {
 	}
 
 	if o.upgradeArgs != "" {
-		errs = appendError(errs, xmlWrap("UpgradeTest", func() error {
-			return skewTest(argFields(o.upgradeArgs, dump, o.clusterIPRange), "upgrade", o.checkSkew)
-		}))
+		if err := xmlWrap("test setup", deploy.TestSetup); err != nil {
+			errs = appendError(errs, err)
+		} else {
+			errs = appendError(errs, xmlWrap("UpgradeTest", func() error {
+				return skewTest(argFields(o.upgradeArgs, dump, o.clusterIPRange), "upgrade", o.checkSkew)
+			}))
+		}
 	}
 
 	testArgs := argFields(o.testArgs, dump, o.clusterIPRange)


### PR DESCRIPTION
Fixes #51695 (after I can get kubetest deployed)