### PR TITLE
Add `--clean` in cri-containerd ci node e2e.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3205,6 +3205,7 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171008-cd94f30a-master
       args:
       - --root=/go/src
+      - "--clean"
       - "--git-cache=/root/.cache/git"
       - "--job=$(JOB_NAME)"
       - "--repo=k8s.io/kubernetes"


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cri-containerd-node-e2e/3/build-log.txt

Actually I don't quite understand the test failure, but I see 2 symptoms:
1) There are a log of merge messages when checkout kubernetes repo;
2) `W1016 20:24:53.997] stat /go/src/k8s.io/kubernetes/test/e2e_node/runner/remote/run_remote.go: no such file or directory`, it seems that the file lost during checkout.

Given so, I guess `--clean` is the cause. :p