### PR TITLE
Let kubemark-prow job use bazel build

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16777,6 +16777,8 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
+      - name: KUBEMARK_BAZEL_BUILD
+        value: y
       volumeMounts:
       - name: service
         mountPath: /etc/service-account


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/53681 is merged, switch the kubemark prow job to build/push image with bazel instead, make sure it's passing before migrate over rest of the Jenkins jobs.

/assign @shyamjvs @BenTheElder 