### PR TITLE
Remove the two not-exist sig-cli projects from the pool

### DIFF
--- a/boskos/resources.json
+++ b/boskos/resources.json
@@ -237,8 +237,6 @@
   {
     "names": [
       "ci-k8s-e2e-gci-tip-gce",
-      "ci-kubernetes-e2e-gce-gci-serial-sig-cli",
-      "ci-kubernetes-e2e-gke-gci-serial-sig-cli",
       "ci-kubernetes-e2e-gke-gpu",
       "e2e-gce-gci-ci-1-4",
       "e2e-gce-gci-ci-1-5",


### PR DESCRIPTION
They've been ghosting in the list - I think they are just currently stuck in janitor clean-up loop which can never find the actual project.

/assign @pwittrock 