### PR TITLE
support jq for mac in bigquery_test

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,10 +121,17 @@ py_library(
 )
 
 http_file(
-    name = "jq",
+    name = "jq_linux",
     executable = 1,
     sha256 = "c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d",
     urls = ["https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64"],
+)
+
+http_file(
+    name = "jq_osx",
+    executable = 1,
+    sha256 = "386e92c982a56fe4851468d7a931dfca29560cee306a0e66c6a1bd4065d3dac5",
+    urls = ["https://github.com/stedolan/jq/releases/download/jq-1.5/jq-osx-amd64"],
 )
 
 new_http_archive(

--- a/metrics/BUILD
+++ b/metrics/BUILD
@@ -13,17 +13,32 @@ filegroup(
     tags = ["automanaged"],
 )
 
+config_setting(
+    name = "k8",
+    values = {"host_cpu": "k8"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin",
+    values = {"host_cpu": "darwin"},
+    visibility = ["//visibility:public"],
+)
+
 py_test(
     name = "bigquery_test",
     srcs = [
         "bigquery.py",
         "bigquery_test.py",
     ],
-    args = ["--jq=$(location @jq//file)"],
-    data = [
-        ":all-srcs",
-        "@jq//file",
-    ],
+    args = select({
+        ":k8": ["--jq=$(location @jq_linux//file)"],
+        ":darwin": ["--jq=$(location @jq_osx//file)"],
+    }),
+    data = glob(["configs/*"]) + ["README.md"] + select({
+        ":k8": ["@jq_linux//file"],
+        ":darwin": ["@jq_osx//file"],
+    }),
     deps = [
         "@dateutil//:dateutil",
         "@influxdb//:influxdb",


### PR DESCRIPTION
This works but it's not necessarily ideal and test-infra Bazel usage on macOS still really only works from Planter for now :man_shrugging: 