### PR TITLE
Enable tide on test-infra.

### DIFF
--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -28,6 +28,8 @@ spec:
       containers:
       - name: tide
         image: gcr.io/k8s-prow/tide:0.6
+        args:
+        - --dry-run=false
         volumeMounts:
         - name: oauth
           mountPath: /etc/github

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -13,7 +13,7 @@ log_level: info
 
 tide:
   queries:
-  - "type:pr state:open repo:kubernetes/test-infra label:lgtm -label:do-not-merge"
+  - "type:pr state:open repo:kubernetes/test-infra label:lgtm label:approved -label:do-not-merge/work-in-progress -label:do-not-merge/hold label:\"cncf-cla: yes\""
 
 push_gateway:
   endpoint: pushgateway


### PR DESCRIPTION
 :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean: :ocean:
This PR is a duplicate of #4709  except that the Tide query is updated to require the `approved` label.
/cc @BenTheElder 
@spxtr 