### PR TITLE
Use go_image rules for Prow components

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,9 +37,33 @@ docker_repositories()
 
 docker_pull(
     name = "distroless-base",
-    digest = "sha256:d19b95495f226aa64cd63a95863aca4da123bde22410a273e68e091113222e4f",  # latest
+    # latest circa 2017/11/29
+    digest = "sha256:bef8d030c7f36dfb73a8c76137616faeea73ac5a8495d535f27c911d0db77af3",
     registry = "gcr.io",
     repository = "distroless/base",
+)
+
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_repositories = "repositories",
+)
+
+_go_repositories()
+
+docker_pull(
+    name = "alpine-base",
+    # 0.1 as of 2017/11/29
+    digest = "sha256:317d39ece9dd09992fa81236964be3f3919b940f42e3143379dd66e4af930f3a",
+    registry = "gcr.io",
+    repository = "k8s-prow/alpine",
+)
+
+docker_pull(
+    name = "git-base",
+    # 0.1 as of 2017/11/29
+    digest = "sha256:92423bd3b24b0274198bb90c00e91b70d81c32e1d6bd26af30c00ca9f5faeb74",
+    registry = "gcr.io",
+    repository = "k8s-prow/git",
 )
 
 git_repository(

--- a/prow/cmd/deck/BUILD
+++ b/prow/cmd/deck/BUILD
@@ -1,10 +1,32 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
     "go_test",
+)
+
+container_image(
+    name = "asset-base",
+    base = "@alpine-base//image",
+    # With paths relative to the current directory.
+    data_path = ".",
+    # Add files under into the root directory.
+    directory = "/",
+    # Everything under static/
+    files = glob(["static/**/*"]),
+)
+
+go_image(
+    name = "image",
+    base = ":asset-base",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/deck",
+    pure = "on",
+    race = "off",
 )
 
 go_binary(

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -1,10 +1,23 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
     "go_test",
+)
+
+go_image(
+    name = "image",
+    base = "@git-base//image",
+    data = [
+        "//prow:configs",
+    ],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/hook",
+    pure = "on",
+    race = "off",
 )
 
 go_binary(

--- a/prow/cmd/horologium/BUILD
+++ b/prow/cmd/horologium/BUILD
@@ -1,10 +1,20 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
     "go_test",
+)
+
+go_image(
+    name = "image",
+    base = "@alpine-base//image",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/horologium",
+    pure = "on",
+    race = "off",
 )
 
 go_binary(

--- a/prow/cmd/jenkins-operator/BUILD
+++ b/prow/cmd/jenkins-operator/BUILD
@@ -2,10 +2,20 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
+)
+
+go_image(
+    name = "image",
+    base = "@alpine-base//image",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
+    pure = "on",
+    race = "off",
 )
 
 go_library(
@@ -15,7 +25,6 @@ go_library(
         "main.go",
     ],
     importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
-    tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
@@ -48,5 +57,4 @@ go_binary(
     importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
     pure = "on",
     race = "off",
-    tags = ["automanaged"],
 )

--- a/prow/cmd/plank/BUILD
+++ b/prow/cmd/plank/BUILD
@@ -1,9 +1,19 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
+)
+
+go_image(
+    name = "image",
+    base = "@alpine-base//image",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/plank",
+    pure = "on",
+    race = "off",
 )
 
 go_binary(

--- a/prow/cmd/sinker/BUILD
+++ b/prow/cmd/sinker/BUILD
@@ -1,10 +1,20 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
     "go_test",
+)
+
+go_image(
+    name = "image",
+    base = "@alpine-base//image",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/sinker",
+    pure = "on",
+    race = "off",
 )
 
 go_binary(

--- a/prow/cmd/splice/BUILD
+++ b/prow/cmd/splice/BUILD
@@ -1,10 +1,20 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
     "go_test",
+)
+
+go_image(
+    name = "image",
+    base = "@git-base//image",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/splice",
+    pure = "on",
+    race = "off",
 )
 
 go_binary(

--- a/prow/cmd/tide/BUILD
+++ b/prow/cmd/tide/BUILD
@@ -1,4 +1,19 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+)
+
+go_image(
+    name = "image",
+    base = "@git-base//image",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/tide",
+    pure = "on",
+    race = "off",
+    visibility = ["//visibility:public"],
+)
 
 go_library(
     name = "go_default_library",

--- a/prow/cmd/tot/BUILD
+++ b/prow/cmd/tot/BUILD
@@ -1,10 +1,20 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
     "go_test",
+)
+
+go_image(
+    name = "image",
+    base = "@alpine-base//image",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/tot",
+    pure = "on",
+    race = "off",
 )
 
 go_binary(


### PR DESCRIPTION
This builds on https://github.com/kubernetes/test-infra/pull/4928, and overlays the statically linked Go binary on either the Alpine or Git base image.