### PR TITLE
Enable the PodSecurityPolicy in default jobs

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gci-gce.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce.env
@@ -6,3 +6,5 @@ STORAGE_BACKEND=etcd2
 TEST_ETCD_IMAGE=2.2.1
 TEST_ETCD_VERSION=2.2.1
 
+# Enable the PodSecurityPolicy in tests.
+ENABLE_POD_SECURITY_POLICY=true

--- a/jobs/env/pull-kubernetes-e2e-gce.env
+++ b/jobs/env/pull-kubernetes-e2e-gce.env
@@ -3,3 +3,6 @@
 # Panic if anything mutates a shared informer cache
 ENABLE_CACHE_MUTATION_DETECTOR=true
 
+# Enable the PodSecurityPolicy in tests.
+# TODO: Enable this by default in the test environment.
+ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
This PR will have no effect until https://github.com/kubernetes/kubernetes/pull/52367 is merged, but by merging this, it means that https://github.com/kubernetes/kubernetes/pull/52367 will be tested in the submit queue.

Are there any other test suites that it should be enabled in for now?

/assign @liggitt @destijl 