### PR TITLE
List of valid cla labels

### DIFF
--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -252,6 +252,7 @@ func getTestSQ(startThreads bool, config *github_util.Config, server *httptest.S
 	sq.GateCLA = true
 	sq.NonBlockingJobNames = someJobNames
 	sq.DoNotMergeMilestones = []string{doNotMergeMilestone}
+	sq.ClaYesLabels = []string{cncfClaYesLabel, claHumanLabel}
 
 	mungeopts.RequiredContexts.Merge = []string{notRequiredReTestContext1, notRequiredReTestContext2}
 	mungeopts.RequiredContexts.Retest = []string{requiredReTestContext1, requiredReTestContext2}
@@ -686,7 +687,7 @@ func TestSubmitQueue(t *testing.T) {
 			name:   "Test7",
 			pr:     ValidPR(),
 			issue:  NoCLAIssue(),
-			reason: noCLA,
+			reason: fmt.Sprintf("%s %q", noCLA, []string{cncfClaYesLabel, claHumanLabel}),
 			state:  "pending",
 			// To avoid false errors in logs
 			lastBuildNumber: LastBuildNumber(),


### PR DESCRIPTION
Define acceptable cla labels as a list in configmap. Default values are "cncf" and "human-approve" but make it possible for projects using their own cla systems (Googlebot)