### PR TITLE
[WIP] Add a Bazel variant of starter.yaml using rules_k8s.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,6 +66,31 @@ docker_pull(
     repository = "k8s-prow/git",
 )
 
+http_archive(
+    name = "io_bazel_rules_k8s",
+    sha256 = "71d096bb3820f17fdeb0a28487a541a388a7af94193558903daf50d9d2c22a05",
+    strip_prefix = "rules_k8s-1fe2676a52ec0cdcc860b4d382e9dfbfede56073",
+    urls = ["https://github.com/bazelbuild/rules_k8s/archive/1fe2676a52ec0cdcc860b4d382e9dfbfede56073.tar.gz"],
+)
+
+load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories", "k8s_defaults")
+
+k8s_repositories()
+
+[k8s_defaults(
+    name = "k8s_" + kind,
+    cluster = "{STABLE_K8S_CLUSTER}",
+    image_chroot = "{STABLE_DOCKER_REPO}/{BUILD_USER}",
+    kind = kind,
+) for kind in [
+    "configmap",
+    "deployment",
+    "secret",
+    "service",
+    "tpr",
+    "ingress",
+]]
+
 git_repository(
     name = "org_dropbox_rules_node",
     commit = "4fe6494f3f8d1a272d47d32ecc66698f6c43ed09",
@@ -113,20 +138,6 @@ py_library(
     sha256 = "5722cd09762faa01276230270ff16af7acf7c5c45d623868d9ba116f15791ce8",
     strip_prefix = "requests-2.13.0/requests",
     urls = ["https://pypi.python.org/packages/16/09/37b69de7c924d318e51ece1c4ceb679bf93be9d05973bb30c35babd596e2/requests-2.13.0.tar.gz"],
-)
-
-new_http_archive(
-    name = "yaml",
-    build_file_content = """
-py_library(
-    name = "yaml",
-    srcs = glob(["*.py"]),
-    visibility = ["//visibility:public"],
-)
-""",
-    sha256 = "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-    strip_prefix = "PyYAML-3.12/lib/yaml",
-    urls = ["https://pypi.python.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"],
 )
 
 new_http_archive(

--- a/print-workspace-status.sh
+++ b/print-workspace-status.sh
@@ -22,6 +22,8 @@ build_date="$(date -u '+%Y%m%d')"
 docker_tag="v${build_date}-${git_commit}"
 cat <<EOF
 STABLE_DOCKER_REPO ${DOCKER_REPO_OVERRIDE:-gcr.io/k8s-testimages}
+# TODO(mattmoor): What default should we give this?
+STABLE_K8S_CLUSTER ${K8S_CLUSTER_OVERRIDE:-}
 STABLE_BUILD_GIT_COMMIT ${git_commit}
 DOCKER_TAG ${docker_tag}
 EOF

--- a/prow/BUILD
+++ b/prow/BUILD
@@ -16,6 +16,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//prow/cluster/starter:all-srcs",
         "//prow/cmd/config:all-srcs",
         "//prow/cmd/deck:all-srcs",
         "//prow/cmd/hook:all-srcs",

--- a/prow/cluster/starter/BUILD
+++ b/prow/cluster/starter/BUILD
@@ -1,0 +1,142 @@
+load("@k8s_configmap//:defaults.bzl", "k8s_configmap")
+
+[k8s_configmap(
+    name = name + "-configmap",
+    template = ":" + name + ".configmap.yaml",
+) for name in [
+    "config",
+    "plugins",
+]]
+
+load("@k8s_deployment//:defaults.bzl", "k8s_deployment")
+
+# The image names within each of the templates.
+images = {
+    "deck": "gcr.io/k8s-prow/deck:0.52",
+    "hook": "gcr.io/k8s-prow/hook:0.172",
+    "horologium": "gcr.io/k8s-prow/horologium:0.8",
+    "plank": "gcr.io/k8s-prow/plank:0.49",
+    "sinker": "gcr.io/k8s-prow/sinker:0.21",
+}
+
+[k8s_deployment(
+    name = name + "-deployment",
+    images = {
+        images[name]: "//prow/cmd/" + name + ":image",
+    },
+    template = ":" + name + ".deployment.yaml",
+) for name in [
+    "deck",
+    "hook",
+    "horologium",
+    "plank",
+    "sinker",
+]]
+
+load("@k8s_service//:defaults.bzl", "k8s_service")
+
+[k8s_service(
+    name = name + "-service",
+    template = ":" + name + ".service.yaml",
+) for name in [
+    "deck",
+    "hook",
+]]
+
+load("@k8s_secret//:defaults.bzl", "k8s_secret")
+
+# If you want to create secrets along with everything else, put
+# something like this in WORKSPACE, with foo.secret.yaml objects.
+# local_repository(
+#     name = "prow_secrets",
+#     path = "../secrets",
+# )
+# Then you can uncomment this, and the dependency below.
+# [k8s_secret(
+#     name = name + "-secret",
+#     template = "@prow_secrets//:" + name + ".secret.yaml",
+# ) for name in ["hmac", "oauth"]]
+# # The secrets for Prow, make changes and run:
+# #   bazel run :secrets.apply
+# # ... to redeploy changes.
+# k8s_objects(
+#     name = "secrets",
+#     objects = [
+#         ":hmac-secret",
+#         ":oauth-secret",
+#     ],
+# )
+
+load("@k8s_tpr//:defaults.bzl", "k8s_tpr")
+
+k8s_tpr(
+    name = "prowjob-tpr",
+    template = ":prowjob.tpr.yaml",
+)
+
+load("@k8s_ingress//:defaults.bzl", "k8s_ingress")
+
+k8s_ingress(
+    name = "prow-ingress",
+    template = ":prow.ingress.yaml",
+)
+
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+
+# The configuration files for Prow, make changes to these files and run:
+#   bazel run :configmaps.apply
+# ... to update them on the cluster.
+k8s_objects(
+    name = "configmaps",
+    objects = [
+        ":config-configmap",
+        ":plugins-configmap",
+    ],
+)
+
+# The deployments for Prow, make changes and run:
+#   bazel run :deployments.apply
+# ... to redeploy.
+k8s_objects(
+    name = "deployments",
+    objects = [
+        ":deck-deployment",
+        ":hook-deployment",
+        ":horologium-deployment",
+        ":plank-deployment",
+        ":sinker-deployment",
+    ],
+)
+
+# A new cluster can be stood up using:
+#   bazel run :everything.apply
+# Then (most) individual components can be replaced using:
+#   bazel run :foo-bar.apply
+k8s_objects(
+    name = "everything",
+    objects = [
+        # Uncomment this (along with its definition above)
+        # to create secrets along with all else.
+        # ":secrets",
+        ":configmaps",
+        ":deployments",
+        ":deck-service",
+        ":hook-service",
+        ":prowjob-tpr",
+        ":prow-ingress",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/cluster/starter/config.configmap.yaml
+++ b/prow/cluster/starter/config.configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  config: |
+    periodics:
+    - interval: 10m
+      agent: kubernetes
+      name: echo-test
+      spec:
+        containers:
+        - image: alpine
+          command: ["/bin/date"]

--- a/prow/cluster/starter/deck.deployment.yaml
+++ b/prow/cluster/starter/deck.deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: deck
+  labels:
+    app: deck
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: deck
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: deck
+        image: gcr.io/k8s-prow/deck:0.52
+        ports:
+          - name: http
+            containerPort: 8080
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: config

--- a/prow/cluster/starter/deck.service.yaml
+++ b/prow/cluster/starter/deck.service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deck
+spec:
+  selector:
+    app: deck
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: NodePort

--- a/prow/cluster/starter/hook.deployment.yaml
+++ b/prow/cluster/starter/hook.deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hook
+  labels:
+    app: hook
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: hook
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: hook
+        image: gcr.io/k8s-prow/hook:0.172
+        imagePullPolicy: Always
+        args:
+        - --dry-run=false
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
+          readOnly: true
+      volumes:
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: config
+        configMap:
+          name: config
+      - name: plugins
+        configMap:
+          name: plugins

--- a/prow/cluster/starter/hook.service.yaml
+++ b/prow/cluster/starter/hook.service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hook
+spec:
+  selector:
+    app: hook
+  ports:
+  - port: 8888
+  type: NodePort

--- a/prow/cluster/starter/horologium.deployment.yaml
+++ b/prow/cluster/starter/horologium.deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: horologium
+  labels:
+    app: horologium
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: horologium
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: horologium
+        image: gcr.io/k8s-prow/horologium:0.8
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: config

--- a/prow/cluster/starter/plank.deployment.yaml
+++ b/prow/cluster/starter/plank.deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: plank
+  labels:
+    app: plank
+spec:
+  replicas: 1 # Do not scale up.
+  template:
+    metadata:
+      labels:
+        app: plank
+    spec:
+      containers:
+      - name: plank
+        image: gcr.io/k8s-prow/plank:0.49
+        args:
+        - --dry-run=false
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: config
+        configMap:
+          name: config

--- a/prow/cluster/starter/plugins.configmap.yaml
+++ b/prow/cluster/starter/plugins.configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plugins
+data:
+  plugins: 

--- a/prow/cluster/starter/prow.ingress.yaml
+++ b/prow/cluster/starter/prow.ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ing
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: deck
+          servicePort: 80
+      - path: /hook
+        backend:
+          serviceName: hook
+          servicePort: 8888

--- a/prow/cluster/starter/prowjob.tpr.yaml
+++ b/prow/cluster/starter/prowjob.tpr.yaml
@@ -1,0 +1,6 @@
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: prow-job.prow.k8s.io
+versions:
+- name: v1

--- a/prow/cluster/starter/sinker.deployment.yaml
+++ b/prow/cluster/starter/sinker.deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: sinker
+  labels:
+    app: sinker
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sinker
+    spec:
+      containers:
+      - name: sinker
+        image: gcr.io/k8s-prow/sinker:0.21
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: config


### PR DESCRIPTION
This is a more polished version of what I demoed at the `sig-testing` weekly meeting on 2017/10/03.

This builds on [prior changes](#4929) to build with `go_image` and leverages that to apply `rules_k8s` to this repository.

For performing development you can redirect where images are pushed and deployed by setting:
```shell
export DOCKER_REPO_OVERRIDE=registry.io/repo
export K8S_CLUSTER_OVERRIDE=my-cluster-name
```

You can then stand up a new Prow setup with:
```
$ bazel run prow/cluster/starter:everything.apply
```

You can then make changes to components, e.g. `prow/plugins/golint` and quickly iterate with:
```
$ bazel run prow/cluster/starter:hook-deployment.apply
```

As a datapoint, I used the above to develop the `buildifier` plugin, and for `hook` this iteration typically took ~7 seconds with a hot Bazel server.