### PR TITLE
WIP: add tool-chains to planter for kubernetes/kubernetes cross compilation

### DIFF
--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -23,6 +23,14 @@ ARG BAZEL_VERSION
 WORKDIR "/workspace"
 RUN mkdir -p "/workspace"
 
+# NOTE: for now this should be in sync with
+# https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/Dockerfile
+ENV KUBE_DYNAMIC_CROSSPLATFORMS \
+  armhf \
+  arm64 \
+  s390x \
+  ppc64el
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
@@ -37,6 +45,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # TODO(bentheelder): we should probably have these as bazel dependencies,
     # remove these from the container if kettle is fixed.
     pip install pylint pyyaml
+
+# NOTE: this is also from <kubernetes>/build/build-image/cross/Dockerfile
+# Use dynamic cgo linking for architectures other than amd64 for the server platforms
+# To install crossbuild essential for other architectures add the following repository.
+RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list.d/cgocrosscompiling.list \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
+  && apt-get update \
+  && apt-get install -y build-essential \
+  && for platform in ${KUBE_DYNAMIC_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 SHELL ["/bin/bash", "-c"]
 

--- a/planter/Makefile
+++ b/planter/Makefile
@@ -12,11 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# note: sync this with planter.sh!
+# NOTE: sync this with planter.sh! (the current stable version that is)
 # this should be bazel version - planter sub version
+#
+# NOTE: override BAZEL_VERSION and IMAGE_VERSION to create test images, then
+# override TAG when running planter. 
+# EG:
+# $ make -C planter BAZEL_VERSION="foo" IMAGE_VERSION="bar"
+# $ TAG="foo-bar" ./planter/planter.sh bazel test //...
+#
 BAZEL_VERSION = 0.5.4
+IMAGE_VERSION = 1
 IMAGE_NAME = gcr.io/k8s-testimages/planter
-TAG = $(BAZEL_VERSION)-1
+TAG = $(BAZEL_VERSION)-$(IMAGE_VERSION)
 
 image:
 	docker build --build-arg BAZEL_VERSION=$(BAZEL_VERSION) -t "$(IMAGE_NAME):$(TAG)" . --pull

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -27,4 +27,5 @@ REPO=${REPO:-${PWD}}
 VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --tmpfs /tmp:exec,mode=777"
 GID="$(id -g ${USER})"
 ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
+docker image pull ${IMAGE}
 docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${IMAGE} ${@}


### PR DESCRIPTION
This isn't tested yet (the image builds but I need to actually do useful things with it), but:
This PR adds cross compilation tool-chains to Planter necessary for eventually testing kubernetes/kubernetes cross compilation with Bazel.