### PR TITLE
Revert "make pull-kubernetes-cross required"

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -19,7 +19,6 @@ github-key-file: /etc/hook-secret-volume/secret
 required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
-  pull-kubernetes-cross,\
   pull-kubernetes-e2e-gce,\
   pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-kubemark-e2e-gce,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -15,7 +15,6 @@ github-key-file: /etc/hook-secret-volume/secret
 required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
-  pull-kubernetes-cross,\
   pull-kubernetes-e2e-gce,\
   pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-kubemark-e2e-gce,\

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -110,7 +110,7 @@ type SubmitQueueConfig struct {
 func FindRequired(t *testing.T, presubmits []Presubmit) []string {
 	var required []string
 	for _, p := range presubmits {
-		if !p.AlwaysRun && p.RunIfChanged == "" {
+		if !p.AlwaysRun {
 			continue
 		}
 		for _, r := range FindRequired(t, p.RunAfterSuccess) {


### PR DESCRIPTION
Reverts kubernetes/test-infra#5043
/cc @BenTheElder 

pull-kubernetes-cross is not being marked as "skipped" on a lot of PRs so we need to make it non-blocking until that is fixed.