### PR TITLE
move release-*-kubeadm jobs to be in parallel with bazel-test

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1521,50 +1521,49 @@ postsubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
-      run_after_success:
-      - name: ci-kubernetes-e2e-kubeadm-gce-1-6
-        agent: kubernetes
-        spec:
-          containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
-            args:
-            - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-            - "--clean"
-            - "--git-cache=/root/.cache/git"
-            - "--timeout=320"
-            - "--upload=gs://kubernetes-jenkins/logs"
-            env:
-            - name: USER
-              value: prow
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/service-account/service-account.json
-            - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-private
-            - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-public
-            volumeMounts:
-            - name: service
-              mountPath: /etc/service-account
-              readOnly: true
-            - name: ssh
-              mountPath: /etc/ssh-key-secret
-              readOnly: true
-            - name: cache-ssd
-              mountPath: /root/.cache
-            ports:
-            - containerPort: 9999
-              hostPort: 9999
-          volumes:
+    - name: ci-kubernetes-e2e-kubeadm-gce-1-6
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--timeout=320"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          volumeMounts:
           - name: service
-            secret:
-              secretName: service-account
+            mountPath: /etc/service-account
+            readOnly: true
           - name: ssh
-            secret:
-              secretName: ssh-key-secret
-              defaultMode: 0400
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
           - name: cache-ssd
-            hostPath:
-              path: /mnt/disks/ssd0
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
 
   - name: ci-kubernetes-bazel-build-1-7
     agent: kubernetes
@@ -1640,93 +1639,92 @@ postsubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
-      run_after_success:
-      - name: ci-kubernetes-e2e-kubeadm-gce-1-7
-        agent: kubernetes
-        spec:
-          containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
-            args:
-            - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-            - "--clean"
-            - "--git-cache=/root/.cache/git"
-            - "--timeout=320"
-            - "--upload=gs://kubernetes-jenkins/logs"
-            env:
-            - name: USER
-              value: prow
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/service-account/service-account.json
-            - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-private
-            - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-public
-            volumeMounts:
-            - name: service
-              mountPath: /etc/service-account
-              readOnly: true
-            - name: ssh
-              mountPath: /etc/ssh-key-secret
-              readOnly: true
-            - name: cache-ssd
-              mountPath: /root/.cache
-            ports:
-            - containerPort: 9999
-              hostPort: 9999
-          volumes:
+    - name: ci-kubernetes-e2e-kubeadm-gce-1-7
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--timeout=320"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          volumeMounts:
           - name: service
-            secret:
-              secretName: service-account
+            mountPath: /etc/service-account
+            readOnly: true
           - name: ssh
-            secret:
-              secretName: ssh-key-secret
-              defaultMode: 0400
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
           - name: cache-ssd
-            hostPath:
-              path: /mnt/disks/ssd0
-      - name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
-        agent: kubernetes
-        spec:
-          containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
-            args:
-            - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-            - "--clean"
-            - "--git-cache=/root/.cache/git"
-            - "--timeout=320"
-            - "--upload=gs://kubernetes-jenkins/logs"
-            env:
-            - name: USER
-              value: prow
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/service-account/service-account.json
-            - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-private
-            - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-              value: /etc/ssh-key-secret/ssh-public
-            volumeMounts:
-            - name: service
-              mountPath: /etc/service-account
-              readOnly: true
-            - name: ssh
-              mountPath: /etc/ssh-key-secret
-              readOnly: true
-            - name: cache-ssd
-              mountPath: /root/.cache
-            ports:
-            - containerPort: 9999
-              hostPort: 9999
-          volumes:
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+    - name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--timeout=320"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          volumeMounts:
           - name: service
-            secret:
-              secretName: service-account
+            mountPath: /etc/service-account
+            readOnly: true
           - name: ssh
-            secret:
-              secretName: ssh-key-secret
-              defaultMode: 0400
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
           - name: cache-ssd
-            hostPath:
-              path: /mnt/disks/ssd0
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
 
   - name: ci-kubernetes-bazel-build-1-8
     agent: kubernetes
@@ -16635,52 +16633,51 @@ periodics:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-    run_after_success:
-    - name: periodic-kubernetes-e2e-kubeadm-gce-1-6
-      agent: kubernetes
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
-          args:
-          - "--repo=k8s.io/kubernetes=release-1.6"
-          - "--clean"
-          - "--git-cache=/root/.cache/git"
-          - "--timeout=320"
-          - "--upload=gs://kubernetes-jenkins/logs"
-          env:
-          - name: USER
-            value: prow
-          - name: REPO_NAME
-            value: kubernetes=release-1.6
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-private
-          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-public
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-          - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
+  - name: periodic-kubernetes-e2e-kubeadm-gce-1-6
+    agent: kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
+        args:
+        - "--repo=k8s.io/kubernetes=release-1.6"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--timeout=320"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        env:
+        - name: USER
+          value: prow
+        - name: REPO_NAME
+          value: kubernetes=release-1.6
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
         - name: service
-          secret:
-            secretName: service-account
+          mountPath: /etc/service-account
+          readOnly: true
         - name: ssh
-          secret:
-            secretName: ssh-key-secret
-            defaultMode: 0400
+          mountPath: /etc/ssh-key-secret
+          readOnly: true
         - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          secretName: ssh-key-secret
+          defaultMode: 0400
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
 
 - name: periodic-kubernetes-bazel-build-1-7
   interval: 2h
@@ -16755,95 +16752,94 @@ periodics:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-    run_after_success:
-    - name: periodic-kubernetes-e2e-kubeadm-gce-1-7
-      agent: kubernetes
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
-          args:
-          - "--repo=k8s.io/kubernetes=release-1.7"
-          - "--clean"
-          - "--git-cache=/root/.cache/git"
-          - "--timeout=320"
-          - "--upload=gs://kubernetes-jenkins/logs"
-          env:
-          - name: USER
-            value: prow
-          - name: REPO_NAME
-            value: kubernetes=release-1.7
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-private
-          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-public
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-          - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
+  - name: periodic-kubernetes-e2e-kubeadm-gce-1-7
+    agent: kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
+        args:
+        - "--repo=k8s.io/kubernetes=release-1.7"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--timeout=320"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        env:
+        - name: USER
+          value: prow
+        - name: REPO_NAME
+          value: kubernetes=release-1.7
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
         - name: service
-          secret:
-            secretName: service-account
+          mountPath: /etc/service-account
+          readOnly: true
         - name: ssh
-          secret:
-            secretName: ssh-key-secret
-            defaultMode: 0400
+          mountPath: /etc/ssh-key-secret
+          readOnly: true
         - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
-    - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
-      agent: kubernetes
-      spec:
-        containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
-          args:
-          - "--repo=k8s.io/kubernetes=release-1.7"
-          - "--clean"
-          - "--git-cache=/root/.cache/git"
-          - "--timeout=320"
-          - "--upload=gs://kubernetes-jenkins/logs"
-          env:
-          - name: USER
-            value: prow
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/service-account/service-account.json
-          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-private
-          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-            value: /etc/ssh-key-secret/ssh-public
-          volumeMounts:
-          - name: service
-            mountPath: /etc/service-account
-            readOnly: true
-          - name: ssh
-            mountPath: /etc/ssh-key-secret
-            readOnly: true
-          - name: cache-ssd
-            mountPath: /root/.cache
-          ports:
-          - containerPort: 9999
-            hostPort: 9999
-        volumes:
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          secretName: ssh-key-secret
+          defaultMode: 0400
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
+    agent: kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170922-a53fa871
+        args:
+        - "--repo=k8s.io/kubernetes=release-1.7"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--timeout=320"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        env:
+        - name: USER
+          value: prow
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMount￼s:
         - name: service
-          secret:
-            secretName: service-account
+          mountPath: /etc/service-account
+          readOnly: true
         - name: ssh
-          secret:
-            secretName: ssh-key-secret
-            defaultMode: 0400
+          mountPath: /etc/ssh-key-secret
+          readOnly: true
         - name: cache-ssd
-          hostPath:
-            path: /mnt/disks/ssd0
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          secretName: ssh-key-secret
+          defaultMode: 0400
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
 
 - name: periodic-kubernetes-bazel-build-1-8
   interval: 2h


### PR DESCRIPTION
These jobs haven't been running, see: https://github.com/kubernetes/test-infra/issues/4716
This moves them to not be two levels deep of `run_after_success`, which is probably what we want, however we also need to see what is going on with `periodic-kubernetes-bazel-test-1-6`