### PR TITLE
Set --provider=aws for aws jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8316,6 +8316,7 @@
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--extract=ci/latest",
       "--mode=docker",
+      "--provider=aws",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
     ],
@@ -8332,6 +8333,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-canary.env",
       "--extract=ci/latest",
+      "--provider=aws",
       "--tag=latest",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8347,6 +8349,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-release-1-7.env",
+      "--provider=aws",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_kops_aws",
@@ -8360,6 +8363,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-release-1.5.env",
+      "--provider=aws",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_kops_aws",
@@ -8373,6 +8377,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-release-1.6.env",
+      "--provider=aws",
       "--timeout=120m"
     ],
     "scenario": "kubernetes_kops_aws",
@@ -8386,6 +8391,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-serial.env",
+      "--provider=aws",
       "--timeout=300m"
     ],
     "scenario": "kubernetes_kops_aws",
@@ -8399,6 +8405,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-slow.env",
+      "--provider=aws",
       "--timeout=150m"
     ],
     "scenario": "kubernetes_kops_aws",
@@ -8412,6 +8419,7 @@
       "--cluster=e2e.kops-aws-updown.test-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-updown.env",
+      "--provider=aws",
       "--state=s3://kops-aws-updown-store",
       "--timeout=30m",
       "--zones=us-west-1b"
@@ -8426,7 +8434,8 @@
       "--cluster=e2e-kops-aws-weave.test-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
-      "--kops-args=\"--networking=weave\""
+      "--kops-args=\"--networking=weave\"",
+      "--provider=aws"
     ],
     "scenario": "kubernetes_kops_aws",
     "sigOwners": [
@@ -10493,6 +10502,7 @@
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--env-file=jobs/env/pull-kops-e2e-kubernetes-aws.env",
       "--extract=release/stable",
+      "--provider=aws",
       "--timeout=55m"
     ],
     "scenario": "kubernetes_kops_aws",
@@ -10735,6 +10745,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/pull-kubernetes-e2e-kops-aws.env",
       "--extract=local",
+      "--provider=aws",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=55m"

--- a/jobs/platform/kops_aws.env
+++ b/jobs/platform/kops_aws.env
@@ -1,6 +1,3 @@
-# Fake provider to trick e2e-runner.sh
-KUBERNETES_PROVIDER=kube-aws
-
 # TODO(zmerlynn): Eliminate the other uses of this env variable
 KUBE_SSH_USER=admin
 
@@ -13,10 +10,3 @@ LOG_DUMP_SAVE_SERVICES=protokube
 # kops testing only ever uses Cloud SDK for status and uploads
 CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK=true
 CLOUDSDK_EXPERIMENTAL_FAST_COMPONENT_UPDATE=false
-
-# Test boilerplate
-HOME=/workspace
-WORKSPACE=/workspace
-# TODO(zmerlynn): This shouldn't be necessary, but it is if you're
-# running the scenario directly on the desktop.
-BOOTSTRAP_MIGRATION=true


### PR DESCRIPTION
Seems awscli will be installed from kops-e2e-runner now as well, but since we want to get rid of that as well -- 

/assign @zmerlynn 