### PR TITLE
Build hyperkube image in build-1.8 job

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -113,7 +113,7 @@
         giturl: 'https://github.com/kubernetes/kubernetes'
         job-name: ci-kubernetes-build-1.8
         repo-name: k8s.io/kubernetes
-        timeout: 100
+        timeout: 120
 
     - kubernetes-federation-build:
         branch: master

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -152,6 +152,7 @@
   "ci-kubernetes-build-1.8": {
     "args": [
       "--extra-publish-file=k8s-stable1",
+      "--hyperkube",
       "--registry=gcr.io/kubernetes-ci-images"
     ],
     "scenario": "kubernetes_build",


### PR DESCRIPTION
Followup to #4420 and #4442 - we should be building/pushing the hyperkube image, too.

(A bit late in the release cycle, but it'd be good to have this in the template for 1.9. Also, it'll still be useful as master diverges from 1.8.)

/assign @krzyzacy 
cc @luxas 