### PR TITLE
Allow Gubernator to read jUnit from all XML in a bucket

### DIFF
--- a/gubernator/view_base.py
+++ b/gubernator/view_base.py
@@ -120,6 +120,13 @@ def gcs_ls(path):
         path += '/'
     return list(gcs.listbucket(path, delimiter='/'))
 
+@memcache_memoize('gs-ls-recursive://', expires=60)
+def gcs_ls_recursive(path):
+    """Enumerate files in a GCS directory recursively. Returns a list of FileStats."""
+    if path[-1] != '/':
+        path += '/'
+
+    return list(gcs.listbucket(path))
 
 def pad_numbers(s):
     """Modify a string to make its numbers suitable for natural sorting."""

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -71,8 +71,9 @@ class JUnitParser(object):
             try:
                 tree = ET.fromstring(re.sub(r'[\x00\x80-\xFF]+', '?', xml))
             except ET.ParseError, e:
-                self.failed.append(
-                    ('Gubernator Internal Fatal XML Parse Error', 0.0, str(e), filename, ''))
+                if re.match(r'junit.*\.xml', os.path.basename(filename)):
+                    self.failed.append(
+                        ('Gubernator Internal Fatal XML Parse Error', 0.0, str(e), filename, ''))
                 return
         if tree.tag == 'testsuite':
             self.handle_suite(tree, filename)
@@ -138,8 +139,8 @@ def build_details(build_dir):
     started = json.loads(started)
     finished = json.loads(finished)
 
-    junit_paths = [f.filename for f in view_base.gcs_ls('%s/artifacts' % build_dir)
-                   if re.match(r'junit_.*\.xml', os.path.basename(f.filename))]
+    junit_paths = [f.filename for f in view_base.gcs_ls_recursive('%s/artifacts' % build_dir)
+                   if re.match(r'.*\.xml', os.path.basename(f.filename))]
 
     junit_futures = {f: gcs_async.read(f) for f in junit_paths}
 

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -140,7 +140,7 @@ def build_details(build_dir):
     finished = json.loads(finished)
 
     junit_paths = [f.filename for f in view_base.gcs_ls_recursive('%s/artifacts' % build_dir)
-                   if re.match(r'.*\.xml', os.path.basename(f.filename))]
+                   if f.filename.endswith('.xml')]
 
     junit_futures = {f: gcs_async.read(f) for f in junit_paths}
 

--- a/gubernator/view_build_test.py
+++ b/gubernator/view_build_test.py
@@ -32,7 +32,7 @@ class ParseJunitTest(unittest.TestCase):
     @staticmethod
     def parse(xml):
         parser = view_build.JUnitParser()
-        parser.parse_xml(xml, 'fp')
+        parser.parse_xml(xml, 'junit_filename.xml')
         return parser.get_results()
 
     def test_normal(self):
@@ -41,7 +41,7 @@ class ParseJunitTest(unittest.TestCase):
         self.assertEqual(results, {
             'passed': ['Second'],
             'skipped': ['First'],
-            'failed': [('Third', 96.49, stack, "fp", "")],
+            'failed': [('Third', 96.49, stack, "junit_filename.xml", "")],
         })
 
     def test_testsuites(self):
@@ -60,7 +60,7 @@ class ParseJunitTest(unittest.TestCase):
                 </testsuite>
             </testsuites>''')
         self.assertEqual(results['failed'], [(
-            'k8s.io/suite TestBad', 0.1, 'something bad', "fp",
+            'k8s.io/suite TestBad', 0.1, 'something bad', "junit_filename.xml",
             "out: first line\nout: second line\nerr: first line",
             )])
 
@@ -82,7 +82,7 @@ class ParseJunitTest(unittest.TestCase):
                 </testsuite>
             </testsuites>''')
         self.assertEqual(results['failed'], [(
-            'k8s.io/suite/sub TestBad', 0.1, 'something bad', "fp",
+            'k8s.io/suite/sub TestBad', 0.1, 'something bad', "junit_filename.xml",
             "out: first line\nout: second line\nerr: first line",
             )])
 
@@ -99,12 +99,14 @@ class ParseJunitTest(unittest.TestCase):
                     </testcase>
                 </testsuite>
             </testsuites>''')['failed']
-        self.assertEqual(failures, [('a Corrupt', 0.0, 'something bad ?', 'fp', '')])
+        self.assertEqual(failures, [('a Corrupt', 0.0, 'something bad ?',
+                                     'junit_filename.xml', '')])
 
     def test_not_xml(self):
         failures = self.parse('\x01')['failed']
         self.assertEqual(failures,
-            [(failures[0][0], 0.0, 'not well-formed (invalid token): line 1, column 0', 'fp', '')])
+            [(failures[0][0], 0.0, 'not well-formed (invalid token): line 1, column 0',
+              'junit_filename.xml', '')])
 
 class BuildTest(main_test.TestBase):
     # pylint: disable=too-many-public-methods


### PR DESCRIPTION
One of the most onerous requirements for the GCS layout is that all
jUnit need to be in a certain place and fit a certain file name format.
This patch removes that requirement and will show jUnit output from all
jUnit XML in the test bucket.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @rmmh 