### PR TITLE
Make tide format logs in JSON.

### DIFF
--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -46,6 +46,7 @@ var (
 
 func main() {
 	flag.Parse()
+	logrus.SetFormatter(&logrus.JSONFormatter{})
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(*configPath); err != nil {


### PR DESCRIPTION
Formatting logs in JSON allows searching specific fields in stackdriver.
/cc @rmmh 

Will the text be automatically recognized as a json payload by stackdriver? 