### PR TITLE
Make mungegithub comment deleter consider comments on issues.

### DIFF
--- a/mungegithub/mungers/comment-deleter.go
+++ b/mungegithub/mungers/comment-deleter.go
@@ -83,9 +83,9 @@ func validComment(comment *githubapi.IssueComment) bool {
 	return true
 }
 
-// Munge is the workhorse the will actually make updates to the PR
+// Munge is the workhorse the will actually make updates to the Issue.
 func (CommentDeleter) Munge(obj *github.MungeObject) {
-	if !obj.IsPR() {
+	if obj.Issue == nil || obj.Issue.State == nil || *obj.Issue.State == "closed" {
 		return
 	}
 


### PR DESCRIPTION
/cc @cblecker 
I tested the sig-mention-handler comment deletion locally with this change and it seems to work now.