### PR TITLE
make pylint and bazel play nice(r)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -346,6 +346,9 @@ new_http_archive(
 py_library(
     name = "dateutil",
     srcs = glob(["**/*.py"]),
+    deps = [
+        "@six_lib//:six",
+    ],
     visibility = ["//visibility:public"],
 )
 """,

--- a/mungegithub/issue_labeler/simple_app.py
+++ b/mungegithub/issue_labeler/simple_app.py
@@ -18,13 +18,15 @@ import os
 import logging
 from logging.handlers import RotatingFileHandler
 
-import numpy as np # pylint: disable=import-error
-from flask import Flask, request # pylint: disable=import-error
-from sklearn.feature_extraction import FeatureHasher # pylint: disable=import-error
-from sklearn.externals import joblib # pylint: disable=import-error
-from sklearn.linear_model import SGDClassifier # pylint: disable=import-error
-from nltk.tokenize import RegexpTokenizer # pylint: disable=import-error
-from nltk.stem.porter import PorterStemmer # pylint: disable=import-error
+# pylint: disable=import-error
+import numpy as np
+from flask import Flask, request
+from sklearn.feature_extraction import FeatureHasher
+from sklearn.externals import joblib
+from sklearn.linear_model import SGDClassifier
+from nltk.tokenize import RegexpTokenizer
+from nltk.stem.porter import PorterStemmer
+# pylint: enable=import-error
 
 APP = Flask(__name__)
 # parameters

--- a/queue_health/graph/graph.py
+++ b/queue_health/graph/graph.py
@@ -29,13 +29,14 @@ import sys
 import time
 import traceback
 
-# pylint: disable=import-error
+# pylint: disable=import-error,wrong-import-position
 import matplotlib
 matplotlib.use('Agg')  # For savefig
-# pylint: disable=wrong-import-position
+
 import matplotlib.dates as mdates
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+
 import numpy
 # pylint: enable=wrong-import-position,import-error
 

--- a/verify/BUILD
+++ b/verify/BUILD
@@ -26,8 +26,8 @@ test_suite(
 py_binary(
     name = "pylint_bin",
     srcs = ["pylint_bin.py"],
+    # NOTE: this should only contain direct third party imports and pylint
     deps = [
-        "@dateutil//:dateutil",
         "@influxdb//:influxdb",
         "@pylint//:pylint",
         "@pytz//:pytz",

--- a/verify/pylint_bin.py
+++ b/verify/pylint_bin.py
@@ -19,7 +19,6 @@ import sys
 
 import pylint
 
-
 if __name__ == '__main__':
     # Otherwise bazel's symlinks confuse pylint/astroid
     EXTRAS = set()
@@ -32,8 +31,10 @@ if __name__ == '__main__':
             if real != full:
                 EXTRAS.add(os.path.dirname(real))
                 break
-    for extra in EXTRAS:
-        sys.path.append(extra)
+    # also do one level up so foo.bar imports work :shrug:
+    EXTRAS = set(os.path.dirname(e) for e in EXTRAS).union(EXTRAS)
+    # append these to the path
+    sys.path.extend(EXTRAS)
 
     # Otherwise this is the entirety of bin/pylint
     pylint.run_pylint()


### PR DESCRIPTION
In Planter at least I'm still getting a problem with an `influxdb` `import-error` in `metrics/bigquery.py` but that's the only pylint failure I get now, which is better than the situation before. I'm not quite sure why that's still a problem however and this is admittedly a bit gross.