### PR TITLE
Add plank test for pod errors besides 422 and fix type switching error.

### DIFF
--- a/prow/kube/client.go
+++ b/prow/kube/client.go
@@ -72,9 +72,29 @@ func (c *Client) log(methodName string, args ...interface{}) {
 	c.Logger.Debugf("%s(%s)", methodName, strings.Join(as, ", "))
 }
 
-type ConflictError error
+type ConflictError struct {
+	e error
+}
 
-type UnprocessableEntityError error
+func (e ConflictError) Error() string {
+	return e.e.Error()
+}
+
+func NewConflictError(e error) ConflictError {
+	return ConflictError{e: e}
+}
+
+type UnprocessableEntityError struct {
+	e error
+}
+
+func (e UnprocessableEntityError) Error() string {
+	return e.e.Error()
+}
+
+func NewUnprocessableEntityError(e error) UnprocessableEntityError {
+	return UnprocessableEntityError{e: e}
+}
 
 type request struct {
 	method      string
@@ -125,7 +145,7 @@ func (c *Client) requestRetryStream(r *request) (io.ReadCloser, error) {
 		return nil, err
 	}
 	if resp.StatusCode == 409 {
-		return nil, ConflictError(fmt.Errorf("body cannot be streamed"))
+		return nil, NewConflictError(fmt.Errorf("body cannot be streamed"))
 	} else if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf("response has status \"%s\"", resp.Status)
 	}
@@ -148,9 +168,9 @@ func (c *Client) requestRetry(r *request) ([]byte, error) {
 		return nil, err
 	}
 	if resp.StatusCode == 409 {
-		return nil, ConflictError(fmt.Errorf("body: %s", string(rb)))
+		return nil, NewConflictError(fmt.Errorf("body: %s", string(rb)))
 	} else if resp.StatusCode == 422 {
-		return nil, UnprocessableEntityError(fmt.Errorf("%s", string(rb)))
+		return nil, NewUnprocessableEntityError(fmt.Errorf("body: %s", string(rb)))
 	} else if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf("response has status \"%s\" and body \"%s\"", resp.Status, string(rb))
 	}


### PR DESCRIPTION
Adding a test for errors besides 422 errors revealed the the type switch in `syncNonPendingJob` was not properly distinguishing the `kube.UnprocessableEntityError` from other errors.
Heres an example showing why:
https://play.golang.org/p/8ig4QOBXP6

The example also shows why the error structs have to name the error fields instead of using embedded fields.
/cc @kargakis 