### PR TITLE
Flip pr-node-e2e job to prow

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -115,11 +115,6 @@
         job-name: pull-kubernetes-e2e-kops-aws
         repo-name: 'k8s.io/kubernetes'
         timeout: 75
-    - kubernetes-node-e2e:
-        max-total: 12
-        job-name: pull-kubernetes-node-e2e
-        repo-name: 'k8s.io/kubernetes'
-        timeout: 90
     - kubernetes-verify:
         max-total: 16
         job-name: pull-kubernetes-verify

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
@@ -86,11 +86,6 @@
         job-name: pull-kubernetes-kubemark-e2e-gce
         repo-name: 'github.com/kubernetes-security/kubernetes'
         timeout: 65
-    - kubernetes-node-e2e:
-        max-total: 12
-        job-name: pull-kubernetes-node-e2e
-        repo-name: 'github.com/kubernetes-security/kubernetes'
-        timeout: 90
     - kubernetes-verify:
         max-total: 16
         job-name: pull-kubernetes-verify

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10445,16 +10445,6 @@
   },
   "pull-kubernetes-node-e2e": {
     "args": [
-      "--branch=${PULL_BASE_REF}",
-      "--properties=test/e2e_node/jenkins/jenkins-pull.properties"
-    ],
-    "scenario": "kubernetes_kubelet",
-    "sigOwners": [
-      "sig-node"
-    ]
-  },
-  "pull-kubernetes-node-e2e-prow": {
-    "args": [
       "--deployment=node",
       "--gcp-project=k8s-jkns-pr-node-e2e",
       "--gcp-zone=us-central1-f",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1046,24 +1046,17 @@ presubmits:
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
   - name: pull-kubernetes-node-e2e
-    agent: jenkins
-    always_run: true
-    context: pull-kubernetes-node-e2e
-    rerun_command: "/test pull-kubernetes-node-e2e"
-    trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
-  - name: pull-kubernetes-node-e2e-prow
     agent: kubernetes
     skip_branches:
     - release-1.4
     - release-1.5
     - release-1.6
     - release-1.7
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-kubernetes-node-e2e-prow
-    rerun_command: "/test pull-kubernetes-node-e2e-prow"
-    trigger: "(?m)^/test pull-kubernetes-node-e2e-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    context: pull-kubernetes-node-e2e
+    rerun_command: "/test pull-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
@@ -1110,16 +1103,15 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-kubernetes-node-e2e-prow
+  - name: pull-kubernetes-node-e2e
     agent: kubernetes
     branches:
     - release-1.7
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-kubernetes-node-e2e-prow
-    rerun_command: "/test pull-kubernetes-node-e2e-prow"
-    trigger: "(?m)^/test pull-kubernetes-node-e2e-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    context: pull-kubernetes-node-e2e
+    rerun_command: "/test pull-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.7
@@ -1166,16 +1158,15 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-kubernetes-node-e2e-prow
+  - name: pull-kubernetes-node-e2e
     agent: kubernetes
     branches:
     - release-1.6
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-kubernetes-node-e2e-prow
-    rerun_command: "/test pull-kubernetes-node-e2e-prow"
-    trigger: "(?m)^/test pull-kubernetes-node-e2e-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    context: pull-kubernetes-node-e2e
+    rerun_command: "/test pull-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
@@ -2135,24 +2126,17 @@ presubmits:
     rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
     trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
   - name: pull-security-kubernetes-node-e2e
-    agent: jenkins
-    always_run: true
-    context: pull-security-kubernetes-node-e2e
-    rerun_command: "/test pull-security-kubernetes-node-e2e"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
-  - name: pull-security-kubernetes-node-e2e-prow
     agent: kubernetes
     skip_branches:
     - release-1.4
     - release-1.5
     - release-1.6
     - release-1.7
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-security-kubernetes-node-e2e-prow
-    rerun_command: "/test pull-security-kubernetes-node-e2e-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-node-e2e-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    context: pull-security-kubernetes-node-e2e
+    rerun_command: "/test pull-security-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
@@ -2199,16 +2183,15 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-node-e2e-prow
+  - name: pull-security-kubernetes-node-e2e
     agent: kubernetes
     branches:
     - release-1.7
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-security-kubernetes-node-e2e-prow
-    rerun_command: "/test pull-security-kubernetes-node-e2e-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-node-e2e-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    context: pull-security-kubernetes-node-e2e
+    rerun_command: "/test pull-security-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-1.7
@@ -2255,16 +2238,15 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-  - name: pull-security-kubernetes-node-e2e-prow
+  - name: pull-security-kubernetes-node-e2e
     agent: kubernetes
     branches:
     - release-1.6
-    always_run: false
-    skip_report: false
-    max_concurrency: 1
-    context: pull-security-kubernetes-node-e2e-prow
-    rerun_command: "/test pull-security-kubernetes-node-e2e-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-node-e2e-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    context: pull-security-kubernetes-node-e2e
+    rerun_command: "/test pull-security-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1609,9 +1609,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-node-e2e
   days_of_results: 1
   num_columns_recent: 20
-- name: pull-kubernetes-node-e2e-prow
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-node-e2e-prow
-  num_columns_recent: 20
 - name: pull-kubernetes-unit
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-unit
   days_of_results: 1
@@ -4042,8 +4039,6 @@ dashboards:
   - name: pull-kubernetes-node-e2e
     test_group_name: pull-kubernetes-node-e2e
     base_options: 'width=10'
-  - name: pull-kubernetes-node-e2e-prow
-    test_group_name: pull-kubernetes-node-e2e-prow
   - name: pull-kubernetes-unit
     test_group_name: pull-kubernetes-unit
     base_options: 'width=10'


### PR DESCRIPTION
Green runs for release branches:

1.6 - https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/53017/pull-kubernetes-node-e2e-prow/6/
1.7 - https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/52755/pull-kubernetes-node-e2e-prow/7/
1.8/master - https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/46662/pull-kubernetes-node-e2e-prow/3/

safe to migrate it to prow now

/assign @yguo0905 @BenTheElder 
