### PR TITLE
Change kube-proxy downgrade testsuite to upgrade-downgrade model

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4020,12 +4020,14 @@
       "--check-version-skew=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env",
-      "--extract=ci/latest-1.7",
       "--extract=ci/latest",
+      "--extract=ci/k8s-stable1",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetDowngrade\\] --upgrade-target=ci/latest-1.7 --upgrade-image=gci --minStartupPods=8",
-      "--timeout=90m"
+      "--skew",
+      "--test_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetDowngrade\\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci --minStartupPods=8",
+      "--timeout=120m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:KubeProxyDaemonSetUpgrade\\] --upgrade-target=ci/latest --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -4040,7 +4042,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-latest-upgrade-kube-proxy-ds.env",
       "--extract=ci/latest",
-      "--extract=ci/latest-1.7",
+      "--extract=ci/k8s-stable1",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--test_args=--ginkgo.focus=Networking --ginkgo.skip=Networking-Performance --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds.env
@@ -2,4 +2,4 @@
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 KUBE_NODE_OS_DISTRIBUTION=gci
-KUBE_PROXY_DAEMONSET=true
+KUBE_PROXY_DAEMONSET=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8187,7 +8187,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=110
+      - --timeout=140
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/52226.

As https://github.com/kubernetes/kubernetes/issues/52226#issuecomment-329003830 and https://github.com/kubernetes/kubernetes/issues/52226#issuecomment-329003830 pointed out, it makes more sense to make the job first upgrade and then downgrade.

Also pin the downgrade version to 1.8 branch and upgrade version to master branch, as this migration will be supported in 1.8->1.9.

/assign @krzyzacy 