### PR TITLE
Don't re-export gcloud config

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -91,7 +91,6 @@ export -f log_dump_custom_get_instances # Export to cluster/log-dump/log-dump.sh
 kubetest "${e2e_args[@]}" "${@}"
 
 if [[ -n "${KOPS_PUBLISH_GREEN_PATH:-}" ]]; then
-  export CLOUDSDK_CONFIG="/workspace/.config/gcloud"
 
   if ! which gsutil; then
     export PATH=/google-cloud-sdk/bin:${PATH}


### PR DESCRIPTION
bootstrap already exported once from https://github.com/kubernetes/test-infra/blob/d8c22c657c282fda6285fe5078e1837d6a15c8f2/jenkins/bootstrap.py#L755

Which this line is introduced from https://github.com/kubernetes/test-infra/pull/1219 (which I reviewed :man_facepalming: ) and I feel like this is not needed anymore (because evolution from kubetest?), or this is setting the wrong service account.

/assign @BenTheElder 
cc @zmerlynn @justinsb 
