### PR TITLE
make it easy to override the image tag in planter

### DIFF
--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -19,8 +19,8 @@
 set -o errexit
 set -o nounset
 IMAGE_NAME="gcr.io/k8s-testimages/planter"
-VERSION="0.5.4-1"
-IMAGE="${IMAGE_NAME}:${VERSION}"
+TAG="${TAG:-0.5.4-1}"
+IMAGE="${IMAGE_NAME}:${TAG}"
 # run our docker image as the host user with bazel cache and current repo dir
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
 REPO=${REPO:-${PWD}}


### PR DESCRIPTION
this allows you to do:
```sh
TAG=0.6.0rc2-1 ./planter/planter.sh bazel version
.
Build label: 0.6.0rc2
Build target: bazel-out/local-fastbuild/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Mon Sep 18 13:25:41 2017 (1505741141)
Build timestamp: 1505741141
Build timestamp as int: 1505741141
```