### PR TITLE
Fix deck log following to not double-encode.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -17,7 +17,7 @@ all: build test
 
 HOOK_VERSION             ?= 0.158
 SINKER_VERSION           ?= 0.18
-DECK_VERSION             ?= 0.46
+DECK_VERSION             ?= 0.50
 SPLICE_VERSION           ?= 0.27
 TOT_VERSION              ?= 0.5
 HOROLOGIUM_VERSION       ?= 0.8

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,8 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.46
+        image: gcr.io/k8s-prow/deck:0.50
+        imagePullPolicy: Always
         ports:
           - name: http
             containerPort: 8080

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -176,7 +176,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.46
+        image: gcr.io/k8s-prow/deck:0.50
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
It still stops after 30s-- the apiserver might be terminating the reader?