### PR TITLE
Make pull-kubernetes-e2e-gke-gpu create custom network

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10262,6 +10262,7 @@
       "--build=bazel",
       "--cluster=",
       "--deployment=gke",
+      "--env=CREATE_CUSTOM_NETWORK=true",
       "--extract=local",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
       "--gcp-node-image=gci",


### PR DESCRIPTION
From https://github.com/kubernetes/test-infra/issues/4472#issuecomment-336304843, making `pull-kubernetes-e2e-gke-gpu` create custom network.

From https://k8s-testgrid.appspot.com/kubernetes-presubmits#pull-kubernetes-e2e-gke-gpu I see empty history. How do I verify it is not failing and who usually triggers this job?

/assign @krzyzacy @mindprince 