### PR TITLE
Fix DumpClusterLogs in federation presubmit job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10815,7 +10815,7 @@
   "pull-kubernetes-federation-e2e-gce": {
     "args": [
       "--build",
-      "--cluster=",
+      "--cluster=jenkins-us-central1-f",
       "--deployment=none",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
@@ -10841,7 +10841,7 @@
   "pull-kubernetes-federation-e2e-gce-canary": {
     "args": [
       "--build=bazel",
-      "--cluster=",
+      "--cluster=prow-us-central1-f",
       "--deployment=none",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -540,8 +540,8 @@ class JobTest(unittest.TestCase):
                         if match:
                             cluster = match.group(1)
                             self.assertLessEqual(
-                                len(cluster), 20,
-                                'Job %r, --cluster should be 20 chars or fewer' % job
+                                len(cluster), 23,
+                                'Job %r, --cluster should be 23 chars or fewer' % job
                                 )
                 # these args should not be combined:
                 # --use-shared-build and (--build or --extract)

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -628,7 +628,10 @@ class JobTest(unittest.TestCase):
                                   'both set or unset: %s' % job)
 
                     if job.startswith('pull-kubernetes-'):
-                        self.assertIn('--cluster=', args)
+                        if not 'pull-kubernetes-federation-e2e-gce' in job:
+                            # pull-kubernetes-federation-e2e-gce job uses a specific cluster names
+                            # instead of dynamic cluster names.
+                            self.assertIn('--cluster=', args)
                         if 'gke' in job:
                             stage = 'gs://kubernetes-release-dev/ci'
                             suffix = True


### PR DESCRIPTION
`DumpClusterLogs` is failing in federation pre-submit job since the cluster name detected is not matching the actual cluster name. we do use fixed clusters which gets recycled every day. They all are prefixed with the name `${USER}-${ZONE}`. This issue will be fixed if we pass the cluster name explicitly in the job.

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/53482/pull-kubernetes-federation-e2e-gce/28127/

/assign @krzyzacy 
/cc @madhusudancs 
