### PR TITLE
allow user to pass '-v' into kubetest

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -150,7 +150,7 @@ func defineFlags() *options {
 	flag.BoolVar(&o.up, "up", false, "If true, start the the e2e cluster. If cluster is already up, recreate it.")
 	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests")
 
-	flag.BoolVar(&verbose, "v", false, "If true, print all command output.")
+	flag.BoolVarP(&verbose, "v", "v", false, "If true, print all command output.")
 	return &o
 }
 


### PR DESCRIPTION
changing from go's builtin flag to spf13/pflag changes single char
flags to require two dashes.  this patch allows either two or one
dashes by making 'v' the shorthand switch for 'v'.