### PR TITLE
Use branched image config for pr-node-e2e jobs in prow

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10433,7 +10433,6 @@
       "--deployment=node",
       "--gcp-project=k8s-jkns-pr-node-e2e",
       "--gcp-zone=us-central1-f",
-      "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml",
       "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
       "--node-tests=true",
       "--provider=gce",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -23,6 +23,7 @@ import collections
 import json
 import os
 import re
+import sys
 
 import config_sort
 import env_gc
@@ -54,10 +55,6 @@ class JobTest(unittest.TestCase):
         'config_test.py', # Script for testing config.json and Prow config.
         'env_gc.py', # Tool script to garbage collect unused .env files.
         'move_extract.py',
-        # Node-e2e image configurations
-        'benchmark-config.yaml',
-        'image-config.yaml',
-        'image-config-serial.yaml',
     ]
     # also exclude .pyc
     excludes.extend(e + 'c' for e in excludes if e.endswith('.py'))
@@ -83,6 +80,10 @@ class JobTest(unittest.TestCase):
     def jobs(self):
         """[(job, job_path)] sequence"""
         for path, _, filenames in os.walk(config_sort.test_infra('jobs')):
+            print >>sys.stderr, path
+            if 'e2e_node' in path:
+                # Node e2e image configs, ignore them
+                continue
             for job in [f for f in filenames if f not in self.excludes]:
                 job_path = os.path.join(path, job)
                 yield job, job_path

--- a/jobs/e2e_node/image-config-1-6.yaml
+++ b/jobs/e2e_node/image-config-1-6.yaml
@@ -1,0 +1,21 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu-docker10:
+    image: e2e-node-ubuntu-trusty-docker10-v2-image # docker 1.10.3
+    project: kubernetes-node-e2e-images
+  ubuntu-docker12:
+    image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
+    project: kubernetes-node-e2e-images
+  coreos-alpha:
+    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    project: coreos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  containervm:
+    image: e2e-node-containervm-v20161208-image # docker 1.11.2
+    project: kubernetes-node-e2e-images
+  gci:
+    image_regex: gci-stable-56-9000-84-2 # docker 1.11.2
+    project: google-containers
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/image-config-1-7.yaml
+++ b/jobs/e2e_node/image-config-1-7.yaml
@@ -1,0 +1,19 @@
+
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    project: ubuntu-os-gke-cloud
+  coreos-alpha:
+    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+    project: coreos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
+  containervm:
+    image: e2e-node-containervm-v20161208-image # docker 1.11.2
+    project: kubernetes-node-e2e-images
+  gci:
+    image_regex: cos-stable-59-9460-64-0 # docker 1.11.2
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -963,6 +963,7 @@ presubmits:
     - release-1.4
     - release-1.5
     - release-1.6
+    - release-1.7
     always_run: false
     skip_report: false
     max_concurrency: 1
@@ -981,6 +982,64 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-node-e2e-prow
+    agent: kubernetes
+    branches:
+    - release-1.7
+    always_run: false
+    skip_report: false
+    max_concurrency: 1
+    context: pull-kubernetes-node-e2e-prow
+    rerun_command: "/test pull-kubernetes-node-e2e-prow"
+    trigger: "(?m)^/test pull-kubernetes-node-e2e-prow,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.7
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -1035,6 +1094,8 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-6.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -1991,6 +2052,7 @@ presubmits:
     - release-1.4
     - release-1.5
     - release-1.6
+    - release-1.7
     always_run: false
     skip_report: false
     max_concurrency: 1
@@ -2009,6 +2071,64 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-node-e2e-prow
+    agent: kubernetes
+    branches:
+    - release-1.7
+    always_run: false
+    skip_report: false
+    max_concurrency: 1
+    context: pull-security-kubernetes-node-e2e-prow
+    rerun_command: "/test pull-security-kubernetes-node-e2e-prow"
+    trigger: "(?m)^/test pull-security-kubernetes-node-e2e-prow,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.7
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -2063,6 +2183,8 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-6.yaml"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json


### PR DESCRIPTION
Move the image config to test-infra should still be the right direction to go, branching is a bit more painful, but maybe more explicit.

/assign @yguo0905 @BenTheElder 