### PR TITLE
Add jq to the bootstrap image

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -25,22 +25,23 @@ ENV WORKSPACE=/workspace \
 # common util tools
 # https://github.com/GoogleCloudPlatform/gsutil/issues/446 for python-openssl
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget \
+    build-essential \
+    ca-certificates \
     curl \
     file \
-    rsync \
-    ca-certificates \
-    build-essential \
-    openssh-client \
     git \
+    jq \
+    openssh-client \
     pkg-config \
-    zip \
-    unzip \
-    xz-utils \
-    zlib1g-dev \
     python \
     python-openssl \
     python-pip \
+    rsync \
+    unzip \
+    wget \
+    xz-utils \
+    zip \
+    zlib1g-dev \
     && apt-get clean
 
 # Install gcloud

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20171005-a3dc7e92
+FROM gcr.io/k8s-testimages/bootstrap:v20171008-2cd48707
 MAINTAINER  Sen Lu <senlu@google.com>
 
 # install go

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -368,7 +368,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -412,7 +412,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -480,7 +480,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -550,7 +550,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -619,7 +619,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -701,7 +701,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-federation-e2e-gce-canary,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -784,7 +784,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-node-e2e-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1162,7 +1162,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1206,7 +1206,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1274,7 +1274,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1344,7 +1344,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1413,7 +1413,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1495,7 +1495,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-federation-e2e-gce-canary,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1578,7 +1578,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-node-e2e-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2530,7 +2530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2564,7 +2564,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2598,7 +2598,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2632,7 +2632,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2666,7 +2666,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2700,7 +2700,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2734,7 +2734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2768,7 +2768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2802,7 +2802,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2836,7 +2836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2870,7 +2870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2904,7 +2904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2938,7 +2938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -2972,7 +2972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3006,7 +3006,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3040,7 +3040,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3074,7 +3074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3108,7 +3108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3142,7 +3142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3176,7 +3176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3246,7 +3246,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3282,7 +3282,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3318,7 +3318,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3354,7 +3354,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3390,7 +3390,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3426,7 +3426,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3462,7 +3462,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3498,7 +3498,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3534,7 +3534,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3570,7 +3570,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3606,7 +3606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3642,7 +3642,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3678,7 +3678,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3714,7 +3714,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3750,7 +3750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3786,7 +3786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3822,7 +3822,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3858,7 +3858,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3894,7 +3894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3930,7 +3930,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3966,7 +3966,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4002,7 +4002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4038,7 +4038,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4074,7 +4074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4110,7 +4110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4146,7 +4146,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4182,7 +4182,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4218,7 +4218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4254,7 +4254,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4290,7 +4290,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4326,7 +4326,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4362,7 +4362,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4398,7 +4398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4434,7 +4434,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4470,7 +4470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4506,7 +4506,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4542,7 +4542,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4578,7 +4578,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4614,7 +4614,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4650,7 +4650,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4684,7 +4684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4718,7 +4718,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4752,7 +4752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4786,7 +4786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4820,7 +4820,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4854,7 +4854,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4888,7 +4888,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4922,7 +4922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4956,7 +4956,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4990,7 +4990,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5024,7 +5024,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5058,7 +5058,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5092,7 +5092,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5126,7 +5126,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5160,7 +5160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5194,7 +5194,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5228,7 +5228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5262,7 +5262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5296,7 +5296,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5330,7 +5330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5364,7 +5364,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5398,7 +5398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5432,7 +5432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5466,7 +5466,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5500,7 +5500,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5534,7 +5534,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5568,7 +5568,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5602,7 +5602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5636,7 +5636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5670,7 +5670,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5704,7 +5704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5738,7 +5738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5772,7 +5772,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5806,7 +5806,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5840,7 +5840,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5874,7 +5874,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5908,7 +5908,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5942,7 +5942,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5976,7 +5976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6010,7 +6010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6044,7 +6044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6078,7 +6078,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6112,7 +6112,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6146,7 +6146,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6180,7 +6180,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6214,7 +6214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6248,7 +6248,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6282,7 +6282,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6316,7 +6316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6350,7 +6350,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6384,7 +6384,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6452,7 +6452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6486,7 +6486,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6554,7 +6554,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6588,7 +6588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6622,7 +6622,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6656,7 +6656,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6690,7 +6690,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6724,7 +6724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6758,7 +6758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6792,7 +6792,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6826,7 +6826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6860,7 +6860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6894,7 +6894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6928,7 +6928,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6962,7 +6962,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6996,7 +6996,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7030,7 +7030,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7064,7 +7064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7098,7 +7098,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7134,7 +7134,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7170,7 +7170,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7206,7 +7206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7242,7 +7242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7278,7 +7278,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7314,7 +7314,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7350,7 +7350,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7386,7 +7386,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7422,7 +7422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7458,7 +7458,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7494,7 +7494,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7530,7 +7530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7566,7 +7566,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7602,7 +7602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7638,7 +7638,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7674,7 +7674,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7710,7 +7710,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7746,7 +7746,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7780,7 +7780,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7814,7 +7814,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7848,7 +7848,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7882,7 +7882,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7916,7 +7916,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7950,7 +7950,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7984,7 +7984,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8018,7 +8018,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8052,7 +8052,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8086,7 +8086,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8120,7 +8120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8154,7 +8154,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8188,7 +8188,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8222,7 +8222,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8256,7 +8256,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8290,7 +8290,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8324,7 +8324,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8358,7 +8358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8392,7 +8392,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8426,7 +8426,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8460,7 +8460,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8494,7 +8494,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8528,7 +8528,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8562,7 +8562,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8596,7 +8596,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8630,7 +8630,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8664,7 +8664,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8698,7 +8698,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8732,7 +8732,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8766,7 +8766,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8800,7 +8800,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8834,7 +8834,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8868,7 +8868,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8902,7 +8902,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8936,7 +8936,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8970,7 +8970,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9004,7 +9004,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9038,7 +9038,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9072,7 +9072,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9106,7 +9106,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9140,7 +9140,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9174,7 +9174,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9208,7 +9208,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9242,7 +9242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9276,7 +9276,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9310,7 +9310,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9344,7 +9344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9378,7 +9378,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9412,7 +9412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9446,7 +9446,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9480,7 +9480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9514,7 +9514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9548,7 +9548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9582,7 +9582,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9616,7 +9616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9650,7 +9650,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9684,7 +9684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9718,7 +9718,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9752,7 +9752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9786,7 +9786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9820,7 +9820,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9854,7 +9854,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9888,7 +9888,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9922,7 +9922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9956,7 +9956,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9990,7 +9990,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10024,7 +10024,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10058,7 +10058,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10092,7 +10092,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10126,7 +10126,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10160,7 +10160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10194,7 +10194,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10228,7 +10228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10262,7 +10262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10296,7 +10296,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10330,7 +10330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10364,7 +10364,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10398,7 +10398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10432,7 +10432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10466,7 +10466,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10500,7 +10500,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10534,7 +10534,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10568,7 +10568,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10602,7 +10602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10636,7 +10636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10670,7 +10670,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10704,7 +10704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10738,7 +10738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10772,7 +10772,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10806,7 +10806,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10840,7 +10840,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10874,7 +10874,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10942,7 +10942,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10976,7 +10976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11010,7 +11010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11044,7 +11044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11078,7 +11078,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11112,7 +11112,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11146,7 +11146,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11180,7 +11180,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11214,7 +11214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11248,7 +11248,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11282,7 +11282,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11316,7 +11316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11350,7 +11350,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11384,7 +11384,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11418,7 +11418,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11452,7 +11452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11486,7 +11486,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11520,7 +11520,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11554,7 +11554,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11588,7 +11588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11622,7 +11622,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11656,7 +11656,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11690,7 +11690,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11724,7 +11724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11758,7 +11758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11793,7 +11793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11827,7 +11827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11861,7 +11861,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11895,7 +11895,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11929,7 +11929,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11963,7 +11963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11997,7 +11997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12031,7 +12031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12065,7 +12065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12099,7 +12099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12133,7 +12133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12167,7 +12167,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12201,7 +12201,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12235,7 +12235,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12269,7 +12269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12303,7 +12303,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12337,7 +12337,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12371,7 +12371,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12405,7 +12405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12439,7 +12439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12473,7 +12473,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12507,7 +12507,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12541,7 +12541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12575,7 +12575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12609,7 +12609,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12643,7 +12643,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12677,7 +12677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12711,7 +12711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12745,7 +12745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12779,7 +12779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12813,7 +12813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12847,7 +12847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12881,7 +12881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12915,7 +12915,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12949,7 +12949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12983,7 +12983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13017,7 +13017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13051,7 +13051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13085,7 +13085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13119,7 +13119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13153,7 +13153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13187,7 +13187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13221,7 +13221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13255,7 +13255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13289,7 +13289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13323,7 +13323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13357,7 +13357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13391,7 +13391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13425,7 +13425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13459,7 +13459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13493,7 +13493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13529,7 +13529,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13565,7 +13565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13601,7 +13601,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13637,7 +13637,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13673,7 +13673,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13709,7 +13709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13745,7 +13745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13781,7 +13781,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13817,7 +13817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13853,7 +13853,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13889,7 +13889,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13925,7 +13925,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13962,7 +13962,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13998,7 +13998,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14034,7 +14034,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14070,7 +14070,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14106,7 +14106,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14142,7 +14142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14178,7 +14178,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14214,7 +14214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14250,7 +14250,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14286,7 +14286,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14322,7 +14322,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14358,7 +14358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14394,7 +14394,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14430,7 +14430,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14466,7 +14466,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14500,7 +14500,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14536,7 +14536,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14622,7 +14622,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14665,7 +14665,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14708,7 +14708,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14751,7 +14751,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14794,7 +14794,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14837,7 +14837,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14880,7 +14880,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14923,7 +14923,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14964,7 +14964,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15074,7 +15074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15113,7 +15113,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15152,7 +15152,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15191,7 +15191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15230,7 +15230,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15269,7 +15269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15308,7 +15308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15347,7 +15347,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15386,7 +15386,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15425,7 +15425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15464,7 +15464,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15503,7 +15503,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15542,7 +15542,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15581,7 +15581,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15620,7 +15620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15659,7 +15659,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15698,7 +15698,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15737,7 +15737,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15776,7 +15776,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15815,7 +15815,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15854,7 +15854,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15893,7 +15893,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15932,7 +15932,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15971,7 +15971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15993,7 +15993,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16030,7 +16030,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16067,7 +16067,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16104,7 +16104,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16141,7 +16141,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -16178,7 +16178,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -16214,7 +16214,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -109,7 +109,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -203,7 +203,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -903,7 +903,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -997,7 +997,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1899,7 +1899,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -1942,7 +1942,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2056,7 +2056,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2174,7 +2174,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2217,7 +2217,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2335,7 +2335,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2378,7 +2378,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -16489,7 +16489,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -16608,7 +16608,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -16653,7 +16653,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -16770,7 +16770,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -16815,7 +16815,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171003-d61471c6
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171006-bfbd469b-master'
+DEFAULT_KUBEKINS_TAG = 'v20171008-cd94f30a-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
Some scripts use `jq`, and the `kubekins-e2e` images used to contain it, until we rebased off of the `bootstrap` image. Let's add it back.

/assign @krzyzacy @BenTheElder 

x-ref https://github.com/kubernetes/kubernetes/issues/53570