### PR TITLE
update heapster e2e test image

### DIFF
--- a/images/heapster/Dockerfile
+++ b/images/heapster/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Kubekins 1.6 + gcloud + heapster
-FROM gcr.io/k8s-testimages/kubekins-test:1.6-v20161220-8366258
+# Kubekins 1.7 + gcloud + heapster
+FROM gcr.io/k8s-testimages/kubekins-test:1.7-latest
 MAINTAINER senlu@google.com
 
 ENV GCLOUD_VERSION 144.0.0

--- a/images/heapster/Makefile
+++ b/images/heapster/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.7
+VERSION = 0.8
 
 image:
 	docker build -t "gcr.io/k8s-testimages/heapster-test:$(VERSION)" .

--- a/scenarios/kubernetes_heapster.py
+++ b/scenarios/kubernetes_heapster.py
@@ -32,7 +32,7 @@ def check(*cmd):
     print >>sys.stderr, 'Run:', cmd
     subprocess.check_call(cmd)
 
-HEAPSTER_IMAGE_VERSION = '0.7'
+HEAPSTER_IMAGE_VERSION = '0.8'
 
 def main(ssh, ssh_pub, robot, project):
     """Run unit/integration heapster test against master in docker"""


### PR DESCRIPTION
Fix [heapster #1844](https://github.com/kubernetes/heapster/pull/1844).

As kubernetes 1.8 needs Golang 1.8, we should update kubeins-test base image for `gcr.io/k8s-testimages/heapster-test` to use Golang 1.8.

Note: After this PR is merged, someone should help to push new image for `gcr.io/k8s-testimages/heapster-test:0.8` to gcr.io

/cc @krzyzacy @piosz  @loburm 