### PR TITLE
remove --pull and --branch from bootstrap.py, redux

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 boskos/** @krzyzacy
 gubernator/** @rmmh
+jenkins/bootstrap* @bentheelder @krzyzacy
 kettle/** @rmmh
 logexporter/** @shyamjvs
 mungegithub/** @cjwagner

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -954,13 +954,6 @@ def parse_args(arguments=None):
     parser.add_argument('--root', default='.', help='Root dir to work with')
     parser.add_argument(
         '--timeout', type=float, default=0, help='Timeout in minutes if set')
-    # TODO(bentheelder): remove --pull and --branch
-    parser.add_argument(
-        '--pull',
-        help='Deprecated, use --repo=k8s.io/foo=master:abcd,12:ef12,45:ff65')
-    parser.add_argument(
-        '--branch',
-        help='Deprecated, use --repo=k8s.io/foo=master')
     parser.add_argument(
         '--repo',
         action='append',
@@ -987,6 +980,10 @@ def parse_args(arguments=None):
         action='store_true',
         help='Clean the git repo before running tests.')
     args = parser.parse_args(arguments)
+    # --pull is deprecated, use --repo=k8s.io/foo=master:abcd,12:ef12,45:ff65
+    setattr(args, 'pull', None)
+    # --branch is deprecated, use --repo=k8s.io/foo=master
+    setattr(args, 'branch', None)
     if bool(args.repo) == bool(args.bare):
         raise argparse.ArgumentTypeError(
             'Expected --repo xor --bare:', args.repo, args.bare)

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -440,21 +440,25 @@ class ParseReposTest(unittest.TestCase):
 
     def test_pull_release_branch(self):
         """--repo=foo=release-3.14,&a-fancy%_branch+:abcd,222 works"""
-        args = bootstrap.parse_args(['--job=foo', '--repo=foo=release-3.14,&a-fancy%_branch+:abcd,222'])
+        args = bootstrap.parse_args(['--job=foo',
+                                     '--repo=foo=release-3.14,&a-fancy%_branch+:abcd,222'])
         self.assertEquals(
             {'foo': ('', 'release-3.14,&a-fancy%_branch+:abcd,222')},
             bootstrap.parse_repos(args))
 
     def test_pull_branch_commit(self):
         """--repo=foo=master,111,222 works"""
-        args = bootstrap.parse_args(['--job=foo', '--repo=foo=master:aaa,111:bbb,222:ccc'])
+        args = bootstrap.parse_args(['--job=foo',
+                                     '--repo=foo=master:aaa,111:bbb,222:ccc'])
         self.assertEquals(
             {'foo': ('', 'master:aaa,111:bbb,222:ccc')},
             bootstrap.parse_repos(args))
 
     def test_multi_repo(self):
         """--repo=foo=master,111,222 bar works"""
-        args = bootstrap.parse_args(['--job=foo', '--repo=foo=master:aaa,111:bbb,222:ccc', '--repo=bar'])
+        args = bootstrap.parse_args(['--job=foo',
+                                     '--repo=foo=master:aaa,111:bbb,222:ccc',
+                                     '--repo=bar'])
         self.assertEquals(
             {
                 'foo': ('', 'master:aaa,111:bbb,222:ccc'),

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -394,45 +394,8 @@ class CheckoutTest(unittest.TestCase):
 class ParseReposTest(unittest.TestCase):
     def test_bare(self):
         """--bare works."""
-        self.assertFalse(
-            bootstrap.parse_repos(FakeArgs(repo=[], branch=[], pull=[], bare=True)))
-
-    def test_deprecated_branch(self):
-        """--repo=foo --branch=bbb works"""
-        self.assertEquals(
-            {'foo': ('bbb', '')},
-            bootstrap.parse_repos(FakeArgs(repo=['foo'], branch='bbb', pull='')))
-
-    def test_deprecated_branch_commit(self):
-        """--repo=foo --branch=bbb:1234 works"""
-        self.assertEquals(
-            {'foo': ('bbb:1234', '')},
-            bootstrap.parse_repos(FakeArgs(repo=['foo'], branch='bbb:1234', pull='')))
-
-    def test_depre_branch_repo_commit(self):
-        """--repo=foo=master:aaa --branch=bar is not allowed"""
-        with self.assertRaises(ValueError):
-            bootstrap.parse_repos(FakeArgs(
-                repo=['foo=master:aaa'], branch='master'))
-        with self.assertRaises(ValueError):
-            bootstrap.parse_repos(FakeArgs(
-                repo=['foo=master'], branch='bar'))
-
-    def test_deprecated_pull(self):
-        """--repo=foo --pull=123 works."""
-        self.assertEquals(
-            {'foo': ('', '123:abc,333:ddd')},
-            bootstrap.parse_repos(FakeArgs(repo=['foo'], branch='', pull='123:abc,333:ddd')))
-
-
-    def test_depre_pull_repo_commit(self):
-        """--repo=foo=master:aaa --pull=123:abc is not allowed"""
-        with self.assertRaises(ValueError):
-            bootstrap.parse_repos(FakeArgs(
-                repo=['foo=master:aaa'], branch='', pull='123:abc'))
-        with self.assertRaises(ValueError):
-            bootstrap.parse_repos(FakeArgs(
-                repo=['foo=master'], branch='', pull='123:abc'))
+        args = bootstrap.parse_args(["--job=foo", "--bare"])
+        self.assertFalse(bootstrap.parse_repos(args))
 
     def test_plain(self):
         """"--repo=foo equals foo=master."""

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -394,75 +394,72 @@ class CheckoutTest(unittest.TestCase):
 class ParseReposTest(unittest.TestCase):
     def test_bare(self):
         """--bare works."""
-        args = bootstrap.parse_args(["--job=foo", "--bare"])
+        args = bootstrap.parse_args(['--job=foo', '--bare'])
         self.assertFalse(bootstrap.parse_repos(args))
 
     def test_pull_branch_none(self):
         """args.pull and args.branch should be None"""
-        args = bootstrap.parse_args(["--job=foo", "--bare"])
+        args = bootstrap.parse_args(['--job=foo', '--bare'])
         self.assertIsNone(args.pull)
         self.assertIsNone(args.branch)
 
     def test_plain(self):
         """"--repo=foo equals foo=master."""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo'])
         self.assertEquals(
             {'foo': ('master', '')},
-            bootstrap.parse_repos(FakeArgs(repo=['foo'], branch='', pull='')))
+            bootstrap.parse_repos(args))
 
     def test_branch(self):
         """--repo=foo=branch."""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo=this'])
         self.assertEquals(
             {'foo': ('this', '')},
-            bootstrap.parse_repos(
-                FakeArgs(repo=['foo=this'], branch='', pull='')))
+            bootstrap.parse_repos(args))
 
     def test_branch_commit(self):
         """--repo=foo=branch:commit works."""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo=this:abcd'])
         self.assertEquals(
             {'foo': ('this:abcd', '')},
-            bootstrap.parse_repos(
-                FakeArgs(repo=['foo=this:abcd'], branch='', pull='')))
+            bootstrap.parse_repos(args))
 
     def test_parse_repos(self):
         """--repo=foo=111,222 works"""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo=111,222'])
         self.assertEquals(
             {'foo': ('', '111,222')},
-            bootstrap.parse_repos(FakeArgs(
-                repo=['foo=111,222'], branch='', pull='')))
+            bootstrap.parse_repos(args))
 
     def test_pull_branch(self):
         """--repo=foo=master,111,222 works"""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo=master,111,222'])
         self.assertEquals(
             {'foo': ('', 'master,111,222')},
-            bootstrap.parse_repos(
-                FakeArgs(repo=['foo=master,111,222'], branch='', pull='')))
+            bootstrap.parse_repos(args))
 
     def test_pull_release_branch(self):
         """--repo=foo=release-3.14,&a-fancy%_branch+:abcd,222 works"""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo=release-3.14,&a-fancy%_branch+:abcd,222'])
         self.assertEquals(
             {'foo': ('', 'release-3.14,&a-fancy%_branch+:abcd,222')},
-            bootstrap.parse_repos(
-                FakeArgs(repo=['foo=release-3.14,&a-fancy%_branch+:abcd,222'],
-                         branch='', pull='')))
+            bootstrap.parse_repos(args))
 
     def test_pull_branch_commit(self):
         """--repo=foo=master,111,222 works"""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo=master:aaa,111:bbb,222:ccc'])
         self.assertEquals(
             {'foo': ('', 'master:aaa,111:bbb,222:ccc')},
-            bootstrap.parse_repos(FakeArgs(
-                repo=['foo=master:aaa,111:bbb,222:ccc'], branch='', pull='')))
+            bootstrap.parse_repos(args))
 
     def test_multi_repo(self):
         """--repo=foo=master,111,222 bar works"""
+        args = bootstrap.parse_args(['--job=foo', '--repo=foo=master:aaa,111:bbb,222:ccc', '--repo=bar'])
         self.assertEquals(
             {
                 'foo': ('', 'master:aaa,111:bbb,222:ccc'),
                 'bar': ('master', '')},
-            bootstrap.parse_repos(
-                FakeArgs(branch='', pull='', repo=[
-                    'foo=master:aaa,111:bbb,222:ccc',
-                    'bar',
-                ])))
+            bootstrap.parse_repos(args))
 
 
 class GSUtilTest(unittest.TestCase):

--- a/jenkins/bootstrap_test.py
+++ b/jenkins/bootstrap_test.py
@@ -397,6 +397,12 @@ class ParseReposTest(unittest.TestCase):
         args = bootstrap.parse_args(["--job=foo", "--bare"])
         self.assertFalse(bootstrap.parse_repos(args))
 
+    def test_pull_branch_none(self):
+        """args.pull and args.branch should be None"""
+        args = bootstrap.parse_args(["--job=foo", "--bare"])
+        self.assertIsNone(args.pull)
+        self.assertIsNone(args.branch)
+
     def test_plain(self):
         """"--repo=foo equals foo=master."""
         self.assertEquals(


### PR DESCRIPTION
fix of #4482. sorta gross but this makes sure the tests actually flex `parse_args` and makes sure `--pull` and `--branch` stay unset.

Also adds myself and @krzyzacy to code owners so we can be notified of any future modifications to bootstrap.py / bootstrap_test.py