### PR TITLE
Build Go binaries statically by default.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,7 @@
 build --workspace_status_command=./print-workspace-status.sh
 run --workspace_status_command=./print-workspace-status.sh
 test --features=race --test_output=errors
+
+# Build static binaries
+build --features=static
+run --features=static

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "ee1fef7ec1379fcf36c002fd3ac0d00d940b147e",
+    commit = "a390e7f7eac912f6e67dc54acf67aa974d05f9c3",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 


### PR DESCRIPTION
With this change:
```shell
$ bazel build prow/cmd/hook
INFO: Analysed target //prow/cmd/hook:hook (1 packages loaded).
INFO: Found 1 target...
Target //prow/cmd/hook:hook up-to-date:
  bazel-bin/prow/cmd/hook/hook
INFO: Elapsed time: 0.779s, Critical Path: 0.11s
INFO: Build completed successfully, 1 total action

$ ldd bazel-bin/prow/cmd/hook/hook
        not a dynamic executable
```