### PR TITLE
Prevent release-note plugin from trying to remove label twice.

### DIFF
--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -214,9 +214,6 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent) e
 				log.WithError(err).Errorf("Failed to comment on %s/%s#%d with comment %q.", org, repo, pr.Number, comment)
 			}
 		}
-	} else {
-		//going to apply some other release-note-label
-		ensureNoRelNoteNeededLabel(gc, log, pr, prLabels)
 	}
 
 	// Add the label if needed


### PR DESCRIPTION
Prow is logging errors when the release-note plugin tries to delete the `release-note-label-needed` twice. This isn't a critical error so this fix can be wrapped into the next hook bump.
/cc @rmmh 