### PR TITLE
Set CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS to true for gke 1.5

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7009,7 +7009,7 @@
     "args": [
       "--check-leaked-resources",
       "--deployment=gke",
-      "--env=CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=false",
+      "--env=CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true",
       "--extract=ci/latest-1.5",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=gci",


### PR DESCRIPTION
False is the default. 