### PR TITLE
Add --concurrent-service-syncs=5 to CONTROLLER_MANAGER_TEST_ARGS for correctness CIs

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
@@ -13,11 +13,11 @@ LOGROTATE_MAX_SIZE=5G
 ALLOWED_NOTREADY_NODES=20
 KUBE_ENABLE_CLUSTER_MONITORING=standalone
 # TODO: Figure if we need to increase QPS for master components.
+# Increase service_controller's parallelism of processing service update
+CONTROLLER_MANAGER_TEST_ARGS=--concurrent-service-syncs=5
 # Increase controller-manager's resync period to simulate production
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
-# Increase service_controller's parallelism of processing service update
-CONCURRENT_SERVICE_SYNCS=5
 
 ### test-env

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
@@ -16,13 +16,12 @@ KUBE_ENABLE_CLUSTER_MONITORING=standalone
 TEST_CLUSTER_LOG_LEVEL=--v=1
 # TODO: Figure if we need to increase QPS for master components.
 SCHEDULER_TEST_ARGS=--kube-api-qps=100
-CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100
+# Increase service_controller's parallelism of processing service update
+CONTROLLER_MANAGER_TEST_ARGS=--kube-api-qps=100 --kube-api-burst=100 --concurrent-service-syncs=5
 APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-inflight=500
 # Increase controller-manager's resync period to simulate production
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
-# Increase service_controller's parallelism of processing service update
-CONCURRENT_SERVICE_SYNCS=5
 
 ### test-env


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/pull/54033#issuecomment-337146424, this is the better way to pass test flag.

Ref: https://github.com/kubernetes/kubernetes/issues/52495.

/assign @shyamjvs 