### PR TITLE
Set project for GCI GKE autoscaling job

### DIFF
--- a/boskos/resources.json
+++ b/boskos/resources.json
@@ -87,7 +87,6 @@
       "gke-up-g1-4-glat-up-mas",
       "jenkins-gke-e2e-serial",
       "jenkins-gke-gci-e2e-serial",
-      "k8s-e2e-gci-gke-autoscaling",
       "k8s-e2e-gci-gke-prod-parallel",
       "k8s-e2e-gci-gke-prod-smoke",
       "k8s-e2e-gci-gke-staging-plel",

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4426,6 +4426,7 @@
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=gci",
+      "--gcp-project=k8s-e2e-gci-gke-autoscaling",
       "--gcp-zone=us-central1-f",
       "--gke-environment=test",
       "--provider=gke",


### PR DESCRIPTION
Make gci-gke-autoscaling job run in its own project.