### PR TITLE
Support append --num-nodes to empty testargs

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -223,9 +223,8 @@ func newGKE(provider, project, zone, region, network, image, cluster string, tes
 
 	// set --num-nodes flag for ginkgo, since NUM_NODES is not set for gke deployer.
 	numNodes := strconv.Itoa(g.shape[defaultPool].Nodes)
-	if *testArgs != "" {
-		*testArgs = strings.Join(setFieldDefault(strings.Fields(*testArgs), "--num-nodes", numNodes), " ")
-	}
+	// testArgs can be empty, and we need to support this case
+	*testArgs = strings.Join(setFieldDefault(strings.Fields(*testArgs), "--num-nodes", numNodes), " ")
 
 	if *upgradeArgs != "" {
 		*upgradeArgs = strings.Join(setFieldDefault(strings.Fields(*upgradeArgs), "--num-nodes", numNodes), " ")


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/4500/files actually caused this regression - some test does not set `--test_args`, and later on wait for ginkgo to default that to something :confused: 

/assign @zmerlynn 

cc @yujuhong @crimsonfaith91 