### PR TITLE
Run kubetest from $PATH in subcall and bump kubeadm images

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170925-f564687f
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170926-17f3c847
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -610,7 +610,7 @@ func skewTest(args []string, prefix string, checkSkew bool) error {
 	defer popS()
 	args = appendField(args, "--report-prefix", prefix)
 	return finishRunning(exec.Command(
-		kubetestPath,
+		"kubetest",
 		"--test",
 		"--test_args="+strings.Join(args, " "),
 		fmt.Sprintf("--v=%t", verbose),

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -40,23 +40,13 @@ import (
 const defaultGinkgoParallel = 25
 
 var (
-	artifacts    = filepath.Join(os.Getenv("WORKSPACE"), "_artifacts")
-	interrupt    = time.NewTimer(time.Duration(0)) // interrupt testing at this time.
-	kubetestPath = initPath(os.Args[0])
-	terminate    = time.NewTimer(time.Duration(0)) // terminate testing at this time.
-	verbose      = false
-	timeout      = time.Duration(0)
-	boskos       = client.NewClient(os.Getenv("JOB_NAME"), "http://boskos")
+	artifacts = filepath.Join(os.Getenv("WORKSPACE"), "_artifacts")
+	interrupt = time.NewTimer(time.Duration(0)) // interrupt testing at this time.
+	terminate = time.NewTimer(time.Duration(0)) // terminate testing at this time.
+	verbose   = false
+	timeout   = time.Duration(0)
+	boskos    = client.NewClient(os.Getenv("JOB_NAME"), "http://boskos")
 )
-
-// Joins os.Getwd() and path
-func initPath(path string) string {
-	d, err := os.Getwd()
-	if err != nil {
-		log.Fatalf("failed initPath(): %v", err)
-	}
-	return filepath.Join(d, path)
-}
 
 type options struct {
 	build               buildStrategy

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -101,7 +101,7 @@ presubmits:
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -632,7 +632,7 @@ presubmits:
       trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1368,7 +1368,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1411,7 +1411,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1525,7 +1525,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1643,7 +1643,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1686,7 +1686,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1804,7 +1804,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1847,7 +1847,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -16773,7 +16773,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -16892,7 +16892,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -16937,7 +16937,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17054,7 +17054,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17099,7 +17099,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170925-c24a92b9
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170926-73462984
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"


### PR DESCRIPTION
The current working directory is changing from [1] /workspace [2] /workspace/k8s.io/kubernetes in [kubeadm upgrade tests](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8/41). I suspect it is because we are pulling down repros to [2]. Update code so that kubetest is run against the workspace location. (Edit: changed tactic to calling with $PATH instead of with a fixed directory)

[1] Call:  /workspace/./test-infra/jenkins/../scenarios/kubernetes_e2e.py --cluster= --deployment=kubernetes-anywhere --env-file=jobs/platform/gce.env --extract=ci/latest-1.7 --extract=ci/latest-1.8 --gcp-zone=us-central1-f --kubeadm=periodic --kubernetes-anywhere-kubelet-ci-version=latest-1.7 --kubernetes-anywhere-kubernetes-version=latest-1.7 --kubernetes-anywhere-upgrade-method=upgrade --provider=kubernetes-anywhere '--test_args=--ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\] --minStartupPods=8' --timeout=300m '--upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.8'
[2] /workspace/k8s.io/kubernetes/kubetest --test --test_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.8 --report-dir=/workspace/_artifacts --disable-log-dump=true --report-prefix=upgrade --v=true --check-version-skew=true: fork/exec /workspace/k8s.io/kubernetes/kubetest: no such file or directory