### PR TITLE
Unforking kubernetes-anywhere in kubeadm image.

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     wget && \
     apt-get clean
 
-ENV TERRAFORM_VERSION=0.7.2 \
+ENV TERRAFORM_VERSION=0.9.4 \
     KUBERNETES_PROVIDER=kubernetes-anywhere \
     KUBECTL_VERSION=1.6.4 \
     PATH=/usr/local/bin:${PATH}

--- a/images/kubeadm/runner
+++ b/images/kubeadm/runner
@@ -22,10 +22,11 @@ if [ ! -e test-infra ]; then
 fi
 
 if [ ! -e kubernetes-anywhere ]; then
-  # This is a short-term fix to get kubeadm e2es stable before the correct fix
-  # is in place. https://github.com/kubernetes/kubeadm/issues/219
-  # TODO(pipejakob): point this back to kubernetes/kubernetes-anywhere
-  git clone https://github.com/pipejakob/kubernetes-anywhere
+  git clone https://github.com/kubernetes/kubernetes-anywhere
+
+  # Explicitly version this dependency so that upstream commits can't
+  # immediately break e2e jobs, and we have control over upgrading/downgrading.
+  git -C kubernetes-anywhere checkout 55ba266ed6d93d7a3a8681fc38808fa96d6d0b97
 fi
 
 # This is required until https://github.com/kubernetes/kubernetes-anywhere/issues/332

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -311,7 +311,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -701,7 +701,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
         args:
         - "--pull=$(PULL_REFS)"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1096,7 +1096,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1139,7 +1139,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170905-5a36d912
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1254,7 +1254,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1373,7 +1373,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1416,7 +1416,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
             args:
             - "--branch=$(PULL_REFS)"
             - "--clean"
@@ -1534,7 +1534,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
           args:
           - "--branch=$(PULL_REFS)"
           - "--clean"
@@ -1577,7 +1577,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
           args:
           - "--branch=$(PULL_REFS)"
           - "--clean"
@@ -16439,7 +16439,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
           args:
           - "--repo=k8s.io/kubernetes=release-1.6"
           - "--clean"
@@ -16559,7 +16559,7 @@ periodics:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
           args:
           - "--repo=k8s.io/kubernetes=release-1.7"
           - "--clean"
@@ -16678,7 +16678,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170906-66644df5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170907-8d0dd967
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"


### PR DESCRIPTION
Addressing my tech debt from https://github.com/kubernetes/test-infra/issues/4044 when I switched the kubeadm image runner to use a private fork of kubernetes-anywhere to speed up fixing the e2e tests. Now that my custom patches have made it upstream, we can stop using my fork (but still want to [pin the commit](https://github.com/kubernetes/kubeadm/issues/191) to use).

Also upgrading terraform to match upstream, where 0.9.4 is used.