### PR TITLE
Add canary jobs to migrate federation jobs from jenkins to prow

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9001,6 +9001,26 @@
       "sig-federation"
     ]
   },
+  "ci-kubernetes-pull-gce-federation-deploy-canary": {
+    "args": [
+      "--cluster=prow-us-central1-f",
+      "--down=false",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-pull-gce-federation-deploy-canary.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-jkns-pr-cnry-e2e-gce-fdrtn",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy-canary",
+      "--test=false",
+      "--timeout=90m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-federation"
+    ]
+  },
   "ci-kubernetes-soak-cos-docker-validation-deploy": {
     "args": [
       "--down=false",
@@ -10277,10 +10297,10 @@
       "--deployment=none",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
-      "--env-file=jobs/env/pull-kubernetes-federation-e2e-gce.env",
+      "--env-file=jobs/env/pull-kubernetes-federation-e2e-gce-canary.env",
       "--extract=local",
       "--federation",
-      "--gcp-project=k8s-jkns-pr-bldr-e2e-gce-fdrtn",
+      "--gcp-project=k8s-jkns-pr-cnry-e2e-gce-fdrtn",
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=30",
       "--multiple-federations",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -775,6 +775,7 @@ class JobTest(unittest.TestCase):
             'pull-kubernetes-federation-e2e-gce': 'pull-kubernetes-federation-e2e-gce-*',
             'ci-kubernetes-pull-gce-federation-deploy': 'pull-kubernetes-federation-e2e-gce-*',
             'pull-kubernetes-federation-e2e-gce-canary': 'pull-kubernetes-federation-e2e-gce-*',
+            'ci-kubernetes-pull-gce-federation-deploy-canary': 'pull-kubernetes-federation-e2e-gce-*',
             'pull-kubernetes-e2e-gce': 'pull-kubernetes-e2e-gce-*',
             'pull-kubernetes-e2e-gce-canary': 'pull-kubernetes-e2e-gce-*',
             'ci-kubernetes-e2e-gce': 'ci-kubernetes-e2e-gce-*',

--- a/jobs/env/ci-kubernetes-pull-gce-federation-deploy-canary.env
+++ b/jobs/env/ci-kubernetes-pull-gce-federation-deploy-canary.env
@@ -1,0 +1,13 @@
+# NOTE: Although this job is a dependency for a pull job, this is
+# being deployed as a CI job because we want this to run this job
+# periodically to bring up and tear down the clusters.
+
+### job-env
+FEDERATION=true
+
+KUBE_REGISTRY=gcr.io/k8s-jkns-pr-cnry-e2e-gce-fdrtn
+
+
+# Where the clusters will be created. Federation components are now deployed to the last one.
+E2E_ZONES=us-central1-a us-central1-b us-central1-f
+FEDERATION_CLUSTERS=us-central1-a us-central1-b us-central1-f

--- a/jobs/env/pull-kubernetes-federation-e2e-gce-canary.env
+++ b/jobs/env/pull-kubernetes-federation-e2e-gce-canary.env
@@ -1,0 +1,18 @@
+# Panic if anything mutates a shared informer cache
+ENABLE_CACHE_MUTATION_DETECTOR=true
+
+FEDERATION=true
+USE_KUBEFED=true
+KUBE_REGISTRY=gcr.io/k8s-jkns-pr-cnry-e2e-gce-fdrtn
+
+# Recycle control plane.
+# We only recycle federation control plane in each run, we don't
+# want to recycle the clusters, it's too slow.
+# This is accomplished by not setting FEDERATION_CLUSTERS env
+# var or setting it to empty string. We set it to empty string
+# to explicitly call it out.
+FEDERATION_CLUSTERS=
+
+# Federation control plane options.
+FEDERATION_DNS_ZONE_NAME=pr-cnry.test-f8n.k8s.io.
+FEDERATION_HOST_CLUSTER_ZONE=us-central1-f

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -711,7 +711,7 @@ presubmits:
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --timeout=110
+        - "--timeout=110"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -16172,6 +16172,41 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+
+- interval: 24h
+  agent: kubernetes
+  name: ci-kubernetes-pull-gce-federation-deploy-canary
+  spec:
+    containers:
+    - args:
+      - --timeout=60
+      - --repo=k8s.io/kubernetes
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
 
 - name: ci-perf-tests-e2e-gce-clusterloader
   interval: 2h

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -161,6 +161,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-soak-gce-federation-test
 - name: ci-kubernetes-pull-gce-federation-deploy
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-pull-gce-federation-deploy
+- name: ci-kubernetes-pull-gce-federation-deploy-canary
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-pull-gce-federation-deploy-canary
 - name: ci-kubernetes-federation-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-federation-build
 - name: ci-kubernetes-federation-build-1.6
@@ -3654,6 +3656,8 @@ dashboards:
     test_group_name: ci-kubernetes-soak-gce-federation-test
   - name: pull-gce-deploy
     test_group_name: ci-kubernetes-pull-gce-federation-deploy
+  - name: pull-gce-deploy-canary
+    test_group_name: ci-kubernetes-pull-gce-federation-deploy-canary
   - name: build
     test_group_name: ci-kubernetes-federation-build
   - name: build-1.6


### PR DESCRIPTION
Ref #2791 
This PR is to test (in canary jobs) before migrating federation pre-submit jobs from jenkins to prow.

/assign @krzyzacy 
/cc @madhusudancs @kubernetes/sig-multicluster-pr-reviews 