### PR TITLE
Set the right kubelet version for the kubeadm PR job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10532,7 +10532,6 @@
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=30",
       "--kubeadm=pull",
-      "--kubernetes-anywhere-kubelet-ci-version=latest",
       "--kubernetes-anywhere-kubernetes-version=ci/latest",
       "--provider=kubernetes-anywhere",
       "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\] --minStartupPods=8",

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -578,6 +578,13 @@ def main(args):
             '--kubernetes-anywhere-kubeadm-version=%s' % version,
         ])
 
+        if args.kubeadm == "pull":
+            # If this is a pull job; the kubelet version should equal
+            # the kubeadm version here: we should use debs from the PR build
+            runner_args.extend([
+                '--kubernetes-anywhere-kubelet-version=%s' % version,
+            ])
+
     if args.aws:
         set_up_aws(args, mode, cluster, runner_args)
     elif args.gce_ssh:


### PR DESCRIPTION
cc @jessicaochen @pipejakob @krzyzacy 
This is needed so that the PR job actually uses the kubelet & other debs from the PR, not post-commit `ci/latest`