### PR TITLE
Fresh deck links - fix header link styling and make the rerun url clickable

### DIFF
--- a/prow/cmd/deck/static/script.js
+++ b/prow/cmd/deck/static/script.js
@@ -216,7 +216,7 @@ function createRerunCell(modal, rerun_command, prowjob) {
     a.title = "Show instructions for rerunning this job.";
     a.onclick = function() {
         modal.style.display = "block";
-        rerun_command.textContent = "kubectl create -f \"" + url + "\"";
+        rerun_command.innerHTML = "kubectl create -f \"<a href='" + url + "'>" + url + "</a>\"";
     };
     a.appendChild(document.createTextNode("\u27F3"));
     c.appendChild(a);

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -15,6 +15,10 @@ header {
     box-shadow: 0px 0px 10px #666;
 }
 
+header a {
+    color: inherit;
+}
+
 h1 {
     font-weight: normal;
     font-size: 2em;


### PR DESCRIPTION
The first fix is purely stylistic but should look nicer (IE the "Prow Status" header will remain white despite being `a:visited` etc.). The second fix makes the Prow URL in the "re-run" job button clickable which is more convenient.