### PR TITLE
Fork off pull-kubernetes-bazel jobs for release-1.6

### DIFF
--- a/gubernator/update_config.py
+++ b/gubernator/update_config.py
@@ -23,18 +23,20 @@ def main(prow_config, gubernator_config):
     with open(prow_config) as prow_file:
         prow_data = yaml.load(prow_file)
 
-    default_presubmits = []
+    default_presubmits = set()
     for job in prow_data['presubmits']['kubernetes/kubernetes']:
         if job.get('always_run'):
-            default_presubmits.append(job['name'])
+            default_presubmits.add(job['name'])
 
     with open(gubernator_config) as gubernator_file:
         gubernator_data = yaml.load(gubernator_file)
 
-    gubernator_data['jobs']['kubernetes-jenkins/pr-logs/directory/'] = default_presubmits
+    gubernator_data['jobs']['kubernetes-jenkins/pr-logs/directory/'] = sorted(
+        default_presubmits)
 
     with open(gubernator_config, 'w+') as gubernator_file:
-        yaml.dump(gubernator_data, gubernator_file, default_flow_style=False, explicit_start=True)
+        yaml.dump(gubernator_data, gubernator_file, default_flow_style=False,
+                  explicit_start=True)
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser()

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -64,7 +64,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -103,6 +103,10 @@ presubmits:
       run_if_changed: '^(cmd/kubeadm|build/debs).*$'
       rerun_command: "/test pull-kubernetes-e2e-kubeadm-gce"
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
+      skip_branches:
+      - release-1.4
+      - release-1.5
+      - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
@@ -146,7 +150,100 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
-
+  - name: pull-kubernetes-bazel-build
+    agent: kubernetes
+    context: pull-kubernetes-bazel-build
+    always_run: true
+    rerun_command: "/test pull-kubernetes-bazel-build"
+    trigger: "(?m)^/test( all| pull-kubernetes-bazel-build),?(\\s+|$)"
+    branches:
+    - release-1.6
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: pull-kubernetes-e2e-kubeadm-gce
+      agent: kubernetes
+      context: pull-kubernetes-e2e-kubeadm-gce
+      max_concurrency: 8
+      skip_report: false
+      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
+      rerun_command: "/test pull-kubernetes-e2e-kubeadm-gce"
+      trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
+      branches:
+      - release-1.6
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--upload=gs://kubernetes-jenkins/pr-logs"
+          - "--git-cache=/root/.cache/git"
+          - "--timeout=75"
+          - "--clean"
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+            value: true
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: ssh
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
     context: pull-kubernetes-bazel-test
@@ -159,7 +256,47 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-bazel-test
+    agent: kubernetes
+    context: pull-kubernetes-bazel-test
+    always_run: true
+    rerun_command: "/test pull-kubernetes-bazel-test"
+    trigger: "(?m)^/test( all| pull-kubernetes-bazel-test),?(\\s+|$)"
+    branches:
+    - release-1.6
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -726,7 +863,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -765,6 +902,104 @@ presubmits:
       run_if_changed: '^(cmd/kubeadm|build/debs).*$'
       rerun_command: "/test pull-security-kubernetes-e2e-kubeadm-gce"
       trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
+      skip_branches:
+      - release-1.4
+      - release-1.5
+      - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
+      spec:
+        containers:
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+          args:
+          - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+          - "--upload=gs://kubernetes-jenkins/pr-logs"
+          - "--git-cache=/root/.cache/git"
+          - "--timeout=75"
+          - "--clean"
+          env:
+          - name: USER
+            value: prow
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/service-account/service-account.json
+          - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-private
+          - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+            value: /etc/ssh-key-secret/ssh-public
+          - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+            value: true
+          volumeMounts:
+          - name: service
+            mountPath: /etc/service-account
+            readOnly: true
+          - name: ssh
+            mountPath: /etc/ssh-key-secret
+            readOnly: true
+          - name: cache-ssd
+            mountPath: /root/.cache
+          ports:
+          - containerPort: 9999
+            hostPort: 9999
+        volumes:
+        - name: service
+          secret:
+            secretName: service-account
+        - name: ssh
+          secret:
+            secretName: ssh-key-secret
+            defaultMode: 0400
+        - name: cache-ssd
+          hostPath:
+            path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-bazel-build
+    agent: kubernetes
+    context: pull-security-kubernetes-bazel-build
+    always_run: true
+    rerun_command: "/test pull-security-kubernetes-bazel-build"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-build),?(\\s+|$)"
+    branches:
+    - release-1.6
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+    run_after_success:
+    - name: pull-security-kubernetes-e2e-kubeadm-gce
+      agent: kubernetes
+      context: pull-security-kubernetes-e2e-kubeadm-gce
+      max_concurrency: 8
+      skip_report: false
+      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
+      rerun_command: "/test pull-security-kubernetes-e2e-kubeadm-gce"
+      trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce,?(\\s+|$)"
+      branches:
+      - release-1.6
       spec:
         containers:
         - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
@@ -820,7 +1055,47 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-bazel-test
+    agent: kubernetes
+    context: pull-security-kubernetes-bazel-test
+    always_run: true
+    rerun_command: "/test pull-security-kubernetes-bazel-test"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-bazel-test),?(\\s+|$)"
+    branches:
+    - release-1.6
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
I think this probably works.

I updated the unit tests to consider tag `vDate-Sha-0.5.2` the same as `vDate-Sha-0.5.4` etc.

/hold
/assign @BenTheElder @krzyzacy 