### PR TITLE
Fix cri-containerd node e2e.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10104,7 +10104,6 @@
       "--deployment=node",
       "--gcp-project=cri-c8d-pr-node-e2e",
       "--gcp-zone=us-central1-f",
-      "--node-args=--image-config-file=test/e2e_node/image-config.yaml --node-envs=PULL_REFS",
       "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/ --container-runtime=remote --container-runtime-endpoint=/var/run/cri-containerd.sock\" --extra-log=\"{\\\"name\\\": \\\"containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"containerd\\\"]}\" --extra-log=\"{\\\"name\\\": \\\"cri-containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"cri-containerd\\\"]}\"",
       "--node-tests=true",
       "--provider=gce",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -106,11 +106,13 @@ presubmits:
           - "--clean"
           - "--git-cache=/root/.cache/git"
           - "--job=$(JOB_NAME)"
-          - "--repo=github.com/kubernetes-incubator/$(REPO_NAME)=$(PULL_REFS)"
           - "--repo=k8s.io/kubernetes"
+          - "--repo=github.com/kubernetes-incubator/$(REPO_NAME)=$(PULL_REFS)"
           - "--service-account=/etc/service-account/service-account.json"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
           - "--timeout=90"
+          - "--"
+          - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd --node-env=\"PULL_REFS=$(PULL_REFS)\""
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/service-account/service-account.json


### PR DESCRIPTION
It seems that kubernetes_e2e requires current directory to be kubernetes.
```
W1012 06:41:00.115] 2017/10/12 06:41:00 main.go:260: Something went wrong: called from invalid working directory: must run from kubernetes directory root: /go/src/github.com/kubernetes-incubator/cri-containerd
```

@krzyzacy 