### PR TITLE
add tests for *Paths in bootstrap/

### DIFF
--- a/bootstrap/BUILD
+++ b/bootstrap/BUILD
@@ -36,6 +36,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "args_test.go",
+        "paths_test.go",
         "repos_test.go",
     ],
     library = ":go_default_library",

--- a/bootstrap/args_test.go
+++ b/bootstrap/args_test.go
@@ -108,8 +108,8 @@ func TestParseArgs(t *testing.T) {
 			t.Errorf("Got error and did not expect one for test %s, %v", test.Name, err)
 		} else if !reflect.DeepEqual(res, test.Expected) {
 			t.Errorf("Args did not match expected for test: %s", test.Name)
-			t.Errorf("%+v", res)
-			t.Errorf("%+v", test.Expected)
+			t.Errorf("%#v", res)
+			t.Errorf("%#v", test.Expected)
 		}
 	}
 }

--- a/bootstrap/paths.go
+++ b/bootstrap/paths.go
@@ -66,6 +66,8 @@ func PRPaths(base string, repos Repos, job, build string) (*Paths, error) {
 		prefix = repo.Name[len("kubernetes/"):]
 	} else if strings.HasPrefix(repo.Name, "github.com/") {
 		prefix = strings.Replace(repo.Name[len("github.com/"):], "/", "_", -1)
+	} else {
+		prefix = strings.Replace(repo.Name, "/", "_", -1)
 	}
 	// Batch merges are those with more than one PR specified.
 	prNums := PullNumbers(repo.Pull)

--- a/bootstrap/paths_test.go
+++ b/bootstrap/paths_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCIPaths(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Base     string
+		Job      string
+		Build    string
+		Expected *Paths
+	}{
+		{
+			Name:  "normal",
+			Base:  "/some/foo/base",
+			Job:   "some-foo-job",
+			Build: "1337",
+			Expected: &Paths{
+				Artifacts:   filepath.Join("/some/foo/base", "some-foo-job", "1337", "artifacts"),
+				BuildLog:    filepath.Join("/some/foo/base", "some-foo-job", "1337", "build-log.txt"),
+				Finished:    filepath.Join("/some/foo/base", "some-foo-job", "1337", "finished.json"),
+				Latest:      filepath.Join("/some/foo/base", "some-foo-job", "latest-build.txt"),
+				ResultCache: filepath.Join("/some/foo/base", "some-foo-job", "jobResultsCache.json"),
+				Started:     filepath.Join("/some/foo/base", "some-foo-job", "1337", "started.json"),
+			},
+		},
+	}
+	for _, test := range tests {
+		res := CIPaths(test.Base, test.Job, test.Build)
+		if !reflect.DeepEqual(res, test.Expected) {
+			t.Errorf("Paths did not match expected for test: %s", test.Name)
+			t.Errorf("%#v", res)
+			t.Errorf("%#v", test.Expected)
+		}
+	}
+}
+
+func TestPRPaths(t *testing.T) {
+	// create some Repos values for use in the test cases below
+	reposEmtpy := Repos{}
+	reposK8sIO, err := ParseRepos([]string{"k8s.io/kubernetes=master:42e2ca8c18c93ba25eb0e5bd02ecba2eaa05e871,52057:b4f639f57ae0a89cdf1b43d1810b617c76f4b1b3,1337:03a564a5309ea84065fb203f628b50c382b65a50"})
+	if err != nil {
+		t.Errorf("got unexpected error parsing test repos: %v", err)
+	}
+	reposK8sIOTestInfra, err := ParseRepos([]string{"k8s.io/test-infra=master:42e2ca8c18c93ba25eb0e5bd02ecba2eaa05e871,52057:b4f639f57ae0a89cdf1b43d1810b617c76f4b1b3"})
+	if err != nil {
+		t.Errorf("got unexpected error parsing test repos: %v", err)
+	}
+	reposKubernetes, err := ParseRepos([]string{"kubernetes/test-infra"})
+	if err != nil {
+		t.Errorf("got unexpected error parsing test repos: %v", err)
+	}
+	reposGithub, err := ParseRepos([]string{"github.com/foo/bar"})
+	if err != nil {
+		t.Errorf("got unexpected error parsing test repos: %v", err)
+	}
+	reposOther, err := ParseRepos([]string{"example.com/foo/bar"})
+	if err != nil {
+		t.Errorf("got unexpected error parsing test repos: %v", err)
+	}
+	// assert some known expected values and the expected failure for len(repos) == 0
+	tests := []struct {
+		Name      string
+		Base      string
+		Repos     Repos
+		Job       string
+		Build     string
+		Expected  *Paths
+		ExpectErr bool
+	}{
+		{
+			Name:  "normal-k8s.io/kubernetes",
+			Base:  "/base",
+			Job:   "some-job",
+			Repos: reposK8sIO,
+			Build: "1337",
+			Expected: &Paths{
+				Artifacts:     filepath.Join("/base", "pull", "batch", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "batch", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "batch", "some-job", "1337"),
+				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
+				PRLatest:      filepath.Join("/base", "pull", "batch", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "batch", "some-job", "jobResultsCache.json"),
+				ResultCache:   filepath.Join("/base", "directory", "some-job", "jobResultsCache.json"),
+				Started:       filepath.Join("/base", "pull", "batch", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "batch", "some-job", "1337", "finished.json"),
+				Latest:        filepath.Join("/base", "directory", "some-job", "latest-build.txt"),
+			},
+			ExpectErr: false,
+		},
+		{
+			Name:  "normal-k8s.io/test-infra",
+			Base:  "/base",
+			Job:   "some-job",
+			Repos: reposK8sIOTestInfra,
+			Build: "1337",
+			Expected: &Paths{
+				Artifacts:     filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337"),
+				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
+				PRLatest:      filepath.Join("/base", "pull", "test-infra/52057", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "test-infra/52057", "some-job", "jobResultsCache.json"),
+				ResultCache:   filepath.Join("/base", "directory", "some-job", "jobResultsCache.json"),
+				Started:       filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "finished.json"),
+				Latest:        filepath.Join("/base", "directory", "some-job", "latest-build.txt"),
+			},
+			ExpectErr: false,
+		},
+		{
+			Name:  "normal-kubernetes/test-infra",
+			Base:  "/base",
+			Job:   "some-job",
+			Repos: reposKubernetes,
+			Build: "1337",
+			Expected: &Paths{
+				Artifacts:     filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "test-infra", "some-job", "1337"),
+				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
+				PRLatest:      filepath.Join("/base", "pull", "test-infra", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "test-infra", "some-job", "jobResultsCache.json"),
+				ResultCache:   filepath.Join("/base", "directory", "some-job", "jobResultsCache.json"),
+				Started:       filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "finished.json"),
+				Latest:        filepath.Join("/base", "directory", "some-job", "latest-build.txt"),
+			},
+			ExpectErr: false,
+		},
+		{
+			Name:  "normal-github",
+			Base:  "/base",
+			Job:   "some-job",
+			Repos: reposGithub,
+			Build: "1337",
+			Expected: &Paths{
+				Artifacts:     filepath.Join("/base", "pull", "foo_bar", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base/pull/foo_bar/some-job/1337/build-log.txt"),
+				PRPath:        filepath.Join("/base/pull/foo_bar/some-job/1337"),
+				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
+				PRLatest:      filepath.Join("/base", "pull", "foo_bar", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "foo_bar", "some-job", "jobResultsCache.json"),
+				ResultCache:   filepath.Join("/base", "directory", "some-job", "jobResultsCache.json"),
+				Started:       filepath.Join("/base", "pull", "foo_bar", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "foo_bar", "some-job", "1337", "finished.json"),
+				Latest:        filepath.Join("/base", "directory", "some-job", "latest-build.txt"),
+			},
+			ExpectErr: false,
+		},
+		{
+			Name:  "normal-other",
+			Base:  "/base",
+			Job:   "some-job",
+			Repos: reposOther,
+			Build: "1337",
+			Expected: &Paths{
+				Artifacts:     filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337"),
+				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
+				PRLatest:      filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "jobResultsCache.json"),
+				ResultCache:   filepath.Join("/base", "/directory/some-job", "jobResultsCache.json"),
+				Started:       filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "finished.json"),
+				Latest:        filepath.Join("/base", "/directory/some-job", "latest-build.txt"),
+			},
+			ExpectErr: false,
+		},
+		{
+			Name:      "expect-failure (no repos)",
+			Base:      "/some/foo/base",
+			Job:       "some-foo-job",
+			Repos:     reposEmtpy,
+			Build:     "1337",
+			Expected:  nil,
+			ExpectErr: true,
+		},
+	}
+	for _, test := range tests {
+		res, err := PRPaths(test.Base, test.Repos, test.Job, test.Build)
+		if test.ExpectErr && err == nil {
+			t.Errorf("err == nil and error expected for test %#v", test.Name)
+		} else if err != nil && !test.ExpectErr {
+			t.Errorf("Got error and did not expect one for test %#v, %v", test.Name, err)
+		} else if !reflect.DeepEqual(res, test.Expected) {
+			t.Errorf("Paths did not match expected for test: %#v", test.Name)
+			t.Errorf("%#v", res)
+			t.Errorf("%#v", test.Expected)
+		}
+	}
+}

--- a/bootstrap/repos.go
+++ b/bootstrap/repos.go
@@ -83,6 +83,8 @@ func ParseRepos(repoArgs []string) (Repos, error) {
 	return repos, nil
 }
 
+// TODO(bentheelder): unit test the methods below
+
 func refHasSHAs(ref string) bool {
 	return strings.Contains(ref, ":")
 }

--- a/bootstrap/repos_test.go
+++ b/bootstrap/repos_test.go
@@ -80,8 +80,8 @@ func TestParseRepos(t *testing.T) {
 			t.Errorf("Got error and did not expect one for test %s, %v", test.Name, err)
 		} else if !reflect.DeepEqual(res, test.Expected) {
 			t.Errorf("Repos did not match expected for test: %s", test.Name)
-			t.Errorf("%+v", res)
-			t.Errorf("%+v", test.Expected)
+			t.Errorf("%#v", res)
+			t.Errorf("%#v", test.Expected)
 			// assert that currently Repos.Main() == Repos[0]
 		} else if len(test.Expected) > 0 && res.Main() != &res[0] {
 			t.Errorf("Expected repos.Main() to be &res[0] for all tests (test: %s)", test.Name)


### PR DESCRIPTION
This adds some basic unit tests for `CIPaths` and `PRPaths` which brings the current code closer to full coverage. In the process I fixed a bug in `PRPaths` mimicking `jenkins/bootstrap.py`'s `pr_paths`, and also improved the debug format of the existing test `Errorf`s (`%#v` is awesome!) 