### PR TITLE
remove a unit test that flakes based on rand

### DIFF
--- a/robots/issue-creator/testowner/owner_test.go
+++ b/robots/issue-creator/testowner/owner_test.go
@@ -86,21 +86,6 @@ func TestOwnerGlob(t *testing.T) {
 	}
 }
 
-func TestOwnerListRandom(t *testing.T) {
-	list := NewOwnerList(map[string]*OwnerInfo{"testname": {
-		User: "a/b/c/d",
-	}})
-	counts := map[string]int{"a": 0, "b": 0, "c": 0, "d": 0}
-	for i := 0; i < 1000; i++ {
-		counts[list.TestOwner("testname")]++
-	}
-	for name, count := range counts {
-		if count <= 200 {
-			t.Errorf("Too few assigments to %s: only %d, expected > 200", name, count)
-		}
-	}
-}
-
 func TestOwnerListFromCsv(t *testing.T) {
 	r := bytes.NewReader([]byte(",,,header nonsense,\n" +
 		",owner,suggested owner,name,sig\n" +


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/issues/5002

Alternatively we could keep it and lower the threshold, but that doesn't really seem useful.
This test attempts to assert that assignment is random and unform(ish)ly distrubuted and can flake since the sample may not be uniform enough, so let's just remove it.