### PR TITLE
mungegithub: Mention -misc sig team instead of -bugs

### DIFF
--- a/mungegithub/mungers/milestone-maintainer.go
+++ b/mungegithub/mungers/milestone-maintainer.go
@@ -76,7 +76,7 @@ const (
 	blockerLabel = "priority/critical-urgent"
 
 	sigLabelPrefix     = "sig/"
-	sigMentionTemplate = "@kubernetes/sig-%s-bugs"
+	sigMentionTemplate = "@kubernetes/sig-%s-misc"
 
 	milestoneOptModes                = "milestone-modes"
 	milestoneOptWarningInterval      = "milestone-warning-interval"

--- a/mungegithub/mungers/milestone-maintainer_test.go
+++ b/mungegithub/mungers/milestone-maintainer_test.go
@@ -113,7 +113,7 @@ func TestMilestoneMaintainer(t *testing.T) {
 
 	expectedBody := `[MILESTONENOTIFIER] Milestone Issue **Needs Approval**
 
-@user @kubernetes/sig-foo-bugs
+@user @kubernetes/sig-foo-misc
 
 
 **Action required**: This issue must have the ` + "`status/approved-for-milestone`" + ` label applied by a SIG maintainer. If the label is not applied within 2 days, the issue will be moved out of the v1.8 milestone.


### PR DESCRIPTION
This will avoid conflicts with prow's sigmentation plugin, which will be prompted by a -bugs team mention to add the kind/bug label.

re: https://github.com/kubernetes/test-infra/issues/4922#issuecomment-337118084