### PR TITLE
Add an experimental cherry-pick bot

### DIFF
--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -26,6 +26,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//experiment/cherrypicker:all-srcs",
         "//experiment/commenter:all-srcs",
     ],
     tags = ["automanaged"],

--- a/experiment/cherrypicker/BUILD
+++ b/experiment/cherrypicker/BUILD
@@ -1,0 +1,53 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "main.go",
+        "server.go",
+    ],
+    importpath = "k8s.io/test-infra/experiment/cherrypicker",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/git:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/hook:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/satori/go.uuid:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cherrypicker",
+    importpath = "k8s.io/test-infra/experiment/cherrypicker",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    importpath = "k8s.io/test-infra/experiment/cherrypicker",
+    library = ":go_default_library",
+    deps = [
+        "//prow/git/localgit:go_default_library",
+        "//prow/github:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)

--- a/experiment/cherrypicker/Dockerfile
+++ b/experiment/cherrypicker/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-prow/git:0.1
+MAINTAINER mkargaki@redhat.com
+
+COPY cherrypicker /cherrypicker
+ENTRYPOINT ["/cherrypicker"]

--- a/experiment/cherrypicker/doc.go
+++ b/experiment/cherrypicker/doc.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Cherrypicker automates cherry-picking of merged PRs in master to
+// release branches. This bot requires its own fork so it can push
+// patches that need to be cherry-picked and open PRs out of those
+// branches.
+//
+// Required scopes: read:org, repo
+package main

--- a/experiment/cherrypicker/main.go
+++ b/experiment/cherrypicker/main.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/git"
+	"k8s.io/test-infra/prow/github"
+)
+
+var (
+	port              = flag.Int("port", 8888, "Port to listen on.")
+	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+)
+
+func main() {
+	flag.Parse()
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
+	// We'll get SIGTERM first and then SIGKILL after our graceful termination
+	// deadline.
+	signal.Ignore(syscall.SIGTERM)
+
+	webhookSecretRaw, err := ioutil.ReadFile(*webhookSecretFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read webhook secret file.")
+	}
+	webhookSecret := bytes.TrimSpace(webhookSecretRaw)
+
+	oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read oauth secret file.")
+	}
+	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
+
+	_, err = url.Parse(*githubEndpoint)
+	if err != nil {
+		logrus.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
+	}
+
+	githubClient := github.NewClient(oauthSecret, *githubEndpoint)
+	if *dryRun {
+		githubClient = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+	}
+
+	gitClient, err := git.NewClient()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting git client.")
+	}
+
+	logger := logrus.StandardLogger()
+	// TODO: Use global option from the prow config.
+	logrus.SetLevel(logrus.DebugLevel)
+	githubClient.Logger = logger.WithField("client", "github")
+	gitClient.Logger = logger.WithField("client", "git")
+
+	// The bot name is used to determine to what fork we can push cherry-pick branches.
+	botName, err := githubClient.BotName()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting bot name.")
+	}
+
+	repos, err := githubClient.GetRepos(botName, true)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error listing bot repositories.")
+	}
+
+	server := NewServer(botName, oauthSecret, webhookSecret, gitClient, githubClient, repos)
+
+	http.Handle("/", server)
+	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
+}

--- a/experiment/cherrypicker/server.go
+++ b/experiment/cherrypicker/server.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"sync"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/git"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/hook"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "cherrypick"
+
+var cherryPickRe = regexp.MustCompile(`(?m)^/cherrypick\s+(.+)$`)
+
+type githubClient interface {
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	CreateComment(org, repo string, number int, comment string) error
+	IsMember(org, user string) (bool, error)
+	CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error)
+	ListPullRequestComments(org, repo string, number int) ([]github.ReviewComment, error)
+	CreateFork(org, repo string) error
+}
+
+// Server implements http.Handler. It validates incoming GitHub webhooks and
+// then dispatches them to the appropriate plugins.
+type Server struct {
+	hmacSecret  []byte
+	credentials string
+	botName     string
+
+	gc *git.Client
+	// Used for unit testing
+	push func(botName, credentials, repo, newBranch string) error
+	ghc  githubClient
+	log  *logrus.Entry
+
+	bare     *http.Client
+	patchURL string
+
+	repoLock sync.Mutex
+	repos    []github.Repo
+}
+
+func NewServer(name, creds string, hmac []byte, gc *git.Client, ghc *github.Client, repos []github.Repo) *Server {
+	return &Server{
+		hmacSecret:  hmac,
+		credentials: creds,
+		botName:     name,
+
+		gc:  gc,
+		ghc: ghc,
+		log: logrus.StandardLogger().WithField("client", "cherrypicker"),
+
+		bare:     &http.Client{},
+		patchURL: "https://patch-diff.githubusercontent.com",
+
+		repos: repos,
+	}
+}
+
+// ServeHTTP validates an incoming webhook and puts it into the event channel.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	eventType, eventGUID, payload, ok := hook.ValidateWebhook(w, r, s.hmacSecret)
+	if !ok {
+		return
+	}
+	fmt.Fprint(w, "Event received. Have a nice day.")
+
+	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
+		logrus.WithError(err).Error("Error parsing event.")
+	}
+}
+
+func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
+	switch eventType {
+	case "issue_comment":
+		var ic github.IssueCommentEvent
+		if err := json.Unmarshal(payload, &ic); err != nil {
+			return err
+		}
+		go func() {
+			if err := s.handleIssueComment(ic); err != nil {
+				s.log.WithError(err).Info("Cherry-pick failed.")
+			}
+		}()
+	case "pull_request":
+		var pr github.PullRequestEvent
+		if err := json.Unmarshal(payload, &pr); err != nil {
+			return err
+		}
+		go func() {
+			if err := s.handlePullRequest(pr); err != nil {
+				s.log.WithError(err).Info("Cherry-pick failed.")
+			}
+		}()
+	default:
+		return fmt.Errorf("received an event of type %q but didn't ask for it", eventType)
+	}
+	return nil
+}
+
+func (s *Server) handleIssueComment(ic github.IssueCommentEvent) error {
+	// Only consider new comments in PRs.
+	if !ic.Issue.IsPullRequest() || ic.Action != github.IssueCommentActionCreated {
+		return nil
+	}
+
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	num := ic.Issue.Number
+	commentAuthor := ic.Comment.User.Login
+
+	cherryPickMatches := cherryPickRe.FindAllStringSubmatch(ic.Comment.Body, -1)
+	if len(cherryPickMatches) == 0 || len(cherryPickMatches[0]) != 2 {
+		return nil
+	}
+	targetBranch := cherryPickMatches[0][1]
+
+	if targetBranch == "master" {
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, "I don't cherrypick pull requests onto master."))
+	}
+
+	if ic.Issue.State != "closed" {
+		// Only members should be able to do cherry-picks.
+		ok, err := s.ghc.IsMember(org, commentAuthor)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			resp := fmt.Sprintf("Only [%s](https://github.com/orgs/%s/people) org members may request cherry picks. You can still do the cherry-pick manually.", org, org)
+			s.log.Info(resp)
+			return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+		}
+		resp := fmt.Sprintf("@%s once the present PR merges, I will cherry-pick it on top of %s in a new PR and assign it to you.", commentAuthor, targetBranch)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+	}
+
+	pr, err := s.ghc.GetPullRequest(org, repo, num)
+	if err != nil {
+		return err
+	}
+	baseBranch := pr.Base.Ref
+
+	// Cherry-pick only merged PRs.
+	if !pr.Merged {
+		resp := "cannot cherry-pick an unmerged PR"
+		s.log.Info(resp)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+	}
+
+	if baseBranch != "master" {
+		resp := "The base branch needs to be master in order to cherry-pick to a different branch."
+		s.log.Info(resp)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(ic.Comment, resp))
+	}
+
+	return s.handle(ic.Comment, org, repo, baseBranch, targetBranch, num)
+}
+
+func (s *Server) handlePullRequest(pre github.PullRequestEvent) error {
+	// Only consider newly merged PRs
+	if pre.Action != github.PullRequestActionClosed {
+		return nil
+	}
+
+	pr := pre.PullRequest
+	if !pr.Merged || pr.MergeSHA == nil {
+		return nil
+	}
+
+	org := pr.Base.Repo.Owner.Login
+	repo := pr.Base.Repo.Name
+	baseBranch := pr.Base.Ref
+	num := pr.Number
+
+	if baseBranch != "master" {
+		// We can't know at this point whether there was actually a /cherrypick comment in the PR.
+		return nil
+	}
+
+	comments, err := s.ghc.ListPullRequestComments(org, repo, num)
+	if err != nil {
+		return err
+	}
+
+	var targetBranch string
+	var ic *github.IssueComment
+	for _, c := range comments {
+		cherryPickMatches := cherryPickRe.FindAllStringSubmatch(c.Body, -1)
+		if len(cherryPickMatches) == 0 || len(cherryPickMatches[0]) != 2 {
+			continue
+		}
+		// TODO: Collect all "/cherrypick" comments and figure out if any
+		// comes from an org member?
+		targetBranch = cherryPickMatches[0][1]
+		ic = &github.IssueComment{ID: c.ID, User: c.User, Body: c.Body, HTMLURL: c.HTMLURL}
+		break
+	}
+	if targetBranch == "" || ic == nil {
+		return nil
+	}
+	return s.handle(*ic, org, repo, baseBranch, targetBranch, num)
+}
+
+var cherryPickBranchFmt = "cherry-pick-%d-to-%s"
+
+func (s *Server) handle(comment github.IssueComment, org, repo, baseBranch, targetBranch string, num int) error {
+	// TODO: Use a whitelist for allowed base and target branches.
+	if baseBranch == targetBranch {
+		resp := fmt.Sprintf("Base branch (%s) needs to differ from target branch (%s)", baseBranch, targetBranch)
+		s.log.Info(resp)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+	}
+
+	// Only members should be able to do cherry-picks.
+	commentAuthor := comment.User.Login
+	ok, err := s.ghc.IsMember(org, commentAuthor)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		resp := fmt.Sprintf("Only [%s](https://github.com/orgs/%s/people) org members may request cherry picks. You can still do the cherry-pick manually.", org, org)
+		s.log.Info(resp)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+	}
+
+	if err := s.ensureForkExists(org, repo); err != nil {
+		return err
+	}
+
+	// Clone the repo, checkout the target branch.
+	startClone := time.Now()
+	r, err := s.gc.Clone(org + "/" + repo)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Clean(); err != nil {
+			s.log.WithError(err).Error("Error cleaning up repo.")
+		}
+	}()
+	if err := r.Checkout(targetBranch); err != nil {
+		return err
+	}
+	s.log.WithField("duration", time.Since(startClone)).Info("Cloned and checked out target branch.")
+
+	// Fetch the patch from Github
+	localPath, err := s.getPatch(org, repo, num)
+	if err != nil {
+		return err
+	}
+
+	if err := r.Config("user.name", "cherrypicker"); err != nil {
+		return err
+	}
+	if err := r.Config("user.email", "cherrypicker@localhost"); err != nil {
+		return err
+	}
+
+	// Checkout a new branch for the cherry-pick.
+	newBranch := fmt.Sprintf(cherryPickBranchFmt, num, targetBranch)
+	if err := r.CheckoutNewBranch(newBranch); err != nil {
+		return err
+	}
+
+	// Apply the patch.
+	if err := r.Apply(localPath); err != nil {
+		resp := fmt.Sprintf("PR %d failed to apply on top of branch %q: %v", num, targetBranch, err)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+	}
+
+	push := r.Push
+	if s.push != nil {
+		push = s.push
+	}
+	// Push the new branch in the bot's fork.
+	if err := push(s.botName, s.credentials, repo, newBranch); err != nil {
+		resp := fmt.Sprintf("Failed to push cherry-picked changes in Github: %v", err)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+	}
+
+	// Open a PR in Github.
+	title := fmt.Sprintf("Automated cherry-pick of #%d on %s", num, targetBranch)
+	// TODO: Make this a configurable template
+	body := fmt.Sprintf("This is an automated cherry-pick of #%d\n\n/assign %s", num, commentAuthor)
+	head := fmt.Sprintf("%s:%s", s.botName, newBranch)
+	createdNum, err := s.ghc.CreatePullRequest(org, repo, title, body, head, targetBranch, true)
+	if err != nil {
+		resp := fmt.Sprintf("New pull request could not be created: %v", err)
+		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+	}
+	resp := fmt.Sprintf("New pull request created: #%d", createdNum)
+	return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))
+}
+
+// ensureForkExists ensures a fork of org/repo exists for the bot.
+func (s *Server) ensureForkExists(org, repo string) error {
+	s.repoLock.Lock()
+	defer s.repoLock.Unlock()
+
+	var exists bool
+	fork := s.botName + "/" + repo
+	for _, r := range s.repos {
+		if !r.Fork {
+			continue
+		}
+		if r.FullName == fork {
+			exists = true
+			break
+		}
+	}
+	// Fork repo if it doesn't exist.
+	if !exists {
+		if err := s.ghc.CreateFork(org, repo); err != nil {
+			return fmt.Errorf("cannot fork %s/%s: %v", org, repo, err)
+		}
+		if err := waitFork(fmt.Sprintf("https://github.com/%s/%s", s.botName, repo)); err != nil {
+			return fmt.Errorf("fork of %s/%s cannot show up on Github: %v", org, repo, err)
+		}
+		s.repos = append(s.repos, github.Repo{FullName: fork, Fork: true})
+	}
+	return nil
+}
+
+func waitFork(forkURL string) error {
+	// Wait for at most 5 minutes for the fork to appear on Github.
+	after := time.After(5 * time.Minute)
+	tick := time.Tick(5 * time.Second)
+
+	for {
+		select {
+		case <-tick:
+			resp, err := http.Get(forkURL)
+			if err == nil && resp.StatusCode == 200 {
+				resp.Body.Close()
+				return nil
+			}
+			if err == nil {
+				resp.Body.Close()
+			}
+		case <-after:
+			return fmt.Errorf("timed out waiting for %s to appear on Github", forkURL)
+		}
+	}
+}
+
+// getPatch gets the patch for the provided PR and creates a local
+// copy of it. It returns its location in the filesystem and any
+// encountered error.
+func (s *Server) getPatch(org, repo string, num int) (string, error) {
+	url := fmt.Sprintf(s.patchURL+"/raw/%s/%s/pull/%d.patch", org, repo, num)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	// TODO: Add retries
+	resp, err := s.bare.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", fmt.Errorf("cannot get Github patch for PR %d: %s", num, resp.Status)
+	}
+	localPath := fmt.Sprintf("/tmp/%d-%s.patch", num, uuid.NewV1().String())
+	out, err := os.Create(localPath)
+	if err != nil {
+		return "", err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return "", err
+	}
+	return localPath, nil
+}

--- a/experiment/cherrypicker/server_test.go
+++ b/experiment/cherrypicker/server_test.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/git/localgit"
+	"k8s.io/test-infra/prow/github"
+)
+
+type fghc struct {
+	sync.Mutex
+	pr       *github.PullRequest
+	isMember bool
+
+	comments   []string
+	prs        []string
+	prComments []github.ReviewComment
+	createdNum int
+}
+
+func (f *fghc) GetPullRequest(org, repo string, number int) (*github.PullRequest, error) {
+	f.Lock()
+	defer f.Unlock()
+	return f.pr, nil
+}
+
+func (f *fghc) CreateComment(org, repo string, number int, comment string) error {
+	f.Lock()
+	defer f.Unlock()
+	f.comments = append(f.comments, fmt.Sprintf("%s/%s#%d %s", org, repo, number, comment))
+	return nil
+}
+
+func (f *fghc) IsMember(org, user string) (bool, error) {
+	f.Lock()
+	defer f.Unlock()
+	return f.isMember, nil
+}
+
+var expectedFmt = `repo=%s title=%q body=%q head=%s base=%s maintainer_can_modify=%t`
+
+func (f *fghc) CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error) {
+	f.Lock()
+	defer f.Unlock()
+	f.prs = append(f.prs, fmt.Sprintf(expectedFmt, org+"/"+repo, title, body, head, base, canModify))
+	return f.createdNum, nil
+}
+
+func (f *fghc) ListPullRequestComments(org, repo string, number int) ([]github.ReviewComment, error) {
+	return f.prComments, nil
+}
+
+func (f *fghc) CreateFork(org, repo string) error {
+	return nil
+}
+
+var initialFiles = map[string][]byte{
+	"bar.go": []byte(`// Package bar does an interesting thing.
+package bar
+
+// Foo does a thing.
+func Foo(wow int) int {
+	return 42 + wow
+}
+`),
+}
+
+var patch = []byte(`From af468c9e69dfdf39db591f1e3e8de5b64b0e62a2 Mon Sep 17 00:00:00 2001
+From: Wise Guy <wise@guy.com>
+Date: Thu, 19 Oct 2017 15:14:36 +0200
+Subject: [PATCH] Update magic number
+
+---
+ bar.go | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/bar.go b/bar.go
+index 1ea52dc..5bd70a9 100644
+--- a/bar.go
++++ b/bar.go
+@@ -3,5 +3,6 @@ package bar
+
+ // Foo does a thing.
+ func Foo(wow int) int {
+-	return 42 + wow
++	// Needs to be 49 because of a reason.
++	return 49 + wow
+ }
+`)
+
+func TestCherryPickIC(t *testing.T) {
+	lg, c, err := localgit.New()
+	if err != nil {
+		t.Fatalf("Making localgit: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Cleaning up localgit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up client: %v", err)
+		}
+	}()
+	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+	if err := lg.CheckoutNewBranch("foo", "bar", "stage"); err != nil {
+		t.Fatalf("Checking out pull branch: %v", err)
+	}
+
+	ghc := &fghc{
+		pr: &github.PullRequest{
+			Base: github.PullRequestBranch{
+				Ref: "master",
+			},
+			Merged: true,
+		},
+		isMember:   true,
+		createdNum: 3,
+	}
+	ic := github.IssueCommentEvent{
+		Action: github.IssueCommentActionCreated,
+		Repo: github.Repo{
+			Owner: github.User{
+				Login: "foo",
+			},
+			Name:     "bar",
+			FullName: "foo/bar",
+		},
+		Issue: github.Issue{
+			Number:      2,
+			State:       "closed",
+			PullRequest: &struct{}{},
+		},
+		Comment: github.IssueComment{
+			User: github.User{
+				Login: "wiseguy",
+			},
+			Body: "/cherrypick stage",
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("test request %+v", r)
+		expected := "/raw/foo/bar/pull/2.patch"
+		if r.URL.Path != expected {
+			t.Fatalf("wrong link was queried: %s, expected: %s", r.URL.Path, expected)
+		}
+		w.Write(patch)
+	}))
+	defer ts.Close()
+
+	botName := "ci-robot"
+	expectedRepo := "foo/bar"
+	expectedTitle := "Automated cherry-pick of #2 on stage"
+	expectedBody := "This is an automated cherry-pick of #2\n\n/assign wiseguy"
+	expectedBase := "stage"
+	expectedHead := fmt.Sprintf(botName+":"+cherryPickBranchFmt, 2, expectedBase)
+	expected := fmt.Sprintf(expectedFmt, expectedRepo, expectedTitle, expectedBody, expectedHead, expectedBase, true)
+
+	s := &Server{
+		credentials: "012345",
+		botName:     botName,
+		gc:          c,
+		push:        func(botName, credentials, repo, newBranch string) error { return nil },
+		ghc:         ghc,
+		hmacSecret:  []byte("sha=abcdefg"),
+		bare:        ts.Client(),
+		patchURL:    ts.URL,
+		log:         logrus.StandardLogger().WithField("client", "cherrypicker"),
+		repos:       []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+	}
+
+	if err := s.handleIssueComment(ic); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if ghc.prs[0] != expected {
+		t.Errorf("Expected (%d):\n%s\nGot (%d):\n%+v\n", len(expected), expected, len(ghc.prs[0]), ghc.prs[0])
+	}
+}
+
+func TestCherryPickPR(t *testing.T) {
+	lg, c, err := localgit.New()
+	if err != nil {
+		t.Fatalf("Making localgit: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Cleaning up localgit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up client: %v", err)
+		}
+	}()
+	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("foo", "bar", initialFiles); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+	if err := lg.CheckoutNewBranch("foo", "bar", "release-1.5"); err != nil {
+		t.Fatalf("Checking out pull branch: %v", err)
+	}
+
+	ghc := &fghc{
+		prComments: []github.ReviewComment{
+			{
+				User: github.User{
+					Login: "developer",
+				},
+				Body: "a review comment",
+			},
+			{
+				User: github.User{
+					Login: "approver",
+				},
+				Body: "/cherrypick release-1.5",
+			},
+			{
+				User: github.User{
+					Login: "approver",
+				},
+				Body: "/approve",
+			},
+		},
+		isMember:   true,
+		createdNum: 3,
+	}
+	pr := github.PullRequestEvent{
+		Action: github.PullRequestActionClosed,
+		PullRequest: github.PullRequest{
+			Base: github.PullRequestBranch{
+				Ref: "master",
+				Repo: github.Repo{
+					Owner: github.User{
+						Login: "foo",
+					},
+					Name: "bar",
+				},
+			},
+			Number:   2,
+			Merged:   true,
+			MergeSHA: new(string),
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("test request %+v", r)
+		expected := "/raw/foo/bar/pull/2.patch"
+		if r.URL.Path != expected {
+			t.Fatalf("wrong link was queried: %s, expected: %s", r.URL.Path, expected)
+		}
+		w.Write(patch)
+	}))
+	defer ts.Close()
+
+	botName := "ci-robot"
+	expectedRepo := "foo/bar"
+	expectedTitle := "Automated cherry-pick of #2 on release-1.5"
+	expectedBody := "This is an automated cherry-pick of #2\n\n/assign approver"
+	expectedBase := "release-1.5"
+	expectedHead := fmt.Sprintf(botName+":"+cherryPickBranchFmt, 2, expectedBase)
+	expected := fmt.Sprintf(expectedFmt, expectedRepo, expectedTitle, expectedBody, expectedHead, expectedBase, true)
+
+	s := &Server{
+		credentials: "012345",
+		botName:     botName,
+		gc:          c,
+		push:        func(botName, credentials, repo, newBranch string) error { return nil },
+		ghc:         ghc,
+		hmacSecret:  []byte("sha=abcdefg"),
+		bare:        ts.Client(),
+		patchURL:    ts.URL,
+		log:         logrus.StandardLogger().WithField("client", "cherrypicker"),
+		repos:       []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+	}
+
+	if err := s.handlePullRequest(pr); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if ghc.prs[0] != expected {
+		t.Errorf("Expected (%d):\n%s\nGot (%d):\n%+v\n", len(expected), expected, len(ghc.prs[0]), ghc.prs[0])
+	}
+}

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -167,6 +167,7 @@ type Repo struct {
 	Name     string `json:"name"`
 	FullName string `json:"full_name"`
 	HTMLURL  string `json:"html_url"`
+	Fork     bool   `json:"fork"`
 }
 
 // IssueEventAction enumerates the triggers for this

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -47,48 +47,8 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	// Our health check uses GET, so just kick back a 200.
-	if r.Method == http.MethodGet {
-		return
-	}
-
-	// Header checks: It must be a POST with an event type and a signature.
-	if r.Method != http.MethodPost {
-		http.Error(w, "405 Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	eventType := r.Header.Get("X-GitHub-Event")
-	if eventType == "" {
-		http.Error(w, "400 Bad Request: Missing X-GitHub-Event Header", http.StatusBadRequest)
-		return
-	}
-	eventGUID := r.Header.Get("X-GitHub-Delivery")
-	if eventGUID == "" {
-		http.Error(w, "400 Bad Request: Missing X-GitHub-Delivery Header", http.StatusBadRequest)
-		return
-	}
-	sig := r.Header.Get("X-Hub-Signature")
-	if sig == "" {
-		http.Error(w, "403 Forbidden: Missing X-Hub-Signature", http.StatusForbidden)
-		return
-	}
-	contentType := r.Header.Get("content-type")
-	if contentType != "application/json" {
-		http.Error(w, "400 Bad Request: Hook only accepts content-type: application/json - please reconfigure this hook on GitHub", http.StatusBadRequest)
-		return
-	}
-
-	payload, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "500 Internal Server Error: Failed to read request body", http.StatusInternalServerError)
-		return
-	}
-
-	// Validate the payload with our HMAC secret.
-	if !github.ValidatePayload(payload, sig, s.HMACSecret) {
-		http.Error(w, "403 Forbidden: Invalid X-Hub-Signature", http.StatusForbidden)
+	eventType, eventGUID, payload, ok := ValidateWebhook(w, r, s.HMACSecret)
+	if !ok {
 		return
 	}
 	fmt.Fprint(w, "Event received. Have a nice day.")
@@ -96,6 +56,59 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := s.demuxEvent(eventType, eventGUID, payload, r.Header); err != nil {
 		logrus.WithError(err).Error("Error parsing event.")
 	}
+}
+
+// ValidateWebhook ensures that the provided request conforms to the
+// format of a Github webhook and the payload can be validated with
+// the provided hmac secret. It returns the event type, the event guid,
+// the payload of the request, and whether the webhook is valid or not.
+func ValidateWebhook(w http.ResponseWriter, r *http.Request, hmacSecret []byte) (string, string, []byte, bool) {
+	defer r.Body.Close()
+
+	// Our health check uses GET, so just kick back a 200.
+	if r.Method == http.MethodGet {
+		return "", "", nil, false
+	}
+
+	// Header checks: It must be a POST with an event type and a signature.
+	if r.Method != http.MethodPost {
+		http.Error(w, "405 Method not allowed", http.StatusMethodNotAllowed)
+		return "", "", nil, false
+	}
+	eventType := r.Header.Get("X-GitHub-Event")
+	if eventType == "" {
+		http.Error(w, "400 Bad Request: Missing X-GitHub-Event Header", http.StatusBadRequest)
+		return "", "", nil, false
+	}
+	eventGUID := r.Header.Get("X-GitHub-Delivery")
+	if eventGUID == "" {
+		http.Error(w, "400 Bad Request: Missing X-GitHub-Delivery Header", http.StatusBadRequest)
+		return "", "", nil, false
+	}
+	sig := r.Header.Get("X-Hub-Signature")
+	if sig == "" {
+		http.Error(w, "403 Forbidden: Missing X-Hub-Signature", http.StatusForbidden)
+		return "", "", nil, false
+	}
+	contentType := r.Header.Get("content-type")
+	if contentType != "application/json" {
+		http.Error(w, "400 Bad Request: Hook only accepts content-type: application/json - please reconfigure this hook on GitHub", http.StatusBadRequest)
+		return "", "", nil, false
+	}
+
+	payload, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "500 Internal Server Error: Failed to read request body", http.StatusInternalServerError)
+		return "", "", nil, false
+	}
+
+	// Validate the payload with our HMAC secret.
+	if !github.ValidatePayload(payload, sig, hmacSecret) {
+		http.Error(w, "403 Forbidden: Invalid X-Hub-Signature", http.StatusForbidden)
+		return "", "", nil, false
+	}
+
+	return eventType, eventGUID, payload, true
 }
 
 func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.Header) error {


### PR DESCRIPTION
This is an external prow plugin that enables cherry-picks between
branches in a single Github repository. It can be used with hook
deployments that contain #5034. You can add the following stanza
in your plugins.yaml file and use it. You also need to run a
separate deployment and service for cherrypicker. By default,
http://{{name}} is assumed as the endpoint for the plugin. In
other words, the plugin needs to run in the same namespace as
hook. The service is required for allowing hook to demux github
events to cherrypicker. If you want to run the plugin elsewhere
(different namespace or outside the cluster), you can use a
different endpoint option.

```yaml
+external_plugins:
+  openshift/origin:
+  - name: cherrypick
+    endpoint: http://cherrypick  # default, can be omitted
+    events:
+    - issue_comment
+    - pull_request
```

<details>

```yaml
kind: List
apiVersion: v1
items:
- apiVersion: v1
  kind: Service
  metadata:
    name: cherrypick
  spec:
    selector:
      app: prow
      component:  cherrypick
    ports:
    - port: 80
      targetPort:: 8888
    type: ClusterIP
- apiVersion: apps/v1beta1
  kind: Deployment
  metadata:
    name: cherrypick
  spec:
    template:
      metadata:
        labels:
          app: prow
          component: cherrypick
      spec:
        containers:
        - name: cherrypick
          image: "${NAME}"
          args:
          - --dry-run=false
          ports:
            - name: http
              containerPort: 8888
          volumeMounts:
          - name: hmac
            mountPath: /etc/webhook
            readOnly: true
          - name: oauth
            mountPath: /etc/github
            readOnly: true
          - name: tmp
            mountPath: /tmp
        volumes:
        - name: hmac
          secret:
            secretName: hmac-token
        - name: oauth
          secret:
            secretName: oauth-token
        - name: tmp
          emptyDir: {}
```
</details>

PoC:
https://github.com/openshift/origin/pull/15422#issuecomment-337248433
https://github.com/openshift/origin/pull/15074#issuecomment-338191881
https://github.com/openshift/origin/pull/16854#issuecomment-338285383 (editable cherry pick since some may be broken)

/cc cjwagner stevekuznetsov spxtr 