### PR TITLE
Upload log in ci cri-containerd build.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3185,6 +3185,7 @@ periodics:
       args:
       - "--repo=github.com/kubernetes-incubator/cri-containerd=master"
       - "--root=/go/src"
+      - "--upload=gs://kubernetes-jenkins/logs"
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json


### PR DESCRIPTION
`--upload=gs://kubernetes-jenkins/logs` is not specified in `gcloud-in-go` https://github.com/kubernetes/test-infra/blob/master/images/gcloud/runner#L21.