### PR TITLE
Pin release-1.6 bazel jobs to bazelbuild:v20170728-71064cf4

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1180,7 +1180,7 @@ postsubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4  # https://github.com/kubernetes/kubernetes/issues/51571
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1215,7 +1215,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+        - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4  # https://github.com/kubernetes/kubernetes/issues/51571
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -15857,7 +15857,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+    - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4  # https://github.com/kubernetes/kubernetes/issues/51571
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -15892,7 +15892,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170829-93ec4e74
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170728-71064cf4  # https://github.com/kubernetes/kubernetes/issues/51571
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -487,7 +487,11 @@ func TestBazelbuildArgs(t *testing.T) {
 		}
 	}
 	pinnedJobs := map[string]string{
-	//job: reason for pinning
+		//job: reason for pinning
+		"ci-kubernetes-bazel-build-1-6":       "https://github.com/kubernetes/kubernetes/issues/51571",
+		"ci-kubernetes-bazel-test-1-6":        "https://github.com/kubernetes/kubernetes/issues/51571",
+		"periodic-kubernetes-bazel-build-1-6": "https://github.com/kubernetes/kubernetes/issues/51571",
+		"periodic-kubernetes-bazel-test-1-6":  "https://github.com/kubernetes/kubernetes/issues/51571",
 	}
 	maxTag := ""
 	maxN := 0


### PR DESCRIPTION
bazelbuild:v20170728-71064cf4 appears to contain bazel 0.5.2, which was the last version to work on release-1.6.

x-ref https://github.com/kubernetes/kubernetes/issues/51571

cc @spxtr  @pipejakob @BenTheElder @luxas