### PR TITLE
migrate to dropbox/rules_node

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,12 +27,12 @@ docker_pull(
 )
 
 git_repository(
-    name = "org_pubref_rules_node",
-    commit = "bd14a465063da90f632bad46c1efbf802c339e68",
-    remote = "https://github.com/pubref/rules_node.git",
+    name = "org_dropbox_rules_node",
+    remote = "https://github.com/dropbox/rules_node.git",
+    commit = "4fe6494f3f8d1a272d47d32ecc66698f6c43ed09",
 )
 
-load("@org_pubref_rules_node//node:rules.bzl", "node_repositories", "npm_repository")
+load("@org_dropbox_rules_node//node:defs.bzl", "node_repositories")
 
 node_repositories()
 
@@ -51,13 +51,6 @@ py_library(
     sha256 = "350496f6fdd8c2bb17a0fa3fd2ec98431280cf12d72dae498b19ac0119c2bbad",
     strip_prefix = "ruamel.yaml-0.15.9",
     url = "https://pypi.python.org/packages/83/90/2eecde4bbd6a67805080091e83a29100c2f7d2afcaf926d75da5839f9283/ruamel.yaml-0.15.9.tar.gz",
-)
-
-npm_repository(
-    name = "npm_mocha",
-    deps = {
-        "mocha": "3.2.0",
-    },
 )
 
 # http_archives can be updated to newer version by doing the following:

--- a/triage/BUILD
+++ b/triage/BUILD
@@ -1,4 +1,4 @@
-load("@org_pubref_rules_node//node:rules.bzl", "mocha_test")
+load("@org_dropbox_rules_node//node:defs.bzl", "mocha_test")
 
 py_test(
     name = "summarize_test",
@@ -19,8 +19,8 @@ py_test(
 
 mocha_test(
     name = "script_test",
+    srcs = ["script_test.js"],
     data = ["js-srcs"],
-    main = "script_test.js",
 )
 
 filegroup(


### PR DESCRIPTION
[These rules](https://github.com/dropbox/rules_node) tentatively work with Bazel `0.5.4` and `0.6.0` on Linux, whereas updating to the latest version of the rules we had before didn't seem to have working `mocha_test` for either. The new pubref rules also seemed to have a new dependency on yarn. These rules have a pinned mocha version that you can override in  `mocha_test` with `mocha_target` as needed which seems pretty nice too.