### PR TITLE
Gate github review process

### DIFF
--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -53,6 +53,9 @@ const (
 	headerRateReset     = "X-RateLimit-Reset"
 
 	maxCommentLen = 65535
+
+	ghApproved         = "APPROVED"
+	ghChangesRequested = "CHANGES_REQUESTED"
 )
 
 var (
@@ -2540,6 +2543,31 @@ func (obj *MungeObject) ListReviews() ([]*github.PullRequestReview, bool) {
 	}
 	obj.prReviews = allReviews
 	return allReviews, true
+}
+
+func (obj *MungeObject) CollectGHReviewStatus() ([]*github.PullRequestReview, []*github.PullRequestReview, bool) {
+	reviews, ok := obj.ListReviews()
+	if !ok {
+		glog.Warning("Cannot get all reviews")
+		return nil, nil, false
+	}
+	var approvedReviews, changesRequestReviews []*github.PullRequestReview
+	latestReviews := make(map[string]*github.PullRequestReview)
+	for _, review := range reviews {
+		reviewer := review.User.GetLogin()
+		if r, exist := latestReviews[reviewer]; !exist || r.GetSubmittedAt().Before(review.GetSubmittedAt()) {
+			latestReviews[reviewer] = review
+		}
+	}
+
+	for _, review := range latestReviews {
+		if review.GetState() == ghApproved {
+			approvedReviews = append(approvedReviews, review)
+		} else if review.GetState() == ghChangesRequested {
+			changesRequestReviews = append(changesRequestReviews, review)
+		}
+	}
+	return approvedReviews, changesRequestReviews, true
 }
 
 func (config *Config) runMungeFunction(obj *MungeObject, fn MungeFunction) error {

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -226,10 +226,10 @@ type SubmitQueue struct {
 	opts                *options.Options
 	NonBlockingJobNames []string
 
-	GateApproved bool
-	GateCLA      bool
- 	GateGHReviewApproved         bool
- 	GateGHReviewChangesRequested bool
+	GateApproved                 bool
+	GateCLA                      bool
+	GateGHReviewApproved         bool
+	GateGHReviewChangesRequested bool
 
 	// AdditionalRequiredLabels is a set of additional labels required for merging
 	// on top of the existing required ("lgtm", "approved", "cncf-cla: yes").
@@ -984,30 +984,30 @@ func noAdditionalLabelMessage(label string) string {
 }
 
 const (
-	unknown                 = "unknown failure"
-	noCLA                   = "PR is missing CLA label; needs one of " + cncfClaYesLabel + " or " + claHumanLabel
-	noLGTM                  = "PR does not have " + lgtmLabel + " label."
-	noApproved              = "PR does not have " + approvedLabel + " label."
-	lgtmEarly               = "The PR was changed after the " + lgtmLabel + " label was added."
-	unmergeable             = "PR is unable to be automatically merged. Needs rebase."
-	undeterminedMergability = "Unable to determine is PR is mergeable. Will try again later."
-	ciFailure               = "Required Github CI test is not green"
-	ciFailureFmt            = ciFailure + ": %s"
-	e2eFailure              = "The e2e tests are failing. The entire submit queue is blocked."
-	e2eRecover              = "The e2e tests started passing. The submit queue is unblocked."
-	merged                  = "MERGED!"
-	mergedSkippedRetest     = "MERGED! (skipped retest because of label)"
-	mergedBatch             = "MERGED! (batch)"
-	mergedByHand            = "MERGED! (by hand outside of submit queue)"
-	ghE2EQueued             = "Queued to run github e2e tests a second time."
-	ghE2EWaitingStart       = "Requested and waiting for github e2e test to start running a second time."
-	ghE2ERunning            = "Running github e2e tests a second time."
-	ghE2EFailed             = "Second github e2e run failed."
-	unmergeableMilestone    = "Milestone is for a future release and cannot be merged"
-	headCommitChanged       = "This PR has changed since we ran the tests"
- 	ghReviewStateUnclear     = "Cannot get gh reviews status"
- 	ghReviewApproved         = "This pr has no Github review \"approved\"."
- 	ghReviewChangesRequested = "Reviewer(s) requested changes through github review process."
+	unknown                  = "unknown failure"
+	noCLA                    = "PR is missing CLA label; needs one of " + cncfClaYesLabel + " or " + claHumanLabel
+	noLGTM                   = "PR does not have " + lgtmLabel + " label."
+	noApproved               = "PR does not have " + approvedLabel + " label."
+	lgtmEarly                = "The PR was changed after the " + lgtmLabel + " label was added."
+	unmergeable              = "PR is unable to be automatically merged. Needs rebase."
+	undeterminedMergability  = "Unable to determine is PR is mergeable. Will try again later."
+	ciFailure                = "Required Github CI test is not green"
+	ciFailureFmt             = ciFailure + ": %s"
+	e2eFailure               = "The e2e tests are failing. The entire submit queue is blocked."
+	e2eRecover               = "The e2e tests started passing. The submit queue is unblocked."
+	merged                   = "MERGED!"
+	mergedSkippedRetest      = "MERGED! (skipped retest because of label)"
+	mergedBatch              = "MERGED! (batch)"
+	mergedByHand             = "MERGED! (by hand outside of submit queue)"
+	ghE2EQueued              = "Queued to run github e2e tests a second time."
+	ghE2EWaitingStart        = "Requested and waiting for github e2e test to start running a second time."
+	ghE2ERunning             = "Running github e2e tests a second time."
+	ghE2EFailed              = "Second github e2e run failed."
+	unmergeableMilestone     = "Milestone is for a future release and cannot be merged"
+	headCommitChanged        = "This PR has changed since we ran the tests"
+	ghReviewStateUnclear     = "Cannot get gh reviews status"
+	ghReviewApproved         = "This pr has no Github review \"approved\"."
+	ghReviewChangesRequested = "Reviewer(s) requested changes through github review process."
 )
 
 // validForMergeExt is the base logic about what PR can be automatically merged.


### PR DESCRIPTION
Add a check to get github reviews, and gate merge if:
1. No gh "approve"
2. At least one gh "change request"

It's a configurable feature and by default it is disable. It's a requirement from istio team.