### PR TITLE
Try to print service account before gsutil cp kops last green

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -100,6 +100,11 @@ if [[ -n "${KOPS_PUBLISH_GREEN_PATH:-}" ]]; then
       exit 1
     fi
   fi
+
+  # TODO(krzyzacy) - debugging
+  gcloud config list
+  gcloud auth list
+
   echo "Publish version to ${KOPS_PUBLISH_GREEN_PATH}: ${KOPS_BASE_URL}"
   echo "${KOPS_BASE_URL}" | gsutil -h "Cache-Control:private, max-age=0, no-transform" cp - "${KOPS_PUBLISH_GREEN_PATH}"
 fi


### PR DESCRIPTION
grrr I don't understand why it's not using the correct service account - from within the docker container as far as I can tell the account is correct but towards the end the service account is changed?

Try to verify if the active account is still correct towards the end.

/assign @BenTheElder @zmerlynn 