### PR TITLE
Allow all 2XX codes when starting a Jenkins build

### DIFF
--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -145,8 +145,8 @@ func (c *Client) Build(pj *kube.ProwJob) (*url.URL, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 201 {
-		return nil, fmt.Errorf("response not 201: %s", resp.Status)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("response not 2XX: %s", resp.Status)
 	}
 	return resp.Location()
 }


### PR DESCRIPTION
Hitting this with Jenkins version 2.60.2.
```
{"job":"origin-ci-ut-origin","level":"warning","msg":"error starting Jenkins build: response not 201: 200 OK","time":"2017-09-27T19:45:23Z"}
```
/cc @stevekuznetsov @spxtr 
/area prow