### PR TITLE
Temporarily reduce pod GC interval

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5,7 +5,7 @@ plank:
 sinker:
   resync_period: 1h
   max_prowjob_age: 48h
-  max_pod_age: 12h
+  max_pod_age: 1h
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Reducing the GC interval because jobs seem to get staled because of node evictions. This should also help us move forward with the plank deployment.

/cc @fejta @krzyzacy @spxtr 
/area prow