### PR TITLE
Add CommentPruner to Prow to save API tokens when deleting stale comments.

### DIFF
--- a/prow/BUILD
+++ b/prow/BUILD
@@ -28,6 +28,7 @@ filegroup(
         "//prow/cmd/splice:all-srcs",
         "//prow/cmd/tide:all-srcs",
         "//prow/cmd/tot:all-srcs",
+        "//prow/commentpruner:all-srcs",
         "//prow/config:all-srcs",
         "//prow/genfiles:all-srcs",
         "//prow/git:all-srcs",

--- a/prow/commentpruner/BUILD
+++ b/prow/commentpruner/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["commentpruner.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["commentpruner_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//prow/github:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/commentpruner/commentpruner.go
+++ b/prow/commentpruner/commentpruner.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package commentpruner facilitates efficiently deleting bot comments as a reaction to webhook events.
+package commentpruner
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+type githubClient interface {
+	BotName() (string, error)
+	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+	DeleteComment(org, repo string, id int) error
+}
+
+// EventClient is a struct that provides bot comment deletion for an event related to an issue.
+// A single client instance should be created for each event and shared by all consumers of the event.
+// The client fetches the comments only once and filters that list repeatedly to find bot comments to
+// delete. This avoids using lots of API tokens when fetching comments for each handler that wants
+// to delete comments. (An HTTP cache only partially helps with this because deletions modify the
+// list of comments so the next call requires GH to send the resource again.)
+type EventClient struct {
+	org    string
+	repo   string
+	number int
+
+	ghc githubClient
+	log *logrus.Entry
+
+	once     sync.Once
+	lock     sync.Mutex
+	comments []github.IssueComment
+}
+
+// NewEventClient creates an EventClient struct. This should be used once per webhook event.
+func NewEventClient(ghc githubClient, log *logrus.Entry, org, repo string, number int) *EventClient {
+	return &EventClient{
+		org:    org,
+		repo:   repo,
+		number: number,
+
+		ghc: ghc,
+		log: log,
+	}
+}
+
+// PruneComments fetches issue comments if they have not yet been fetched for this webhook event
+// and then deletes any bot comments indicated by the func 'shouldPrune'.
+func (c *EventClient) PruneComments(shouldPrune func(github.IssueComment) bool) {
+	c.once.Do(func() {
+		botName, err := c.ghc.BotName()
+		if err != nil {
+			c.log.WithError(err).Error("failed to get the bot's name. Pruning will consider all comments.")
+		}
+		comments, err := c.ghc.ListIssueComments(c.org, c.repo, c.number)
+		if err != nil {
+			c.log.WithError(err).Errorf("failed to list comments for %s/%s#%d", c.org, c.repo, c.number)
+		}
+		if botName != "" {
+			for _, comment := range comments {
+				if comment.User.Login == botName {
+					c.comments = append(c.comments, comment)
+				}
+			}
+		}
+	})
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	var remaining []github.IssueComment
+	for _, comment := range c.comments {
+		removed := false
+		if shouldPrune(comment) {
+			if err := c.ghc.DeleteComment(c.org, c.repo, comment.ID); err != nil {
+				c.log.WithError(err).Errorf("failed to delete stale comment with ID '%d'", comment.ID)
+			} else {
+				removed = true
+			}
+		}
+		if !removed {
+			remaining = append(remaining, comment)
+		}
+	}
+	c.comments = remaining
+}

--- a/prow/commentpruner/commentpruner_test.go
+++ b/prow/commentpruner/commentpruner_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commentpruner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+type fakeGHClient struct {
+	comments        []github.IssueComment
+	deletedComments []int
+	listCallCount   int
+}
+
+func (f *fakeGHClient) BotName() (string, error) {
+	return "k8s-ci-robot", nil
+}
+
+func (f *fakeGHClient) ListIssueComments(_, _ string, _ int) ([]github.IssueComment, error) {
+	f.listCallCount++
+	return f.comments, nil
+}
+
+func (f *fakeGHClient) DeleteComment(_, _ string, ID int) error {
+	f.deletedComments = append(f.deletedComments, ID)
+	return nil
+}
+
+func newFakeGHClient(commentsToLogins map[int]string) *fakeGHClient {
+	comments := make([]github.IssueComment, 0, len(commentsToLogins))
+	for num, login := range commentsToLogins {
+		comments = append(comments, github.IssueComment{ID: num, User: github.User{Login: login}})
+	}
+	return &fakeGHClient{
+		comments:        comments,
+		deletedComments: []int{},
+	}
+}
+
+func testPruneFunc(errorComments *[]int, toPrunes, toErrs []int) func(github.IssueComment) bool {
+	return func(ic github.IssueComment) bool {
+		for _, toErr := range toErrs {
+			if ic.ID == toErr {
+				*errorComments = append(*errorComments, ic.ID)
+				break
+			}
+		}
+		for _, toPrune := range toPrunes {
+			if ic.ID == toPrune {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func TestPruneComments(t *testing.T) {
+	botLogin := "k8s-ci-robot"
+	humanLogin := "cjwagner"
+
+	var errs *[]int
+	tcs := []struct {
+		name            string
+		comments        map[int]string
+		callers         []func(github.IssueComment) bool
+		expectedDeleted []int
+	}{
+		{
+			name:            "One caller, multiple deletions.",
+			comments:        map[int]string{1: botLogin, 2: botLogin, 3: botLogin},
+			callers:         []func(github.IssueComment) bool{testPruneFunc(errs, []int{1, 2}, nil)},
+			expectedDeleted: []int{1, 2},
+		},
+		{
+			name:            "One caller, no deletions.",
+			comments:        map[int]string{3: botLogin},
+			callers:         []func(github.IssueComment) bool{testPruneFunc(errs, []int{1, 2}, nil)},
+			expectedDeleted: []int{},
+		},
+		{
+			name:     "Two callers.",
+			comments: map[int]string{1: botLogin, 2: botLogin, 3: botLogin, 4: botLogin, 5: botLogin},
+			callers: []func(github.IssueComment) bool{
+				testPruneFunc(errs, []int{1, 2}, nil),
+				testPruneFunc(errs, []int{4}, []int{1, 2}),
+			},
+			expectedDeleted: []int{1, 2, 4},
+		},
+		{
+			name:     "Three callers. Some Human messages",
+			comments: map[int]string{1: humanLogin, 2: botLogin, 3: botLogin, 4: botLogin, 5: botLogin, 6: humanLogin, 7: botLogin},
+			callers: []func(github.IssueComment) bool{
+				testPruneFunc(errs, []int{2, 3}, []int{1, 6}),
+				testPruneFunc(errs, []int{5}, []int{1, 2, 3, 6}),
+				testPruneFunc(errs, []int{4}, []int{1, 2, 3, 5, 6}),
+			},
+			expectedDeleted: []int{2, 3, 4, 5},
+		},
+	}
+
+	/*
+		Ensure the following:
+		When multiple callers ask for comment deletion from the same client...
+		- They should not see comments deleted by previous caller.
+		- Comments should be listed only once.
+		- All comments that are stale should be deleted.
+	*/
+	for _, tc := range tcs {
+		errs = &[]int{}
+		fgc := newFakeGHClient(tc.comments)
+		client := NewEventClient(fgc, logrus.WithField("client", "commentpruner"), "org", "repo", 1)
+		for _, call := range tc.callers {
+			client.PruneComments(call)
+		}
+
+		if fgc.listCallCount != 1 {
+			t.Errorf("[%s]: Expected comments to be fetched exactly once, instead got %d.", tc.name, fgc.listCallCount)
+		}
+		if len(*errs) > 0 {
+			t.Errorf("[%s]: The following comments should not have been seen be subsequent callers: %v.", tc.name, *errs)
+		}
+		sort.Ints(tc.expectedDeleted)
+		sort.Ints(fgc.deletedComments)
+		if !reflect.DeepEqual(tc.expectedDeleted, fgc.deletedComments) {
+			t.Errorf("[%s]: Expected the comments %#v to be deleted, but %#v were deleted instead.", tc.name, tc.expectedDeleted, fgc.deletedComments)
+		}
+	}
+}

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -30,6 +30,7 @@ go_library(
         "server.go",
     ],
     deps = [
+        "//prow/commentpruner:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -19,6 +19,7 @@ package hook
 import (
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/commentpruner"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -39,6 +40,13 @@ func (s *Server) handleReviewEvent(l *logrus.Entry, re github.ReviewEvent) {
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
+			pc.CommentPruner = commentpruner.NewEventClient(
+				pc.GitHubClient,
+				l.WithField("client", "commentpruner"),
+				re.Repo.Owner.Login,
+				re.Repo.Name,
+				re.PullRequest.Number,
+			)
 			if err := h(pc, re); err != nil {
 				pc.Logger.WithError(err).Error("Error handling ReviewEvent.")
 			}
@@ -81,6 +89,13 @@ func (s *Server) handleReviewCommentEvent(l *logrus.Entry, rce github.ReviewComm
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
+			pc.CommentPruner = commentpruner.NewEventClient(
+				pc.GitHubClient,
+				l.WithField("client", "commentpruner"),
+				rce.Repo.Owner.Login,
+				rce.Repo.Name,
+				rce.PullRequest.Number,
+			)
 			if err := h(pc, rce); err != nil {
 				pc.Logger.WithError(err).Error("Error handling ReviewCommentEvent.")
 			}
@@ -122,6 +137,13 @@ func (s *Server) handlePullRequestEvent(l *logrus.Entry, pr github.PullRequestEv
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
+			pc.CommentPruner = commentpruner.NewEventClient(
+				pc.GitHubClient,
+				l.WithField("client", "commentpruner"),
+				pr.Repo.Owner.Login,
+				pr.Repo.Name,
+				pr.PullRequest.Number,
+			)
 			if err := h(pc, pr); err != nil {
 				pc.Logger.WithError(err).Error("Error handling PullRequestEvent.")
 			}
@@ -184,6 +206,13 @@ func (s *Server) handleIssueEvent(l *logrus.Entry, i github.IssueEvent) {
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
+			pc.CommentPruner = commentpruner.NewEventClient(
+				pc.GitHubClient,
+				l.WithField("client", "commentpruner"),
+				i.Repo.Owner.Login,
+				i.Repo.Name,
+				i.Issue.Number,
+			)
 			if err := h(pc, i); err != nil {
 				pc.Logger.WithError(err).Error("Error handleing IssueEvent.")
 			}
@@ -225,6 +254,13 @@ func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ic github.IssueComment
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
+			pc.CommentPruner = commentpruner.NewEventClient(
+				pc.GitHubClient,
+				l.WithField("client", "commentpruner"),
+				ic.Repo.Owner.Login,
+				ic.Repo.Name,
+				ic.Issue.Number,
+			)
 			if err := h(pc, ic); err != nil {
 				pc.Logger.WithError(err).Error("Error handling IssueCommentEvent.")
 			}
@@ -296,6 +332,13 @@ func (s *Server) handleGenericComment(l *logrus.Entry, ce *github.GenericComment
 			pc.Logger = l.WithField("plugin", p)
 			pc.Config = s.ConfigAgent.Config()
 			pc.PluginConfig = s.Plugins.Config()
+			pc.CommentPruner = commentpruner.NewEventClient(
+				pc.GitHubClient,
+				l.WithField("client", "commentpruner"),
+				ce.Repo.Owner.Login,
+				ce.Repo.Name,
+				ce.Number,
+			)
 			if err := h(pc, *ce); err != nil {
 				pc.Logger.WithError(err).Error("Error handling GenericCommentEvent.")
 			}

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -23,6 +23,7 @@ go_library(
         "respond.go",
     ],
     deps = [
+        "//prow/commentpruner:go_default_library",
         "//prow/config:go_default_library",
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/commentpruner"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
@@ -107,6 +108,8 @@ type PluginClient struct {
 	KubeClient   *kube.Client
 	GitClient    *git.Client
 	SlackClient  *slack.Client
+
+	CommentPruner *commentpruner.EventClient
 
 	// Config provides information about the jobs
 	// that we know how to run for repos.


### PR DESCRIPTION
This is a prow parallel to mungegithub's comment-deleter munger.

/cc @rmmh 