### PR TITLE
port some more bootstrap functionality, cleanup tests more, refactor …

### DIFF
--- a/bootstrap/env.go
+++ b/bootstrap/env.go
@@ -163,14 +163,14 @@ func NodeName() (string, error) {
 }
 
 // BuildName returns the name of the ID/name for the current build
-// and sets os.Setenv(BuildEnv, res) if not already set
+// and sets os.Setenv(BuildNumberEnv, res) if not already set
 func BuildName(started time.Time) (string, error) {
 	/*
 		TODO(fejta): right now jenkins sets the BUILD_NUMBER and does this
 					 in an environment variable. Consider migrating this to a
 					 bootstrap.py flag
 	*/
-	_, exists := os.LookupEnv(BuildEnv)
+	_, exists := os.LookupEnv(BuildNumberEnv)
 	if !exists {
 		// Automatically generate a build number if none is set
 		nodeName, err := NodeName()
@@ -179,10 +179,10 @@ func BuildName(started time.Time) (string, error) {
 		}
 		uniq := fmt.Sprintf("%x-%d", hash(nodeName), os.Getpid())
 		autogen := started.Format("20060102-150400-") + uniq
-		err = os.Setenv(BuildEnv, autogen)
+		err = os.Setenv(BuildNumberEnv, autogen)
 		if err != nil {
 			return "", err
 		}
 	}
-	return os.Getenv(BuildEnv), nil
+	return os.Getenv(BuildNumberEnv), nil
 }

--- a/bootstrap/env_test.go
+++ b/bootstrap/env_test.go
@@ -186,9 +186,9 @@ func TestNodeName(t *testing.T) {
 	if err != nil {
 		t.Errorf("Got an unexpected err running NodeName: %v", err)
 	}
-	nodeNameEnvVal := os.Getenv(NodeNameEnv)
-	if nodeNameEnvVal != name {
-		t.Errorf("Expected os.Getenv(`%s`) to equal %#v not %#v", NodeNameEnv, name, nodeNameEnvVal)
+	valNodeNameEnv := os.Getenv(NodeNameEnv)
+	if valNodeNameEnv != name {
+		t.Errorf("Expected os.Getenv(`%s`) to equal %#v not %#v", NodeNameEnv, name, valNodeNameEnv)
 	}
 }
 
@@ -201,8 +201,8 @@ func TestBuildName(t *testing.T) {
 	if name == "" {
 		t.Errorf("Expected a non-empty build name")
 	}
-	buildEnvVal := os.Getenv(BuildEnv)
-	if buildEnvVal != name {
-		t.Errorf("Expected os.Getenv(`%s`) to equal %#v not %#v", BuildEnv, name, buildEnvVal)
+	valBuildNumberEnv := os.Getenv(BuildNumberEnv)
+	if valBuildNumberEnv != name {
+		t.Errorf("Expected os.Getenv(`%s`) to equal %#v not %#v", BuildNumberEnv, name, valBuildNumberEnv)
 	}
 }

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -25,21 +25,21 @@ import (
 
 // Constant Keys for known environment variables and URLs
 const (
-	BuildEnv          string = "BUILD_NUMBER"
-	BootstrapEnv      string = "BOOTSTRAP_MIGRATION"
-	CloudSDKEnv       string = "CLOUDSDK_CONFIG"
-	GCEPrivKeyEnv     string = "JENKINS_GCE_SSH_PRIVATE_KEY_FILE"
-	GCEPubKeyEnv      string = "JENKINS_GCE_SSH_PUBLIC_KEY_FILE"
-	AWSPrivKeyEnv     string = "JENKINS_AWS_SSH_PRIVATE_KEY_FILE"
-	AWSPubKeyEnv      string = "JENKINS_AWS_SSH_PUBLIC_KEY_FILE"
-	Gubernator        string = "https://k8s-gubernator.appspot.com/build"
-	HomeEnv           string = "HOME"
-	JenkinsHomeEnv    string = "JENKINS_HOME"
-	JobEnv            string = "JOB_NAME"
-	NodeNameEnv       string = "NODE_NAME"
-	ServiceAccountEnv string = "GOOGLE_APPLICATION_CREDENTIALS"
-	WorkspaceEnv      string = "WORKSPACE"
-	GCSArtifactsEnv   string = "GCS_ARTIFACTS_DIR"
+	BuildNumberEnv         string = "BUILD_NUMBER"
+	BootstrapEnv           string = "BOOTSTRAP_MIGRATION"
+	CloudSDKEnv            string = "CLOUDSDK_CONFIG"
+	GCEPrivKeyEnv          string = "JENKINS_GCE_SSH_PRIVATE_KEY_FILE"
+	GCEPubKeyEnv           string = "JENKINS_GCE_SSH_PUBLIC_KEY_FILE"
+	AWSPrivKeyEnv          string = "JENKINS_AWS_SSH_PRIVATE_KEY_FILE"
+	AWSPubKeyEnv           string = "JENKINS_AWS_SSH_PUBLIC_KEY_FILE"
+	GubernatorBaseBuildURL string = "https://k8s-gubernator.appspot.com/build/"
+	HomeEnv                string = "HOME"
+	JenkinsHomeEnv         string = "JENKINS_HOME"
+	JobEnv                 string = "JOB_NAME"
+	NodeNameEnv            string = "NODE_NAME"
+	ServiceAccountEnv      string = "GOOGLE_APPLICATION_CREDENTIALS"
+	WorkspaceEnv           string = "WORKSPACE"
+	GCSArtifactsEnv        string = "GCS_ARTIFACTS_DIR"
 )
 
 // Bootstrap is the "real main" for bootstrap, after argument parsing

--- a/bootstrap/paths_test.go
+++ b/bootstrap/paths_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestCIPaths(t *testing.T) {
-	tests := []struct {
+	testCases := []struct {
 		Name     string
 		Base     string
 		Job      string
@@ -45,10 +45,10 @@ func TestCIPaths(t *testing.T) {
 			},
 		},
 	}
-	for _, test := range tests {
+	for _, test := range testCases {
 		res := CIPaths(test.Base, test.Job, test.Build)
 		if !reflect.DeepEqual(res, test.Expected) {
-			t.Errorf("Paths did not match expected for test: %s", test.Name)
+			t.Errorf("Paths did not match expected for test: %#v", test.Name)
 			t.Errorf("%#v", res)
 			t.Errorf("%#v", test.Expected)
 		}
@@ -58,7 +58,7 @@ func TestCIPaths(t *testing.T) {
 func TestPRPaths(t *testing.T) {
 	// create some Repos values for use in the test cases below
 	reposEmtpy := Repos{}
-	reposK8sIO, err := ParseRepos([]string{"k8s.io/kubernetes=master:42e2ca8c18c93ba25eb0e5bd02ecba2eaa05e871,52057:b4f639f57ae0a89cdf1b43d1810b617c76f4b1b3,1337:03a564a5309ea84065fb203f628b50c382b65a50"})
+	reposK8sIO, err := ParseRepos([]string{"k8s.io/kubernetes=master:42e2ca8c18c93ba25eb0e5bd02ecba2eaa05e871,52057:b4f639f57ae0a89cdf1b43d1810b617c76f4b1b3,2001:03a564a5309ea84065fb203f628b50c382b65a50"})
 	if err != nil {
 		t.Errorf("got unexpected error parsing test repos: %v", err)
 	}
@@ -66,20 +66,20 @@ func TestPRPaths(t *testing.T) {
 	if err != nil {
 		t.Errorf("got unexpected error parsing test repos: %v", err)
 	}
-	reposKubernetes, err := ParseRepos([]string{"kubernetes/test-infra"})
+	reposKubernetes, err := ParseRepos([]string{"kubernetes/test-infra=master:0efa7e1b,2001:8b376c6c"})
 	if err != nil {
 		t.Errorf("got unexpected error parsing test repos: %v", err)
 	}
-	reposGithub, err := ParseRepos([]string{"github.com/foo/bar"})
+	reposGithub, err := ParseRepos([]string{"github.com/foo/bar=master:0efa7e1b,2001:8b376c6c"})
 	if err != nil {
 		t.Errorf("got unexpected error parsing test repos: %v", err)
 	}
-	reposOther, err := ParseRepos([]string{"example.com/foo/bar"})
+	reposOther, err := ParseRepos([]string{"example.com/foo/bar=master:0efa7e1b,2001:8b376c6c"})
 	if err != nil {
 		t.Errorf("got unexpected error parsing test repos: %v", err)
 	}
 	// assert some known expected values and the expected failure for len(repos) == 0
-	tests := []struct {
+	testCases := []struct {
 		Name      string
 		Base      string
 		Repos     Repos
@@ -115,15 +115,15 @@ func TestPRPaths(t *testing.T) {
 			Repos: reposK8sIOTestInfra,
 			Build: "1337",
 			Expected: &Paths{
-				Artifacts:     filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "artifacts"),
-				BuildLog:      filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "build-log.txt"),
-				PRPath:        filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337"),
+				Artifacts:     filepath.Join("/base", "pull", "test-infra", "52057", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "test-infra", "52057", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "test-infra", "52057", "some-job", "1337"),
 				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
-				PRLatest:      filepath.Join("/base", "pull", "test-infra/52057", "some-job", "latest-build.txt"),
-				PRResultCache: filepath.Join("/base", "pull", "test-infra/52057", "some-job", "jobResultsCache.json"),
+				PRLatest:      filepath.Join("/base", "pull", "test-infra", "52057", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "test-infra", "52057", "some-job", "jobResultsCache.json"),
 				ResultCache:   filepath.Join("/base", "directory", "some-job", "jobResultsCache.json"),
-				Started:       filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "started.json"),
-				Finished:      filepath.Join("/base", "pull", "test-infra/52057", "some-job", "1337", "finished.json"),
+				Started:       filepath.Join("/base", "pull", "test-infra", "52057", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "test-infra", "52057", "some-job", "1337", "finished.json"),
 				Latest:        filepath.Join("/base", "directory", "some-job", "latest-build.txt"),
 			},
 			ExpectErr: false,
@@ -135,15 +135,15 @@ func TestPRPaths(t *testing.T) {
 			Repos: reposKubernetes,
 			Build: "1337",
 			Expected: &Paths{
-				Artifacts:     filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "artifacts"),
-				BuildLog:      filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "build-log.txt"),
-				PRPath:        filepath.Join("/base", "pull", "test-infra", "some-job", "1337"),
+				Artifacts:     filepath.Join("/base", "pull", "test-infra", "2001", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "test-infra", "2001", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "test-infra", "2001", "some-job", "1337"),
 				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
-				PRLatest:      filepath.Join("/base", "pull", "test-infra", "some-job", "latest-build.txt"),
-				PRResultCache: filepath.Join("/base", "pull", "test-infra", "some-job", "jobResultsCache.json"),
+				PRLatest:      filepath.Join("/base", "pull", "test-infra", "2001", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "test-infra", "2001", "some-job", "jobResultsCache.json"),
 				ResultCache:   filepath.Join("/base", "directory", "some-job", "jobResultsCache.json"),
-				Started:       filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "started.json"),
-				Finished:      filepath.Join("/base", "pull", "test-infra", "some-job", "1337", "finished.json"),
+				Started:       filepath.Join("/base", "pull", "test-infra", "2001", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "test-infra", "2001", "some-job", "1337", "finished.json"),
 				Latest:        filepath.Join("/base", "directory", "some-job", "latest-build.txt"),
 			},
 			ExpectErr: false,
@@ -155,15 +155,15 @@ func TestPRPaths(t *testing.T) {
 			Repos: reposGithub,
 			Build: "1337",
 			Expected: &Paths{
-				Artifacts:     filepath.Join("/base", "pull", "foo_bar", "some-job", "1337", "artifacts"),
-				BuildLog:      filepath.Join("/base/pull/foo_bar/some-job/1337/build-log.txt"),
-				PRPath:        filepath.Join("/base/pull/foo_bar/some-job/1337"),
+				Artifacts:     filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "1337"),
 				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
-				PRLatest:      filepath.Join("/base", "pull", "foo_bar", "some-job", "latest-build.txt"),
-				PRResultCache: filepath.Join("/base", "pull", "foo_bar", "some-job", "jobResultsCache.json"),
+				PRLatest:      filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "jobResultsCache.json"),
 				ResultCache:   filepath.Join("/base", "directory", "some-job", "jobResultsCache.json"),
-				Started:       filepath.Join("/base", "pull", "foo_bar", "some-job", "1337", "started.json"),
-				Finished:      filepath.Join("/base", "pull", "foo_bar", "some-job", "1337", "finished.json"),
+				Started:       filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "foo_bar", "2001", "some-job", "1337", "finished.json"),
 				Latest:        filepath.Join("/base", "directory", "some-job", "latest-build.txt"),
 			},
 			ExpectErr: false,
@@ -175,15 +175,15 @@ func TestPRPaths(t *testing.T) {
 			Repos: reposOther,
 			Build: "1337",
 			Expected: &Paths{
-				Artifacts:     filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "artifacts"),
-				BuildLog:      filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "build-log.txt"),
-				PRPath:        filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337"),
+				Artifacts:     filepath.Join("/base", "pull", "example.com_foo_bar", "2001", "some-job", "1337", "artifacts"),
+				BuildLog:      filepath.Join("/base", "pull", "example.com_foo_bar", "2001", "some-job", "1337", "build-log.txt"),
+				PRPath:        filepath.Join("/base", "pull", "example.com_foo_bar", "2001", "some-job", "1337"),
 				PRBuildLink:   filepath.Join("/base", "directory", "some-job", "1337.txt"),
-				PRLatest:      filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "latest-build.txt"),
-				PRResultCache: filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "jobResultsCache.json"),
+				PRLatest:      filepath.Join("/base", "pull", "example.com_foo_bar", "2001", "some-job", "latest-build.txt"),
+				PRResultCache: filepath.Join("/base", "pull", "example.com_foo_bar", "2001", "some-job", "jobResultsCache.json"),
 				ResultCache:   filepath.Join("/base", "/directory/some-job", "jobResultsCache.json"),
-				Started:       filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "started.json"),
-				Finished:      filepath.Join("/base", "pull", "example.com_foo_bar", "some-job", "1337", "finished.json"),
+				Started:       filepath.Join("/base", "pull", "example.com_foo_bar", "2001", "some-job", "1337", "started.json"),
+				Finished:      filepath.Join("/base", "pull", "example.com_foo_bar", "2001", "some-job", "1337", "finished.json"),
 				Latest:        filepath.Join("/base", "/directory/some-job", "latest-build.txt"),
 			},
 			ExpectErr: false,
@@ -198,7 +198,7 @@ func TestPRPaths(t *testing.T) {
 			ExpectErr: true,
 		},
 	}
-	for _, test := range tests {
+	for _, test := range testCases {
 		res, err := PRPaths(test.Base, test.Repos, test.Job, test.Build)
 		if test.ExpectErr && err == nil {
 			t.Errorf("err == nil and error expected for test %#v", test.Name)
@@ -208,6 +208,33 @@ func TestPRPaths(t *testing.T) {
 			t.Errorf("Paths did not match expected for test: %#v", test.Name)
 			t.Errorf("%#v", res)
 			t.Errorf("%#v", test.Expected)
+		}
+	}
+}
+
+func TestGubernatorBuildURL(t *testing.T) {
+	// test with and without gs://
+	tests := []struct {
+		Name     string
+		Paths    *Paths
+		Expected string
+	}{
+		{
+			Name:     "with gs://",
+			Paths:    CIPaths("gs://foo", "bar", "baz"),
+			Expected: "https://k8s-gubernator.appspot.com/build/foo/bar/baz",
+		},
+		{
+			Name:     "without gs://",
+			Paths:    CIPaths("/foo", "bar", "baz"),
+			Expected: "/foo/bar/baz",
+		},
+	}
+	for _, test := range tests {
+		res := GubernatorBuildURL(test.Paths)
+		if res != test.Expected {
+			t.Errorf("result did not match expected for test case %#v", test.Name)
+			t.Errorf("%#v != %#v", res, test.Expected)
 		}
 	}
 }


### PR DESCRIPTION
…Repo related methods

- tidies up `Repo` related methods
- overhauls some unit tests
- normalizes some variable/constant names and formatting
- ports the new bootstrap argument parsing functionality for job/scenario args (a bare `--` terminates the bootstrap args, args following this are passed to the job/scenario)
- ports `gubernator_uri` -> `GubernatorBuildURL`