### PR TITLE
Make prow-canary job picks up kubekins:latest-master

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16053,7 +16053,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       args:
       - --bare
       - --timeout=85


### PR DESCRIPTION
rather than manually rerun every time

/assign @BenTheElder 