### PR TITLE
make it easier to supply extra docker args when running planter

### DIFF
--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -27,4 +27,4 @@ REPO=${REPO:-${PWD}}
 VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --tmpfs /tmp:exec,mode=777"
 GID="$(id -g ${USER})"
 ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
-docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${IMAGE} ${@}
+docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}


### PR DESCRIPTION
for example: `TAG=0.6.1-1 DOCKER_EXTRA=-it planter/planter.sh /bin/bash` (useful for debugging)