### PR TITLE
Bump m60 job images

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5271,7 +5271,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171002-aae4252c
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171002-6e8d729f
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5407,7 +5407,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171002-aae4252c
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171002-6e8d729f
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5543,7 +5543,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171002-aae4252c
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171002-6e8d729f
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
Includes https://github.com/kubernetes/test-infra/pull/4839

Currently they got https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-qa-serial-m60/1343/

/assign @wonderfly @kewu1992 