### PR TITLE
Move federation testing to non-blocking

### DIFF
--- a/metrics/configs/pr-consistency-config.yaml
+++ b/metrics/configs/pr-consistency-config.yaml
@@ -43,7 +43,6 @@ query: |
             'pr:pull-kubernetes-bazel-test',
             'pr:pull-kubernetes-e2e-gce-etcd3',
             'pr:pull-kubernetes-e2e-kops-aws',
-            'pr:pull-kubernetes-federation-e2e-gce',
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',
             'pr:pull-kubernetes-unit',

--- a/metrics/configs/weekly-consistency-config.yaml
+++ b/metrics/configs/weekly-consistency-config.yaml
@@ -40,7 +40,6 @@ query: |
             'pr:pull-kubernetes-bazel-test',
             'pr:pull-kubernetes-e2e-gce-etcd3',
             'pr:pull-kubernetes-e2e-kops-aws',
-            'pr:pull-kubernetes-federation-e2e-gce',
             'pr:pull-kubernetes-kubemark-e2e-gce',
             'pr:pull-kubernetes-node-e2e',
             'pr:pull-kubernetes-unit',

--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -21,7 +21,6 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce-etcd3,\
   pull-kubernetes-e2e-kops-aws,\
-  pull-kubernetes-federation-e2e-gce,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\
   pull-kubernetes-unit,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -17,7 +17,6 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce-etcd3,\
   pull-kubernetes-e2e-kops-aws,\
-  pull-kubernetes-federation-e2e-gce,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\
   pull-kubernetes-unit,\


### PR DESCRIPTION
As part of the sig-multicluster plan to move federation out of k/k, we're disabling federation testing on the submit queue. We still have ongoing CI testing for head and 1.7 branches with active buildcops.

To be usable for per-PR testing, federation testing currently requires testing against a pre-deployed set of clusters (the clusters are recycled daily on HEAD @ 0810 PST). This causes a manual merge headache when some PRs can slip through the cracks between cluster recycling. The federation testsuite is often the first one to catch some k/k bugs. The upside is that fed oncalls can be first line responders. However, the downside is that the handoff for routing bugs is too cumbersome. Fed oncall has to track and nurse the bug fixing process through a manual merge and redeployment of test clusters.

We plan to resuscitate this test in another form once federation has moved to its own repo. An important component behind this is the work done in #4177 which will allow the pre-deployed set of clusters requirement to be lifted.