### PR TITLE
Make the Prow build URL template human-readable

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,5 +1,26 @@
 plank:
-  job_url_template: 'https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  job_url_template: >-
+    https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/
+      {{- if eq .Spec.Type "presubmit" -}}
+        pr-logs/pull
+      {{- else if eq .Spec.Type "batch" -}}
+        pr-logs/pull
+      {{- else -}}
+        logs
+      {{- end -}}
+      {{- if ne .Spec.Refs.Org "" -}}
+        {{- if ne .Spec.Refs.Org "kubernetes" -}}
+          /{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo -}}
+        {{- else if ne .Spec.Refs.Repo "kubernetes" -}}
+          /{{.Spec.Refs.Repo -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if eq .Spec.Type "presubmit" -}}
+        /{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end -}}
+      {{- else if eq .Spec.Type "batch" -}}
+        /batch
+      {{- end -}}
+    /{{.Spec.Job}}/{{.Status.BuildID -}}/
   report_template: '[Full PR test history](https://k8s-gubernator.appspot.com/pr/{{if eq .Spec.Refs.Org "kubernetes"}}{{if eq .Spec.Refs.Repo "kubernetes"}}{{else}}{{.Spec.Refs.Repo}}/{{end}}{{else}}{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{end}}{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://k8s-gubernator.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://github.com/kubernetes/community/blob/master/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
 
 sinker:


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @spxtr @kargakis 

Was changing this template downstream in our config and it was a real nuisance to do in one line ... if y'all want this, here is a more readable way to achieve the same thing.