### PR TITLE
Update ci-kubernetes-bazel-{build,test} to match make rules on master

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -32,7 +32,7 @@
   },
   "ci-kubernetes-bazel-build": {
     "args": [
-      "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/...",
+      "--build=// -//vendor/...",
       "--release=//build/release-tars"
     ],
     "scenario": "kubernetes_bazel",
@@ -72,9 +72,10 @@
   },
   "ci-kubernetes-bazel-test": {
     "args": [
-      "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",
-      "--test-args=--test_tag_filters=-integration",
-      "--test-args=--flaky_test_attempts=3"
+      "--test=//... //hack:verify-all -//build/... -//vendor/...",
+      "--test-args=--build_tag_filters=-e2e,-integration",
+      "--test-args=--flaky_test_attempts=3",
+      "--test_args=--test_tag_filters=-e2e,-integration"
     ],
     "scenario": "kubernetes_bazel",
     "sigOwners": [


### PR DESCRIPTION
I'm not sure how to update this for PR jobs without breaking the release branches, though - we need some way to specify a different set of targets per-branch.

@BenTheElder @krzyzacy 