### PR TITLE
Make prow config location configurable

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -31,6 +31,10 @@ label:
   # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
   milestone_maintainers_id: 2460384
 
+config_updater:
+  config_file: prow/config.yaml
+  plugin_file: prow/plugins.yaml
+
 plugins:
   google/cadvisor:
   - trigger

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -18,9 +18,10 @@ package updateconfig
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"strings"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
@@ -186,7 +187,7 @@ func TestUpdateConfig(t *testing.T) {
 			maps: map[string]kube.ConfigMap{},
 		}
 
-		if err := handle(fgc, fkc, log, event); err != nil {
+		if err := handle(fgc, fkc, log, event, "prow/config.yaml", "prow/plugins.yaml"); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
/cc @stevekuznetsov @spxtr 
/area prow

I don't feel strong about making this configurable but at least we won't need to change anything once defaults change to something else (I've heard rumours of having a `.prow.yml` file at the root of a repo).