### PR TITLE
Extend milestone munger for code slush and freeze

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -37,5 +37,5 @@ label-file: "/gitrepos/kubernetes/labels.yaml"
 alias-file: "/gitrepos/kubernetes/OWNERS_ALIASES"
 use-reviewers: true
 # milestone-maintainer
-active-milestone: v1.8
-milestone-grace-period: 168h
+milestone-modes: v1.8=dev,v1.9=dev
+milestone-freeze-date: TBD

--- a/mungegithub/mungers/matchers/comment/notification.go
+++ b/mungegithub/mungers/matchers/comment/notification.go
@@ -47,10 +47,15 @@ func ParseNotification(comment *Comment) *Notification {
 		return nil
 	}
 
+	return NewNotification(match[1], match[2], match[3])
+}
+
+// NewNotification creates a new notification
+func NewNotification(name, arguments, context string) *Notification {
 	return &Notification{
-		Name:      strings.ToUpper(match[1]),
-		Arguments: strings.TrimSpace(match[2]),
-		Context:   strings.TrimSpace(match[3]),
+		Name:      strings.ToUpper(name),
+		Arguments: strings.TrimSpace(arguments),
+		Context:   strings.TrimSpace(context),
 	}
 }
 
@@ -74,4 +79,9 @@ func (n *Notification) String() string {
 // Post a new notification on Github
 func (n Notification) Post(obj *mgh.MungeObject) error {
 	return obj.WriteComment(n.String())
+}
+
+// Equal compares this notification to the given notification for equivalence
+func (n *Notification) Equal(o *Notification) bool {
+	return (o != nil && n.Name == o.Name && n.Arguments == o.Arguments && n.Context == o.Context)
 }

--- a/mungegithub/mungers/milestone-maintainer.go
+++ b/mungegithub/mungers/milestone-maintainer.go
@@ -35,22 +35,166 @@ import (
 	githubapi "github.com/google/go-github/github"
 )
 
+type milestoneState int
+
+type milestoneOptName string
+
+// milestoneStateConfig defines the label and notification
+// configuration for a given milestone state.
+type milestoneStateConfig struct {
+	// The milestone label to apply to the label (all other milestone state labels will be removed)
+	label string
+	// The title of the notification message
+	title string
+	// Whether the notification should be repeated on the configured interval
+	warnOnInterval bool
+	// Whether sigs should be mentioned in the notification message
+	notifySIGs bool
+}
+
 const (
 	milestoneNotifierName = "MilestoneNotifier"
 
-	milestoneRemoved          = "Milestone Removed"
-	milestoneLabelsIncomplete = "Milestone Labels **Incomplete**"
-	milestoneLabelsComplete   = "Milestone Labels **Complete**"
+	milestoneModeDev    = "dev"
+	milestoneModeSlush  = "slush"
+	milestoneModeFreeze = "freeze"
 
-	priorityCriticalUrgent = "priority/critical-urgent"
+	milestoneCurrent        milestoneState = iota // No change is required.
+	milestoneNeedsLabeling                        // One or more priority/*, kind/* and sig/* labels are missing.
+	milestoneNeedsApproval                        // The status/needs-approval label is missing.
+	milestoneNeedsAttention                       // A status/* label is missing or an update is required.
+	milestoneNeedsRemoval                         // The issue needs to be removed from the milestone.
 
-	commentDetail = `<details>
-Additional instructions available <a href="https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md">here</a>
-The commands available for adding these labels are documented <a href="https://github.com/kubernetes/test-infra/blob/master/commands.md">here</a>
-</details>`
+	milestoneLabelsIncompleteLabel = "milestone/incomplete-labels"
+	milestoneNeedsApprovalLabel    = "milestone/needs-approval"
+	milestoneNeedsAttentionLabel   = "milestone/needs-attention"
+	milestoneRemovedLabel          = "milestone/removed"
+
+	statusApprovedLabel   = "status/approved-for-milestone"
+	statusInProgressLabel = "status/in-progress"
+
+	blockerLabel = "priority/critical-urgent"
+
+	sigLabelPrefix     = "sig/"
+	sigMentionTemplate = "@kubernetes/sig-%s-bugs"
+
+	milestoneOptActiveMilestone      = "active-milestone"
+	milestoneOptMode                 = "milestone-mode"
+	milestoneOptWarningInterval      = "milestone-warning-interval"
+	milestoneOptLabelGracePeriod     = "milestone-label-grace-period"
+	milestoneOptApprovalGracePeriod  = "milestone-approval-grace-period"
+	milestoneOptSlushUpdateInterval  = "milestone-slush-update-interval"
+	milestoneOptFreezeUpdateInterval = "milestone-freeze-update-interval"
+	milestoneOptFreezeDate           = "milestone-freeze-date"
+
+	milestoneDetail = `<details>
+<summary>Help</summary>
+<ul>
+ <li><a href="https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md">Additional instructions</a></li>
+ <li><a href="https://github.com/kubernetes/test-infra/blob/master/commands.md">Commands for setting labels</a></li>
+</ul>
+</details>
+`
+
+	milestoneMessageTemplate = `
+{{- if .warnUnapproved}}
+**Action required**: This issue must have the {{.approvedLabel}} label applied by a SIG maintainer.{{.unapprovedRemovalWarning}}
+{{end -}}
+{{- if .removeUnapproved}}
+**Important**: This issue was missing the {{.approvedLabel}} label for more than {{.approvalGracePeriod}}.
+{{end -}}
+{{- if .warnMissingInProgress}}
+**Action required**: During code {{.mode}}, issues in the milestone should be in progress.
+If this issue is not being actively worked on, please remove it from the milestone.
+If it is being worked on, please add the {{.inProgressLabel}} label so it can be tracked with other in-flight issues.
+{{end -}}
+{{- if .warnUpdateRequired}}
+**Action Required**: This issue has not been updated since {{.lastUpdated}}. Please provide an update.
+{{end -}}
+{{- if .warnUpdateInterval}}
+**Note**: This issue is marked as {{.blockerLabel}}, and must be updated every {{.updateInterval}} during code {{.mode}}.
+
+Example update:
+
+` + "```" + `
+ACK.  In progress
+ETA: DD/MM/YYYY
+Risks: Complicated fix required
+` + "```" + `
+{{end -}}
+{{- if .warnNonBlockerRemoval}}
+**Note**: If this issue is not resolved or labeled as {{.blockerLabel}} by {{.freezeDate}} it will be moved out of the {{.milestone}}.
+{{end -}}
+{{- if .removeNonBlocker}}
+**Important**: Code freeze is in effect and only issues with {{.blockerLabel}} may remain in the {{.milestone}}.
+{{end -}}
+{{- if .warnIncompleteLabels}}
+**Action required**: This issue requires label changes.{{.incompleteLabelsRemovalWarning}}
+
+{{range $index, $labelError := .labelErrors -}}
+{{$labelError}}
+{{end -}}
+{{end -}}
+{{- if .removeIncompleteLabels}}
+**Important**: This issue was missing labels required for the {{.milestone}} for more than {{.labelGracePeriod}}:
+
+{{range $index, $labelError := .labelErrors -}}
+{{$labelError}}
+{{end}}
+{{end -}}
+{{- if .summarizeLabels -}}
+<details{{if .onlySummary}} open{{end}}>
+<summary>Issue Labels</summary>
+
+- {{range $index, $sigLabel := .sigLabels}}{{if $index}} {{end}}{{$sigLabel}}{{end}}: Issue will be escalated to these SIGs if needed.
+- {{.priorityLabel}}: {{.priorityDescription}}
+- {{.kindLabel}}: {{.kindDescription}}
+</details>
+{{- end -}}
+`
 )
 
 var (
+	milestoneModes = sets.NewString(milestoneModeDev, milestoneModeSlush, milestoneModeFreeze)
+
+	milestoneStateConfigs = map[milestoneState]milestoneStateConfig{
+		milestoneCurrent: {
+			title: "Milestone Issue **Current**",
+		},
+		milestoneNeedsLabeling: {
+			title:          "Milestone Labels **Incomplete**",
+			label:          milestoneLabelsIncompleteLabel,
+			warnOnInterval: true,
+		},
+		milestoneNeedsApproval: {
+			title:          "Milestone Issue **Needs Approval**",
+			label:          milestoneNeedsApprovalLabel,
+			warnOnInterval: true,
+			notifySIGs:     true,
+		},
+		milestoneNeedsAttention: {
+			title:          "Milestone Issue **Needs Attention**",
+			label:          milestoneNeedsAttentionLabel,
+			warnOnInterval: true,
+			notifySIGs:     true,
+		},
+		milestoneNeedsRemoval: {
+			title:      "Milestone **Removed**",
+			label:      milestoneRemovedLabel,
+			notifySIGs: true,
+		},
+	}
+
+	// milestoneStateLabels is the set of milestone labels applied by
+	// the munger.  statusApprovedLabel is not included because it is
+	// applied manually rather than by the munger.
+	milestoneStateLabels = []string{
+		milestoneLabelsIncompleteLabel,
+		milestoneNeedsApprovalLabel,
+		milestoneNeedsAttentionLabel,
+		milestoneRemovedLabel,
+	}
+
 	kindMap = map[string]string{
 		"kind/bug":     "Fixes a bug discovered during the current release.",
 		"kind/feature": "New functionality.",
@@ -58,35 +202,86 @@ var (
 	}
 
 	priorityMap = map[string]string{
-		priorityCriticalUrgent:        "Never automatically move out of a release milestone; continually escalate to contributor and SIG through all available channels.",
+		blockerLabel:                  "Never automatically move out of a release milestone; continually escalate to contributor and SIG through all available channels.",
 		"priority/important-soon":     "Escalate to the issue owners and SIG owner; move out of milestone after several unsuccessful escalation attempts.",
 		"priority/important-longterm": "Escalate to the issue owners; move out of the milestone after 1 attempt.",
 	}
-
-	milestoneRemovedLabel          = "milestone-removed"
-	milestoneLabelsIncompleteLabel = "milestone-labels-incomplete"
-	milestoneLabelsCompleteLabel   = "milestone-labels-complete"
-	milestoneLabels                = []string{milestoneRemovedLabel, milestoneLabelsCompleteLabel, milestoneLabelsIncompleteLabel}
 )
 
-// milestoneNotification configures the active notification for the munger
-type milestoneNotification struct {
-	description string
-	message     string
+// issueChange encapsulates changes to make to an issue.
+type issueChange struct {
+	notification        *c.Notification
+	label               string
+	commentInterval     *time.Duration
+	removeFromMilestone bool
 }
 
-// MilestoneMaintainer enforces the process for sheperding issues into the release.
-type MilestoneMaintainer struct {
-	botName  string
-	features *features.Features
+type milestoneArgValidator func(name string) error
 
-	activeMilestone string
-	gracePeriod     time.Duration
-	warningInterval time.Duration
+// MilestoneMaintainer enforces the process for shepherding issues into the release.
+type MilestoneMaintainer struct {
+	botName    string
+	features   *features.Features
+	validators map[string]milestoneArgValidator
+
+	activeMilestone      string
+	mode                 string
+	warningInterval      time.Duration
+	labelGracePeriod     time.Duration
+	approvalGracePeriod  time.Duration
+	slushUpdateInterval  time.Duration
+	freezeUpdateInterval time.Duration
+	freezeDate           string
 }
 
 func init() {
-	RegisterMungerOrDie(&MilestoneMaintainer{})
+	RegisterMungerOrDie(NewMilestoneMaintainer())
+}
+
+func NewMilestoneMaintainer() *MilestoneMaintainer {
+	m := &MilestoneMaintainer{}
+	m.validators = map[string]milestoneArgValidator{
+		milestoneOptActiveMilestone: func(name string) error {
+			if len(m.activeMilestone) == 0 {
+				return fmt.Errorf("%s must be supplied", name)
+			}
+			return nil
+		},
+		milestoneOptMode: func(name string) error {
+			if !milestoneModes.Has(m.mode) {
+				return fmt.Errorf("%s must be one of %v", name, milestoneModes.List())
+			}
+			return nil
+		},
+		milestoneOptWarningInterval: func(name string) error {
+			return durationGreaterThanZero(name, m.warningInterval)
+		},
+		milestoneOptLabelGracePeriod: func(name string) error {
+			return durationGreaterThanZero(name, m.labelGracePeriod)
+		},
+		milestoneOptApprovalGracePeriod: func(name string) error {
+			return durationGreaterThanZero(name, m.approvalGracePeriod)
+		},
+		milestoneOptSlushUpdateInterval: func(name string) error {
+			return durationGreaterThanZero(name, m.slushUpdateInterval)
+		},
+		milestoneOptFreezeUpdateInterval: func(name string) error {
+			return durationGreaterThanZero(name, m.freezeUpdateInterval)
+		},
+		milestoneOptFreezeDate: func(name string) error {
+			if m.mode == milestoneModeSlush && len(m.freezeDate) == 0 {
+				return fmt.Errorf("%s must be supplied when milestone-mode is 'slush'", name)
+			}
+			return nil
+		},
+	}
+	return m
+}
+func durationGreaterThanZero(name string, value time.Duration) error {
+	if value <= 0 {
+		return fmt.Errorf("%s must be greater than zero", name)
+	}
+	return nil
 }
 
 // Name is the name usable in --pr-mungers
@@ -97,15 +292,12 @@ func (m *MilestoneMaintainer) RequiredFeatures() []string { return []string{} }
 
 // Initialize will initialize the munger
 func (m *MilestoneMaintainer) Initialize(config *github.Config, features *features.Features) error {
-	if len(m.activeMilestone) == 0 {
-		return errors.New("active-milestone must be supplied")
+	for name, validator := range m.validators {
+		if err := validator(name); err != nil {
+			return err
+		}
 	}
-	if m.gracePeriod <= 0 {
-		return errors.New("milestone-grace-period must be greater than zero")
-	}
-	if m.warningInterval <= 0 {
-		return errors.New("milestone-warning-interval must be greater than zero")
-	}
+
 	m.botName = config.BotName
 	m.features = features
 	return nil
@@ -118,28 +310,35 @@ func (m *MilestoneMaintainer) EachLoop() error { return nil }
 
 // RegisterOptions registers options for this munger; returns any that require a restart when changed.
 func (m *MilestoneMaintainer) RegisterOptions(opts *options.Options) sets.String {
-	opts.RegisterString(&m.activeMilestone, "active-milestone", "", "The active milestone that this munger will maintain issues for.")
-	opts.RegisterDuration(&m.gracePeriod, "milestone-grace-period", 72*time.Hour, "The grace period to wait before removing an incomplete issue from the active milestone.")
-	opts.RegisterDuration(&m.warningInterval, "milestone-warning-interval", 24*time.Hour, "The interval to wait between warning about an incomplete issue in the active milestone.")
+	opts.RegisterString(&m.activeMilestone, milestoneOptActiveMilestone, "", "The active milestone that this munger will maintain issues for.")
+	opts.RegisterString(&m.mode, milestoneOptMode, milestoneModeDev, fmt.Sprintf("The release cycle process to enforce.  Valid values are %v.", milestoneModes.List()))
+	opts.RegisterDuration(&m.warningInterval, milestoneOptWarningInterval, 24*time.Hour, "The interval to wait between warning about an incomplete issue in the active milestone.")
+	opts.RegisterDuration(&m.labelGracePeriod, milestoneOptLabelGracePeriod, 72*time.Hour, "The grace period to wait before removing a non-blocking issue with incomplete labels from the active milestone.")
+	opts.RegisterDuration(&m.approvalGracePeriod, milestoneOptApprovalGracePeriod, 168*time.Hour, "The grace period to wait before removing a non-blocking issue without sig approval from the active milestone.")
+	opts.RegisterDuration(&m.slushUpdateInterval, milestoneOptSlushUpdateInterval, 72*time.Hour, "The expected interval, during code slush, between updates to a blocking issue in the active milestone.")
+	opts.RegisterDuration(&m.freezeUpdateInterval, milestoneOptFreezeUpdateInterval, 24*time.Hour, "The expected interval, during code freeze, between updates to a blocking issue in the active milestone.")
+	opts.RegisterString(&m.freezeDate, milestoneOptFreezeDate, "", fmt.Sprintf("The date string indicating when code freeze will take effect."))
 	opts.RegisterUpdateCallback(func(changed sets.String) error {
-		if changed.Has("active-milestone") {
-			if len(m.activeMilestone) == 0 {
-				return errors.New("active-milestone must be supplied")
-			}
-		}
-		if changed.Has("milestone-grace-period") {
-			if m.gracePeriod <= 0 {
-				return errors.New("milestone-grace-period must be greater than zero")
-			}
-		}
-		if changed.Has("milestone-warning-interval") {
-			if m.warningInterval <= 0 {
-				return errors.New("milestone-warning-interval must be greater than zero")
+		for name, validator := range m.validators {
+			if changed.Has(name) {
+				if err := validator(name); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
 	})
 	return nil
+}
+
+func (m *MilestoneMaintainer) updateInterval() time.Duration {
+	if m.mode == milestoneModeSlush {
+		return m.slushUpdateInterval
+	}
+	if m.mode == milestoneModeFreeze {
+		return m.freezeUpdateInterval
+	}
+	return 0
 }
 
 // Munge is the workhorse the will actually make updates to the issue
@@ -148,39 +347,268 @@ func (m *MilestoneMaintainer) Munge(obj *github.MungeObject) {
 		return
 	}
 
+	change := m.issueChange(obj)
+	if change == nil {
+		return
+	}
+
+	if !updateMilestoneStateLabel(obj, change.label) {
+		return
+	}
+
 	comment, ok := latestNotificationComment(obj, m.botName)
 	if !ok {
 		return
 	}
-
-	labelName, notifyState := notificationState(obj, comment, m.botName, m.gracePeriod, m.warningInterval)
-	// Always attempt to ensure the milestone label
-	if len(labelName) > 0 && !ensureLabel(obj, labelName) {
-		return
-	}
-	if notifyState == nil {
-		// No notification change is required
-		return
-	}
-
-	if comment != nil {
-		if err := obj.DeleteComment(comment.Source.(*githubapi.IssueComment)); err != nil {
+	if !notificationIsCurrent(change.notification, comment, change.commentInterval) {
+		if comment != nil {
+			if err := obj.DeleteComment(comment.Source.(*githubapi.IssueComment)); err != nil {
+				return
+			}
+		}
+		if err := change.notification.Post(obj); err != nil {
 			return
 		}
 	}
 
-	notification := c.Notification{
-		Name:      milestoneNotifierName,
-		Arguments: notifyState.description,
-		Context:   notifyState.message,
-	}
-	if err := notification.Post(obj); err != nil {
-		return
-	}
-
-	if labelName == milestoneRemovedLabel {
+	if change.removeFromMilestone {
 		obj.ClearMilestone()
 	}
+}
+
+// issueChange computes the changes required to modify the state of
+// the issue to reflect the milestone process. If a nil return value
+// is returned, no action should be taken.
+func (m *MilestoneMaintainer) issueChange(obj *github.MungeObject) *issueChange {
+	icc := m.issueChangeConfig(obj)
+	if icc == nil {
+		return nil
+	}
+
+	messageBody := icc.messageBody()
+	if messageBody == nil {
+		return nil
+	}
+
+	stateConfig := milestoneStateConfigs[icc.state]
+
+	mentions := mungerutil.GetIssueUsers(obj.Issue).AllUsers().Mention().Join()
+	if stateConfig.notifySIGs {
+		sigMentions := icc.sigMentions()
+		if len(sigMentions) > 0 {
+			mentions = fmt.Sprintf("%s %s", mentions, sigMentions)
+		}
+	}
+
+	message := fmt.Sprintf("%s\n\n%s\n%s", mentions, *messageBody, milestoneDetail)
+
+	var commentInterval *time.Duration
+	if stateConfig.warnOnInterval {
+		commentInterval = &m.warningInterval
+	}
+
+	return &issueChange{
+		notification:        c.NewNotification(milestoneNotifierName, stateConfig.title, message),
+		label:               stateConfig.label,
+		removeFromMilestone: icc.state == milestoneNeedsRemoval,
+		commentInterval:     commentInterval,
+	}
+}
+
+// issueChangeConfig computes the configuration required to determine
+// the changes to make to an issue so that it reflects the milestone
+// process. If a nil return value is returned, no action should be
+// taken.
+func (m *MilestoneMaintainer) issueChangeConfig(obj *github.MungeObject) *issueChangeConfig {
+	updateInterval := m.updateInterval()
+
+	icc := &issueChangeConfig{
+		enabledSections: sets.String{},
+		templateArguments: map[string]interface{}{
+			"approvalGracePeriod": durationToMaxDays(m.approvalGracePeriod),
+			"approvedLabel":       quoteLabel(statusApprovedLabel),
+			"blockerLabel":        quoteLabel(blockerLabel),
+			"freezeDate":          m.freezeDate,
+			"inProgressLabel":     quoteLabel(statusInProgressLabel),
+			"labelGracePeriod":    durationToMaxDays(m.labelGracePeriod),
+			"milestone":           fmt.Sprintf("%s milestone", m.activeMilestone),
+			"mode":                m.mode,
+			"updateInterval":      durationToMaxDays(updateInterval),
+		},
+		sigLabels: []string{},
+	}
+
+	isBlocker := obj.HasLabel(blockerLabel)
+
+	if kind, priority, sigs, labelErrors := checkLabels(obj.Issue.Labels); len(labelErrors) == 0 {
+		icc.summarizeLabels(kind, priority, sigs)
+		if !obj.HasLabel(statusApprovedLabel) {
+			if isBlocker {
+				icc.warnUnapproved(nil, m.activeMilestone)
+			} else {
+				removeAfter, ok := gracePeriodRemaining(obj, m.botName, milestoneNeedsApprovalLabel, m.approvalGracePeriod, time.Now(), false)
+				if !ok {
+					return nil
+				}
+
+				if removeAfter == nil || *removeAfter >= 0 {
+					icc.warnUnapproved(removeAfter, m.activeMilestone)
+				} else {
+					icc.removeUnapproved()
+				}
+			}
+			return icc
+		}
+
+		if m.mode == milestoneModeDev {
+			// Status and updates are not required for dev mode
+			return icc
+		}
+
+		if m.mode == milestoneModeFreeze && !isBlocker {
+			icc.removeNonBlocker()
+			return icc
+		}
+
+		if !obj.HasLabel(statusInProgressLabel) {
+			icc.warnMissingInProgress()
+		}
+
+		if !isBlocker {
+			icc.enableSection("warnNonBlockerRemoval")
+		} else if updateInterval > 0 {
+			lastUpdateTime, ok := findLastModificationTime(obj)
+			if !ok {
+				return nil
+			}
+
+			durationSinceUpdate := time.Since(*lastUpdateTime)
+			if durationSinceUpdate > updateInterval {
+				icc.warnUpdateRequired(*lastUpdateTime)
+			}
+			icc.enableSection("warnUpdateInterval")
+		}
+	} else {
+		removeAfter, ok := gracePeriodRemaining(obj, m.botName, milestoneLabelsIncompleteLabel, m.labelGracePeriod, time.Now(), isBlocker)
+		if !ok {
+			return nil
+		}
+
+		if removeAfter == nil || *removeAfter >= 0 {
+			icc.warnIncompleteLabels(removeAfter, labelErrors, m.activeMilestone)
+		} else {
+			icc.removeIncompleteLabels(labelErrors)
+		}
+	}
+	return icc
+}
+
+// issueChangeConfig is the config required to change an issue (via
+// comments and labeling) to reflect the reuqirements of the milestone
+// maintainer.
+type issueChangeConfig struct {
+	state             milestoneState
+	enabledSections   sets.String
+	sigLabels         []string
+	templateArguments map[string]interface{}
+}
+
+func (icc *issueChangeConfig) messageBody() *string {
+	for _, sectionName := range icc.enabledSections.List() {
+		// If an issue will be removed from the milestone, suppress non-removal sections
+		if icc.state != milestoneNeedsRemoval || strings.HasPrefix(sectionName, "remove") {
+			icc.templateArguments[sectionName] = true
+		}
+	}
+
+	icc.templateArguments["onlySummary"] = icc.state == milestoneCurrent
+
+	return approvers.GenerateTemplateOrFail(milestoneMessageTemplate, "message", icc.templateArguments)
+}
+
+func (icc *issueChangeConfig) enableSection(sectionName string) {
+	icc.enabledSections.Insert(sectionName)
+}
+
+func (icc *issueChangeConfig) summarizeLabels(kindLabel, priorityLabel string, sigLabels []string) {
+	icc.enableSection("summarizeLabels")
+	icc.state = milestoneCurrent
+	icc.sigLabels = sigLabels
+	quotedSigLabels := []string{}
+	for _, sigLabel := range sigLabels {
+		quotedSigLabels = append(quotedSigLabels, quoteLabel(sigLabel))
+	}
+	arguments := map[string]interface{}{
+		"kindLabel":           quoteLabel(kindLabel),
+		"kindDescription":     kindMap[kindLabel],
+		"priorityLabel":       quoteLabel(priorityLabel),
+		"priorityDescription": priorityMap[priorityLabel],
+		"sigLabels":           quotedSigLabels,
+	}
+	for k, v := range arguments {
+		icc.templateArguments[k] = v
+	}
+}
+
+func (icc *issueChangeConfig) warnUnapproved(removeAfter *time.Duration, milestone string) {
+	icc.enableSection("warnUnapproved")
+	icc.state = milestoneNeedsApproval
+	var warning string
+	if removeAfter != nil {
+		warning = fmt.Sprintf(" If the label is not applied within %s, the issue will be moved out of the %s milestone.",
+			durationToMaxDays(*removeAfter), milestone)
+	}
+	icc.templateArguments["unapprovedRemovalWarning"] = warning
+
+}
+
+func (icc *issueChangeConfig) removeUnapproved() {
+	icc.enableSection("removeUnapproved")
+	icc.state = milestoneNeedsRemoval
+}
+
+func (icc *issueChangeConfig) removeNonBlocker() {
+	icc.enableSection("removeNonBlocker")
+	icc.state = milestoneNeedsRemoval
+}
+
+func (icc *issueChangeConfig) warnMissingInProgress() {
+	icc.enableSection("warnMissingInProgress")
+	icc.state = milestoneNeedsAttention
+}
+
+func (icc *issueChangeConfig) warnUpdateRequired(lastUpdated time.Time) {
+	icc.enableSection("warnUpdateRequired")
+	icc.state = milestoneNeedsAttention
+	icc.templateArguments["lastUpdated"] = lastUpdated.Format("Jan 2")
+}
+
+func (icc *issueChangeConfig) warnIncompleteLabels(removeAfter *time.Duration, labelErrors []string, milestone string) {
+	icc.enableSection("warnIncompleteLabels")
+	icc.state = milestoneNeedsLabeling
+	var warning string
+	if removeAfter != nil {
+		warning = fmt.Sprintf(" If the required changes are not made within %s, the issue will be moved out of the %s milestone.",
+			durationToMaxDays(*removeAfter), milestone)
+	}
+	icc.templateArguments["incompleteLabelsRemovalWarning"] = warning
+	icc.templateArguments["labelErrors"] = labelErrors
+}
+
+func (icc *issueChangeConfig) removeIncompleteLabels(labelErrors []string) {
+	icc.enableSection("removeIncompleteLabels")
+	icc.state = milestoneNeedsRemoval
+	icc.templateArguments["labelErrors"] = labelErrors
+}
+
+func (icc *issueChangeConfig) sigMentions() string {
+	mentions := []string{}
+	for _, label := range icc.sigLabels {
+		sig := strings.TrimPrefix(label, sigLabelPrefix)
+		target := fmt.Sprintf(sigMentionTemplate, sig)
+		mentions = append(mentions, target)
+	}
+	return strings.Join(mentions, " ")
 }
 
 // ignoreObject indicates whether the munger should ignore the given
@@ -188,6 +616,11 @@ func (m *MilestoneMaintainer) Munge(obj *github.MungeObject) {
 func ignoreObject(obj *github.MungeObject, activeMilestone string) bool {
 	// Only target issues
 	if obj.IsPR() {
+		return true
+	}
+
+	// Ignore closed issues
+	if obj.Issue.State != nil && *obj.Issue.State == "closed" {
 		return true
 	}
 
@@ -199,40 +632,6 @@ func ignoreObject(obj *github.MungeObject, activeMilestone string) bool {
 
 	// Only target issues in the active milestone
 	return milestone != activeMilestone
-}
-
-// notificationState returns the state required to ensure the munger's
-// notification is kept current. If a nil return value is returned,
-// no action should be taken.
-func notificationState(obj *github.MungeObject, comment *c.Comment, botName string, gracePeriod, warningInterval time.Duration) (string, *milestoneNotification) {
-	notification := c.ParseNotification(comment)
-
-	kindLabel, priorityLabel, sigLabels, labelErrors := checkLabels(obj.Issue.Labels)
-
-	labelsComplete := len(labelErrors) == 0
-	if labelsComplete {
-		return milestoneLabelsCompleteLabel, labelsCompleteState(obj.Issue, notification, kindLabel, priorityLabel, sigLabels)
-	}
-
-	isBlocker := (priorityLabel == priorityCriticalUrgent)
-	var removeAfter *time.Duration
-	// Blockers are never removed from the milestone so grace period computation can be skipped
-	if !isBlocker {
-		removeAfter = gracePeriodRemaining(obj, botName, gracePeriod, time.Now())
-		failedToComputeGracePeriod := removeAfter == nil
-		if failedToComputeGracePeriod {
-			return "", nil
-		}
-	}
-	// removeAfter is guaranteed to be non-nil for non-blockers
-	if isBlocker || *removeAfter >= 0 {
-		var createdAt *time.Time
-		if comment != nil {
-			createdAt = comment.CreatedAt
-		}
-		return milestoneLabelsIncompleteLabel, labelsIncompleteState(obj.Issue, notification, labelErrors, warningInterval, createdAt, removeAfter)
-	}
-	return milestoneRemovedLabel, removalState(obj.Issue, notification, labelErrors, *obj.Issue.Milestone.Title, gracePeriod)
 }
 
 // latestNotificationComment returns the most recent notification
@@ -251,160 +650,30 @@ func latestNotificationComment(obj *github.MungeObject, botName string) (*c.Comm
 	return notifications.GetLast(), true
 }
 
-// labelsCompleteState returns the notification state for an issue
-// that has the required labels to remain in the active milestone.
-func labelsCompleteState(issue *githubapi.Issue, notification *c.Notification, kindLabel, priorityLabel string, sigLabels []string) *milestoneNotification {
-	const template = `{{.mention}}
-
-Issue label settings:
-
-- {{range $index, $sigLabel := .sigLabels}}{{if $index}} {{end}}{{$sigLabel}}{{end}}: Issue will be escalated to these SIGs if needed.
-- {{.priorityLabel}}: {{.priorityDescription}}
-- {{.kindLabel}}: {{.kindDescription}}
-
-{{.detail}}
-`
-
-	isCurrent := notification != nil && notification.Arguments == milestoneLabelsComplete
-	if isCurrent {
-		return nil
-	}
-
-	mention := mungerutil.GetIssueUsers(issue).AllUsers().Mention().Join()
-	message := approvers.GenerateTemplateOrFail(template, "message", map[string]interface{}{
-		"mention":             mention,
-		"sigLabels":           sigLabels,
-		"priorityLabel":       priorityLabel,
-		"priorityDescription": priorityMap[priorityLabel],
-		"kindLabel":           kindLabel,
-		"kindDescription":     kindMap[kindLabel],
-		"detail":              commentDetail,
-	})
-	if message == nil {
-		return nil
-	}
-
-	return &milestoneNotification{
-		description: milestoneLabelsComplete,
-		message:     *message,
-	}
-}
-
-// labelsIncompleteState returns the notification state for an issue
-// lacking the labels required for the active milestone.
-func labelsIncompleteState(issue *githubapi.Issue, notification *c.Notification, labelErrors []string, warningInterval time.Duration, commentCreatedAt *time.Time, removeAfter *time.Duration) *milestoneNotification {
-	const template = `{{.mention}}
-
-**Action required**: This issue requires label changes.{{.warning}}
-
-{{range $index, $labelError := .labelErrors -}}
-{{$labelError}}
-{{end}}
-{{.detail}}
-`
-
-	mention := mungerutil.GetIssueUsers(issue).AllUsers().Mention().Join()
-	var warning string
-	if removeAfter != nil {
-		warning = fmt.Sprintf(" If the required changes are not made within %s, the issue will be moved out of the %s milestone.", durationToMaxDays(*removeAfter), *issue.Milestone.Title)
-	}
-	message := approvers.GenerateTemplateOrFail(template, "message", map[string]interface{}{
-		"mention":     mention,
-		"warning":     warning,
-		"labelErrors": labelErrors,
-		"detail":      commentDetail,
-	})
-	if message == nil {
-		return nil
-	}
-
-	if warningIsCurrent(notification, *message, commentCreatedAt, warningInterval) {
-		return nil
-	}
-
-	return &milestoneNotification{
-		description: milestoneLabelsIncomplete,
-		message:     *message,
-	}
-}
-
-// warningIsCurrent indicates whether the given notification
-// represents is an up-to-date warning. The notification is the
-// previous warning from the munger. The message is the warning
-// generated from the current labels on the issue.
-func warningIsCurrent(notification *c.Notification, message string, commentCreatedAt *time.Time, warningInterval time.Duration) bool {
-	hasNotification := (notification != nil && notification.Arguments == milestoneLabelsIncomplete)
-	return hasNotification && notification.Context == strings.TrimSpace(message) && commentCreatedAt != nil && time.Since(*commentCreatedAt) < warningInterval
-}
-
-// removalState returns the notification state for an issue that will
-// be removed from the active milestone.
-func removalState(issue *githubapi.Issue, notification *c.Notification, labelErrors []string, milestone string, gracePeriod time.Duration) *milestoneNotification {
-	const template = `{{.mention}}
-
-**Important**:
-This issue was missing labels required for the {{.milestone}} milestone for more than {{.dayPhrase}}:
-
-{{range $index, $labelError := .labelErrors -}}
-{{$labelError}}
-{{end}}
-Removing it from the milestone.
-
-{{.detail}}
-`
-
-	mention := mungerutil.GetIssueUsers(issue).AllUsers().Mention().Join()
-	message := approvers.GenerateTemplateOrFail(template, "message", map[string]interface{}{
-		"mention":     mention,
-		"milestone":   milestone,
-		"dayPhrase":   durationToMaxDays(gracePeriod),
-		"labelErrors": labelErrors,
-		"detail":      commentDetail,
-	})
-	if message == nil {
-		return nil
-	}
-
-	return &milestoneNotification{
-		description: milestoneRemoved,
-		message:     *message,
-	}
-}
-
-// ensureLabel ensures that the desired label becomes the only
-// milestone label set on the given issue. Returns true if the label
-// is set on the issue, false otherwise. Any error encountered is
-// expected to be logged in the called function rather than being
-// handled by the caller.
-func ensureLabel(obj *github.MungeObject, desiredLabel string) bool {
-	for _, label := range milestoneLabels {
-		if label == desiredLabel {
-			if !obj.HasLabel(label) {
-				if err := obj.AddLabel(label); err != nil {
-					return false
-				}
-			}
-		} else if obj.HasLabel(label) {
-			if err := obj.RemoveLabel(label); err != nil {
-				return false
-			}
-		}
-	}
-	return true
+// notificationIsCurrent indicates whether the given notification
+// matches the most recent notification comment and the comment
+// interval - if provided - has not been exceeded.
+func notificationIsCurrent(notification *c.Notification, comment *c.Comment, commentInterval *time.Duration) bool {
+	oldNotification := c.ParseNotification(comment)
+	notificationsEqual := oldNotification != nil && oldNotification.Equal(notification)
+	return notificationsEqual && (commentInterval == nil || comment != nil && comment.CreatedAt != nil && time.Since(*comment.CreatedAt) < *commentInterval)
 }
 
 // gracePeriodRemaining returns the difference between the start of
 // the grace period and the grace period interval. Returns nil the
 // grace period start cannot be determined.
-func gracePeriodRemaining(obj *github.MungeObject, botName string, gracePeriod time.Duration, defaultStart time.Time) *time.Duration {
-	tempStart := gracePeriodStart(obj, botName, defaultStart)
+func gracePeriodRemaining(obj *github.MungeObject, botName, labelName string, gracePeriod time.Duration, defaultStart time.Time, isBlocker bool) (*time.Duration, bool) {
+	if isBlocker {
+		return nil, true
+	}
+	tempStart := gracePeriodStart(obj, botName, labelName, defaultStart)
 	if tempStart == nil {
-		return nil
+		return nil, false
 	}
 	start := *tempStart
 
 	remaining := -time.Since(start.Add(gracePeriod))
-	return &remaining
+	return &remaining, true
 }
 
 // gracePeriodStart determines when the grace period for the given
@@ -412,8 +681,7 @@ func gracePeriodRemaining(obj *github.MungeObject, botName string, gracePeriod t
 // milestone-labels-incomplete label was last applied. If the label
 // is not set, the default will be returned. nil will be returned if
 // an error occurs while accessing the object's label events.
-func gracePeriodStart(obj *github.MungeObject, botName string, defaultStart time.Time) *time.Time {
-	labelName := milestoneLabelsIncompleteLabel
+func gracePeriodStart(obj *github.MungeObject, botName, labelName string, defaultStart time.Time) *time.Time {
 	if !obj.HasLabel(labelName) {
 		return &defaultStart
 	}
@@ -454,18 +722,18 @@ func checkLabels(labels []githubapi.Label) (kindLabel, priorityLabel string, sig
 	kindLabel, err = uniqueLabelName(labels, kindMap)
 	if err != nil || len(kindLabel) == 0 {
 		kindLabels := formatLabelString(kindMap)
-		labelErrors = append(labelErrors, fmt.Sprintf("_**kind**_: Must specify exactly one of [%s].", kindLabels))
+		labelErrors = append(labelErrors, fmt.Sprintf("_**kind**_: Must specify exactly one of %s.", kindLabels))
 	}
 
 	priorityLabel, err = uniqueLabelName(labels, priorityMap)
 	if err != nil || len(priorityLabel) == 0 {
 		priorityLabels := formatLabelString(priorityMap)
-		labelErrors = append(labelErrors, fmt.Sprintf("_**priority**_: Must specify exactly one of [%s].", priorityLabels))
+		labelErrors = append(labelErrors, fmt.Sprintf("_**priority**_: Must specify exactly one of %s.", priorityLabels))
 	}
 
 	sigLabels = sigLabelNames(labels)
 	if len(sigLabels) == 0 {
-		labelErrors = append(labelErrors, "_**sig owner**_: Must specify at least one label prefixed with `sig/`.")
+		labelErrors = append(labelErrors, fmt.Sprintf("_**sig owner**_: Must specify at least one label prefixed with `%s`.", sigLabelPrefix))
 	}
 
 	return
@@ -493,7 +761,7 @@ func uniqueLabelName(labels []githubapi.Label, labelMap map[string]string) (stri
 func sigLabelNames(labels []githubapi.Label) []string {
 	labelNames := []string{}
 	for _, label := range labels {
-		if strings.HasPrefix(*label.Name, "sig/") {
+		if strings.HasPrefix(*label.Name, sigLabelPrefix) {
 			labelNames = append(labelNames, *label.Name)
 		}
 	}
@@ -504,9 +772,39 @@ func sigLabelNames(labels []githubapi.Label) []string {
 func formatLabelString(labelMap map[string]string) string {
 	labelList := []string{}
 	for k := range labelMap {
-		labelList = append(labelList, fmt.Sprintf("`%s`", k))
+		labelList = append(labelList, quoteLabel(k))
 	}
 	sort.Strings(labelList)
 
-	return strings.Join(labelList, ", ")
+	maxIndex := len(labelList) - 1
+	if maxIndex == 0 {
+		return labelList[0]
+	}
+	return strings.Join(labelList[0:maxIndex], ", ") + " or " + labelList[maxIndex]
+}
+
+// quoteLabel formats a label name as inline code in markdown (e.g. `labelName`)
+func quoteLabel(label string) string {
+	if len(label) > 0 {
+		return fmt.Sprintf("`%s`", label)
+	}
+	return label
+}
+
+// updateMilestoneStateLabel ensures that the given milestone state
+// label is the only state label set on the given issue.
+func updateMilestoneStateLabel(obj *github.MungeObject, labelName string) bool {
+	if len(labelName) > 0 && !obj.HasLabel(labelName) {
+		if err := obj.AddLabel(labelName); err != nil {
+			return false
+		}
+	}
+	for _, stateLabel := range milestoneStateLabels {
+		if stateLabel != labelName && obj.HasLabel(stateLabel) {
+			if err := obj.RemoveLabel(stateLabel); err != nil {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/mungegithub/mungers/milestone-maintainer_test.go
+++ b/mungegithub/mungers/milestone-maintainer_test.go
@@ -20,13 +20,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
-	c "k8s.io/test-infra/mungegithub/mungers/matchers/comment"
-
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/github"
 	github_test "k8s.io/test-infra/mungegithub/github/testing"
+	c "k8s.io/test-infra/mungegithub/mungers/matchers/comment"
 
 	githubapi "github.com/google/go-github/github"
 )
@@ -42,12 +44,13 @@ func TestMilestoneMaintainer(t *testing.T) {
 	activeMilestone := "v1.8"
 	milestone := &githubapi.Milestone{Title: &activeMilestone, Number: intPtr(1)}
 	m := MilestoneMaintainer{
-		activeMilestone: activeMilestone,
-		gracePeriod:     72 * time.Hour,
-		warningInterval: 24 * time.Hour,
+		activeMilestone:     activeMilestone,
+		approvalGracePeriod: 72 * time.Hour,
+		labelGracePeriod:    72 * time.Hour,
+		warningInterval:     24 * time.Hour,
 	}
 
-	issue := github_test.Issue("user", 1, []string{}, false)
+	issue := github_test.Issue("user", 1, []string{"kind/bug", "sig/foo", "priority/important-soon"}, false)
 	issue.Milestone = milestone
 
 	config := &github.Config{Org: "o", Project: "r"}
@@ -99,7 +102,7 @@ func TestMilestoneMaintainer(t *testing.T) {
 
 	m.Munge(obj)
 
-	expectedLabel := milestoneLabelsIncompleteLabel
+	expectedLabel := milestoneNeedsApprovalLabel
 	if !obj.HasLabel(expectedLabel) {
 		t.Fatalf("Issue labels do not include '%s'", expectedLabel)
 	}
@@ -108,13 +111,347 @@ func TestMilestoneMaintainer(t *testing.T) {
 		t.Fatalf("Expected comment count of %d, got %d", 1, len(comments))
 	}
 
+	expectedBody := `[MILESTONENOTIFIER] Milestone Issue **Needs Approval**
+
+@user @kubernetes/sig-foo-bugs
+
+
+**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 2 days, the issue will be moved out of the v1.8 milestone.
+<details>
+<summary>Issue Labels</summary>
+
+- ` + "`sig/foo`" + `: Issue will be escalated to these SIGs if needed.
+- ` + "`priority/important-soon`" + `: Escalate to the issue owners and SIG owner; move out of milestone after several unsuccessful escalation attempts.
+- ` + "`kind/bug`" + `: Fixes a bug discovered during the current release.
+</details>
+<details>
+<summary>Help</summary>
+<ul>
+ <li><a href="https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md">Additional instructions</a></li>
+ <li><a href="https://github.com/kubernetes/test-infra/blob/master/commands.md">Commands for setting labels</a></li>
+</ul>
+</details>`
+	if comments[0].Body == nil || expectedBody != *comments[0].Body {
+		t.Fatalf("Expected Body:\n\n%s\n\nGot:\n\n%s", expectedBody, *comments[0].Body)
+	}
+
 	server.Close()
 }
 
-func milestoneTestComment(label string, context string, createdAt time.Time) *c.Comment {
+// TestNewIssueChangeConfig validates the creation of an IssueChange
+// for a given issue state.
+func TestNewIssueChangeConfig(t *testing.T) {
+	const incompleteLabels = `
+_**kind**_: Must specify exactly one of ` + "`kind/bug`, `kind/cleanup` or `kind/feature`." + `
+_**sig owner**_: Must specify at least one label prefixed with ` + "`sig/`." + `
+`
+	const blockerCompleteLabels = `
+<summary>Issue Labels</summary>
+
+- ` + "`sig/foo`: Issue will be escalated to these SIGs if needed." + `
+- ` + "`priority/critical-urgent`: Never automatically move out of a release milestone; continually escalate to contributor and SIG through all available channels." + `
+- ` + "`kind/bug`: Fixes a bug discovered during the current release." + `
+</details>
+`
+
+	const nonBlockerCompleteLabels = `
+<summary>Issue Labels</summary>
+
+- ` + "`sig/foo`: Issue will be escalated to these SIGs if needed." + `
+- ` + "`priority/important-soon`: Escalate to the issue owners and SIG owner; move out of milestone after several unsuccessful escalation attempts." + `
+- ` + "`kind/bug`: Fixes a bug discovered during the current release." + `
+</details>
+`
+
+	munger := &MilestoneMaintainer{
+		botName:             milestoneTestBotName,
+		activeMilestone:     "v1.8",
+		labelGracePeriod:    3 * day,
+		approvalGracePeriod: 7 * day,
+		warningInterval:     day,
+		slushUpdateInterval: 3 * day,
+		freezeDate:          "the time heck freezes over",
+	}
+
+	createdNow := time.Now()
+	createdPastLabelGracePeriod := createdNow.Add(-(munger.labelGracePeriod + time.Hour))
+	createdPastApprovalGracePeriod := createdNow.Add(-(munger.approvalGracePeriod + time.Hour))
+	createdPastSlushUpdateInterval := createdNow.Add(-(munger.slushUpdateInterval + time.Hour))
+
+	tests := map[string]struct {
+		// The mode of the munger
+		mode string
+		// Labels to add to the test issue
+		labels []string
+		// Whether the test issues milestone labels should be complete
+		labelsComplete bool
+		// Whether the test issue should be a blocker
+		isBlocker bool
+		// Whether the test issue should be approved for the milestone
+		isApproved bool
+		// Events to add to the test issue
+		events []*githubapi.IssueEvent
+		// Comments to add to the test issue
+		comments []*githubapi.IssueComment
+		// Sections expected to be enabled
+		expectedSections sets.String
+		// Expected milestone state
+		expectedState milestoneState
+		// Expected message body
+		expectedBody string
+	}{
+		"Incomplete labels within grace period": {
+			expectedSections: sets.NewString("warnIncompleteLabels"),
+			expectedState:    milestoneNeedsLabeling,
+			expectedBody: `
+**Action required**: This issue requires label changes. If the required changes are not made within 2 days, the issue will be moved out of the v1.8 milestone.
+` + incompleteLabels,
+		},
+		"Incomplete labels outside of grace period": {
+			labels:           []string{milestoneLabelsIncompleteLabel},
+			events:           milestoneLabelEvents(milestoneLabelsIncompleteLabel, createdPastLabelGracePeriod),
+			expectedSections: sets.NewString("removeIncompleteLabels"),
+			expectedState:    milestoneNeedsRemoval,
+			expectedBody: `
+**Important**: This issue was missing labels required for the v1.8 milestone for more than 3 days:
+
+_**kind**_: Must specify exactly one of ` + "`kind/bug`, `kind/cleanup` or `kind/feature`." + `
+_**sig owner**_: Must specify at least one label prefixed with ` + "`sig/`.",
+		},
+		"Incomplete labels outside of grace period, blocker": {
+			labels:           []string{milestoneLabelsIncompleteLabel},
+			isBlocker:        true,
+			events:           milestoneLabelEvents(milestoneLabelsIncompleteLabel, createdPastLabelGracePeriod),
+			expectedSections: sets.NewString("warnIncompleteLabels"),
+			expectedState:    milestoneNeedsLabeling,
+			expectedBody: `
+**Action required**: This issue requires label changes.
+
+_**kind**_: Must specify exactly one of ` + "`kind/bug`, `kind/cleanup` or `kind/feature`." + `
+_**sig owner**_: Must specify at least one label prefixed with ` + "`sig/`." + `
+`,
+		},
+		"Complete labels, not approved, blocker": {
+			labelsComplete:   true,
+			isBlocker:        true,
+			expectedSections: sets.NewString("summarizeLabels", "warnUnapproved"),
+			expectedState:    milestoneNeedsApproval,
+			expectedBody: `
+**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer.
+<details>` + blockerCompleteLabels,
+		},
+		"Complete labels, not approved, non-blocker, within grace period": {
+			labelsComplete:   true,
+			expectedSections: sets.NewString("summarizeLabels", "warnUnapproved"),
+			expectedState:    milestoneNeedsApproval,
+			expectedBody: `
+**Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 6 days, the issue will be moved out of the v1.8 milestone.
+<details>` + nonBlockerCompleteLabels,
+		},
+		"Complete labels, not approved, non-blocker, outside of grace period": {
+			labels:           []string{milestoneNeedsApprovalLabel},
+			labelsComplete:   true,
+			events:           milestoneLabelEvents(milestoneNeedsApprovalLabel, createdPastApprovalGracePeriod),
+			expectedSections: sets.NewString("summarizeLabels", "removeUnapproved"),
+			expectedState:    milestoneNeedsRemoval,
+			expectedBody:     "**Important**: This issue was missing the `status/approved-for-milestone` label for more than 7 days.",
+		},
+		"dev - Complete labels and approved": {
+			labelsComplete:   true,
+			isApproved:       true,
+			expectedSections: sets.NewString("summarizeLabels"),
+			expectedState:    milestoneCurrent,
+			expectedBody:     "<details open>" + nonBlockerCompleteLabels,
+		},
+		"slush - Complete labels, approved, non-blocker, missing in-progress": {
+			mode:             milestoneModeSlush,
+			labelsComplete:   true,
+			isApproved:       true,
+			expectedSections: sets.NewString("summarizeLabels", "warnMissingInProgress", "warnNonBlockerRemoval"),
+			expectedState:    milestoneNeedsAttention,
+			expectedBody: `
+**Action required**: During code slush, issues in the milestone should be in progress.
+If this issue is not being actively worked on, please remove it from the milestone.
+If it is being worked on, please add the ` + "`status/in-progress`" + ` label so it can be tracked with other in-flight issues.
+
+**Note**: If this issue is not resolved or labeled as ` + "`priority/critical-urgent`" + ` by the time heck freezes over it will be moved out of the v1.8 milestone.
+<details>` + nonBlockerCompleteLabels,
+		},
+		"slush - Complete labels, approved, non-blocker": {
+			mode:             milestoneModeSlush,
+			labels:           []string{"status/in-progress"},
+			labelsComplete:   true,
+			isApproved:       true,
+			expectedSections: sets.NewString("summarizeLabels", "warnNonBlockerRemoval"),
+			expectedState:    milestoneCurrent,
+			expectedBody: `
+**Note**: If this issue is not resolved or labeled as ` + "`priority/critical-urgent`" + ` by the time heck freezes over it will be moved out of the v1.8 milestone.
+<details open>` + nonBlockerCompleteLabels,
+		},
+		"slush - Complete labels, approved, blocker, missing in-progress, update not due": {
+			mode:             milestoneModeSlush,
+			labelsComplete:   true,
+			isApproved:       true,
+			isBlocker:        true,
+			events:           milestoneLabelEvents(statusApprovedLabel, createdNow),
+			comments:         milestoneIssueComments(createdNow),
+			expectedSections: sets.NewString("summarizeLabels", "warnMissingInProgress", "warnUpdateInterval"),
+			expectedState:    milestoneNeedsAttention,
+			expectedBody: `
+**Action required**: During code slush, issues in the milestone should be in progress.
+If this issue is not being actively worked on, please remove it from the milestone.
+If it is being worked on, please add the ` + "`status/in-progress`" + ` label so it can be tracked with other in-flight issues.
+
+**Note**: This issue is marked as ` + "`priority/critical-urgent`" + `, and must be updated every 3 days during code slush.
+
+Example update:
+
+` + "```" + `
+ACK.  In progress
+ETA: DD/MM/YYYY
+Risks: Complicated fix required
+` + "```" + `
+<details>` + blockerCompleteLabels,
+		},
+		"slush - Complete labels, approved, blocker, update not due": {
+			mode:             milestoneModeSlush,
+			labels:           []string{"status/in-progress"},
+			labelsComplete:   true,
+			isApproved:       true,
+			isBlocker:        true,
+			events:           milestoneLabelEvents(statusApprovedLabel, createdNow),
+			comments:         milestoneIssueComments(createdNow),
+			expectedSections: sets.NewString("summarizeLabels", "warnUpdateInterval"),
+			expectedState:    milestoneCurrent,
+			expectedBody: `
+**Note**: This issue is marked as ` + "`priority/critical-urgent`" + `, and must be updated every 3 days during code slush.
+
+Example update:
+
+` + "```" + `
+ACK.  In progress
+ETA: DD/MM/YYYY
+Risks: Complicated fix required
+` + "```" + `
+<details open>` + blockerCompleteLabels,
+		},
+		"slush - Complete labels, approved, blocker, update due": {
+			mode:             milestoneModeSlush,
+			labels:           []string{"status/in-progress"},
+			labelsComplete:   true,
+			isApproved:       true,
+			isBlocker:        true,
+			events:           milestoneLabelEvents(statusApprovedLabel, createdNow),
+			comments:         milestoneIssueComments(createdPastSlushUpdateInterval),
+			expectedSections: sets.NewString("summarizeLabels", "warnUpdateInterval", "warnUpdateRequired"),
+			expectedState:    milestoneNeedsAttention,
+			expectedBody: `
+**Action Required**: This issue has not been updated since ` + createdPastSlushUpdateInterval.Format("Jan 2") + `. Please provide an update.
+
+**Note**: This issue is marked as ` + "`priority/critical-urgent`" + `, and must be updated every 3 days during code slush.
+
+Example update:
+
+` + "```" + `
+ACK.  In progress
+ETA: DD/MM/YYYY
+Risks: Complicated fix required
+` + "```" + `
+<details>` + blockerCompleteLabels,
+		},
+		"freeze - Complete labels, approved, non-blocker": {
+			mode:             milestoneModeFreeze,
+			labelsComplete:   true,
+			isApproved:       true,
+			expectedSections: sets.NewString("summarizeLabels", "removeNonBlocker"),
+			expectedState:    milestoneNeedsRemoval,
+			expectedBody:     "**Important**: Code freeze is in effect and only issues with `priority/critical-urgent` may remain in the v1.8 milestone.",
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if len(test.mode) == 0 {
+				munger.mode = milestoneModeDev
+			} else {
+				munger.mode = test.mode
+			}
+
+			labels := test.labels
+			if test.isBlocker {
+				labels = append(labels, blockerLabel)
+			} else {
+				labels = append(labels, "priority/important-soon")
+			}
+			if test.labelsComplete {
+				labels = append(labels, "kind/bug")
+				labels = append(labels, "sig/foo")
+			}
+			if test.isApproved {
+				labels = append(labels, statusApprovedLabel)
+			}
+
+			issue := github_test.Issue("user", 1, labels, false)
+			// Ensure issue was created before any comments or events
+			createdLongAgo := createdNow.Add(-28 * day)
+			issue.CreatedAt = &createdLongAgo
+			milestone := &githubapi.Milestone{Title: stringPtr(munger.activeMilestone), Number: intPtr(1)}
+			issue.Milestone = milestone
+
+			client, server, mux := github_test.InitServer(t, issue, nil, test.events, nil, nil, nil, nil)
+			defer server.Close()
+
+			config := &github.Config{Org: "o", Project: "r"}
+
+			path := fmt.Sprintf("/repos/%s/%s/issues/%d", config.Org, config.Project, *issue.Number)
+			mux.HandleFunc(fmt.Sprintf("%s/comments", path), func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "GET" {
+					w.WriteHeader(http.StatusOK)
+					data, err := json.Marshal(test.comments)
+					if err != nil {
+						t.Errorf("Unexpected error: %v", err)
+					}
+					w.Write(data)
+					return
+				}
+				t.Fatalf("Unexpected method: %s", r.Method)
+			})
+
+			config.SetClient(client)
+			obj, err := config.GetObject(*issue.Number)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			icc := munger.issueChangeConfig(obj)
+			if icc == nil {
+				t.Fatalf("%s: Expected non-nil issue change config", testName)
+			}
+
+			if !test.expectedSections.Equal(icc.enabledSections) {
+				t.Fatalf("%s: Expected sections %v, got %v", testName, test.expectedSections, icc.enabledSections)
+			}
+
+			if test.expectedState != icc.state {
+				t.Fatalf("%s: Expected state %v, got %v", testName, test.expectedState, icc.state)
+			}
+
+			messageBody := icc.messageBody()
+			if messageBody == nil {
+				t.Fatalf("%s: Expected non-nil message body", testName)
+			}
+			expectedBody := strings.TrimSpace(test.expectedBody)
+			trimmedBody := strings.TrimSpace(*messageBody)
+			if expectedBody != trimmedBody {
+				t.Fatalf("%s: Expected message body:\n\n%s\nGot:\n\n%s", testName, expectedBody, trimmedBody)
+			}
+		})
+	}
+}
+
+func milestoneTestComment(title string, context string, createdAt time.Time) *c.Comment {
 	n := &c.Notification{
 		Name:      milestoneNotifierName,
-		Arguments: label,
+		Arguments: title,
 		Context:   context,
 	}
 	return &c.Comment{
@@ -138,150 +475,68 @@ func milestoneLabelEvents(label string, createdAt time.Time) []*githubapi.IssueE
 	}
 }
 
-// TestNotificationState validates how the notificationState() method
-// responds to the possible label and notification states of issues in
-// a milestone.
-func TestNotificationState(t *testing.T) {
-	createdNow := time.Now()
-	warningInterval := day
-	createdYesterday := createdNow.Add(-(warningInterval + time.Hour))
-	gracePeriod := 3 * day
-	createdLongAgo := createdNow.Add(-(gracePeriod + time.Hour))
-	tests := map[string]struct {
-		// Labels to apply to the test issue
-		labels []string
-		// Comment to add to the test issue
-		comment *c.Comment
-		// Events to add to the test issue
-		events []*githubapi.IssueEvent
-		// Munger label expected to have been decided by notificationState
-		expectedLabel string
-		// Description expected to have been decided by notificationState
-		expectedDescription string
-	}{
-		"Label and comment with summary for complete labels": {
-			labels:              []string{"kind/bug", "priority/important-soon", "sig/foo"},
-			expectedLabel:       milestoneLabelsCompleteLabel,
-			expectedDescription: milestoneLabelsComplete,
+func milestoneIssueComments(createdAt time.Time) []*githubapi.IssueComment {
+	return []*githubapi.IssueComment{
+		{
+			Body:      stringPtr("foo"),
+			UpdatedAt: &createdAt,
+			CreatedAt: &createdAt,
+			User: &githubapi.User{
+				Login: githubapi.String("bar"),
+			},
 		},
-		"Do nothing for up-to-date summary": {
-			labels:        []string{"kind/bug", "priority/important-soon", "sig/foo"},
-			comment:       milestoneTestComment(milestoneLabelsComplete, "foo", createdNow),
-			expectedLabel: milestoneLabelsCompleteLabel,
-		},
-		"Label and warn for the first time": {
-			expectedLabel:       milestoneLabelsIncompleteLabel,
-			expectedDescription: milestoneLabelsIncomplete,
-		},
-		"Non-blocker is removed from milestone after grace period": {
-			labels:              []string{milestoneLabelsIncompleteLabel},
-			comment:             milestoneTestComment(milestoneLabelsIncomplete, "foo", createdYesterday),
-			events:              milestoneLabelEvents(milestoneLabelsIncompleteLabel, createdLongAgo),
-			expectedLabel:       milestoneRemovedLabel,
-			expectedDescription: milestoneRemoved,
-		},
-		"Blocker is not removed from milestone after grace period": {
-			labels:              []string{milestoneLabelsIncompleteLabel, priorityCriticalUrgent},
-			events:              milestoneLabelEvents(milestoneLabelsIncompleteLabel, createdLongAgo),
-			expectedLabel:       milestoneLabelsIncompleteLabel,
-			expectedDescription: milestoneLabelsIncomplete,
-		},
-	}
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			issue := github_test.Issue("user", 1, test.labels, false)
-			milestone := &githubapi.Milestone{Title: stringPtr("v1.8"), Number: intPtr(1)}
-			issue.Milestone = milestone
-
-			client, server, _ := github_test.InitServer(t, issue, nil, test.events, nil, nil, nil, nil)
-			defer server.Close()
-
-			config := &github.Config{Org: "o", Project: "r"}
-			config.SetClient(client)
-			obj, err := config.GetObject(*issue.Number)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			label, notifyState := notificationState(obj, test.comment, milestoneTestBotName, gracePeriod, warningInterval)
-
-			if test.expectedLabel != label {
-				t.Fatalf("%s: Expected label '%s', got '%s'", testName, test.expectedLabel, label)
-			}
-
-			if len(test.expectedDescription) == 0 && notifyState != nil {
-				t.Fatalf("%s: Expected no change in notification state", testName)
-			}
-			if len(test.expectedDescription) != 0 {
-				if notifyState == nil {
-					t.Fatalf("%s: Expected a change in notification state", testName)
-				}
-				if test.expectedDescription != notifyState.description {
-					t.Fatalf("%s: Expected description %s, got %s", testName, test.expectedDescription, notifyState.description)
-				}
-			}
-		})
 	}
 }
 
-func milestoneTestNotification(arg, context string) *c.Notification {
-	return &c.Notification{
-		Name:      milestoneNotifierName,
-		Arguments: arg,
-		Context:   context,
-	}
-}
-
-func TestWarningIsCurrent(t *testing.T) {
+func TestNotificationIsCurrent(t *testing.T) {
 	createdNow := time.Now()
 	warningInterval := day
 	createdYesterday := createdNow.Add(-(warningInterval + time.Hour))
 
-	realSample := "@erictune @jcbsmpsn @liggitt\n\n**Action required**: This issue requires label changes. If the required changes are not made within 6 days, the issue will be moved out of the v1.8 milestone.\n\n_**kind**_: Must specify at most one of [`kind/bug`, `kind/cleanup`, `kind/feature`].\n_**priority**_: Must specify at most one of [`priority/critical-urgent`, `priority/important-longterm`, `priority/important-soon`].\n_**sig owner**_: Must specify at least one label prefixed with `sig/`.\n\n<details>\nAdditional instructions available <a href=\"https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md\">here</a>\n</details>"
+	realSample := "@foo @bar @baz\n\n**Action required**: This issue requires label changes. If the required changes are not made within 6 days, the issue will be moved out of the v1.8 milestone.\n\n_**kind**_: Must specify at most one of [`kind/bug`, `kind/cleanup`, `kind/feature`].\n_**priority**_: Must specify at most one of [`priority/critical-urgent`, `priority/important-longterm`, `priority/important-soon`].\n_**sig owner**_: Must specify at least one label prefixed with `sig/`.\n\n<details>\nAdditional instructions available <a href=\"https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md\">here</a>\n</details>"
 
 	tests := map[string]struct {
-		label             string
-		message           string
-		createdAt         time.Time
-		newMessage        string
-		expectedIsCurrent bool
+		message            string
+		newMessage         string
+		createdAt          time.Time
+		nilCommentInterval bool
+		expectedIsCurrent  bool
 	}{
 		"Not current if no notification exists": {},
-		"Not current if the notification is not a warning": {
-			label:   milestoneLabelsComplete,
-			message: "foo",
-		},
 		"Not current if the message is different": {
-			label:      milestoneLabelsIncomplete,
 			message:    "foo",
 			newMessage: "bar",
 		},
 		"Not current if the warning interval has elapsed": {
-			label:      milestoneLabelsIncomplete,
 			message:    "foo",
 			newMessage: "foo",
 			createdAt:  createdYesterday,
 		},
-		"Warning is current": {
-			label:             milestoneLabelsIncomplete,
-			message:           "foo",
-			newMessage:        "foo",
-			createdAt:         createdNow,
-			expectedIsCurrent: true,
+		"Not current if the message is different and the comment interval is nil": {
+			message:            "foo",
+			newMessage:         "bar",
+			nilCommentInterval: true,
 		},
-		"Warning is current, real sample": {
-			label:             milestoneLabelsIncomplete,
-			createdAt:         createdNow,
+		"Notification is current, real sample": {
 			message:           realSample,
 			newMessage:        realSample,
+			createdAt:         createdNow,
 			expectedIsCurrent: true,
 		},
 	}
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			comment := milestoneTestComment(test.label, test.message, test.createdAt)
-			notification := c.ParseNotification(comment)
-			isCurrent := warningIsCurrent(notification, test.newMessage, &test.createdAt, warningInterval)
+			var oldComment *c.Comment
+			if len(test.message) > 0 {
+				oldComment = milestoneTestComment("foo", test.message, test.createdAt)
+			}
+			newComment := milestoneTestComment("foo", test.newMessage, createdNow)
+			notification := c.ParseNotification(newComment)
+			var commentInterval *time.Duration
+			if !test.nilCommentInterval {
+				commentInterval = &warningInterval
+			}
+			isCurrent := notificationIsCurrent(notification, oldComment, commentInterval)
 			if test.expectedIsCurrent != isCurrent {
 				t.Logf("notification %#v\n", notification)
 				t.Fatalf("%s: expected warningIsCurrent to be %t, but got %t", testName, test.expectedIsCurrent, isCurrent)
@@ -375,7 +630,7 @@ func TestSigLabelNames(t *testing.T) {
 	// Expect labels without sig/ prefix to be filtered out
 	expectedLabelNames := []string{"sig/foo", "sig/bar"}
 	if len(expectedLabelNames) != len(labelNames) {
-		t.Errorf("Wrong number of labels. Got %v, wanted %v.", labelNames, expectedLabelNames)
+		t.Fatalf("Wrong number of labels. Got %v, wanted %v.", labelNames, expectedLabelNames)
 	}
 	for _, ln1 := range expectedLabelNames {
 		var found bool


### PR DESCRIPTION
This PR is a reworking of the milestone munger to support [the rest of the process](https://github.com/kubernetes/community/blob/master/contributors/devel/release/issues.md) proposed by @pwittrock.  The goal is to modularize support of each requirement (e.g. labels complete, approved, updated) and the change (notification/label/milestone) implied to allow the munger to be easier to understand and maintain.