### PR TITLE
convert pull-kubernetes-e2e-gce-gpu to prow

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -90,11 +90,6 @@
         job-name: pull-kubernetes-e2e-gce-etcd3
         repo-name: 'k8s.io/kubernetes'
         timeout: 85
-    - kubernetes-e2e-gce-gpu:
-        max-total: 12
-        job-name: pull-kubernetes-e2e-gce-gpu
-        repo-name: 'k8s.io/kubernetes'
-        timeout: 80
     - kubernetes-federation-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-federation-e2e-gce

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
@@ -86,11 +86,6 @@
         job-name: pull-kubernetes-e2e-gce-etcd3
         repo-name: 'github.com/kubernetes-security/kubernetes'
         timeout: 85
-    - kubernetes-e2e-gce-gpu:
-        max-total: 12
-        job-name: pull-kubernetes-e2e-gce-gpu
-        repo-name: 'github.com/kubernetes-security/kubernetes'
-        timeout: 80
     - kubernetes-e2e-kops-aws:
         max-total: 12
         job-name: pull-kubernetes-e2e-kops-aws

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10247,27 +10247,6 @@
   },
   "pull-kubernetes-e2e-gce-gpu": {
     "args": [
-      "--build",
-      "--cluster=",
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/env/pull-kubernetes-e2e.env",
-      "--env-file=jobs/env/pull-kubernetes-e2e-gce-gpu.env",
-      "--extract=local",
-      "--gcp-project=k8s-jkns-pr-gce-gpus",
-      "--gcp-zone=us-west1-b",
-      "--mode=docker",
-      "--provider=gce",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gpu",
-      "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
-      "--timeout=60m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-scheduling"
-    ]
-  },
-  "pull-kubernetes-e2e-gce-gpu-prow": {
-    "args": [
       "--build=bazel",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
@@ -10277,7 +10256,7 @@
       "--gcp-project=k8s-jkns-pr-gce-gpus",
       "--gcp-zone=us-west1-b",
       "--provider=gce",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gpu-prow",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-gpu",
       "--test_args=--ginkgo.focus=\\[Feature:GPU\\] --minStartupPods=8",
       "--timeout=60m"
     ],

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -670,11 +670,6 @@ class JobTest(unittest.TestCase):
     def test_all_project_are_unique(self):
         # pylint: disable=line-too-long
         allowed_list = {
-            # these jobs need to share the gpu project while we test the prow one
-            # the prow one is manually triggered anyhow
-            'pull-kubernetes-e2e-gce-gpu': 'pull-kubernetes-e2e-gce-gpu*',
-            'pull-kubernetes-e2e-gce-gpu-prow': 'pull-kubernetes-e2e-gce-gpu*',
-
             # The cos image validation jobs intentionally share projects.
             'ci-kubernetes-e2e-gce-cosdev-k8sdev-default': 'ci-kubernetes-e2e-gce-cos*',
             'ci-kubernetes-e2e-gce-cosdev-k8sdev-serial': 'ci-kubernetes-e2e-gce-cos*',

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -352,21 +352,17 @@ presubmits:
     rerun_command: "/test pull-kubernetes-e2e-gce-gci"
     trigger: "(?m)^/test pull-kubernetes-e2e-gce-gci,?(\\s+|$)"
   - name: pull-kubernetes-e2e-gce-gpu
-    agent: jenkins
-    always_run: false
-    context: pull-kubernetes-e2e-gce-gpu
-    rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
-    trigger: "(?m)^/test pull-kubernetes-e2e-gce-gpu,?(\\s+|$)"
-  - name: pull-kubernetes-e2e-gce-gpu-prow
     agent: kubernetes
     skip_branches:
     - release-1.4
     - release-1.5
     - release-1.6
-    always_run: false
-    context: pull-kubernetes-e2e-gce-gpu-prow
-    rerun_command: "/test pull-kubernetes-e2e-gce-gpu-prow"
-    trigger: "(?m)^/test pull-kubernetes-e2e-gce-gpu-prow,?(\\s+|$)"
+    always_run: true
+    skip_report: true
+    max_concurrency: 12
+    context: pull-kubernetes-e2e-gce-gpu
+    rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170918-d0ba8897
@@ -841,21 +837,17 @@ presubmits:
     rerun_command: "/test pull-security-kubernetes-e2e-gce-gci"
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gce-gci,?(\\s+|$)"
   - name: pull-security-kubernetes-e2e-gce-gpu
-    agent: jenkins
-    always_run: false
-    context: pull-security-kubernetes-e2e-gce-gpu
-    rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
-    trigger: "(?m)^/test pull-security-kubernetes-e2e-gce-gpu,?(\\s+|$)"
-  - name: pull-security-kubernetes-e2e-gce-gpu-prow
     agent: kubernetes
     skip_branches:
     - release-1.4
     - release-1.5
     - release-1.6
-    always_run: false
-    context: pull-security-kubernetes-e2e-gce-gpu-prow
-    rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-e2e-gce-gpu-prow,?(\\s+|$)"
+    always_run: true
+    skip_report: true
+    max_concurrency: 12
+    context: pull-security-kubernetes-e2e-gce-gpu
+    rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170918-d0ba8897

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1612,9 +1612,6 @@ test_groups:
 - name: pull-kubernetes-e2e-gce-gpu
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-gpu
   days_of_results: 1
-- name: pull-kubernetes-e2e-gce-gpu-prow
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gce-gpu-prow
-  days_of_results: 1
 - name: pull-kubernetes-e2e-gke-gpu
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-gke-gpu
   days_of_results: 1
@@ -4099,9 +4096,6 @@ dashboards:
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gce-gpu
     test_group_name: pull-kubernetes-e2e-gce-gpu
-    base_options: 'width=10'
-  - name: pull-kubernetes-e2e-gce-gpu-prow
-    test_group_name: pull-kubernetes-e2e-gce-gpu-prow
     base_options: 'width=10'
   - name: pull-kubernetes-e2e-gke-gpu
     test_group_name: pull-kubernetes-e2e-gke-gpu


### PR DESCRIPTION
This will put the gpu job back to `always_run: true` but on Prow now instead of Jenkins :-)
/assign @krzyzacy 
/cc @mindprince 
ref: https://github.com/kubernetes/test-infra/issues/4642#issuecomment-330716188