### PR TITLE
Use periodic kubeadm job as blocking for releases

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2978,8 +2978,6 @@ dashboards:
     test_group_name: ci-kubernetes-verify-release-1.8
   - name: test-go-1.8
     test_group_name: ci-kubernetes-test-go-release-1.8
-  - name: gce-kubeadm-1.8
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8
   - name: gce-kubeadm-1.7-on-1.8
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7-on-1-8
   - name: periodic-gce-kubeadm-1.8

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -3357,8 +3357,8 @@ dashboards:
     test_group_name: ci-kubernetes-test-go-release-1.7
   - name: verify-1.7
     test_group_name: ci-kubernetes-verify-release-1.7
-  - name: gce-kubeadm-1.7
-    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-7
+  - name: periodic-gce-kubeadm-1.7
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-7
   - name: gce-kubeadm-1.6-on-1.7
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-6-on-1-7
   - name: gce-kubeadm-upgrade-1.6-1.7


### PR DESCRIPTION
Instead of non-periodic.  The periodic jobs exercise the same code, and provide more frequent results.  As a release team member who enjoys seeing 3 consecutive passes for go / no-go signal, the periodic job is my preferred option.

WDYT @krzyzacy @luxas @pipejakob