### PR TITLE
Fix federation pre-submit job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9506,7 +9506,6 @@
       "--mode=docker",
       "--provider=gce",
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
-      "--tag=v20170728-faff708c",
       "--test=false",
       "--timeout=90m"
     ],
@@ -10794,7 +10793,6 @@
       "--provider=gce",
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-federation-e2e-gce",
-      "--tag=v20170728-faff708c",
       "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
       "--timeout=90m"
     ],


### PR DESCRIPTION
federation pre-submit job was pinned to run a particular version of kubekins (reason not sure, needs investigation. maybe @madhusudancs knows this) and it is failing currently with the below error:
```
W1005 04:07:17.890] flag provided but not defined: -ginkgo-parallel
W1005 04:07:17.891] Usage of /workspace/kubetest:
```

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/53482/pull-kubernetes-federation-e2e-gce/28126/

reason could be the kubekins image we were using might not have the `-ginkgo-parallel` flag defined.

So anyway to fix this issue, i remove the kubekins version pinning and use the latest kubekins image.

/assign @krzyzacy 
/cc @madhusudancs 