### PR TITLE
Make kops-aws presubmit blocking again

### DIFF
--- a/metrics/configs/pr-consistency-config.yaml
+++ b/metrics/configs/pr-consistency-config.yaml
@@ -42,6 +42,7 @@ query: |
             'pr:pull-kubernetes-bazel-build',
             'pr:pull-kubernetes-bazel-test',
             'pr:pull-kubernetes-e2e-gce-etcd3',
+            'pr:pull-kubernetes-e2e-kops-aws',
             'pr:pull-kubernetes-federation-e2e-gce',
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',

--- a/metrics/configs/weekly-consistency-config.yaml
+++ b/metrics/configs/weekly-consistency-config.yaml
@@ -39,6 +39,7 @@ query: |
             'pr:pull-kubernetes-bazel-build',
             'pr:pull-kubernetes-bazel-test',
             'pr:pull-kubernetes-e2e-gce-etcd3',
+            'pr:pull-kubernetes-e2e-kops-aws',
             'pr:pull-kubernetes-federation-e2e-gce',
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',

--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -20,6 +20,7 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce-etcd3,\
+  pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-federation-e2e-gce,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -16,6 +16,7 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce-etcd3,\
+  pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-federation-e2e-gce,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\


### PR DESCRIPTION
#4293 moved the kops-aws presubmit to non-blocking until it was capable of providing good signal, and maintainable going forward

Since then:
- #4393 addressed the issue where the wrong code was being tested (#4315)
- #4370 noted that the janitor job was broken, it's been fixed, so we're no longer hitting AWS quota (#4370)
- #4429 migrated ithe job to use the kubernetes_e2e scenario and latest kubetest, so that kops is following the same conventions as other jobs

I think we've met the criteria of good signal, and maintainable going forward.  In the interest of making sure the kubernetes 1.8 release team has good signal across multiple cloud providers, I would like to see this moved back to blocking.

/cc @cjwagner @krzyzacy @justinsb @liggitt
FYI @jdumars @shyamjvs