### PR TITLE
Support global max concurrency

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -21,8 +21,8 @@ DECK_VERSION             ?= 0.50
 SPLICE_VERSION           ?= 0.27
 TOT_VERSION              ?= 0.5
 HOROLOGIUM_VERSION       ?= 0.8
-PLANK_VERSION            ?= 0.48
-JENKINS-OPERATOR_VERSION ?= 0.44
+PLANK_VERSION            ?= 0.49
+JENKINS-OPERATOR_VERSION ?= 0.45
 TIDE_VERSION             ?= 0.7
 
 # These are the usual GKE variables.

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.43
+        image: gcr.io/k8s-prow/jenkins-operator:0.45
         args:
         - --dry-run=false
         - --jenkins-token-file=/etc/jenkins/jenkins

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.48
+        image: gcr.io/k8s-prow/plank:0.49
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.48
+        image: gcr.io/k8s-prow/plank:0.49
         args:
         - --dry-run=false
         volumeMounts:

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -97,6 +97,10 @@ type Plank struct {
 	// will be passed a kube.ProwJob and can provide an optional blurb below
 	// the test failures comment.
 	ReportTemplate *template.Template `json:"-"`
+
+	// MaxConcurrency is the maximum number of tests running concurrently that
+	// will be allowed by plank. 0 implies no limit.
+	MaxConcurrency int `json:"max_concurrency,omitempty"`
 }
 
 // JenkinsOperator is config for the jenkins-operator controller.
@@ -114,6 +118,10 @@ type JenkinsOperator struct {
 	// will be passed a kube.ProwJob and can provide an optional blurb below
 	// the test failures comment.
 	ReportTemplate *template.Template `json:"-"`
+
+	// MaxConcurrency is the maximum number of tests running concurrently that
+	// will be allowed by jenkins-operator. 0 implies no limit.
+	MaxConcurrency int `json:"max_concurrency,omitempty"`
 }
 
 // Sinker is config for the sinker controller.
@@ -230,6 +238,9 @@ func parseConfig(c *Config) error {
 		return fmt.Errorf("parsing template: %v", err)
 	}
 	c.Plank.ReportTemplate = reportTmpl
+	if c.Plank.MaxConcurrency < 0 {
+		return fmt.Errorf("plank has invalid max_concurrency (%d), it needs to be a non-negative number", c.Plank.MaxConcurrency)
+	}
 
 	jenkinsURLTmpl, err := template.New("JobURL").Parse(c.JenkinsOperator.JobURLTemplateString)
 	if err != nil {
@@ -242,6 +253,9 @@ func parseConfig(c *Config) error {
 		return fmt.Errorf("parsing template: %v", err)
 	}
 	c.JenkinsOperator.ReportTemplate = jenkinsReportTmpl
+	if c.JenkinsOperator.MaxConcurrency < 0 {
+		return fmt.Errorf("jenkins-operator has invalid max_concurrency (%d), it needs to be a non-negative number", c.JenkinsOperator.MaxConcurrency)
+	}
 
 	if c.Sinker.ResyncPeriodString == "" {
 		c.Sinker.ResyncPeriod = time.Hour

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -87,12 +87,25 @@ type Controller struct {
 // canExecuteConcurrently checks whether the provided ProwJob can
 // be executed concurrently.
 func (c *Controller) canExecuteConcurrently(pj *kube.ProwJob) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if max := c.ca.Config().Plank.MaxConcurrency; max > 0 {
+		var running int
+		for _, num := range c.pendingJobs {
+			running += num
+		}
+		if running >= max {
+			logrus.Infof("Not starting another job, already %d running.", running)
+			return false
+		}
+	}
+
 	if pj.Spec.MaxConcurrency == 0 {
+		c.pendingJobs[pj.Spec.Job]++
 		return true
 	}
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	numPending := c.pendingJobs[pj.Spec.Job]
 	if numPending >= pj.Spec.MaxConcurrency {
 		logrus.WithField("job", pj.Spec.Job).Infof("Not starting another instance of %s, already %d running.", pj.Spec.Job, numPending)


### PR DESCRIPTION
Depends on https://github.com/kubernetes/test-infra/pull/4712. Only the last commit is new.

Fixes https://github.com/kubernetes/test-infra/issues/4691
/area prow