### PR TITLE
Enable logexporter for kubemark-scale job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8894,7 +8894,8 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=1080m"
+      "--timeout=1080m",
+      "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
Seems like we're missing some logs (most importantly kubemark apiserver) since we've enabled hollow node logs in kubemark-scale, due to the logs volume.
Logexporter should hopefully help with this situation.

/cc @wojtek-t 