### PR TITLE
Revert "Bump to e2e-kubeadm:v20171006-99427ec8"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -109,7 +109,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -203,7 +203,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -903,7 +903,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -997,7 +997,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1899,7 +1899,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1942,7 +1942,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2056,7 +2056,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2174,7 +2174,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2217,7 +2217,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2335,7 +2335,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2378,7 +2378,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -16489,7 +16489,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -16608,7 +16608,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -16653,7 +16653,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -16770,7 +16770,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -16815,7 +16815,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171006-99427ec8
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"


### PR DESCRIPTION
This reverts commit 17c8eb57bd042d347f93e966135acb59dd775a91.

`jq` is missing from the new image, and `pull-kubernetes-e2e-kubeadm-gce` is broken - https://github.com/kubernetes/kubernetes/issues/53570.