### PR TITLE
Use bazel 0.6.1 on all branches except release-1.6

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -18,16 +18,16 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 K8S ?= master
 
 GO ?= 1.8.3
-BAZEL ?= 0.5.4
+BAZEL ?= 0.6.1
 
 ifeq ($(K8S), 1.8)
 	GO = 1.8.3
-	BAZEL = 0.5.4
+	BAZEL = 0.6.1
 endif
 
 ifeq ($(K8S), 1.7)
 	GO = 1.8.3
-	BAZEL = 0.5.4
+	BAZEL = 0.6.1
 endif
 
 ifeq ($(K8S), 1.6)

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -64,7 +64,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -262,7 +262,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1093,7 +1093,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1291,7 +1291,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2299,7 +2299,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2334,7 +2334,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -2614,7 +2614,7 @@ postsubmits:
     - release-1.7
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2651,7 +2651,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -2818,7 +2818,7 @@ postsubmits:
     - release-1.8
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2855,7 +2855,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -3043,7 +3043,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17160,7 +17160,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -17197,7 +17197,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17322,7 +17322,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -17359,7 +17359,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -381,7 +381,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -439,7 +439,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -497,7 +497,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -555,7 +555,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.6
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -599,7 +599,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -667,7 +667,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -737,7 +737,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -806,7 +806,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -888,7 +888,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-federation-e2e-gce-canary,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -971,7 +971,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-node-e2e-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1025,7 +1025,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-node-e2e-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -1409,7 +1409,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1467,7 +1467,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1525,7 +1525,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1583,7 +1583,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.6
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1627,7 +1627,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1695,7 +1695,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1765,7 +1765,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1834,7 +1834,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1916,7 +1916,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-federation-e2e-gce-canary,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1999,7 +1999,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-node-e2e-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2053,7 +2053,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-node-e2e-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -3085,7 +3085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3119,7 +3119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3153,7 +3153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3187,7 +3187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3221,7 +3221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3255,7 +3255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3289,7 +3289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3323,7 +3323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3357,7 +3357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3391,7 +3391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3425,7 +3425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3459,7 +3459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3493,7 +3493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3527,7 +3527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3561,7 +3561,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3595,7 +3595,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3629,7 +3629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3663,7 +3663,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3697,7 +3697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3731,7 +3731,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3801,7 +3801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3837,7 +3837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3873,7 +3873,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3909,7 +3909,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3945,7 +3945,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3981,7 +3981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4017,7 +4017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4053,7 +4053,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4089,7 +4089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4125,7 +4125,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4161,7 +4161,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4197,7 +4197,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4233,7 +4233,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4269,7 +4269,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4305,7 +4305,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4341,7 +4341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4377,7 +4377,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4413,7 +4413,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4449,7 +4449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4485,7 +4485,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4521,7 +4521,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4557,7 +4557,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4593,7 +4593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4629,7 +4629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4665,7 +4665,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4701,7 +4701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4737,7 +4737,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4773,7 +4773,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4809,7 +4809,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4845,7 +4845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4881,7 +4881,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4917,7 +4917,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4953,7 +4953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4989,7 +4989,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5025,7 +5025,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5061,7 +5061,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5097,7 +5097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5133,7 +5133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5169,7 +5169,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5205,7 +5205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5239,7 +5239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5273,7 +5273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5307,7 +5307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5341,7 +5341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5375,7 +5375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5409,7 +5409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5443,7 +5443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5477,7 +5477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5511,7 +5511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5545,7 +5545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5579,7 +5579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5613,7 +5613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5647,7 +5647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5681,7 +5681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5715,7 +5715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5749,7 +5749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5783,7 +5783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5817,7 +5817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5851,7 +5851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5885,7 +5885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5919,7 +5919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5953,7 +5953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5987,7 +5987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6021,7 +6021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6055,7 +6055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6089,7 +6089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6123,7 +6123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6157,7 +6157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6191,7 +6191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6225,7 +6225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6259,7 +6259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6293,7 +6293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6327,7 +6327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6361,7 +6361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6395,7 +6395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6429,7 +6429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6463,7 +6463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6497,7 +6497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6531,7 +6531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6565,7 +6565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6599,7 +6599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6633,7 +6633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6667,7 +6667,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6701,7 +6701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6735,7 +6735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6769,7 +6769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6803,7 +6803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6837,7 +6837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6871,7 +6871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6905,7 +6905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6939,7 +6939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7007,7 +7007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7041,7 +7041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7109,7 +7109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7143,7 +7143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7177,7 +7177,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7211,7 +7211,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7245,7 +7245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7279,7 +7279,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7313,7 +7313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7347,7 +7347,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7381,7 +7381,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7415,7 +7415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7449,7 +7449,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7483,7 +7483,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7517,7 +7517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7551,7 +7551,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7585,7 +7585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7619,7 +7619,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7653,7 +7653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7689,7 +7689,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7725,7 +7725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7761,7 +7761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7797,7 +7797,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7833,7 +7833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7869,7 +7869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7905,7 +7905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7941,7 +7941,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7977,7 +7977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8013,7 +8013,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8049,7 +8049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8085,7 +8085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8121,7 +8121,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8157,7 +8157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8193,7 +8193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8229,7 +8229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8265,7 +8265,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8301,7 +8301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8335,7 +8335,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8369,7 +8369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8403,7 +8403,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8437,7 +8437,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8471,7 +8471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8505,7 +8505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8539,7 +8539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8573,7 +8573,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8607,7 +8607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8641,7 +8641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8675,7 +8675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8709,7 +8709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8743,7 +8743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8777,7 +8777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8811,7 +8811,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8845,7 +8845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8879,7 +8879,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8913,7 +8913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8947,7 +8947,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8981,7 +8981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9015,7 +9015,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9049,7 +9049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9083,7 +9083,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9117,7 +9117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9151,7 +9151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9185,7 +9185,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9219,7 +9219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9253,7 +9253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9287,7 +9287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9321,7 +9321,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9355,7 +9355,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9389,7 +9389,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9423,7 +9423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9457,7 +9457,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9491,7 +9491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9525,7 +9525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9559,7 +9559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9593,7 +9593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9627,7 +9627,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9661,7 +9661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9695,7 +9695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9729,7 +9729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9763,7 +9763,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9797,7 +9797,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9831,7 +9831,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9865,7 +9865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9899,7 +9899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9933,7 +9933,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9967,7 +9967,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10001,7 +10001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10035,7 +10035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10069,7 +10069,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10103,7 +10103,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10137,7 +10137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10171,7 +10171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10205,7 +10205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10239,7 +10239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10273,7 +10273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10307,7 +10307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10341,7 +10341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10375,7 +10375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10409,7 +10409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10443,7 +10443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10477,7 +10477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10511,7 +10511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10545,7 +10545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10579,7 +10579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10613,7 +10613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10647,7 +10647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10681,7 +10681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10715,7 +10715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10749,7 +10749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10783,7 +10783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10817,7 +10817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10851,7 +10851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10885,7 +10885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10919,7 +10919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10953,7 +10953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10987,7 +10987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11021,7 +11021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11055,7 +11055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11089,7 +11089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11123,7 +11123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11157,7 +11157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11191,7 +11191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11225,7 +11225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11259,7 +11259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11293,7 +11293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11327,7 +11327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11361,7 +11361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11395,7 +11395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11429,7 +11429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11497,7 +11497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11531,7 +11531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11565,7 +11565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11599,7 +11599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11633,7 +11633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11667,7 +11667,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11701,7 +11701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11735,7 +11735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11769,7 +11769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11803,7 +11803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11837,7 +11837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11871,7 +11871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11905,7 +11905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11939,7 +11939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11973,7 +11973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12007,7 +12007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12041,7 +12041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12075,7 +12075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12109,7 +12109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12143,7 +12143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12177,7 +12177,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12211,7 +12211,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12245,7 +12245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12279,7 +12279,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12313,7 +12313,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12348,7 +12348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12382,7 +12382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12416,7 +12416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12450,7 +12450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12484,7 +12484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12518,7 +12518,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12552,7 +12552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12586,7 +12586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12620,7 +12620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12654,7 +12654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12688,7 +12688,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12722,7 +12722,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12756,7 +12756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12790,7 +12790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12824,7 +12824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12858,7 +12858,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12892,7 +12892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12926,7 +12926,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12960,7 +12960,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12994,7 +12994,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13028,7 +13028,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13062,7 +13062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13096,7 +13096,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13130,7 +13130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13164,7 +13164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13198,7 +13198,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13232,7 +13232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13266,7 +13266,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13300,7 +13300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13334,7 +13334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13368,7 +13368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13402,7 +13402,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13436,7 +13436,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13470,7 +13470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13504,7 +13504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13538,7 +13538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13572,7 +13572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13606,7 +13606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13640,7 +13640,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13674,7 +13674,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13708,7 +13708,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13742,7 +13742,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13776,7 +13776,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13810,7 +13810,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13844,7 +13844,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13878,7 +13878,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13912,7 +13912,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13946,7 +13946,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13980,7 +13980,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14014,7 +14014,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14048,7 +14048,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14084,7 +14084,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14120,7 +14120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14156,7 +14156,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14192,7 +14192,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14228,7 +14228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14264,7 +14264,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14300,7 +14300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14336,7 +14336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14372,7 +14372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14408,7 +14408,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14444,7 +14444,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14480,7 +14480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14517,7 +14517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14553,7 +14553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14589,7 +14589,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14625,7 +14625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14661,7 +14661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14697,7 +14697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14733,7 +14733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14769,7 +14769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14805,7 +14805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14841,7 +14841,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14877,7 +14877,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14913,7 +14913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14949,7 +14949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14985,7 +14985,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15021,7 +15021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15055,7 +15055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15091,7 +15091,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15177,7 +15177,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15220,7 +15220,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15263,7 +15263,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15306,7 +15306,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15349,7 +15349,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15392,7 +15392,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15435,7 +15435,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15478,7 +15478,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15519,7 +15519,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15629,7 +15629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15668,7 +15668,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15707,7 +15707,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15746,7 +15746,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15785,7 +15785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15824,7 +15824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15863,7 +15863,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15902,7 +15902,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15941,7 +15941,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15980,7 +15980,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16019,7 +16019,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16058,7 +16058,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16097,7 +16097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16136,7 +16136,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16175,7 +16175,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16214,7 +16214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16253,7 +16253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16292,7 +16292,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16331,7 +16331,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16370,7 +16370,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16409,7 +16409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16448,7 +16448,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16487,7 +16487,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16526,7 +16526,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16548,7 +16548,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - --bare
       - --timeout=80
@@ -16582,7 +16582,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16619,7 +16619,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16656,7 +16656,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16693,7 +16693,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16730,7 +16730,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -16780,7 +16780,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171006-bfbd469b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16802,7 +16802,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -16838,7 +16838,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -64,7 +64,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -163,7 +163,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -262,7 +262,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -306,7 +306,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1093,7 +1093,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1192,7 +1192,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1291,7 +1291,7 @@ presubmits:
     - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.4
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -1335,7 +1335,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170929-ed26bd34-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2299,7 +2299,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2334,7 +2334,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -2500,7 +2500,7 @@ postsubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-e6088edc  # https://github.com/kubernetes/kubernetes/issues/51571
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2535,7 +2535,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170925-e6088edc  # https://github.com/kubernetes/kubernetes/issues/51571
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -2614,7 +2614,7 @@ postsubmits:
     - release-1.7
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2651,7 +2651,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -2818,7 +2818,7 @@ postsubmits:
     - release-1.8
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2855,7 +2855,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -3043,7 +3043,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17045,7 +17045,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20170925-e6088edc  # https://github.com/kubernetes/kubernetes/issues/51571
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -17080,7 +17080,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-e6088edc  # https://github.com/kubernetes/kubernetes/issues/51571
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17160,7 +17160,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -17197,7 +17197,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17322,7 +17322,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -17359,7 +17359,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20170925-2204c0cb
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171005-2f37588f-0.5.4
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -112,7 +112,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -209,7 +209,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1141,7 +1141,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1238,7 +1238,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2368,7 +2368,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2411,7 +2411,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2454,7 +2454,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2568,7 +2568,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2686,7 +2686,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2729,7 +2729,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2772,7 +2772,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2890,7 +2890,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2933,7 +2933,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -17113,7 +17113,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -17232,7 +17232,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17277,7 +17277,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17394,7 +17394,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17439,7 +17439,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171008-52d4c1d0
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -495,17 +495,7 @@ func TestBazelbuildArgs(t *testing.T) {
 		}
 	}
 	pinnedJobs := map[string]string{
-		//job: reason for pinning
-		"ci-kubernetes-bazel-build-1-6":        "https://github.com/kubernetes/kubernetes/issues/51571",
-		"ci-kubernetes-bazel-test-1-6":         "https://github.com/kubernetes/kubernetes/issues/51571",
-		"periodic-kubernetes-bazel-build-1-6":  "https://github.com/kubernetes/kubernetes/issues/51571",
-		"periodic-kubernetes-bazel-test-1-6":   "https://github.com/kubernetes/kubernetes/issues/51571",
-		"pull-test-infra-bazel":                "canary testing the latest bazel on test-infra",
-		"ci-test-infra-bazel":                  "canary testing the latest bazel on test-infra",
-		"pull-kubernetes-bazel-build":          "need different versions of bazel for release branches",
-		"pull-kubernetes-bazel-test":           "need different versions of bazel for release branches",
-		"pull-security-kubernetes-bazel-build": "need different versions of bazel for release branches",
-		"pull-security-kubernetes-bazel-test":  "need different versions of bazel for release branches",
+	//job: reason for pinning
 	}
 	maxTag := ""
 	maxN := 0

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171008-cd94f30a-master'
+DEFAULT_KUBEKINS_TAG = 'v20171011-8265ed12-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
I backported fixes to release-1.7 and release-1.8 so that they can also be built with bazel 0.6.1. release-1.6 remains the outlier.

/assign @krzyzacy @BenTheElder 