### PR TITLE
Fix DumpClusterLogs in ci-kubernetes-pull-gce-federation-deploy

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8982,6 +8982,7 @@
   },
   "ci-kubernetes-pull-gce-federation-deploy": {
     "args": [
+      "--cluster=jenkins-us-central1-f",
       "--down=false",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-pull-gce-federation-deploy.env",


### PR DESCRIPTION
This change got missed out in daily recycle job. if we don't specify the cluster name, the default `bootstrap-e2e` is getting used for cluster name. This cause `DumpClusterLogs` to fail.

Apart from this cluster name is also used for network. not sure of the impact of this. So its better to keep the same cluster name for both `ci-kubernetes-pull-gce-federation-deploy` and the `pull-kubernetes-federation-e2e-gce`.

/assign @krzyzacy 
/cc @madhusudancs 