### PR TITLE
Fix workspace consistency in kops-e2e-runner

### DIFF
--- a/jenkins/e2e-image/kops-e2e-runner.sh
+++ b/jenkins/e2e-image/kops-e2e-runner.sh
@@ -34,11 +34,11 @@ if [[ -z "${KOPS_BASE_URL:-}" ]]; then
   fi
 fi
 
-curl -fsS --retry 3 -o "${WORKSPACE}/kops" "${KOPS_BASE_URL}/linux/amd64/kops"
-chmod +x "${WORKSPACE}/kops"
+curl -fsS --retry 3 -o "/workspace/kops" "${KOPS_BASE_URL}/linux/amd64/kops"
+chmod +x "/workspace/kops"
 
 # Get kubectl on the path (works after e2e-runner.sh:unpack_binaries)
-export PRIORITY_PATH="/workspace/kubernetes/platforms/linux/amd64"
+export PRIORITY_PATH="${WORKSPACE}/kubernetes/platforms/linux/amd64"
 
 e2e_args=( \
   --deployment=kops \


### PR DESCRIPTION
So kops need to be in `/workspace` while kubernetes is checked out from `${WORKSPACE}`

/assign @ixdy @BenTheElder 