### PR TITLE
Disable cluster log logic for kubeadm tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8005,7 +8005,6 @@
       "--extract=ci/latest-1.6",
       "--gcp-zone=us-central1-f",
       "--kubeadm=ci",
-      "--kubernetes-anywhere-dump-cluster-logs=true",
       "--kubernetes-anywhere-kubelet-ci-version=latest-1.6",
       "--kubernetes-anywhere-kubernetes-version=latest-1.6",
       "--provider=kubernetes-anywhere",


### PR DESCRIPTION
PR for enabling kubeadm cluster log logic got automatically merged before it was ready. 

https://github.com/kubernetes/test-infra/pull/4971

Use flag to turn off cluster logging till a working version is ready.