### PR TITLE
Bump timeout for gce-gci-serial-stable1 job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -134,7 +134,7 @@
         max-total: 12
         job-name: pull-kubernetes-cross
         repo-name: 'k8s.io/kubernetes'
-        timeout: 80
+        timeout: 90
     - kubernetes-e2e-kops-aws:
         max-total: 12
         job-name: pull-kubernetes-e2e-kops-aws

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
@@ -70,7 +70,7 @@
         max-total: 12
         job-name: pull-kubernetes-cross
         repo-name: 'github.com/kubernetes-security/kubernetes'
-        timeout: 80
+        timeout: 90
     - kubernetes-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-e2e-gce

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4366,7 +4366,7 @@
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
-      "--timeout=300m"
+      "--timeout=500m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8970,7 +8970,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=320
+      - --timeout=520
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
misconfigured, agree with @abgworrall we will want a unified timeout for all serial jobs, will look into that in 1.9 dev cycle.

fixes https://github.com/kubernetes/kubernetes/issues/52734

/assign @BenTheElder 