### PR TITLE
Increase service_controller's parallelism for correctness CIs

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
@@ -18,5 +18,7 @@ KUBE_ENABLE_CLUSTER_MONITORING=standalone
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+# Increase service_controller's parallelism of processing service update
+CONCURRENT_SERVICE_SYNCS=5
 
 ### test-env

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
@@ -23,5 +23,7 @@ APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-infligh
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+# Increase service_controller's parallelism of processing service update
+CONCURRENT_SERVICE_SYNCS=5
 
 ### test-env


### PR DESCRIPTION
Ref upstream issue: https://github.com/kubernetes/kubernetes/issues/52495.
Follow up of https://github.com/kubernetes/kubernetes/pull/52684.

LB tests are still failing on https://k8s-testgrid.appspot.com/google-gce-scale#gce-scale-correctness&sort-by-failures=. I'd like to increase `CONCURRENT_SERVICE_SYNCS` on correctness suite and see if it help. If so, we may want to bump it up by default. Though we never really test service_controller with parallelism > 1, probably some bugs will pop.

Make it 5 for now as it is what the [majority of other controllers use](https://github.com/kubernetes/kubernetes/blob/5af2ac5344286c3f9e84db3b16f9cda0f2df68b6/cmd/kube-controller-manager/app/options/options.go#L64-L73).
```
ConcurrentEndpointSyncs:                         5,
ConcurrentServiceSyncs:                          1,
ConcurrentRCSyncs:                               5,
ConcurrentRSSyncs:                               5,
ConcurrentDaemonSetSyncs:                        2,
ConcurrentJobSyncs:                              5,
ConcurrentResourceQuotaSyncs:                    5,
ConcurrentDeploymentSyncs:                       5,
ConcurrentNamespaceSyncs:                        10,
ConcurrentSATokenSyncs:                          5,
```

/assign @shyamjvs 
cc @bowei @nicksardo 