### PR TITLE
Allow parentheses around the WIP pull request prefix

### DIFF
--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	titleRegex = regexp.MustCompile(`(?i)^(\[WIP\]|WIP)`)
+	titleRegex = regexp.MustCompile(`(?i)^\W?WIP\W`)
 )
 
 type event struct {

--- a/prow/plugins/wip/wip-label_test.go
+++ b/prow/plugins/wip/wip-label_test.go
@@ -114,7 +114,19 @@ func TestHasWipPrefix(t *testing.T) {
 			expected: true,
 		},
 		{
+			title:    "WIP: dummy title",
+			expected: true,
+		},
+		{
 			title:    "[WIP] dummy title",
+			expected: true,
+		},
+		{
+			title:    "(WIP) dummy title",
+			expected: true,
+		},
+		{
+			title:    "<WIP> dummy title",
 			expected: true,
 		},
 		{
@@ -124,6 +136,18 @@ func TestHasWipPrefix(t *testing.T) {
 		{
 			title:    "[wip] dummy title",
 			expected: true,
+		},
+		{
+			title:    "(wip) dummy title",
+			expected: true,
+		},
+		{
+			title:    "<wip> dummy title",
+			expected: true,
+		},
+		{
+			title:    "Wipe out GCP project before reusing",
+			expected: false,
 		},
 	}
 


### PR DESCRIPTION
We're seeing developers use `(WIP)` as a prefix.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @kargakis