### PR TITLE
Fixup some kubeadm upgrade job bugs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10108,50 +10108,6 @@
       "UNKNOWN"
     ]
   },
-  "periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.6",
-      "--extract=ci/latest-1.7",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=periodic",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-1.6",
-      "--kubernetes-anywhere-kubernetes-version=latest-1.6",
-      "--kubernetes-anywhere-upgrade-method=init",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--timeout=300m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\]|\\[Conformance\\] --upgrade-target=ci/latest-1.7"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
-  "periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8": {
-    "args": [
-      "--cluster=",
-      "--deployment=kubernetes-anywhere",
-      "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.7",
-      "--extract=ci/latest-1.8",
-      "--gcp-zone=us-central1-f",
-      "--kubeadm=periodic",
-      "--kubernetes-anywhere-kubelet-ci-version=latest-1.7",
-      "--kubernetes-anywhere-kubernetes-version=latest-1.7",
-      "--kubernetes-anywhere-upgrade-method=upgrade",
-      "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
-      "--timeout=300m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\]|\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --upgrade-target=ci/latest-1.8"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-cluster-lifecycle"
-    ]
-  },
   "periodic-kubernetes-bazel-build-1-6": {
     "args": [
       "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/...",
@@ -10265,6 +10221,50 @@
       "--provider=kubernetes-anywhere",
       "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
       "--timeout=300m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=periodic",
+      "--kubernetes-anywhere-kubelet-ci-version=latest-1.6",
+      "--kubernetes-anywhere-kubernetes-version=latest-1.6",
+      "--kubernetes-anywhere-upgrade-method=init",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\]|\\[Conformance\\] --upgrade-target=ci/latest-1.7"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
+  "periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest-1.7",
+      "--extract=ci/latest-1.8",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=periodic",
+      "--kubernetes-anywhere-kubelet-ci-version=latest-1.7",
+      "--kubernetes-anywhere-kubernetes-version=latest-1.7",
+      "--kubernetes-anywhere-upgrade-method=upgrade",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
+      "--timeout=300m",
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\]|\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --upgrade-target=ci/latest-1.8"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16801,13 +16801,13 @@ periodics:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
-    - name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+    - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
       agent: kubernetes
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170921-fe3862d9
           args:
-          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--repo=k8s.io/kubernetes=release-1.7"
           - "--clean"
           - "--git-cache=/root/.cache/git"
           - "--timeout=320"
@@ -16963,13 +16963,13 @@ periodics:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  - name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
     agent: kubernetes
     spec:
       containers:
       - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170921-fe3862d9
         args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
         - "--git-cache=/root/.cache/git"
         - "--timeout=320"

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1098,10 +1098,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-latest-rollback-etcd
 - name: ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-1-5-rollback-etcd
-- name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-  gcs_prefix: kubernetes-jenkins/logs/periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-- name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
-  gcs_prefix: kubernetes-jenkins/logs/periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+- name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
 # charts tests
 - name: ci-kubernetes-charts-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-charts-gce
@@ -2883,6 +2883,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
   - name: periodic-gce-kubeadm-1.8
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-8
+  - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: gci-gce-1.8
     test_group_name: ci-kubernetes-e2e-gci-gce-stable1
   - name: gci-gce-slow-1.8
@@ -2980,6 +2982,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
   - name: periodic-gce-kubeadm-1.8
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-8
+  - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: gci-gce-1.8
     test_group_name: ci-kubernetes-e2e-gci-gce-stable1
   - name: gci-gce-slow-1.8
@@ -3315,10 +3319,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: ci-gce-kubeadm-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
-  - name: periodic-ci-gce-kubeadm-upgrade-1.6-1.7
-    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-  - name: periodic-ci-gce-kubeadm-upgrade-1.7-1.8
-    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+  - name: periodic-kubernetes-e2e-gce-kubeadm-upgrade-1-6-1-7
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
   - name: ci-bazel-build-1.7
     test_group_name: ci-kubernetes-bazel-build-1-7
   - name: ci-bazel-test-1.7
@@ -3360,9 +3362,7 @@ dashboards:
   - name: gce-kubeadm-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: gce-kubeadm-upgrade-1.6-1.7
-    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-  - name: gce-kubeadm-upgrade-1.7-1.8
-    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
   - name: kubelet-1.7
     test_group_name: ci-kubernetes-node-kubelet-1.7
   - name: aws-release-1-7
@@ -3731,15 +3731,15 @@ dashboards:
   - name: kubeadm-gce-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: kubeadm-gce-upgrade-1.6-1.7
-    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-  - name: kubeadm-gce-upgrade-1.7-1.8
-    test_group_name: periodic-ci-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
   - name: kubeadm-gce-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
   - name: periodic-kubeadm-gce-1.7
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-7
   - name: kubeadm-gce-1.7-on-1.8
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
+  - name: kubeadm-gce-upgrade-1.7-1.8
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   - name: kubeadm-gce-1.8
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8
   - name: periodic-kubeadm-gce-1.8


### PR DESCRIPTION
1. Renames `periodic-{ci-,}kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7` and `periodic-{ci-,}kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8`. The ci shouldn't have been there
2. Actually specify the repo and release branch manually in periodic jobs like done elsewhere
3. Remove v1.7->v1.8 jobs from release-1.7 dashboard
4. Add v1.7->v1.8 to release-1.8 dashboard

cc @jessicaochen @pipejakob @krzyzacy 