### PR TITLE
Unpin gcloud for gke-canary job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5448,7 +5448,6 @@
       "--cluster=",
       "--deployment=gke",
       "--extract=ci/latest",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-b",
       "--ginkgo-parallel",


### PR DESCRIPTION
See if canary job will produce logs if we do not use gcloud from their staging bucket.

/assign @zmerlynn @shyamjvs 