### PR TITLE
Dump Cluster Logs For Kubeadm Tests

### DIFF
--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171011-9ecbe875-master
 MAINTAINER beacham@google.com
 
 RUN apt-get update && apt-get install -y \

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7942,10 +7942,10 @@
       "--extract=ci/latest-1.6",
       "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
+      "--kubernetes-anywhere-dump-cluster-logs=true",
       "--kubernetes-anywhere-kubelet-ci-version=latest-1.6",
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
       "--provider=kubernetes-anywhere",
-      "--kubernetes-anywhere-dump-cluster-logs=true",
       "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
       "--timeout=300m"
     ],

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7945,7 +7945,7 @@
       "--kubernetes-anywhere-kubelet-ci-version=latest-1.6",
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
       "--provider=kubernetes-anywhere",
-      "--kubernetes-anywhere-dump-cluster-logs=true"
+      "--kubernetes-anywhere-dump-cluster-logs=true",
       "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
       "--timeout=300m"
     ],

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7945,6 +7945,7 @@
       "--kubernetes-anywhere-kubelet-ci-version=latest-1.6",
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
       "--provider=kubernetes-anywhere",
+      "--kubernetes-anywhere-dump-cluster-logs=true"
       "--test_args=--ginkgo.focus=\\[Conformance\\] --minStartupPods=8",
       "--timeout=300m"
     ],

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -112,7 +112,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -209,7 +209,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1202,7 +1202,7 @@ presubmits:
       - release-1.6  # doesn't have BUILD files under //vendor/k8s.io
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1299,7 +1299,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2490,7 +2490,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2533,7 +2533,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2576,7 +2576,7 @@ postsubmits:
         agent: kubernetes
         spec:
           containers:
-          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+          - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
             args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--clean"
@@ -2690,7 +2690,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2808,7 +2808,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2851,7 +2851,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -2894,7 +2894,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3012,7 +3012,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3055,7 +3055,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -17235,7 +17235,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -17354,7 +17354,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17399,7 +17399,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17516,7 +17516,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17561,7 +17561,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-12fd4621
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171011-bb9b2c17
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"


### PR DESCRIPTION
First attempt to get dumping cluster logs working for kubeadm tests. Trying to use default logdump script with provider as GCE (instead of kubernetes-anywhere which is not supported). 

Using a flag guard (kubernetes-anywhere-dump-cluster-logs) to minimize test impact as cluster log dumping is sorted out.

Context:
https://github.com/kubernetes/kubeadm/issues/256
https://github.com/kubernetes/kubernetes/issues/50760