### PR TITLE
Fix bad yaml.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -17290,7 +17290,7 @@ periodics:
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        "volumeMount￼s":
+        volumeMounts:
         - name: service
           mountPath: /etc/service-account
           readOnly: true


### PR DESCRIPTION
It looks like a foreign character somehow made its way into this job's `volumeMounts`. This resulted in the job dying with errors about missing service account credentials.

The github diff doesn't show it, but there's a unicode character between the `t` and the `s` of this string.

    E1003 21:51:26.327] unexpected error
    Traceback (most recent call last):
      File "./test-infra/jenkins/bootstrap.py", line 924, in bootstrap
      File "./test-infra/jenkins/bootstrap.py", line 678, in setup_credentials
    IOError: [Errno Cannot find service account credentials] /etc/service-account/service-account.json: 'Create service account and then create key at https://console.developers.google.com/iam-admin/serviceaccounts/project'
    Traceback (most recent call last):
      File "./test-infra/jenkins/bootstrap.py", line 1008, in <module>
        bootstrap(ARGS)
      File "./test-infra/jenkins/bootstrap.py", line 941, in bootstrap
        setup_credentials(call, args.service_account, upload)
      File "./test-infra/jenkins/bootstrap.py", line 678, in setup_credentials
        'Create service account and then create key at '
    IOError: [Errno Cannot find service account credentials] /etc/service-account/service-account.json: 'Create service account and then create key at https://console.developers.google.com/iam-admin/serviceaccounts/project':