### PR TITLE
Make sinker work if the pods are in another namespace.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -16,7 +16,7 @@ all: build test
 
 
 HOOK_VERSION             ?= 0.165
-SINKER_VERSION           ?= 0.19
+SINKER_VERSION           ?= 0.20
 DECK_VERSION             ?= 0.50
 SPLICE_VERSION           ?= 0.27
 TOT_VERSION              ?= 0.5

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -13,12 +13,21 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.19
+        args:
+        - --build-cluster=/etc/cluster/cluster
+        image: gcr.io/k8s-prow/sinker:0.20
         volumeMounts:
+        - mountPath: /etc/cluster
+          name: cluster
+          readOnly: true
         - name: config
           mountPath: /etc/config
           readOnly: true
       volumes:
+      - name: cluster
+        secret:
+          defaultMode: 420
+          secretName: build-cluster
       - name: config
         configMap:
           name: config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -145,7 +145,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.19
+        image: gcr.io/k8s-prow/sinker:0.20
         volumeMounts:
         - name: config
           mountPath: /etc/config


### PR DESCRIPTION
We didn't notice this because plank was cleaning up pods.
/area prow