### PR TITLE
Use default build method for federation pre-submit

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10333,7 +10333,7 @@
   },
   "pull-kubernetes-federation-e2e-gce-canary": {
     "args": [
-      "--build=bazel",
+      "--build",
       "--cluster=prow-us-central1-f",
       "--deployment=none",
       "--env-file=jobs/platform/gce.env",


### PR DESCRIPTION
Federation pre-submit cannot use bazel build method yet. There is an [issue](https://github.com/kubernetes/test-infra/issues/4947) raised for it and we shall resolve it parallely. in the meanwhile, for federation pre-submit we can go ahead with default build mechanism (`make quick-release`). So request to please merge this change.

/assign @krzyzacy
/cc @madhusudancs @kubernetes/sig-multicluster-pr-reviews 