### PR TITLE
make gce canary job build using host-go on prow

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10291,16 +10291,18 @@
   },
   "pull-kubernetes-e2e-gce-canary": {
     "args": [
+      "--build=host-go",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
       "--env-file=jobs/env/pull-kubernetes-e2e-gce-canary.env",
+      "--extract=local",
       "--gcp-project=k8s-jkns-pr-gce",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=55m",
-      "--use-shared-build=bazel"
+      "--timeout=55m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -286,7 +286,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170912-28a27e20
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -677,7 +677,7 @@ presubmits:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170912-28a27e20
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -90,53 +90,6 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
     run_after_success:
-    - name: pull-kubernetes-e2e-gce-canary
-      agent: kubernetes
-      always_run: true
-      max_concurrency: 8
-      skip_report: true
-      context: pull-kubernetes-e2e-gce-canary
-      rerun_command: "/test pull-kubernetes-e2e-gce-canary"
-      trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-canary),?(\\s+|$)"
-      skip_branches:
-      - release-1.4
-      - release-1.5
-      - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
-      spec:
-        containers:
-        - args:
-          - "--timeout=75"
-          - "--clean"
-          - "--git-cache=/root/.cache/git"
-          - "--job=$(JOB_NAME)"
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--service-account=/etc/service-account/service-account.json"
-          - "--upload=gs://kubernetes-jenkins/pr-logs"
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          - name: USER
-            value: prow
-          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-private
-          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-public
-          image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170913-207d52da
-          volumeMounts:
-          - mountPath: /etc/service-account
-            name: service
-            readOnly: true
-          - mountPath: /etc/ssh-key-secret
-            name: ssh
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
-        - name: ssh
-          secret:
-            defaultMode: 256
-            secretName: ssh-key-secret
     - name: pull-kubernetes-e2e-kubeadm-gce
       agent: kubernetes
       context: pull-kubernetes-e2e-kubeadm-gce
@@ -303,6 +256,52 @@ presubmits:
           path: /mnt/disks/ssd0
         name: cache-ssd
 
+  - name: pull-kubernetes-e2e-gce-canary
+    agent: kubernetes
+    always_run: false
+    max_concurrency: 8
+    skip_report: true
+    context: pull-kubernetes-e2e-gce-canary
+    rerun_command: "/test pull-kubernetes-e2e-gce-canary"
+    trigger: "(?m)^/test pull-kubernetes-e2e-gce-canary,?(\\s+|$)"
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    spec:
+      containers:
+      - args:
+        - "--timeout=75"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170912-28a27e20
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
   - name: pull-kubernetes-e2e-gce-etcd3
     agent: jenkins
     always_run: true
@@ -484,53 +483,6 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
     run_after_success:
-    - name: pull-security-kubernetes-e2e-gce-canary
-      agent: kubernetes
-      always_run: true
-      max_concurrency: 8
-      skip_report: true
-      context: pull-security-kubernetes-e2e-gce-canary
-      rerun_command: "/test pull-security-kubernetes-e2e-gce-canary"
-      trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-canary),?(\\s+|$)"
-      skip_branches:
-      - release-1.4
-      - release-1.5
-      - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
-      spec:
-        containers:
-        - args:
-          - "--timeout=75"
-          - "--clean"
-          - "--git-cache=/root/.cache/git"
-          - "--job=$(JOB_NAME)"
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-          - "--service-account=/etc/service-account/service-account.json"
-          - "--upload=gs://kubernetes-jenkins/pr-logs"
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          - name: USER
-            value: prow
-          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-private
-          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-public
-          image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170913-207d52da
-          volumeMounts:
-          - mountPath: /etc/service-account
-            name: service
-            readOnly: true
-          - mountPath: /etc/ssh-key-secret
-            name: ssh
-            readOnly: true
-        volumes:
-        - name: service
-          secret:
-            secretName: service-account
-        - name: ssh
-          secret:
-            defaultMode: 256
-            secretName: ssh-key-secret
     - name: pull-security-kubernetes-e2e-kubeadm-gce
       agent: kubernetes
       context: pull-security-kubernetes-e2e-kubeadm-gce
@@ -582,7 +534,6 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
-
   - name: pull-security-kubernetes-bazel-test
     agent: kubernetes
     context: pull-security-kubernetes-bazel-test
@@ -696,6 +647,52 @@ presubmits:
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
+  - name: pull-security-kubernetes-e2e-gce-canary
+    agent: kubernetes
+    always_run: false
+    max_concurrency: 8
+    skip_report: true
+    context: pull-security-kubernetes-e2e-gce-canary
+    rerun_command: "/test pull-security-kubernetes-e2e-gce-canary"
+    trigger: "(?m)^/test pull-security-kubernetes-e2e-gce-canary,?(\\s+|$)"
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    spec:
+      containers:
+      - args:
+        - "--timeout=75"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170912-28a27e20
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
   - name: pull-security-kubernetes-e2e-gce-etcd3
     agent: jenkins
     always_run: true


### PR DESCRIPTION
This will let us test e2e with `make all` in a container on prow. If this goes well the next step is to make sure jobs have access to a container with the correct go version for the branch and move jobs that would have used `make quick-release` (IE `kubetest` with `--build` or `--build=quick`) off of Jenkins and onto Prow.

Depends on #4551 