### PR TITLE
remove deps from verify/pylint_bin

### DIFF
--- a/experiment/bilge.py
+++ b/experiment/bilge.py
@@ -22,7 +22,7 @@ even something as simple as pushing new code while builds are already queued.
 
 import sys
 
-import requests
+import requests # pylint: disable=import-error
 
 
 def prune(host):

--- a/experiment/find_developers.py
+++ b/experiment/find_developers.py
@@ -25,7 +25,7 @@ import os
 import random
 import sys
 
-import requests
+import requests # pylint: disable=import-error
 
 def download_content():
     """Downloads contributor data from github."""

--- a/experiment/flakedetector.py
+++ b/experiment/flakedetector.py
@@ -32,7 +32,7 @@ from __future__ import print_function
 
 import operator
 
-import requests
+import requests # pylint: disable=import-error
 
 def main(): # pylint: disable=too-many-branches
     """Run flake detector."""

--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -33,7 +33,7 @@ import argparse
 import hashlib
 import json
 import os
-import ruamel.yaml as yaml
+import ruamel.yaml as yaml # pylint: disable=import-error
 
 
 # TODO(yguo0905): Generate Prow and testgrid configurations.

--- a/experiment/graphql_issue_example.py
+++ b/experiment/graphql_issue_example.py
@@ -21,7 +21,7 @@ import sys
 import json
 import argparse
 
-import requests
+import requests # pylint: disable=import-error
 
 GITHUB_API_URL = "https://api.github.com"
 

--- a/jenkins/hourly_maintenance.py
+++ b/jenkins/hourly_maintenance.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 import traceback
 
-import requests
+import requests # pylint: disable=import-error
 
 def container_images():
     """find all running images."""

--- a/jobs/config_sort.py
+++ b/jobs/config_sort.py
@@ -21,7 +21,7 @@ import cStringIO
 import json
 import os
 
-import ruamel.yaml as yaml
+import ruamel.yaml as yaml # pylint: disable=import-error
 
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -26,7 +26,7 @@ import re
 
 import config_sort
 import env_gc
-import yaml
+import yaml # pylint: disable=import-error
 
 # pylint: disable=too-many-public-methods, too-many-branches, too-many-locals, too-many-statements
 

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -29,8 +29,9 @@ from xml.etree import cElementTree as ET
 
 import multiprocessing
 import multiprocessing.pool
-import requests
-import yaml
+
+import requests # pylint: disable=import-error
+import yaml # pylint: disable=import-error
 
 import model
 

--- a/metrics/bigquery.py
+++ b/metrics/bigquery.py
@@ -27,9 +27,9 @@ import sys
 import time
 import traceback
 
-import influxdb
-import requests
-import yaml
+import influxdb # pylint: disable=import-error
+import requests # pylint: disable=import-error
+import yaml     # pylint: disable=import-error
 
 def check(*cmd, **keyargs):
     """Logs and runs the command, raising on errors."""

--- a/queue_health/poll/poller.py
+++ b/queue_health/poll/poller.py
@@ -22,7 +22,7 @@ import sys
 import time
 import traceback
 
-import requests
+import requests # pylint: disable=import-error
 
 def get_submit_queue_json(path):
     for count in range(3):

--- a/queue_health/weekly_commit_stats.py
+++ b/queue_health/weekly_commit_stats.py
@@ -20,7 +20,7 @@ import json
 import sys
 
 
-import requests  # pip install requests
+import requests # pylint: disable=import-error
 
 
 SESSION = requests.Session()

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -531,7 +531,8 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
                         try:
                             kubernetes_e2e.main(args)
                         except RuntimeError as err:
-                            if not err.message.startswith('Failed to get shared build location'):
+                            if not str(err.message)\
+                                   .startswith('Failed to get shared build location'):
                                 raise err
 
 if __name__ == '__main__':

--- a/verify/BUILD
+++ b/verify/BUILD
@@ -26,15 +26,6 @@ test_suite(
 py_binary(
     name = "pylint_bin",
     srcs = ["pylint_bin.py"],
-    deps = [
-        "@dateutil//:dateutil",
-        "@influxdb//:influxdb",
-        "@pylint//:pylint",
-        "@pytz//:pytz",
-        "@requests//:requests",  # TODO(fejta): figure out a better solution
-        "@ruamel_yaml//ruamel/yaml:ruamel.yaml",
-        "@yaml//:yaml",
-    ],
 )
 
 filegroup(


### PR DESCRIPTION
An alternate solution, I don't think pylint actually needs to depend on all our third party python deps, that's just so that it can check for import errors. We can just ignore those for third party deps when linting and not have pylint depend on them.