### PR TITLE
Make all canary job use :latest-master tag

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9219,7 +9219,7 @@
       "--kubemark-nodes=100",
       "--mode=docker",
       "--provider=gce",
-      "--tag=latest",
+      "--tag=latest-master",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=240m"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3356,7 +3356,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7074,7 +7074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11768,7 +11768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15609,7 +15609,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16016,7 +16016,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:latest
+    - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=110


### PR DESCRIPTION
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-prow-canary/19136 is a good-ish run

ref https://github.com/kubernetes/test-infra/pull/4876

flip all canary job to use the new image and let them soak for a bit (in case still missing some dependency)

/assign @BenTheElder 