### PR TITLE
make a bazel version of pull-kubernetes-e2e-gce-etcd3 for master

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10344,6 +10344,27 @@
       "UNKNOWN"
     ]
   },
+  "pull-kubernetes-e2e-gce-etcd3-bazel": {
+    "args": [
+      "--build=bazel",
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/pull-kubernetes-e2e.env",
+      "--env-file=jobs/env/pull-kubernetes-e2e-gce-etcd3-bazel.env",
+      "--extract=local",
+      "--gcp-project=k8s-jkns-pr-gce-etcd3",
+      "--gcp-zone=us-central1-f",
+      "--mode=docker",
+      "--provider=gce",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-etcd3-bazel",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  },
   "pull-kubernetes-e2e-gce-gci": {
     "args": [
       "--build",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -636,6 +636,10 @@ class JobTest(unittest.TestCase):
     def test_all_project_are_unique(self):
         # pylint: disable=line-too-long
         allowed_list = {
+            # intentionally shared across prow / jenkins variants
+            'pull-kubernetes-e2e-gce-etcd3': 'pull-kubernetes-e2e-gce-etcd3*',
+            'pull-kubernetes-e2e-gce-etcd3-bazel': 'pull-kubernetes-e2e-gce-etcd3*',
+
             # The cos image validation jobs intentionally share projects.
             'ci-kubernetes-e2e-gce-cosdev-k8sdev-default': 'ci-kubernetes-e2e-gce-cos*',
             'ci-kubernetes-e2e-gce-cosdev-k8sdev-serial': 'ci-kubernetes-e2e-gce-cos*',

--- a/jobs/env/pull-kubernetes-e2e-gce-etcd3-bazel.env
+++ b/jobs/env/pull-kubernetes-e2e-gce-etcd3-bazel.env
@@ -1,0 +1,6 @@
+# Force to use container-vm.
+KUBE_NODE_OS_DISTRIBUTION=debian
+
+# Panic if anything mutates a shared informer cache
+ENABLE_CACHE_MUTATION_DETECTOR=true
+

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -346,6 +346,50 @@ presubmits:
     context: pull-kubernetes-e2e-gce-etcd3
     rerun_command: "/test pull-kubernetes-e2e-gce-etcd3"
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-etcd3),?(\\s+|$)"
+  - name: pull-kubernetes-e2e-gce-etcd3-bazel
+    agent: kubernetes
+    branches:
+    - master
+    always_run: true
+    skip_report: true
+    context: pull-kubernetes-e2e-gce-etcd3-bazel
+    rerun_command: "/test pull-kubernetes-e2e-gce-etcd3-bazel"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-etcd3-bazel),?(\\s+|$)"
+    spec:
+      containers:
+      - args:
+        - "--timeout=90"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
   - name: pull-kubernetes-e2e-gce-gci
     agent: jenkins
     context: pull-kubernetes-e2e-gce-gci
@@ -775,6 +819,50 @@ presubmits:
     context: pull-security-kubernetes-e2e-gce-etcd3
     rerun_command: "/test pull-security-kubernetes-e2e-gce-etcd3"
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-etcd3),?(\\s+|$)"
+  - name: pull-security-kubernetes-e2e-gce-etcd3-bazel
+    agent: kubernetes
+    branches:
+    - master
+    always_run: true
+    skip_report: true
+    context: pull-security-kubernetes-e2e-gce-etcd3-bazel
+    rerun_command: "/test pull-security-kubernetes-e2e-gce-etcd3-bazel"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-etcd3-bazel),?(\\s+|$)"
+    spec:
+      containers:
+      - args:
+        - "--timeout=90"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        image: gcr.io/k8s-testimages/kubekins-e2e-prow:latest
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
   - name: pull-security-kubernetes-e2e-gce-gci
     agent: jenkins
     context: pull-security-kubernetes-e2e-gce-gci

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1618,6 +1618,9 @@ test_groups:
 - name: pull-kubernetes-e2e-gce-etcd3
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-etcd3
   days_of_results: 1
+- name: pull-kubernetes-e2e-gce-etcd3-bazel
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-etcd3-bazel
+  days_of_results: 1
 - name: pull-kubernetes-e2e-gce-gci
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-gci
   days_of_results: 1
@@ -4120,6 +4123,9 @@ dashboards:
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-etcd3
     test_group_name: pull-kubernetes-e2e-gce-etcd3
+    base_options: 'width=10'
+  - name: pull-kubernetes-e2e-gce-etcd3-bazel
+    test_group_name: pull-kubernetes-e2e-gce-etcd3-bazel
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-gci
     test_group_name: pull-kubernetes-e2e-gce-gci


### PR DESCRIPTION
if this works well we can move more jobs to using bazel when testing against master and branch off older releases as needed