### PR TITLE
Revert "Decrease max-inflight-requests for 5k performance"

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-performance.env
@@ -17,7 +17,7 @@ TEST_CLUSTER_LOG_LEVEL=--v=1
 # Increase throughput in master components.
 SCHEDULER_TEST_ARGS=--kube-api-qps=100
 CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100
-APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-inflight=500
+APISERVER_TEST_ARGS=--max-requests-inflight=3000 --max-mutating-requests-inflight=1000
 # Increase controller-manager's resync period to simulate production
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism


### PR DESCRIPTION
Reverts kubernetes/test-infra#4671

Didn't help, and in fact seems to hurt us.