### PR TITLE
Make Hook include event type and GUID in logs.

### DIFF
--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 )
 
-func (s *Server) handleReviewEvent(re github.ReviewEvent) {
-	l := logrus.WithFields(logrus.Fields{
+func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
+	l = l.WithFields(logrus.Fields{
 		"org":      re.Repo.Owner.Login,
 		"repo":     re.Repo.Name,
 		"pr":       re.PullRequest.Number,
@@ -49,6 +49,7 @@ func (s *Server) handleReviewEvent(re github.ReviewEvent) {
 		return
 	}
 	s.handleGenericComment(
+		l,
 		&github.GenericCommentEvent{
 			IsPR:        true,
 			Action:      action,
@@ -61,12 +62,11 @@ func (s *Server) handleReviewEvent(re github.ReviewEvent) {
 			Assignees:   re.PullRequest.Assignees,
 			IssueState:  re.PullRequest.State,
 		},
-		l,
 	)
 }
 
-func (s *Server) handleReviewCommentEvent(rce github.ReviewCommentEvent) {
-	l := logrus.WithFields(logrus.Fields{
+func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewCommentEvent) {
+	l = l.WithFields(logrus.Fields{
 		"org":       rce.Repo.Owner.Login,
 		"repo":      rce.Repo.Name,
 		"pr":        rce.PullRequest.Number,
@@ -91,6 +91,7 @@ func (s *Server) handleReviewCommentEvent(rce github.ReviewCommentEvent) {
 		return
 	}
 	s.handleGenericComment(
+		l,
 		&github.GenericCommentEvent{
 			IsPR:        true,
 			Action:      action,
@@ -103,12 +104,11 @@ func (s *Server) handleReviewCommentEvent(rce github.ReviewCommentEvent) {
 			Assignees:   rce.PullRequest.Assignees,
 			IssueState:  rce.PullRequest.State,
 		},
-		l,
 	)
 }
 
-func (s *Server) handlePullRequestEvent(pr github.PullRequestEvent) {
-	l := logrus.WithFields(logrus.Fields{
+func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEvent) {
+	l = l.WithFields(logrus.Fields{
 		"org":    pr.Repo.Owner.Login,
 		"repo":   pr.Repo.Name,
 		"pr":     pr.Number,
@@ -132,6 +132,7 @@ func (s *Server) handlePullRequestEvent(pr github.PullRequestEvent) {
 		return
 	}
 	s.handleGenericComment(
+		l,
 		&github.GenericCommentEvent{
 			IsPR:        true,
 			Action:      action,
@@ -144,12 +145,11 @@ func (s *Server) handlePullRequestEvent(pr github.PullRequestEvent) {
 			Assignees:   pr.PullRequest.Assignees,
 			IssueState:  pr.PullRequest.State,
 		},
-		l,
 	)
 }
 
-func (s *Server) handlePushEvent(pe github.PushEvent) {
-	l := logrus.WithFields(logrus.Fields{
+func (s *Server) handlePushEvent(l *logrus.Entry, pe github.PushEvent) {
+	l = l.WithFields(logrus.Fields{
 		"org":  pe.Repo.Owner.Name,
 		"repo": pe.Repo.Name,
 		"ref":  pe.Ref,
@@ -169,8 +169,8 @@ func (s *Server) handlePushEvent(pe github.PushEvent) {
 	}
 }
 
-func (s *Server) handleIssueEvent(i github.IssueEvent) {
-	l := logrus.WithFields(logrus.Fields{
+func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
+	l = l.WithFields(logrus.Fields{
 		"org":    i.Repo.Owner.Login,
 		"repo":   i.Repo.Name,
 		"pr":     i.Issue.Number,
@@ -194,6 +194,7 @@ func (s *Server) handleIssueEvent(i github.IssueEvent) {
 		return
 	}
 	s.handleGenericComment(
+		l,
 		&github.GenericCommentEvent{
 			IsPR:        i.Issue.IsPullRequest(),
 			Action:      action,
@@ -206,12 +207,11 @@ func (s *Server) handleIssueEvent(i github.IssueEvent) {
 			Assignees:   i.Issue.Assignees,
 			IssueState:  i.Issue.State,
 		},
-		l,
 	)
 }
 
-func (s *Server) handleIssueCommentEvent(ic github.IssueCommentEvent) {
-	l := logrus.WithFields(logrus.Fields{
+func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueCommentEvent) {
+	l = l.WithFields(logrus.Fields{
 		"org":    ic.Repo.Owner.Login,
 		"repo":   ic.Repo.Name,
 		"pr":     ic.Issue.Number,
@@ -235,6 +235,7 @@ func (s *Server) handleIssueCommentEvent(ic github.IssueCommentEvent) {
 		return
 	}
 	s.handleGenericComment(
+		l,
 		&github.GenericCommentEvent{
 			IsPR:        ic.Issue.IsPullRequest(),
 			Action:      action,
@@ -247,12 +248,11 @@ func (s *Server) handleIssueCommentEvent(ic github.IssueCommentEvent) {
 			Assignees:   ic.Issue.Assignees,
 			IssueState:  ic.Issue.State,
 		},
-		l,
 	)
 }
 
-func (s *Server) handleStatusEvent(se github.StatusEvent) {
-	l := logrus.WithFields(logrus.Fields{
+func (s *Server) handleStatusEvent(l *logrus.Entry, se github.StatusEvent) {
+	l = l.WithFields(logrus.Fields{
 		"org":     se.Repo.Owner.Login,
 		"repo":    se.Repo.Name,
 		"context": se.Context,
@@ -289,11 +289,11 @@ func genericCommentAction(action string) github.GenericCommentEventAction {
 	return ""
 }
 
-func (s *Server) handleGenericComment(ce *github.GenericCommentEvent, log *logrus.Entry) {
+func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericCommentEvent) {
 	for p, h := range s.Plugins.GenericCommentHandlers(ce.Repo.Owner.Login, ce.Repo.Name) {
 		go func(p string, h plugins.GenericCommentHandler) {
 			pc := s.Plugins.PluginClient
-			pc.Logger = log.WithField("plugin", p)
+			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
 			if err := h(pc, *ce); err != nil {

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -52,6 +52,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "400 Bad Request: Missing X-GitHub-Event Header", http.StatusBadRequest)
 		return
 	}
+	eventGUID := r.Header.Get("X-GitHub-Delivery")
+	if eventGUID == "" {
+		http.Error(w, "400 Bad Request: Missing X-GitHub-Delivery Header", http.StatusBadRequest)
+		return
+	}
 	sig := r.Header.Get("X-Hub-Signature")
 	if sig == "" {
 		http.Error(w, "403 Forbidden: Missing X-Hub-Signature", http.StatusForbidden)
@@ -76,15 +81,21 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	fmt.Fprint(w, "Event received. Have a nice day.")
 
-	if err := s.demuxEvent(eventType, payload); err != nil {
+	if err := s.demuxEvent(eventType, eventGUID, payload); err != nil {
 		logrus.WithError(err).Error("Error parsing event.")
 	}
 }
 
-func (s *Server) demuxEvent(eventType string, payload []byte) error {
+func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte) error {
+	l := logrus.WithFields(
+		logrus.Fields{
+			"event-type": eventType,
+			"event-GUID": eventGUID,
+		},
+	)
 	// We don't want to fail the webhook due to a metrics error.
 	if counter, err := s.Metrics.WebhookCounter.GetMetricWithLabelValues(eventType); err != nil {
-		logrus.WithError(err).Warn("Failed to get metric for eventType " + eventType)
+		l.WithError(err).Warn("Failed to get metric for eventType " + eventType)
 	} else {
 		counter.Inc()
 	}
@@ -94,43 +105,43 @@ func (s *Server) demuxEvent(eventType string, payload []byte) error {
 		if err := json.Unmarshal(payload, &i); err != nil {
 			return err
 		}
-		go s.handleIssueEvent(i)
+		go s.handleIssueEvent(l, i)
 	case "issue_comment":
 		var ic github.IssueCommentEvent
 		if err := json.Unmarshal(payload, &ic); err != nil {
 			return err
 		}
-		go s.handleIssueCommentEvent(ic)
+		go s.handleIssueCommentEvent(l, ic)
 	case "pull_request":
 		var pr github.PullRequestEvent
 		if err := json.Unmarshal(payload, &pr); err != nil {
 			return err
 		}
-		go s.handlePullRequestEvent(pr)
+		go s.handlePullRequestEvent(l, pr)
 	case "pull_request_review":
 		var re github.ReviewEvent
 		if err := json.Unmarshal(payload, &re); err != nil {
 			return err
 		}
-		go s.handleReviewEvent(re)
+		go s.handleReviewEvent(l, re)
 	case "pull_request_review_comment":
 		var rce github.ReviewCommentEvent
 		if err := json.Unmarshal(payload, &rce); err != nil {
 			return err
 		}
-		go s.handleReviewCommentEvent(rce)
+		go s.handleReviewCommentEvent(l, rce)
 	case "push":
 		var pe github.PushEvent
 		if err := json.Unmarshal(payload, &pe); err != nil {
 			return err
 		}
-		go s.handlePushEvent(pe)
+		go s.handlePushEvent(l, pe)
 	case "status":
 		var se github.StatusEvent
 		if err := json.Unmarshal(payload, &se); err != nil {
 			return err
 		}
-		go s.handleStatusEvent(se)
+		go s.handleStatusEvent(l, se)
 	}
 	return nil
 }

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -46,9 +46,10 @@ func TestServeHTTPErrors(t *testing.T) {
 			// GET
 			Method: http.MethodGet,
 			Header: map[string]string{
-				"X-GitHub-Event":  "ping",
-				"X-Hub-Signature": hmac,
-				"content-type":    "application/json",
+				"X-GitHub-Event":    "ping",
+				"X-GitHub-Delivery": "I am unique",
+				"X-Hub-Signature":   hmac,
+				"content-type":      "application/json",
 			},
 			Body: body,
 			Code: http.StatusMethodNotAllowed,
@@ -57,6 +58,29 @@ func TestServeHTTPErrors(t *testing.T) {
 			// No event
 			Method: http.MethodPost,
 			Header: map[string]string{
+				"X-GitHub-Delivery": "I am unique",
+				"X-Hub-Signature":   hmac,
+				"content-type":      "application/json",
+			},
+			Body: body,
+			Code: http.StatusBadRequest,
+		},
+		{
+			// No content type
+			Method: http.MethodPost,
+			Header: map[string]string{
+				"X-GitHub-Event":    "ping",
+				"X-GitHub-Delivery": "I am unique",
+				"X-Hub-Signature":   hmac,
+			},
+			Body: body,
+			Code: http.StatusBadRequest,
+		},
+		{
+			// No event guid
+			Method: http.MethodPost,
+			Header: map[string]string{
+				"X-GitHub-Event":  "ping",
 				"X-Hub-Signature": hmac,
 				"content-type":    "application/json",
 			},
@@ -67,7 +91,9 @@ func TestServeHTTPErrors(t *testing.T) {
 			// No signature
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event": "ping",
+				"X-GitHub-Event":    "ping",
+				"X-GitHub-Delivery": "I am unique",
+				"content-type":      "application/json",
 			},
 			Body: body,
 			Code: http.StatusForbidden,
@@ -76,9 +102,10 @@ func TestServeHTTPErrors(t *testing.T) {
 			// Bad signature
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":  "ping",
-				"X-Hub-Signature": "this doesn't work",
-				"content-type":    "application/json",
+				"X-GitHub-Event":    "ping",
+				"X-GitHub-Delivery": "I am unique",
+				"X-Hub-Signature":   "this doesn't work",
+				"content-type":      "application/json",
 			},
 			Body: body,
 			Code: http.StatusForbidden,
@@ -87,9 +114,10 @@ func TestServeHTTPErrors(t *testing.T) {
 			// Good
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":  "ping",
-				"X-Hub-Signature": hmac,
-				"content-type":    "application/json",
+				"X-GitHub-Event":    "ping",
+				"X-GitHub-Delivery": "I am unique",
+				"X-Hub-Signature":   hmac,
+				"content-type":      "application/json",
 			},
 			Body: body,
 			Code: http.StatusOK,

--- a/prow/phony/phony.go
+++ b/prow/phony/phony.go
@@ -32,6 +32,7 @@ func SendHook(address, eventType string, payload, hmac []byte) error {
 		return err
 	}
 	req.Header.Set("X-GitHub-Event", eventType)
+	req.Header.Set("X-GitHub-Delivery", "GUID")
 	req.Header.Set("X-Hub-Signature", github.PayloadSignature(payload, hmac))
 	req.Header.Set("content-type", "application/json")
 


### PR DESCRIPTION
The event GUID will make it easy to filter logs for messages related to a specific webhook event, especially when tracking behavior across multiple plugins or when multiple similar hooks arrive in close succession. 

/cc @BenTheElder 