### PR TITLE
kops: Fix weave job arguments

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8235,7 +8235,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--extract=ci/latest",
-      "--kops-args=\"--networking=weave\"",
+      "--kops-args=--networking=weave",
       "--provider=aws",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort"
     ],


### PR DESCRIPTION
This doesn't need shell escaping.

cc @justinsb 