### PR TITLE
teach kubetest to use make all

### DIFF
--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -43,7 +43,7 @@ func (b *buildStrategy) Set(value string) error {
 		value = buildDefault
 	}
 	switch value {
-	case "bazel", "quick", "release":
+	case "bazel", "quick", "release", "all":
 		*b = buildStrategy(value)
 		return nil
 	}
@@ -56,7 +56,7 @@ func (b *buildStrategy) Enabled() bool {
 }
 
 // Build kubernetes according to specified strategy.
-// This may be a bazel, quick or full release build depending on --build=B.
+// This may be all, bazel, quick or full release build depending on --build=B.
 func (b *buildStrategy) Build() error {
 	var target string
 	switch *b {
@@ -66,6 +66,8 @@ func (b *buildStrategy) Build() error {
 		target = "quick-release"
 	case "release":
 		target = "release"
+	case "all":
+		target = "all"
 	default:
 		return fmt.Errorf("Unknown build strategy: %v", b)
 	}

--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -43,7 +43,7 @@ func (b *buildStrategy) Set(value string) error {
 		value = buildDefault
 	}
 	switch value {
-	case "bazel", "quick", "release", "all":
+	case "bazel", "quick", "release", "host-go":
 		*b = buildStrategy(value)
 		return nil
 	}
@@ -56,7 +56,7 @@ func (b *buildStrategy) Enabled() bool {
 }
 
 // Build kubernetes according to specified strategy.
-// This may be all, bazel, quick or full release build depending on --build=B.
+// This may be a bazel, host-go, quick or full release build depending on --build=B.
 func (b *buildStrategy) Build() error {
 	var target string
 	switch *b {
@@ -66,7 +66,10 @@ func (b *buildStrategy) Build() error {
 		target = "quick-release"
 	case "release":
 		target = "release"
-	case "all":
+	// you really should use "bazel" or "quick" in most cases, but in CI
+	// we are mimicking these in our job container without an extra level
+	// of sandboxing in some cases
+	case "host-go":
 		target = "all"
 	default:
 		return fmt.Errorf("Unknown build strategy: %v", b)

--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -43,7 +43,7 @@ func (b *buildStrategy) Set(value string) error {
 		value = buildDefault
 	}
 	switch value {
-	case "bazel", "quick", "release", "host-go":
+	case "bazel", "host-go", "quick", "release":
 		*b = buildStrategy(value)
 		return nil
 	}
@@ -62,15 +62,15 @@ func (b *buildStrategy) Build() error {
 	switch *b {
 	case "bazel":
 		target = "bazel-release"
-	case "quick":
-		target = "quick-release"
-	case "release":
-		target = "release"
 	// you really should use "bazel" or "quick" in most cases, but in CI
 	// we are mimicking these in our job container without an extra level
 	// of sandboxing in some cases
 	case "host-go":
 		target = "all"
+	case "quick":
+		target = "quick-release"
+	case "release":
+		target = "release"
 	default:
 		return fmt.Errorf("Unknown build strategy: %v", b)
 	}


### PR DESCRIPTION
This should make it possible to have some jobs build with `make all` in docker on Prow instead of using quick/release on Jenkins. While ideally all jobs should use bazel eventually, this will be useful for older releases.