### PR TITLE
Migrate node+ubuntu branched jobs

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -103,31 +103,6 @@
         repo-name: k8s.io/kubernetes
         timeout: 100
 
-    - kubernetes-node-kubelet-1.6:
-        branch: release-1.6
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
-        job-name: ci-kubernetes-node-kubelet-1.6
-        repo-name: k8s.io/kubernetes
-        timeout: 90
-    - kubernetes-node-kubelet-non-cri-1.6:
-        branch: release-1.6
-        frequency: 'H H/6 * * *' # 4 times a day for older jobs.
-        job-name: ci-kubernetes-node-kubelet-non-cri-1.6
-        repo-name: k8s.io/kubernetes
-        timeout: 90
-    - kubernetes-node-kubelet-1.7:
-        branch: release-1.7
-        frequency: 'H/5 * * * *'
-        job-name: ci-kubernetes-node-kubelet-1.7
-        repo-name: k8s.io/kubernetes
-        timeout: 90
-    - kubernetes-node-kubelet-stable1:
-        branch: release-1.8
-        frequency: 'H/5 * * * *'
-        job-name: ci-kubernetes-node-kubelet-stable1
-        repo-name: k8s.io/kubernetes
-        timeout: 90
-
     - kubernetes-node-docker:  # dawnchen
         branch: master
         frequency: '@hourly'
@@ -146,40 +121,3 @@
         job-name: ci-kubernetes-node-cos-docker-validation
         repo-name: k8s.io/kubernetes
         timeout: 90
-
-    - kubernetes-e2e-gce-ubuntu-node:  # @kubernetes/ubuntu-image on github
-        branch: master
-        frequency: 'H/30 * * * *'
-        job-name: ci-kubernetes-e2e-gce-ubuntu-node
-        repo-name: k8s.io/kubernetes
-        timeout: 90
-    - kubernetes-e2e-gce-ubuntu-node-serial:  # @kubernetes/ubuntu-image on github
-        branch: master
-        frequency: 'H H/2 * * *'
-        job-name: ci-kubernetes-e2e-gce-ubuntu-node-serial
-        repo-name: k8s.io/kubernetes
-        timeout: 240
-    - kubernetes-e2e-gce-ubuntu-1-6-node:  # @kubernetes/ubuntu-image on github
-        branch: release-1.6
-        frequency: 'H/30 * * * *'
-        job-name: ci-kubernetes-e2e-gce-ubuntu-1-6-node
-        repo-name: k8s.io/kubernetes
-        timeout: 90
-    - kubernetes-e2e-gce-ubuntu-1-6-node-serial:  # @kubernetes/ubuntu-image on github
-        branch: release-1.6
-        frequency: 'H H/2 * * *'
-        job-name: ci-kubernetes-e2e-gce-ubuntu-1-6-node-serial
-        repo-name: k8s.io/kubernetes
-        timeout: 240
-    - kubernetes-e2e-gce-ubuntu-1-7-node:  # @kubernetes/ubuntu-image on github
-        branch: release-1.7
-        frequency: 'H/30 * * * *'
-        job-name: ci-kubernetes-e2e-gce-ubuntu-1-7-node
-        repo-name: k8s.io/kubernetes
-        timeout: 90
-    - kubernetes-e2e-gce-ubuntu-1-7-node-serial:  # @kubernetes/ubuntu-image on github
-        branch: release-1.7
-        frequency: 'H H/2 * * *'
-        job-name: ci-kubernetes-e2e-gce-ubuntu-1-7-node-serial
-        repo-name: k8s.io/kubernetes
-        timeout: 240

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2957,58 +2957,102 @@
   },
   "ci-kubernetes-e2e-gce-ubuntu-1-6-node": {
     "args": [
-      "--branch=release-1.6",
-      "--properties=test/e2e_node/jenkins/jenkins-ci-ubuntu.properties"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ubuntu-node",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--images=ubuntu-gke-1604-xenial-v20170420-1 --image-project=ubuntu-os-gke-cloud --system-spec-name=gke",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
     ]
   },
   "ci-kubernetes-e2e-gce-ubuntu-1-6-node-serial": {
     "args": [
-      "--branch=release-1.6",
-      "--properties=test/e2e_node/jenkins/jenkins-serial-ubuntu.properties"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ubuntu-node",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--images=ubuntu-gke-1604-xenial-v20170420-1 --image-project=ubuntu-os-gke-cloud --system-spec-name=gke",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\" --feature-gates=DynamicKubeletConfig=true",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=1 --focus=\"\\[Serial\\]\" --skip=\"\\[Flaky\\]|\\[Benchmark\\]\"",
+      "--timeout=180m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
     ]
   },
   "ci-kubernetes-e2e-gce-ubuntu-1-7-node": {
     "args": [
-      "--branch=release-1.7",
-      "--properties=test/e2e_node/jenkins/jenkins-ci-ubuntu.properties"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ubuntu-node",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--images=ubuntu-gke-1604-xenial-v20170420-1 --image-project=ubuntu-os-gke-cloud --system-spec-name=gke",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
     ]
   },
   "ci-kubernetes-e2e-gce-ubuntu-1-7-node-serial": {
     "args": [
-      "--branch=release-1.7",
-      "--properties=test/e2e_node/jenkins/jenkins-serial-ubuntu.properties"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ubuntu-node",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--images=ubuntu-gke-1604-xenial-v20170420-1 --image-project=ubuntu-os-gke-cloud --system-spec-name=gke",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\" --feature-gates=DynamicKubeletConfig=true",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=1 --focus=\"\\[Serial\\]\" --skip=\"\\[Flaky\\]|\\[Benchmark\\]\"",
+      "--timeout=180m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
     ]
   },
   "ci-kubernetes-e2e-gce-ubuntu-node": {
     "args": [
-      "--properties=test/e2e_node/jenkins/jenkins-ci-ubuntu.properties"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ubuntu-node",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--images=ubuntu-gke-1604-xenial-v20170420-1 --image-project=ubuntu-os-gke-cloud --system-spec-name=gke",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
     ]
   },
   "ci-kubernetes-e2e-gce-ubuntu-node-serial": {
     "args": [
-      "--properties=test/e2e_node/jenkins/jenkins-serial-ubuntu.properties"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ubuntu-node",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--images=ubuntu-gke-1604-xenial-v20170420-1 --image-project=ubuntu-os-gke-cloud --system-spec-name=gke",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\" --feature-gates=DynamicKubeletConfig=true",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=1 --focus=\"\\[Serial\\]\" --skip=\"\\[Flaky\\]|\\[Benchmark\\]\"",
+      "--timeout=180m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-node"
     ]
@@ -8748,24 +8792,6 @@
       "sig-node"
     ]
   },
-  "ci-kubernetes-node-kubelet-1.6": {
-    "args": [
-      "--branch=release-1.6"
-    ],
-    "scenario": "kubernetes_kubelet",
-    "sigOwners": [
-      "UNKNOWN"
-    ]
-  },
-  "ci-kubernetes-node-kubelet-1.7": {
-    "args": [
-      "--branch=release-1.7"
-    ],
-    "scenario": "kubernetes_kubelet",
-    "sigOwners": [
-      "UNKNOWN"
-    ]
-  },
   "ci-kubernetes-node-kubelet-benchmark": {
     "args": [
       "--deployment=node",
@@ -8817,14 +8843,21 @@
       "sig-node"
     ]
   },
-  "ci-kubernetes-node-kubelet-non-cri-1.6": {
+  "ci-kubernetes-node-kubelet-non-cri-1-6": {
     "args": [
-      "--branch=release-1.6",
-      "--properties=test/e2e_node/jenkins/non-cri_validation/jenkins-validation.properties"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ci-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/non-cri-image-config.yaml.yaml",
+      "--node-test-args=--kubelet-flags=\"--enable-cri=false\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "ci-kubernetes-node-kubelet-serial": {
@@ -8846,11 +8879,53 @@
   },
   "ci-kubernetes-node-kubelet-stable1": {
     "args": [
-      "--branch=release-1.8"
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ci-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
     ],
-    "scenario": "kubernetes_kubelet",
+    "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
+    ]
+  },
+  "ci-kubernetes-node-kubelet-stable2": {
+    "args": [
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ci-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-7.yaml",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-kubernetes-node-kubelet-stable3": {
+    "args": [
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ci-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-1-6.yaml",
+      "--node-test-args=--kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Serial\\]\"",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
     ]
   },
   "ci-kubernetes-pull-gce-federation-deploy": {

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -748,6 +748,13 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-serial': 'ci-kubernetes-e2e-gke-ubuntu*',
             'ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-slow': 'ci-kubernetes-e2e-gke-ubuntu*',
             'ci-kubernetes-e2e-gke-ubuntustable1-k8sstable1-updown': 'ci-kubernetes-e2e-gke-ubuntu*',
+            # ubuntu node image tests share the same ubuntu project
+            'ci-kubernetes-e2e-gce-ubuntu-1-6-node': 'ci-kubernetes-e2e-ubuntu-node*',
+            'ci-kubernetes-e2e-gce-ubuntu-1-7-node': 'ci-kubernetes-e2e-ubuntu-node*',
+            'ci-kubernetes-e2e-gce-ubuntu-node': 'ci-kubernetes-e2e-ubuntu-node*',
+            'ci-kubernetes-e2e-gce-ubuntu-1-6-node-serial': 'ci-kubernetes-e2e-ubuntu-node*',
+            'ci-kubernetes-e2e-gce-ubuntu-1-7-node-serial': 'ci-kubernetes-e2e-ubuntu-node*',
+            'ci-kubernetes-e2e-gce-ubuntu-node-serial': 'ci-kubernetes-e2e-ubuntu-node*',
             # The 1.5 and 1.6 scalability jobs intentionally share projects.
             'ci-kubernetes-e2e-gci-gce-scalability-release-1-7': 'ci-kubernetes-e2e-gci-gce-scalability-release-*',
             'ci-kubernetes-e2e-gci-gce-scalability-stable1': 'ci-kubernetes-e2e-gci-gce-scalability-release-*',
@@ -787,6 +794,10 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-node-kubelet-conformance': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-benchmark': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet': 'ci-kubernetes-node-kubelet-*',
+            'ci-kubernetes-node-kubelet-stable1': 'ci-kubernetes-node-kubelet-*',
+            'ci-kubernetes-node-kubelet-stable2': 'ci-kubernetes-node-kubelet-*',
+            'ci-kubernetes-node-kubelet-stable3': 'ci-kubernetes-node-kubelet-*',
+            'ci-kubernetes-node-kubelet-non-cri-1-6': 'ci-kubernetes-node-kubelet-*',
         }
         for soak_prefix in [
                 'ci-kubernetes-soak-gce-1.5',

--- a/jobs/e2e_node/non-cri-image-config.yaml
+++ b/jobs/e2e_node/non-cri-image-config.yaml
@@ -1,0 +1,14 @@
+images:
+  containervm:
+    image: e2e-node-containervm-v20161208-image # docker 1.11.2
+    project: kubernetes-node-e2e-images
+  gci:
+    image_regex: gci-beta-56-9000-80-0 # docker 1.11.2
+    project: google-containers
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+  ubuntu-docker12:
+    image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
+    project: kubernetes-node-e2e-images
+  ubuntu-docker10:
+    image: e2e-node-ubuntu-trusty-docker10-v2-image # docker 1.10.3
+    project: kubernetes-node-e2e-images

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7814,6 +7814,229 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
+- name: ci-kubernetes-e2e-gce-ubuntu-1-6-node
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
+      args:
+      - --repo=k8s.io/kubernetes=release-1.6
+      - --timeout=90
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+- name: ci-kubernetes-e2e-gce-ubuntu-1-6-node-serial
+  interval: 2h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
+      args:
+      - --repo=k8s.io/kubernetes=release-1.6
+      - --timeout=240
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+
+- name: ci-kubernetes-e2e-gce-ubuntu-1-7-node
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.7
+      args:
+      - --repo=k8s.io/kubernetes=release-1.7
+      - --timeout=90
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+- name: ci-kubernetes-e2e-gce-ubuntu-1-7-node-serial
+  interval: 2h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.7
+      args:
+      - --repo=k8s.io/kubernetes=release-1.7
+      - --timeout=240
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+- name: ci-kubernetes-e2e-gce-ubuntu-node
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --timeout=90
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+- name: ci-kubernetes-e2e-gce-ubuntu-node-serial
+  interval: 2h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --timeout=240
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
 - tags:
   - generated   # AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT!
   interval: 2h
@@ -16701,6 +16924,43 @@ periodics:
         secretName: ssh-key-secret
         defaultMode: 0400
 
+- name: ci-kubernetes-node-kubelet-non-cri-1-6
+  interval: 6h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
+      args:
+      - --repo=k8s.io/kubernetes=release-1.6
+      - --timeout=90
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
 - name: ci-kubernetes-node-kubelet-serial
   interval: 4h
   agent: kubernetes
@@ -16710,6 +16970,117 @@ periodics:
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+- name: ci-kubernetes-node-kubelet-stable1
+  interval: 1h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.8
+      args:
+      - --repo=k8s.io/kubernetes=release-1.8
+      - --timeout=90
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+- name: ci-kubernetes-node-kubelet-stable2
+  interval: 2h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.7
+      args:
+      - --repo=k8s.io/kubernetes=release-1.7
+      - --timeout=90
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
+- name: ci-kubernetes-node-kubelet-stable3
+  interval: 6h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171011-8265ed12-1.6
+      args:
+      - --repo=k8s.io/kubernetes=release-1.6
+      - --timeout=90
       - --root=/go/src
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -456,27 +456,22 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-1.6
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.6
+- name: ci-kubernetes-node-kubelet-stable2
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-stable2
   test_name_config:
     name_elements:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-1.7
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-1.7
+- name: ci-kubernetes-node-kubelet-stable3
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-stable3
   test_name_config:
     name_elements:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-non-cri-1.6
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-non-cri-1.6
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-non-cri-1-6
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-non-cri-1-6
 - name: ci-kops-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kops-build
 - name: ci-kubernetes-e2e-gce-large-manual-up
@@ -2407,9 +2402,9 @@ dashboards:
   - name: verify-1.6
     test_group_name: ci-kubernetes-verify-release-1.6
   - name: kubelet-1.6
-    test_group_name: ci-kubernetes-node-kubelet-1.6
+    test_group_name: ci-kubernetes-node-kubelet-stable3
   - name: kubelet-non-cri-1.6
-    test_group_name: ci-kubernetes-node-kubelet-non-cri-1.6
+    test_group_name: ci-kubernetes-node-kubelet-non-cri-1-6
   - name: gce-alpha-features-1.6
     test_group_name: ci-kubernetes-e2e-gce-alpha-features-release-1-6
   - name: gce-etcd2-1.6
@@ -2506,7 +2501,7 @@ dashboards:
   - name: verify-1.6
     test_group_name: ci-kubernetes-verify-release-1.6
   - name: kubelet-1.6
-    test_group_name: ci-kubernetes-node-kubelet-1.6
+    test_group_name: ci-kubernetes-node-kubelet-stable3
   - name: gke-serial-1.6
     test_group_name: ci-kubernetes-e2e-gke-serial-release-1-6
   - name: gke-1.6
@@ -2954,7 +2949,7 @@ dashboards:
   - name: verify-1.7
     test_group_name: ci-kubernetes-verify-release-1.7
   - name: kubelet-1.7
-    test_group_name: ci-kubernetes-node-kubelet-1.7
+    test_group_name: ci-kubernetes-node-kubelet-stable2
   - name: federation-build-1.7
     test_group_name: ci-kubernetes-federation-build-1.7
   - name: gce-release-1-7
@@ -3070,7 +3065,7 @@ dashboards:
   - name: gce-kubeadm-upgrade-1.6-1.7
     test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-6-1-7
   - name: kubelet-1.7
-    test_group_name: ci-kubernetes-node-kubelet-1.7
+    test_group_name: ci-kubernetes-node-kubelet-stable2
   - name: aws-release-1-7
     test_group_name: ci-kubernetes-e2e-kops-aws-release-1-7
   - name: gke-serial-release-1-7
@@ -3674,17 +3669,22 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet-conformance
   - name: kubelet-1.8
     test_group_name: ci-kubernetes-node-kubelet-stable1
-  - name: kubelet-1.6
-    test_group_name: ci-kubernetes-node-kubelet-1.6
   - name: kubelet-1.7
-    test_group_name: ci-kubernetes-node-kubelet-1.7
+    test_group_name: ci-kubernetes-node-kubelet-stable2
+  - name: kubelet-1.6
+    test_group_name: ci-kubernetes-node-kubelet-stable3
+  - name: docker-kubelet
+    test_group_name: ci-kubernetes-node-docker
+  - name: docker-e2e
+    test_group_name: ci-kubernetes-e2e-gci-gce-docker
+  - name: docker-kubelet-benchmark
+    test_group_name: ci-kubernetes-node-docker-benchmark
 
 - name: sig-node-ppc64le
   dashboard_tab:
   - name: conformance
     test_group_name: ppc64le-conformance
     description: 'conformance test results for ppc64le'
-
 
 # Move sig-release here
 


### PR DESCRIPTION
For node job, since I'll need to rename from node-1.6 -> node-1-6 anyway, I'd just convert them to stable-2|3.

Referencing https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/jenkins-ci-ubuntu.properties and https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/jenkins-serial-ubuntu.properties for ubuntu jobs, but double check for me.

I'll do another PR for generated node jobs as well.

/assign @yguo0905 