### PR TITLE
Bump plank to 0.45

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,7 +21,7 @@ DECK_VERSION             ?= 0.50
 SPLICE_VERSION           ?= 0.27
 TOT_VERSION              ?= 0.5
 HOROLOGIUM_VERSION       ?= 0.8
-PLANK_VERSION            ?= 0.44
+PLANK_VERSION            ?= 0.45
 JENKINS-OPERATOR_VERSION ?= 0.43
 TIDE_VERSION             ?= 0.3
 

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.44
+        image: gcr.io/k8s-prow/plank:0.45
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.44
+        image: gcr.io/k8s-prow/plank:0.45
         args:
         - --dry-run=false
         volumeMounts:


### PR DESCRIPTION
include https://github.com/kubernetes/test-infra/pull/4580

nightly dark-magic

/assign @BenTheElder 
cc @kargakis 