### PR TITLE
Enable slackevents plugin on all repos.

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -47,7 +47,6 @@ plugins:
   kubernetes/kubernetes:
   - trigger
   - release-note
-  - slackevents
 
   kubernetes/test-infra:
   - trigger
@@ -67,6 +66,7 @@ plugins:
   - yuks
   - wip
   - shrug
+  - slackevents
 
   kubernetes-incubator:
   - cla


### PR DESCRIPTION
This won't change which slack channels receive messages, it just allows sig mentions to be detected in any kubernetes repository.
/cc @BenTheElder 