### PR TITLE
Use preloaded gpu image for device-plugin testing.

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-device-plugin-gpu.env
@@ -1,4 +1,6 @@
 ### job-env
 KUBE_FEATURE_GATES=DevicePlugins=true
 KUBE_NODE_OS_DISTRIBUTION=gci
+KUBE_GCE_NODE_IMAGE=gke-1-8-0-beta-1-cos-stable-60-9592-90-0-preloaded-nvidia-gpu
+KUBE_GCE_NODE_PROJECT=gke-node-images
 NODE_ACCELERATORS=type=nvidia-tesla-k80,count=2


### PR DESCRIPTION
This image has the nvidia driver installer container image preloaded.
This image also allows loading untrusted kernel modules.
Both these things make the usage of the image faster for gpus.
We will use such preloaded images for gpu clusters in GKE and recommend them for gpu clusters in GCE.