### PR TITLE
Add a simple script update-gofmt.sh

### DIFF
--- a/verify/update-gofmt.sh
+++ b/verify/update-gofmt.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +18,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-diff=$(find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -d 2>&1)
-if [[ -n "${diff}" ]]; then
-  echo "${diff}"
-  echo
-  echo "Please run verify/update-gofmt.sh"
-  exit 1
-fi
+find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -w


### PR DESCRIPTION
When I change code, I can verify gofmt by `verify/verify-gofmt.sh` easily but I don't have an easy way to update gofmt. This PR adds a simple script to do this. BTW, maybe it should not be in dir `verify`, but I see there is a script called `update-bazel.sh` in the dir, so I also put the new update script here.