### PR TITLE
Upgrade with kubeadm to released version

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9992,7 +9992,7 @@
       "--cluster=",
       "--deployment=kubernetes-anywhere",
       "--env-file=jobs/platform/gce.env",
-      "--extract=ci/latest-1.8",
+      "--extract=release/latest-1.8",
       "--extract=ci/latest-1.7",
       "--gcp-zone=us-central1-f",
       "--kubeadm=periodic",
@@ -10003,7 +10003,7 @@
       "--skew",
       "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
       "--timeout=300m",
-      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/latest-1.8"
+      "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=release/latest-1.8"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
Kubeadm upgrade command (only used for 1.7 -> 1.8 and higher) pulls images for kube-apiserver and other control plane components as part of upgrade. This fails when the version specified does not have a corresponding image at gcr.io/google_containers.

For example ci/latest-1.8 is **1.8.1-beta.0.34+10cc3b77425acd**. There is no such image at gcr.io/google_containers/kube-apiserver-amd64:**v1.8.1-beta.0.34_10cc3b77425acd** [1]

However, there are images for released version such as gcr.io/google_containers/kube-apiserver-amd64:**v1.8.1-beta.0**

Using the released version instead of the ci version will ensure images are available for the test. We still are testing that the *latest* kubeadm is able to perform the upgrade.

[1] From failing test:
Oct  9 20:51:10 ubuntu dockerd[4003]: time="2017-10-09T20:51:10.993678937Z" level=error msg="Handler for GET /v1.24/images/gcr.io/google_containers/kube-apiserver-amd64:v1.8.1-beta.0.34_10cc3b77425acd/json returned error: No such image: gcr.io/google_containers/kube-apiserver-amd64:v1.8.1-beta.0.34_10cc3b77425acd"
Oct  9 20:51:11 ubuntu dockerd[4003]: time="2017-10-09T20:51:11.056654454Z" level=error msg="Attempting next endpoint for pull after error: manifest unknown: Failed to fetch \"v1.8.1-beta.0.34_10cc3b77425acd\" from request \"/v2/google_containers/kube-apiserver-amd64/manifests/v1.8.1-beta.0.34_10cc3b77425acd\"."