### PR TITLE
use bazel 0.6 for pull-test-infra-bazel

### DIFF
--- a/gubernator/test_requirements.txt
+++ b/gubernator/test_requirements.txt
@@ -1,5 +1,6 @@
 webtest
 nosegae
 pylint==1.6.4
+setuptools
 coverage
 pyyaml

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1247,7 +1247,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-test-infra-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.6.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -492,6 +492,7 @@ func TestBazelbuildArgs(t *testing.T) {
 		"ci-kubernetes-bazel-test-1-6":        "https://github.com/kubernetes/kubernetes/issues/51571",
 		"periodic-kubernetes-bazel-build-1-6": "https://github.com/kubernetes/kubernetes/issues/51571",
 		"periodic-kubernetes-bazel-test-1-6":  "https://github.com/kubernetes/kubernetes/issues/51571",
+		"pull-test-infra-bazel":               "canary testing the latest bazel on test-infra",
 	}
 	maxTag := ""
 	maxN := 0


### PR DESCRIPTION
Using https://github.com/kubernetes/test-infra/pull/4820 let's flip on the latest bazelbuild image with bazel 0.6 for `pull-test-infra-bazel`.