### PR TITLE
Add skew test using kubeadm for ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -327,6 +327,27 @@
       "sig-cli"
     ]
   },
+  "ci-kubernetes-e2e-gce-1-6-1-7-master-skew": {
+    "args": [
+      "--check-version-skew=false",
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest-1.6",
+      "--extract=ci/latest-1.7",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=ci",
+      "--kubernetes-anywhere-kubelet-ci-version=latest-1.6",
+      "--kubernetes-anywhere-kubernetes-version=latest-1.7",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=300m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
   "ci-kubernetes-e2e-gce-1-6-1-7-upgrade-cluster": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2589,6 +2589,49 @@ postsubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+    - name: ci-kubernetes-e2e-gce-1-6-1-7-master-skew
+      agent: kubernetes
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--clean"
+          - "--git-cache=/root/.cache/git"
+          - "--timeout=320"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: ssh
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
 
   - name: ci-kubernetes-bazel-build-1-8
     agent: kubernetes

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1038,6 +1038,9 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
 - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-7-1-8
+# master cluster tests
+- name: ci-kubernetes-e2e-gce-1-6-1-7-master-skew
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-1-6-1-7-master-skew
 # charts tests
 - name: ci-kubernetes-charts-gce
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-charts-gce
@@ -2405,6 +2408,11 @@ dashboards:
   - name: gke-gci-1.7-gci-master-upgrade-cluster-new
     test_group_name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
     description: 'Upgrade master and node, in gke(gci), from 1.7 to master, and run skewed e2e tests'
+
+- name: skew-clusters
+  dashboard_tab:
+  - name: 1-6-1-7-cluster
+    test_group_name: ci-kubernetes-e2e-gce-1-6-1-7-master-skew
 
 - name: etcd-upgrades
   dashboard_tab:


### PR DESCRIPTION
The new test should cover same test scenarios as ci-kubernetes-e2e-gce-1-6-1-7-upgrade-master. kubeadm can set up cluster with different master and node version. So upgrade step is not required.