### PR TITLE
Add kubeadm upgrade testing

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8325,27 +8325,6 @@
       "sig-cluster-lifecycle"
     ]
   },
-  "ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.6",
-      "--extract=ci/latest-1.7",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=ci",
-      "--kubernetes-anywhere-kubernetes-version=latest-1.6",
-      "--kubernetes-anywhere-upgrade-method=kubeadm-init",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--timeout=300m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --ginkgo.focus=\\[Conformance\\] --upgrade-target=ci/latest-1.7"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
   "ci-kubernetes-e2e-mlkube-gke": {
     "args": [
       "--charts",
@@ -10076,6 +10055,48 @@
     "scenario": "execute",
     "sigOwners": [
       "UNKNOWN"
+    ]
+  },
+  "periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=periodic",
+      "--kubernetes-anywhere-kubernetes-version=latest-1.6",
+      "--kubernetes-anywhere-upgrade-method=kubeadm-upgrade",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\]|\\[Conformance\\] --upgrade-target=ci/latest-1.7"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.8",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=periodic",
+      "--kubernetes-anywhere-kubernetes-version=latest-1.7",
+      "--kubernetes-anywhere-upgrade-method=kubeadm-upgrade",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\]|\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --upgrade-target=ci/latest-1.8"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
     ]
   },
   "periodic-kubernetes-bazel-build-1-6": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8325,6 +8325,27 @@
       "sig-cluster-lifecycle"
     ]
   },
+  "ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=ci",
+      "--kubernetes-anywhere-kubernetes-version=latest-1.6",
+      "--kubernetes-anywhere-upgrade-method=kubeadm-init",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --ginkgo.focus=\\[Conformance\\] --upgrade-target=ci/latest-1.7"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
   "ci-kubernetes-e2e-mlkube-gke": {
     "args": [
       "--charts",

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -50,6 +50,8 @@ var (
 		"(kubernetes-anywhere only) Time limit between starting a cluster and making a successful call to the Kubernetes API.")
 	kubernetesAnywhereNumNodes = flag.Int("kubernetes-anywhere-num-nodes", 4,
 		"(kubernetes-anywhere only) Number of nodes to be deployed in the cluster.")
+	kubernetesAnywhereUpgradeMethod = flag.String("kubernetes-anywhere-upgrade-method", "kubeadm-upgrade",
+		"(kubernetes-anywhere only) Indicates whether to do the control plane upgrade with kubeadm method \"kubeadm-init\" or \"kubeadm-upgrade\"")
 )
 
 const kubernetesAnywhereConfigTemplate = `
@@ -72,6 +74,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase2.kubelet_version="{{.KubeletVersion}}"
 .phase2.kubeadm.version="{{.KubeadmVersion}}"
 .phase2.kube_context_name="{{.KubeContext}}"
+.phase2.upgrade_method="{{.UpgradeMethod}}"
 
 .phase3.run_addons=y
 .phase3.weave_net={{if eq .Phase2Provider "kubeadm" -}} y {{- else -}} n {{- end}}
@@ -87,6 +90,7 @@ type kubernetesAnywhere struct {
 	Phase2Provider    string
 	KubeadmVersion    string
 	KubeletVersion    string
+	UpgradeMethod     string
 	KubernetesVersion string
 	NumNodes          int
 	Project           string
@@ -133,6 +137,7 @@ func newKubernetesAnywhere(project, zone string) (deployer, error) {
 		Phase2Provider:    *kubernetesAnywherePhase2Provider,
 		KubeadmVersion:    *kubernetesAnywhereKubeadmVersion,
 		KubeletVersion:    kubeletVersion,
+		UpgradeMethod:     *kubernetesAnywhereUpgradeMethod,
 		KubernetesVersion: *kubernetesAnywhereKubernetesVersion,
 		NumNodes:          *kubernetesAnywhereNumNodes,
 		Project:           project,

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1577,6 +1577,49 @@ postsubmits:
           - name: cache-ssd
             hostPath:
               path: /mnt/disks/ssd0
+      - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+        agent: kubernetes
+        spec:
+          containers:
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170908-a7a2772e
+            args:
+            - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+            - "--clean"
+            - "--git-cache=/root/.cache/git"
+            - "--timeout=320"
+            - "--upload=gs://kubernetes-jenkins/logs"
+            env:
+            - name: USER
+              value: prow
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/service-account/service-account.json
+            - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-private
+            - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+              value: /etc/ssh-key-secret/ssh-public
+            volumeMounts:
+            - name: service
+              mountPath: /etc/service-account
+              readOnly: true
+            - name: ssh
+              mountPath: /etc/ssh-key-secret
+              readOnly: true
+            - name: cache-ssd
+              mountPath: /root/.cache
+            ports:
+            - containerPort: 9999
+              hostPort: 9999
+          volumes:
+          - name: service
+            secret:
+              secretName: service-account
+          - name: ssh
+            secret:
+              secretName: ssh-key-secret
+              defaultMode: 0400
+          - name: cache-ssd
+            hostPath:
+              path: /mnt/disks/ssd0
 
   - name: ci-kubernetes-bazel-build-1-8
     agent: kubernetes

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1577,49 +1577,6 @@ postsubmits:
           - name: cache-ssd
             hostPath:
               path: /mnt/disks/ssd0
-      - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-        agent: kubernetes
-        spec:
-          containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170908-a7a2772e
-            args:
-            - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-            - "--clean"
-            - "--git-cache=/root/.cache/git"
-            - "--timeout=320"
-            - "--upload=gs://kubernetes-jenkins/logs"
-            env:
-            - name: USER
-              value: prow
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/service-account/service-account.json
-            - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-private
-            - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-public
-            volumeMounts:
-            - name: service
-              mountPath: /etc/service-account
-              readOnly: true
-            - name: ssh
-              mountPath: /etc/ssh-key-secret
-              readOnly: true
-            - name: cache-ssd
-              mountPath: /root/.cache
-            ports:
-            - containerPort: 9999
-              hostPort: 9999
-          volumes:
-          - name: service
-            secret:
-              secretName: service-account
-          - name: ssh
-            secret:
-              secretName: ssh-key-secret
-              defaultMode: 0400
-          - name: cache-ssd
-            hostPath:
-              path: /mnt/disks/ssd0
 
   - name: ci-kubernetes-bazel-build-1-8
     agent: kubernetes
@@ -16291,6 +16248,49 @@ periodics:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+    - name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170920-20580b10
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--timeout=320"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: ssh
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
 
 - name: periodic-kubernetes-bazel-build-1-8
   interval: 2h
@@ -16381,6 +16381,49 @@ periodics:
           value: prow
         - name: REPO_NAME
           value: kubernetes=release-1.8
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: ssh
+          mountPath: /etc/ssh-key-secret
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          secretName: ssh-key-secret
+          defaultMode: 0400
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+    agent: kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170920-20580b10
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--timeout=320"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        env:
+        - name: USER
+          value: prow
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
         - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1092,6 +1092,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
 - name: ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd
+- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
 # charts tests
 - name: ci-kubernetes-charts-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-charts-gce
@@ -3300,6 +3302,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: ci-gce-kubeadm-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
+  - name: ci-gce-kubeadm-upgrade-1.6-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
   - name: ci-bazel-build-1.7
     test_group_name: ci-kubernetes-bazel-build-1-7
   - name: ci-bazel-test-1.7
@@ -3340,6 +3344,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: gce-kubeadm-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
+  - name: gce-kubeadm-upgrade-1.6-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
   - name: kubelet-1.7
     test_group_name: ci-kubernetes-node-kubelet-1.7
   - name: aws-release-1-7
@@ -3699,6 +3705,8 @@ dashboards:
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-6
   - name: kubeadm-gce-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
+  - name: kubeadm-gce-upgrade-1.6-1.7
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
   - name: kubeadm-gce-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: periodic-kubeadm-gce-1.7
@@ -4215,6 +4223,6 @@ dashboard_groups:
 
 - name: sig-scalability-all  # TODO(fejta): rename this to sig-scalability
   dashboard_names:
-  - sig-scalability  # TODO(fejta): rename this google-kubemark 
+  - sig-scalability  # TODO(fejta): rename this google-kubemark
   - google-gce-scale
   - google-gke-scale

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1092,8 +1092,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
 - name: ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd
-- name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+- name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+  gcs_prefix: kubernetes-jenkins/logs/periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+- name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  gcs_prefix: kubernetes-jenkins/logs/periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
 # charts tests
 - name: ci-kubernetes-charts-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-charts-gce
@@ -3302,8 +3304,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: ci-gce-kubeadm-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
-  - name: ci-gce-kubeadm-upgrade-1.6-1.7
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+  - name: periodic-ci-gce-kubeadm-upgrade-1.6-1.7
+    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+  - name: periodic-ci-gce-kubeadm-upgrade-1.7-1.8
+    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: ci-bazel-build-1.7
     test_group_name: ci-kubernetes-bazel-build-1-7
   - name: ci-bazel-test-1.7
@@ -3345,7 +3349,9 @@ dashboards:
   - name: gce-kubeadm-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: gce-kubeadm-upgrade-1.6-1.7
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+  - name: gce-kubeadm-upgrade-1.7-1.8
+    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: kubelet-1.7
     test_group_name: ci-kubernetes-node-kubelet-1.7
   - name: aws-release-1-7
@@ -3706,7 +3712,9 @@ dashboards:
   - name: kubeadm-gce-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: kubeadm-gce-upgrade-1.6-1.7
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+  - name: kubeadm-gce-upgrade-1.7-1.8
+    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: kubeadm-gce-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: periodic-kubeadm-gce-1.7


### PR DESCRIPTION
Implements test configs for https://github.com/kubernetes/kubeadm/issues/311. Design doc is [here](https://docs.google.com/document/d/13BGepI99bw6rPoweRN_J65h3UDUMsyprTj3S65F1kOk/edit).

I wasn't sure if we also needed to invoke these upgrade tests on `release-1.6-*` gates, or whether 1.7 is enough. If I've missed any out or if there's any plumbing I missed, please feel free to call it out in the PR.

**Note**: A PR needs to be submitted to kubernetes-anywhere first (see [design doc](https://docs.google.com/document/d/1PoDeqD8qu1KbAd-fb7xOVB1G7YTyD6VLLlhaVB3QeA4/edit)).

/cc @jessicaochen @luxas @pipejakob 