### PR TITLE
add test job using docker in docker on kubernetes

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10203,6 +10203,17 @@
       "UNKNOWN"
     ]
   },
+  "pull-kubernetes-dind-build": {
+    "args": [
+      "--env=KUBE_RELEASE_RUN_TESTS=n",
+      "make",
+      "quick-release"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "pull-kubernetes-e2e-gce": {
     "args": [
       "--build",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -237,6 +237,45 @@ presubmits:
     rerun_command: "/test pull-kubernetes-cross"
     trigger: "(?m)^/test pull-kubernetes-cross,?(\\s+|$)"
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
+  - name: pull-kubernetes-dind-build
+    agent: kubernetes
+    context: pull-kubernetes-dind-build
+    always_run: false
+    rerun_command: "/test pull-kubernetes-dind-build"
+    trigger: "(?m)^/test pull-kubernetes-dind-build,?(\\s+|$)"
+    spec:
+      containers:
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph-storage
+          mountPath: /var/lib/docker
+      - name: build
+        image: gcr.io/k8s-testimages/e2e-prow
+        env:
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+        args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --timeout=110
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: docker-graph-storage
+        emptyDir: {}
+
   - name: pull-kubernetes-e2e-gce
     agent: jenkins
     context: pull-kubernetes-e2e-gce
@@ -631,6 +670,45 @@ presubmits:
     rerun_command: "/test pull-security-kubernetes-cross"
     trigger: "(?m)^/test pull-security-kubernetes-cross,?(\\s+|$)"
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
+  - name: pull-security-kubernetes-dind-build
+    agent: kubernetes
+    context: pull-security-kubernetes-dind-build
+    always_run: false
+    rerun_command: "/test pull-security-kubernetes-dind-build"
+    trigger: "(?m)^/test pull-security-kubernetes-dind-build,?(\\s+|$)"
+    spec:
+      containers:
+      - name: dind
+        image: docker:dind
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph-storage
+          mountPath: /var/lib/docker
+      - name: build
+        image: gcr.io/k8s-testimages/e2e-prow
+        env:
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+        args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --timeout=110
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: docker-graph-storage
+        emptyDir: {}
+
   - name: pull-security-kubernetes-e2e-gce
     agent: jenkins
     context: pull-security-kubernetes-e2e-gce

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1608,6 +1608,9 @@ test_groups:
 - name: pull-kubernetes-e2e-gce-canary
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-canary
   days_of_results: 1
+- name: pull-kubernetes-dind-build
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-dind-build
+  days_of_results: 1
 - name: pull-kubernetes-e2e-gce-etcd3
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-etcd3
   days_of_results: 1
@@ -4101,6 +4104,9 @@ dashboards:
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-canary
     test_group_name: pull-kubernetes-e2e-gce-canary
+    base_options: 'width=10'
+  - name: pull-kubernetes-dind-build
+    test_group_name: pull-kubernetes-dind-build
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-etcd3
     test_group_name: pull-kubernetes-e2e-gce-etcd3


### PR DESCRIPTION
This is part of testing a *horrible* idea for getting off of jenkins: use a docker-in-docker container to allow the standard kubernetes dockerized builds on kubernetes.
In the long term we definitely want to prefer moving more things to bazel builds intead, but this might work as a stopgap for winding down Jenkins.

Edit: Per discussion with @ixdy I think we can use this for periodic/CI jobs only to test `make release` and then use `make` inside a container based on the build container everything else (PRs). Once bazel cross build works we can only used this with older k8s releases.