### PR TITLE
Specify storage media type for 1.8 GCE upgrade jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3087,6 +3087,7 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/k8s-stable1",
       "--extract=ci/k8s-stable2",
@@ -3106,6 +3107,7 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/k8s-stable1",
       "--extract=ci/k8s-stable2",
@@ -3125,6 +3127,7 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/k8s-stable1",
       "--extract=ci/k8s-stable2",


### PR DESCRIPTION
The GCE upgrade script still errors/prompts if you default to proto
storage with etcd3. To get around this, we explicitly indicate we want
proto storage.

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master/1281#master-upgrade-sig-cluster-lifecycle-master-upgrade for how this fails.

```
Expected error:
    <*errors.errorString | 0xc42023ea20>: {
        s: "error running /workspace/kubernetes_skew/cluster/gce/upgrade.sh [-M v1.8.0-beta.1.276+d064982571d6e1]; got error exit status 1, stdout \"The default etcd storage media type in 1.6 has changed from application/json to application/vnd.kubernetes.protobuf.\\nDocumentation about the change can be found at https://kubernetes.io/docs/admin/etcd_upgrade.\\n\\nETCD2 DOES NOT SUPPORT PROTOBUF: If you wish to have to ability to downgrade to etcd2 later application/json must be used.\\n\\nIt's HIGHLY recommended that etcd be backed up before this step!!\\n\\nTo enable using json, before running this script set:\\nexport STORAGE_MEDIA_TYPE=application/json\\n\\nTo enable using protobuf, before running this script set:\\nexport STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf\\n\\n\", stderr \"STORAGE_MEDIA_TYPE must be specified when run non-interactively.\\n\"",
    }
    error running /workspace/kubernetes_skew/cluster/gce/upgrade.sh [-M v1.8.0-beta.1.276+d064982571d6e1]; got error exit status 1, stdout "The default etcd storage media type in 1.6 has changed from application/json to application/vnd.kubernetes.protobuf.\nDocumentation about the change can be found at https://kubernetes.io/docs/admin/etcd_upgrade.\n\nETCD2 DOES NOT SUPPORT PROTOBUF: If you wish to have to ability to downgrade to etcd2 later application/json must be used.\n\nIt's HIGHLY recommended that etcd be backed up before this step!!\n\nTo enable using json, before running this script set:\nexport STORAGE_MEDIA_TYPE=application/json\n\nTo enable using protobuf, before running this script set:\nexport STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf\n\n", stderr "STORAGE_MEDIA_TYPE must be specified when run non-interactively.\n"
not to have occurred

k8s.io/kubernetes/test/e2e/lifecycle.glob..func2.3.1.1()
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/lifecycle/cluster_upgrade.go:137 +0xfe
k8s.io/kubernetes/test/e2e/chaosmonkey.(*chaosmonkey).Do(0xc421895280)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/chaosmonkey/chaosmonkey.go:110 +0x3e9
k8s.io/kubernetes/test/e2e/lifecycle.runUpgradeSuite(0xc4201f8a20, 0x5a897c0, 0xb, 0xb, 0xc420d455f0, 0xc4213ba1e0, 0xc421421c40, 0x2, 0xc421421960)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/lifecycle/cluster_upgrade.go:407 +0x63a
k8s.io/kubernetes/test/e2e/lifecycle.glob..func2.3.1()
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/lifecycle/cluster_upgrade.go:142 +0x284
k8s.io/kubernetes/test/e2e.RunE2ETests(0xc420ec2750)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e.go:371 +0x219
k8s.io/kubernetes/test/e2e.TestE2E(0xc420ec2750)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e_test.go:47 +0x2b
testing.tRunner(0xc420ec2750, 0x3d31450)
	/usr/local/go/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:697 +0x2ca
```

/assign @krzyzacy 