### PR TITLE
Revert "Update ci-kubernetes-bazel-{build,test} to match make rules on master"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -32,7 +32,7 @@
   },
   "ci-kubernetes-bazel-build": {
     "args": [
-      "--build=// -//vendor/...",
+      "--build=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //vendor/k8s.io/...",
       "--release=//build/release-tars"
     ],
     "scenario": "kubernetes_bazel",
@@ -72,10 +72,9 @@
   },
   "ci-kubernetes-bazel-test": {
     "args": [
-      "--test=//... //hack:verify-all -//build/... -//vendor/...",
-      "--test-args=--build_tag_filters=-e2e,-integration",
-      "--test-args=--flaky_test_attempts=3",
-      "--test_args=--test_tag_filters=-e2e,-integration"
+      "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...",
+      "--test-args=--test_tag_filters=-integration",
+      "--test-args=--flaky_test_attempts=3"
     ],
     "scenario": "kubernetes_bazel",
     "sigOwners": [


### PR DESCRIPTION
This reverts commit 3c46eb7917d8d7450953eec0da8891a58df2e12c (#4874).

`bazel query` was broken in several different ways.

/assign @krzyzacy @BenTheElder 