### PR TITLE
Disable audit in performance testing to match production

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-performance.env
@@ -22,3 +22,5 @@ TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
 # Switch off image puller to avoid bloating node objects (#44701)
 PREPULL_E2E_IMAGES=false
+# Turn off advanced audit logging to simulate production
+ENABLE_APISERVER_ADVANCED_AUDIT=false

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
@@ -24,6 +24,8 @@ TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
 # Switch off image puller to avoid bloating node objects (#44701)
 PREPULL_E2E_IMAGES=false
+# Turn off advanced audit logging to simulate production
+ENABLE_APISERVER_ADVANCED_AUDIT=false
 
 ### e2e-env
 # We should eventually lift this condition when we know our bounds (#48938).


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/51899#issuecomment-331924016

if the [slimmed down audit config](https://github.com/kubernetes/kubernetes/pull/52998) doesn't get us within target latencies, we can disable completely to match production settings and continue work in 1.9 to meet latency goals at scale