### PR TITLE
link to contributor guidlines in ok-to-test message

### DIFF
--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -111,7 +111,7 @@ func handlePR(c client, trustedOrg string, pr github.PullRequestEvent) error {
 func welcomeMsg(ghc githubClient, pr github.PullRequest, trustedOrg string) error {
 	commentTemplate := `Hi @%s. Thanks for your PR.
 
-I'm waiting for a [%s](https://github.com/orgs/%s/people) %smember to verify that this patch is reasonable to test. If it is, they should reply with ` + "`/ok-to-test`" + ` on its own line. Until that is done, I will not automatically test new commits in this PR, but the usual testing commands by org members will still work. Regular contributors should join the org to skip this step.
+I'm waiting for a [%s](https://github.com/orgs/%s/people) %smember to verify that this patch is reasonable to test. If it is, they should reply with ` + "`/ok-to-test`" + ` on its own line. Until that is done, I will not automatically test new commits in this PR, but the usual testing commands by org members will still work. Regular contributors should [join the org](https://github.com/kubernetes/community/blob/master/community-membership.md#member) to skip this step.
 
 I understand the commands that are listed [here](https://github.com/kubernetes/test-infra/blob/master/commands.md).
 


### PR DESCRIPTION
We have semi-official instructions now, so let us link to them in the message that most new-comers will see when they first make a PR.

I did not see a dup of work, but let me know if this is already done.

I think this is the right place, but please let me know if I am mistaken.