### PR TITLE
Fix provider passed to test for kubernetes-anywhere

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20170926-17f3c847
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20170927-e7d89d16
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -132,6 +132,12 @@ func newKubernetesAnywhere(project, zone string) (deployer, error) {
 		return nil, err
 	}
 
+	// Set KUBERNETES_CONFORMANCE_PROVIDER since KUBERNETES_CONFORMANCE_TEST is set
+	// to ensure the right provider is passed onto the test.
+	if err := os.Setenv("KUBERNETES_CONFORMANCE_PROVIDER", "kubernetes-anywhere"); err != nil {
+		return nil, err
+	}
+
 	k := &kubernetesAnywhere{
 		path:              *kubernetesAnywherePath,
 		Phase2Provider:    *kubernetesAnywherePhase2Provider,

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -101,7 +101,7 @@ presubmits:
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -633,7 +633,7 @@ presubmits:
       trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1370,7 +1370,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1413,7 +1413,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1527,7 +1527,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1645,7 +1645,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1688,7 +1688,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1806,7 +1806,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1849,7 +1849,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -16962,7 +16962,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -17081,7 +17081,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17126,7 +17126,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17243,7 +17243,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17288,7 +17288,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-dde45725
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20170927-df2003e2
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"


### PR DESCRIPTION
Kubernetes upgrade tests had errors showing a provider of skeletion [1]. This was because the test is [configured as a conformance test ](https://github.com/kubernetes/test-infra/blob/master/kubetest/anywhere.go#L131)and the [ginkgo_e2e logic](https://github.com/kubernetes/kubernetes/blob/533fba78f7aca56b74bddd6c41552ce8896e4ab6/hack/ginkgo-e2e.sh#L51) relies on the KUBERNETES_CONFORMANCE_PROVIDER variable as the provider for the test. Address this by setting the KUBERNETES_CONFORMANCE_PROVIDER variable. Note that other kubetest providers like gke also use the same approach.

[1]
W0927 17:20:20.582] 2017/09/27 17:20:20 util.go:154: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest-1.8 --report-dir=/workspace/_artifacts --disable-log-dump=true --report-prefix=upgrade
I0927 17:20:20.725] Conformance test: not doing test setup.