### PR TITLE
Warn when empty plugins are loaded. (Fix #4857)

### DIFF
--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -229,6 +229,10 @@ func (pa *PluginAgent) Load(path string) error {
 		return err
 	}
 
+	if len(np.Plugins) == 0 {
+		logrus.Warn("no plugins specified-- check syntax?")
+	}
+
 	if err := validatePlugins(np.Plugins); err != nil {
 		return err
 	}


### PR DESCRIPTION
@crunk1 lost a bunch of time tracking down a misconfigured plugins list because of this.