### PR TITLE
Clean up stale needs-sig comments

### DIFF
--- a/mungegithub/mungers/sig-mention-handler_test.go
+++ b/mungegithub/mungers/sig-mention-handler_test.go
@@ -35,7 +35,6 @@ const (
 	committeeSteering   = "committee/steering"
 	wgContainerIdentity = "wg/container-identity"
 	username            = "Ali"
-	needsSigLabel       = "needs-sig"
 )
 
 func TestSigMentionHandler(t *testing.T) {


### PR DESCRIPTION
This adds a isStaleIssueComment handler to the sig-mention munger. Based off of the needs_rebase munger.

Fixes #3906.