### PR TITLE
Revert "Run gce-scale-performance job against release-1.8"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2926,7 +2926,7 @@
     "args": [
       "--cluster=gce-scale-cluster",
       "--env-file=jobs/env/ci-kubernetes-e2e-gce-scale-performance.env",
-      "--extract=ci/latest-1.8",
+      "--extract=ci/latest",
       "--gcp-project=kubernetes-scale",
       "--gcp-zone=us-east1-a",
       "--mode=docker",


### PR DESCRIPTION
Reverts kubernetes/test-infra#4746

So we don't need to merge https://github.com/kubernetes/kubernetes/pull/53090 into 1.8.

/cc @liggitt @jdumars 