### PR TITLE
Use correct location for 1.6 bazel artifacts.

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171002-aae4252c
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171003-06931d34
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -123,7 +123,7 @@ func newKubernetesAnywhere(project, zone string) (deployer, error) {
 		if err != nil {
 			return nil, err
 		}
-		kubeletVersion = fmt.Sprintf("gs://kubernetes-release-dev/bazel/%v/bin/linux/amd64/", resolvedVersion)
+		kubeletVersion = bazelBuildPath(resolvedVersion)
 	}
 
 	// Set KUBERNETES_CONFORMANCE_TEST so the auth info is picked up
@@ -164,6 +164,17 @@ func resolveCIVersion(version string) (string, error) {
 	}
 	file := fmt.Sprintf("gs://kubernetes-release-dev/ci/%v.txt", version)
 	return readGSFile(file)
+}
+
+func bazelBuildPath(version string) string {
+	// This replicates the logic from scenarios/kubernetes_e2e.py, to
+	// accommodate the fact that bazel artifacts are stored in a different
+	// location for 1.6 builds.
+	if strings.HasPrefix(version, "v1.6.") {
+		return fmt.Sprintf("gs://kubernetes-release-dev/bazel/%v/build/debs/", version)
+	} else {
+		return fmt.Sprintf("gs://kubernetes-release-dev/bazel/%v/bin/linux/amd64/", version)
+	}
 }
 
 // Implemented as a function var for testing.

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -105,7 +105,7 @@ presubmits:
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -700,7 +700,7 @@ presubmits:
       trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1500,7 +1500,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1543,7 +1543,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1657,7 +1657,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1775,7 +1775,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1818,7 +1818,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1936,7 +1936,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -1979,7 +1979,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -17110,7 +17110,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -17229,7 +17229,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17274,7 +17274,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17391,7 +17391,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17436,7 +17436,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171002-4f9aae5e
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"


### PR DESCRIPTION
We recently added functionality to kubetest to resolve symbolic versions of kubelet, like `latest-1.7`, by expanding them to their bazel CI paths. Unfortunately, the bazel rules on the 1.6 release branch store artifacts in a different scheme than newer releases. This was causing any kubeadm e2e tests that tried to use 1.6 kubelets to fail, since the deb artifacts couldn't be found.

fixes https://github.com/kubernetes/kubeadm/issues/481