### PR TITLE
make pull-kubernetes-cross required

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -19,6 +19,7 @@ github-key-file: /etc/hook-secret-volume/secret
 required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
+  pull-kubernetes-cross,\
   pull-kubernetes-e2e-gce,\
   pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-kubemark-e2e-gce,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -15,6 +15,7 @@ github-key-file: /etc/hook-secret-volume/secret
 required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
+  pull-kubernetes-cross,\
   pull-kubernetes-e2e-gce,\
   pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-kubemark-e2e-gce,\

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -110,7 +110,7 @@ type SubmitQueueConfig struct {
 func FindRequired(t *testing.T, presubmits []Presubmit) []string {
 	var required []string
 	for _, p := range presubmits {
-		if !p.AlwaysRun {
+		if !p.AlwaysRun && p.RunIfChanged == "" {
 			continue
 		}
 		for _, r := range FindRequired(t, p.RunAfterSuccess) {


### PR DESCRIPTION
This job only runs on PRs that touch build, but when it does run we ought to require that it is green, otherwise `make release` will fail on master.

related to #4932 