### PR TITLE
move gke-gpu to prow and report status for gpu jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -70,11 +70,6 @@
         job-name: pull-kubernetes-e2e-gke-gci
         repo-name: 'k8s.io/kubernetes'
         timeout: 75
-    - kubernetes-e2e-gke-gpu:
-        max-total: 1
-        job-name: pull-kubernetes-e2e-gke-gpu
-        repo-name: 'k8s.io/kubernetes'
-        timeout: 80
     - kubernetes-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-e2e-gce

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10450,7 +10450,7 @@
   },
   "pull-kubernetes-e2e-gke-gpu": {
     "args": [
-      "--build",
+      "--build=bazel",
       "--cluster=",
       "--deployment=gke",
       "--extract=local",
@@ -10460,7 +10460,6 @@
       "--gcp-zone=us-west1-b",
       "--gke-create-command=alpha container clusters create --quiet --enable-kubernetes-alpha --accelerator=type=nvidia-tesla-k80,count=2",
       "--gke-environment=test",
-      "--mode=docker",
       "--provider=gke",
       "--stage=gs://kubernetes-release-dev/ci",
       "--stage-suffix=pull-gke-gpu",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -319,7 +319,7 @@ presubmits:
     - release-1.5
     - release-1.6
     always_run: true
-    skip_report: true
+    skip_report: false
     max_concurrency: 12
     context: pull-kubernetes-e2e-gce-gpu
     rerun_command: "/test pull-kubernetes-e2e-gce-gpu"
@@ -374,6 +374,7 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+
   - name: pull-kubernetes-e2e-gke
     agent: jenkins
     context: pull-kubernetes-e2e-gke
@@ -385,10 +386,68 @@ presubmits:
     rerun_command: "/test pull-kubernetes-e2e-gke-gci"
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-gci,?(\\s+|$)"
   - name: pull-kubernetes-e2e-gke-gpu
-    agent: jenkins
+    agent: kubernetes
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    - release-1.6
+    always_run: false
+    skip_report: false
+    max_concurrency: 1
     context: pull-kubernetes-e2e-gke-gpu
     rerun_command: "/test pull-kubernetes-e2e-gke-gpu"
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-gpu,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170918-d0ba8897
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   - name: pull-kubernetes-e2e-kops-aws
     agent: jenkins
     always_run: true
@@ -774,7 +833,7 @@ presubmits:
     - release-1.5
     - release-1.6
     always_run: true
-    skip_report: true
+    skip_report: false
     max_concurrency: 12
     context: pull-security-kubernetes-e2e-gce-gpu
     rerun_command: "/test pull-security-kubernetes-e2e-gce-gpu"
@@ -829,6 +888,7 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+
   - name: pull-security-kubernetes-e2e-gke
     agent: jenkins
     context: pull-security-kubernetes-e2e-gke
@@ -840,10 +900,68 @@ presubmits:
     rerun_command: "/test pull-security-kubernetes-e2e-gke-gci"
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-gci,?(\\s+|$)"
   - name: pull-security-kubernetes-e2e-gke-gpu
-    agent: jenkins
+    agent: kubernetes
+    skip_branches:
+    - release-1.4
+    - release-1.5
+    - release-1.6
+    always_run: false
+    skip_report: false
+    max_concurrency: 1
     context: pull-security-kubernetes-e2e-gke-gpu
     rerun_command: "/test pull-security-kubernetes-e2e-gke-gpu"
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-gpu,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e-prow:v20170918-d0ba8897
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   - name: pull-security-kubernetes-e2e-kops-aws
     agent: jenkins
     always_run: true


### PR DESCRIPTION
The gce-gpu job has been working great on Prow, let's flip it back to reporting the status and move the gke-gpu job to prow.