### PR TITLE
Remove extra quotes.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -112,7 +112,7 @@ presubmits:
           - "--upload=gs://kubernetes-jenkins/pr-logs"
           - "--timeout=90"
           - "--"
-          - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd --node-env=\"PULL_REFS=$(PULL_REFS)\""
+          - "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd --node-env=PULL_REFS=$(PULL_REFS)"
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/service-account/service-account.json


### PR DESCRIPTION
Remove extra quote. Golang `exec.Command` won't get rid of the quotes, and the string got by `run_remote.go` will be contain extra quotes:
`"PULL_REFS=master:e71db95d0eb6de2f98a83baac588b3a2b687ce9c,349:313db2103340c671d8096b0fc9f42932d2e5aead"`