### PR TITLE
Update test-infra go_rules and e2e image to go1.9

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/test-infra",
-	"GoVersion": "go1.7",
+	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./prow/...",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,15 @@
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "ee1fef7ec1379fcf36c002fd3ac0d00d940b147e",
+    commit = "c72631a220406c4fae276861ee286aaec82c5af2",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
-go_register_toolchains()
+go_register_toolchains(
+    go_version = "1.9.1",
+)
 
 http_archive(
     name = "io_bazel_rules_docker",

--- a/bootstrap/BUILD
+++ b/bootstrap/BUILD
@@ -9,12 +9,14 @@ go_library(
         "paths.go",
         "repos.go",
     ],
+    importpath = "k8s.io/test-infra/bootstrap",
     visibility = ["//visibility:private"],
     deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
 )
 
 go_binary(
     name = "bootstrap",
+    importpath = "k8s.io/test-infra/bootstrap",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
@@ -41,5 +43,6 @@ go_test(
         "paths_test.go",
         "repos_test.go",
     ],
+    importpath = "k8s.io/test-infra/bootstrap",
     library = ":go_default_library",
 )

--- a/boskos/BUILD
+++ b/boskos/BUILD
@@ -9,6 +9,7 @@ load(
 
 go_binary(
     name = "boskos",
+    importpath = "k8s.io/test-infra/boskos",
     library = ":go_default_library",
 )
 
@@ -16,6 +17,7 @@ go_test(
     name = "go_default_test",
     srcs = ["boskos_test.go"],
     data = ["resources.json"],
+    importpath = "k8s.io/test-infra/boskos",
     library = ":go_default_library",
     deps = [
         "//boskos/common:go_default_library",
@@ -26,6 +28,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["boskos.go"],
+    importpath = "k8s.io/test-infra/boskos",
     deps = [
         "//boskos/ranch:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/boskos/client/BUILD
+++ b/boskos/client/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["client_test.go"],
+    importpath = "k8s.io/test-infra/boskos/client",
     library = ":go_default_library",
     deps = ["//boskos/common:go_default_library"],
 )
@@ -16,6 +17,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["client.go"],
+    importpath = "k8s.io/test-infra/boskos/client",
     deps = ["//boskos/common:go_default_library"],
 )
 

--- a/boskos/common/BUILD
+++ b/boskos/common/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["common.go"],
+    importpath = "k8s.io/test-infra/boskos/common",
 )
 
 filegroup(

--- a/boskos/janitor/BUILD
+++ b/boskos/janitor/BUILD
@@ -9,12 +9,14 @@ load(
 
 go_binary(
     name = "janitor",
+    importpath = "k8s.io/test-infra/boskos/janitor",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["janitor.go"],
+    importpath = "k8s.io/test-infra/boskos/janitor",
     deps = [
         "//boskos/client:go_default_library",
         "//boskos/common:go_default_library",
@@ -38,6 +40,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["janitor_test.go"],
+    importpath = "k8s.io/test-infra/boskos/janitor",
     library = ":go_default_library",
     deps = ["//boskos/common:go_default_library"],
 )

--- a/boskos/metrics/BUILD
+++ b/boskos/metrics/BUILD
@@ -10,6 +10,7 @@ load(
 
 go_binary(
     name = "metrics",
+    importpath = "k8s.io/test-infra/boskos/metrics",
     library = ":go_default_library",
     tags = ["automanaged"],
 )
@@ -17,6 +18,7 @@ go_binary(
 go_library(
     name = "go_default_library",
     srcs = ["metrics.go"],
+    importpath = "k8s.io/test-infra/boskos/metrics",
     tags = ["automanaged"],
     deps = [
         "//boskos/client:go_default_library",

--- a/boskos/ranch/BUILD
+++ b/boskos/ranch/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["ranch_test.go"],
+    importpath = "k8s.io/test-infra/boskos/ranch",
     library = ":go_default_library",
     deps = ["//boskos/common:go_default_library"],
 )
@@ -16,6 +17,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["ranch.go"],
+    importpath = "k8s.io/test-infra/boskos/ranch",
     deps = [
         "//boskos/common:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/boskos/reaper/BUILD
+++ b/boskos/reaper/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "reaper",
+    importpath = "k8s.io/test-infra/boskos/reaper",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["reaper.go"],
+    importpath = "k8s.io/test-infra/boskos/reaper",
     deps = [
         "//boskos/client:go_default_library",
         "//boskos/common:go_default_library",

--- a/experiment/commenter/BUILD
+++ b/experiment/commenter/BUILD
@@ -41,12 +41,14 @@ load(
 
 go_binary(
     name = "commenter",
+    importpath = "k8s.io/test-infra/experiment/commenter",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/commenter",
     deps = ["//prow/github:go_default_library"],
 )
 
@@ -66,6 +68,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    importpath = "k8s.io/test-infra/experiment/commenter",
     library = ":go_default_library",
     deps = ["//prow/github:go_default_library"],
 )

--- a/gcsweb/cmd/gcsweb/BUILD
+++ b/gcsweb/cmd/gcsweb/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "gcsweb",
+    importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["gcsweb.go"],
+    importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
     deps = ["//gcsweb/pkg/version:go_default_library"],
 )
 

--- a/gcsweb/pkg/version/BUILD
+++ b/gcsweb/pkg/version/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["version.go"],
+    importpath = "k8s.io/test-infra/gcsweb/pkg/version",
 )
 
 filegroup(

--- a/ghclient/BUILD
+++ b/ghclient/BUILD
@@ -12,6 +12,7 @@ go_test(
         "core_test.go",
         "wrappers_test.go",
     ],
+    importpath = "k8s.io/test-infra/ghclient",
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
@@ -23,6 +24,7 @@ go_library(
         "core.go",
         "wrappers.go",
     ],
+    importpath = "k8s.io/test-infra/ghclient",
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -17,7 +17,7 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 K8S ?= master
 
-GO ?= 1.8.3
+GO ?= 1.9.1
 BAZEL ?= 0.6.1
 
 ifeq ($(K8S), 1.8)

--- a/jenkins/test-image/Dockerfile-1.9
+++ b/jenkins/test-image/Dockerfile-1.9
@@ -1,0 +1,54 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a build environment for building and running kubernetes
+# unit and integration tests
+
+FROM golang:1.9.1
+LABEL authors="Sen Lu <senlu@google.com>"
+
+# Setup workspace and symlink to gopath
+WORKDIR /workspace
+RUN mkdir -p /go/src/k8s.io/kubernetes /workspace \
+    && ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+
+# Install linux packages
+# bc is needed by shell2junit
+# dnsutils is needed by federation cluster scripts.
+# file is used when uploading test artifacts to GCS.
+# jq is used by hack/verify-godep-licenses.sh
+# python-pip is needed to install the AWS cli.
+# netcat is used by integration test scripts.
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
+        bc \
+	dnsutils \
+	file \
+	jq \
+	python-pip \
+	netcat-openbsd \
+	rsync \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Install docker
+# Note: 1.11+ changes the tarball format
+RUN curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \
+    | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
+
+# Install any go packages
+# TODO(fejta): migrate this to a unit test image
+RUN go get \
+        github.com/golang/lint/golint

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -9,6 +9,7 @@ load(
 
 go_binary(
     name = "kubetest",
+    importpath = "k8s.io/test-infra/kubetest",
     library = ":go_default_library",
 )
 
@@ -29,6 +30,7 @@ go_library(
         "stage.go",
         "util.go",
     ],
+    importpath = "k8s.io/test-infra/kubetest",
     deps = [
         "//boskos/client:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
@@ -56,5 +58,6 @@ go_test(
         "main_test.go",
         "util_test.go",
     ],
+    importpath = "k8s.io/test-infra/kubetest",
     library = ":go_default_library",
 )

--- a/label_sync/BUILD
+++ b/label_sync/BUILD
@@ -11,6 +11,7 @@ load(
 
 go_binary(
     name = "label_sync",
+    importpath = "k8s.io/test-infra/label_sync",
     library = ":go_default_library",
     tags = ["automanaged"],
 )
@@ -21,6 +22,7 @@ go_test(
     data = [
         "//label_sync:test_examples",
     ],
+    importpath = "k8s.io/test-infra/label_sync",
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = ["//prow/github:go_default_library"],
@@ -29,6 +31,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/label_sync",
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",

--- a/logexporter/cmd/BUILD
+++ b/logexporter/cmd/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "cmd",
+    importpath = "k8s.io/test-infra/logexporter/cmd",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/logexporter/cmd",
     deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )
 

--- a/maintenance/migratestatus/BUILD
+++ b/maintenance/migratestatus/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "migratestatus",
+    importpath = "k8s.io/test-infra/maintenance/migratestatus",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["migratestatus.go"],
+    importpath = "k8s.io/test-infra/maintenance/migratestatus",
     deps = [
         "//maintenance/migratestatus/migrator:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/maintenance/migratestatus/migrator/BUILD
+++ b/maintenance/migratestatus/migrator/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["migrator_test.go"],
+    importpath = "k8s.io/test-infra/maintenance/migratestatus/migrator",
     library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
@@ -16,6 +17,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["migrator.go"],
+    importpath = "k8s.io/test-infra/maintenance/migratestatus/migrator",
     deps = [
         "//ghclient:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/mungegithub/BUILD
+++ b/mungegithub/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "mungegithub",
+    importpath = "k8s.io/test-infra/mungegithub",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["mungegithub.go"],
+    importpath = "k8s.io/test-infra/mungegithub",
     deps = [
         "//mungegithub/features:go_default_library",
         "//mungegithub/github:go_default_library",

--- a/mungegithub/example-one-off/BUILD
+++ b/mungegithub/example-one-off/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "example-one-off",
+    importpath = "k8s.io/test-infra/mungegithub/example-one-off",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/mungegithub/example-one-off",
     deps = [
         "//mungegithub/github:go_default_library",
         "//mungegithub/options:go_default_library",

--- a/mungegithub/features/BUILD
+++ b/mungegithub/features/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["repo-updates_test.go"],
+    importpath = "k8s.io/test-infra/mungegithub/features",
     library = ":go_default_library",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
@@ -25,6 +26,7 @@ go_library(
         "repo-updates.go",
         "server.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/features",
     deps = [
         "//mungegithub/github:go_default_library",
         "//mungegithub/mungeopts:go_default_library",

--- a/mungegithub/github/BUILD
+++ b/mungegithub/github/BUILD
@@ -12,6 +12,7 @@ go_test(
         "github_test.go",
         "status_change_test.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/github",
     library = ":go_default_library",
     deps = [
         "//mungegithub/github/testing:go_default_library",
@@ -26,6 +27,7 @@ go_library(
         "status_change.go",
         "webhook.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/github",
     deps = [
         "//mungegithub/options:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/mungegithub/github/testing/BUILD
+++ b/mungegithub/github/testing/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["github.go"],
+    importpath = "k8s.io/test-infra/mungegithub/github/testing",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/mungeopts/BUILD
+++ b/mungegithub/mungeopts/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["mungeopts.go"],
+    importpath = "k8s.io/test-infra/mungegithub/mungeopts",
     deps = [
         "//mungegithub/options:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",

--- a/mungegithub/mungers/BUILD
+++ b/mungegithub/mungers/BUILD
@@ -26,6 +26,7 @@ go_test(
         "//mungegithub:configs",
     ],
     features = ["-race"],
+    importpath = "k8s.io/test-infra/mungegithub/mungers",
     library = ":go_default_library",
     deps = [
         "//mungegithub/features:go_default_library",
@@ -82,6 +83,7 @@ go_library(
         "submit-queue.go",
         "submit-queue-batch.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers",
     deps = [
         "//mungegithub/features:go_default_library",
         "//mungegithub/github:go_default_library",

--- a/mungegithub/mungers/approvers/BUILD
+++ b/mungegithub/mungers/approvers/BUILD
@@ -12,6 +12,7 @@ go_test(
         "approvers_test.go",
         "owners_test.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/approvers",
     library = ":go_default_library",
     deps = ["//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library"],
 )
@@ -19,6 +20,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["owners.go"],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/approvers",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",

--- a/mungegithub/mungers/e2e/BUILD
+++ b/mungegithub/mungers/e2e/BUILD
@@ -12,6 +12,7 @@ go_test(
         "e2e_test.go",
         "resolved_test.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/e2e",
     library = ":go_default_library",
     deps = [
         "//mungegithub/options:go_default_library",
@@ -25,6 +26,7 @@ go_library(
         "e2e.go",
         "resolved.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/e2e",
     deps = [
         "//mungegithub/mungers/flakesync:go_default_library",
         "//mungegithub/options:go_default_library",

--- a/mungegithub/mungers/e2e/fake/BUILD
+++ b/mungegithub/mungers/e2e/fake/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["fake.go"],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/e2e/fake",
     deps = [
         "//mungegithub/mungers/e2e:go_default_library",
         "//mungegithub/mungers/flakesync:go_default_library",

--- a/mungegithub/mungers/flakesync/BUILD
+++ b/mungegithub/mungers/flakesync/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["cache_test.go"],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/flakesync",
     library = ":go_default_library",
     deps = ["//vendor/github.com/google/gofuzz:go_default_library"],
 )
@@ -16,6 +17,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["cache.go"],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/flakesync",
 )
 
 filegroup(

--- a/mungegithub/mungers/matchers/BUILD
+++ b/mungegithub/mungers/matchers/BUILD
@@ -17,6 +17,7 @@ go_test(
     data = [
         "//mungegithub:configs",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers",
     library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
@@ -33,6 +34,7 @@ go_library(
         "operators.go",
         "pinger.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers",
     deps = [
         "//mungegithub/github:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/mungers/matchers/comment/BUILD
+++ b/mungegithub/mungers/matchers/comment/BUILD
@@ -17,6 +17,7 @@ go_test(
         "operators_test.go",
         "pinger_test.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/comment",
     library = ":go_default_library",
 )
 
@@ -31,6 +32,7 @@ go_library(
         "operators.go",
         "pinger.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/comment",
     deps = [
         "//mungegithub/github:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/mungers/matchers/event/BUILD
+++ b/mungegithub/mungers/matchers/event/BUILD
@@ -12,6 +12,7 @@ go_test(
         "event_test.go",
         "finder_test.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/event",
     library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
@@ -23,6 +24,7 @@ go_library(
         "finder.go",
         "operators.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/event",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/mungers/mungerutil/BUILD
+++ b/mungegithub/mungers/mungerutil/BUILD
@@ -12,6 +12,7 @@ go_test(
         "time_cache_test.go",
         "util_test.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/mungerutil",
     library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
@@ -24,6 +25,7 @@ go_library(
         "time_cache.go",
         "util.go",
     ],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/mungerutil",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/mungers/shield/BUILD
+++ b/mungegithub/mungers/shield/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["shield.go"],
+    importpath = "k8s.io/test-infra/mungegithub/mungers/shield",
 )
 
 filegroup(

--- a/mungegithub/options/BUILD
+++ b/mungegithub/options/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["options_test.go"],
+    importpath = "k8s.io/test-infra/mungegithub/options",
     library = ":go_default_library",
     deps = ["//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library"],
 )
@@ -16,6 +17,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["options.go"],
+    importpath = "k8s.io/test-infra/mungegithub/options",
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/mungegithub/reports/BUILD
+++ b/mungegithub/reports/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["reports.go"],
+    importpath = "k8s.io/test-infra/mungegithub/reports",
     deps = [
         "//mungegithub/github:go_default_library",
         "//mungegithub/options:go_default_library",

--- a/mungegithub/sharedmux/BUILD
+++ b/mungegithub/sharedmux/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["sharedmux.go"],
+    importpath = "k8s.io/test-infra/mungegithub/sharedmux",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/config/BUILD
+++ b/prow/cmd/config/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/config",
     visibility = ["//visibility:private"],
     deps = [
         "//prow/config:go_default_library",
@@ -14,6 +15,7 @@ go_library(
 go_binary(
     name = "config",
     data = ["//prow:configs"],
+    importpath = "k8s.io/test-infra/prow/cmd/config",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/deck/BUILD
+++ b/prow/cmd/deck/BUILD
@@ -9,6 +9,7 @@ load(
 
 go_binary(
     name = "deck",
+    importpath = "k8s.io/test-infra/prow/cmd/deck",
     library = ":go_default_library",
 )
 
@@ -18,6 +19,7 @@ go_test(
         "jobs_test.go",
         "main_test.go",
     ],
+    importpath = "k8s.io/test-infra/prow/cmd/deck",
     library = ":go_default_library",
     deps = [
         "//prow/kube:go_default_library",
@@ -31,6 +33,7 @@ go_library(
         "jobs.go",
         "main.go",
     ],
+    importpath = "k8s.io/test-infra/prow/cmd/deck",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -12,6 +12,7 @@ go_binary(
     data = [
         "//prow:configs",
     ],
+    importpath = "k8s.io/test-infra/prow/cmd/hook",
     library = ":go_default_library",
 )
 
@@ -21,6 +22,7 @@ go_test(
     data = [
         "//prow:configs",
     ],
+    importpath = "k8s.io/test-infra/prow/cmd/hook",
     library = ":go_default_library",
     deps = ["//prow/plugins:go_default_library"],
 )
@@ -28,6 +30,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/hook",
     deps = [
         "//prow/config:go_default_library",
         "//prow/git:go_default_library",

--- a/prow/cmd/horologium/BUILD
+++ b/prow/cmd/horologium/BUILD
@@ -9,12 +9,14 @@ load(
 
 go_binary(
     name = "horologium",
+    importpath = "k8s.io/test-infra/prow/cmd/horologium",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/horologium",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",
@@ -39,6 +41,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/horologium",
     library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",

--- a/prow/cmd/jenkins-operator/BUILD
+++ b/prow/cmd/jenkins-operator/BUILD
@@ -14,6 +14,7 @@ go_library(
         "logs.go",
         "main.go",
     ],
+    importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
@@ -40,6 +41,7 @@ filegroup(
 
 go_binary(
     name = "jenkins-operator",
+    importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
     library = ":go_default_library",
     tags = ["automanaged"],
 )

--- a/prow/cmd/mkpj/BUILD
+++ b/prow/cmd/mkpj/BUILD
@@ -10,12 +10,14 @@ go_binary(
     name = "mkpj",
     args = ["--config-path=$(location //prow:config.yaml)"],
     data = ["//prow:config.yaml"],
+    importpath = "k8s.io/test-infra/prow/cmd/mkpj",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/mkpj",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/phony/BUILD
+++ b/prow/cmd/phony/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "phony",
+    importpath = "k8s.io/test-infra/prow/cmd/phony",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/phony",
     deps = [
         "//prow/phony:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/cmd/plank/BUILD
+++ b/prow/cmd/plank/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "plank",
+    importpath = "k8s.io/test-infra/prow/cmd/plank",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/plank",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/cmd/sinker/BUILD
+++ b/prow/cmd/sinker/BUILD
@@ -9,12 +9,14 @@ load(
 
 go_binary(
     name = "sinker",
+    importpath = "k8s.io/test-infra/prow/cmd/sinker",
     library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/sinker",
     library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
@@ -25,6 +27,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/sinker",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/splice/BUILD
+++ b/prow/cmd/splice/BUILD
@@ -9,12 +9,14 @@ load(
 
 go_binary(
     name = "splice",
+    importpath = "k8s.io/test-infra/prow/cmd/splice",
     library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/splice",
     library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
@@ -25,6 +27,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/splice",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/tide/BUILD
+++ b/prow/cmd/tide/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/tide",
     visibility = ["//visibility:private"],
     deps = [
         "//prow/config:go_default_library",
@@ -16,6 +17,7 @@ go_library(
 
 go_binary(
     name = "tide",
+    importpath = "k8s.io/test-infra/prow/cmd/tide",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/tot/BUILD
+++ b/prow/cmd/tot/BUILD
@@ -9,18 +9,21 @@ load(
 
 go_binary(
     name = "tot",
+    importpath = "k8s.io/test-infra/prow/cmd/tot",
     library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/tot",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/tot",
     deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
 )
 

--- a/prow/commentpruner/BUILD
+++ b/prow/commentpruner/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["commentpruner.go"],
+    importpath = "k8s.io/test-infra/prow/commentpruner",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -13,6 +14,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["commentpruner_test.go"],
+    importpath = "k8s.io/test-infra/prow/commentpruner",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/config/BUILD
+++ b/prow/config/BUILD
@@ -18,6 +18,7 @@ go_test(
         "//prow:configs",
         "//scenarios",
     ],
+    importpath = "k8s.io/test-infra/prow/config",
     library = ":go_default_library",
     deps = [
         "//prow/kube:go_default_library",
@@ -32,6 +33,7 @@ go_library(
         "config.go",
         "jobs.go",
     ],
+    importpath = "k8s.io/test-infra/prow/config",
     deps = [
         "//prow/kube:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",

--- a/prow/genfiles/BUILD
+++ b/prow/genfiles/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["genfiles.go"],
+    importpath = "k8s.io/test-infra/prow/genfiles",
     visibility = ["//visibility:public"],
     deps = ["//prow/github:go_default_library"],
 )
@@ -10,6 +11,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["genfiles_test.go"],
+    importpath = "k8s.io/test-infra/prow/genfiles",
     library = ":go_default_library",
 )
 

--- a/prow/git/BUILD
+++ b/prow/git/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["git.go"],
+    importpath = "k8s.io/test-infra/prow/git",
     deps = ["//vendor/github.com/sirupsen/logrus:go_default_library"],
 )
 
@@ -31,5 +32,6 @@ filegroup(
 go_test(
     name = "go_default_xtest",
     srcs = ["git_test.go"],
+    importpath = "k8s.io/test-infra/prow/git_test",
     deps = ["//prow/git/localgit:go_default_library"],
 )

--- a/prow/git/localgit/BUILD
+++ b/prow/git/localgit/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["localgit.go"],
+    importpath = "k8s.io/test-infra/prow/git/localgit",
     deps = [
         "//prow/git:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/github/BUILD
+++ b/prow/github/BUILD
@@ -14,6 +14,7 @@ go_test(
         "links_test.go",
         "types_test.go",
     ],
+    importpath = "k8s.io/test-infra/prow/github",
     library = ":go_default_library",
 )
 
@@ -25,6 +26,7 @@ go_library(
         "links.go",
         "types.go",
     ],
+    importpath = "k8s.io/test-infra/prow/github",
     deps = [
         "//vendor/github.com/shurcooL/githubql:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",

--- a/prow/github/fakegithub/BUILD
+++ b/prow/github/fakegithub/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["fakegithub.go"],
+    importpath = "k8s.io/test-infra/prow/github/fakegithub",
     deps = ["//prow/github:go_default_library"],
 )
 

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -12,6 +12,7 @@ go_test(
         "hook_test.go",
         "server_test.go",
     ],
+    importpath = "k8s.io/test-infra/prow/hook",
     library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
@@ -29,6 +30,7 @@ go_library(
         "plugins.go",
         "server.go",
     ],
+    importpath = "k8s.io/test-infra/prow/hook",
     deps = [
         "//prow/commentpruner:go_default_library",
         "//prow/config:go_default_library",

--- a/prow/jenkins/BUILD
+++ b/prow/jenkins/BUILD
@@ -12,6 +12,7 @@ go_library(
         "controller.go",
         "jenkins.go",
     ],
+    importpath = "k8s.io/test-infra/prow/jenkins",
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
@@ -42,6 +43,7 @@ go_test(
         "controller_test.go",
         "jenkins_test.go",
     ],
+    importpath = "k8s.io/test-infra/prow/jenkins",
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [

--- a/prow/kube/BUILD
+++ b/prow/kube/BUILD
@@ -12,6 +12,7 @@ go_test(
         "client_test.go",
         "prowjob_test.go",
     ],
+    importpath = "k8s.io/test-infra/prow/kube",
     library = ":go_default_library",
 )
 
@@ -22,6 +23,7 @@ go_library(
         "prowjob.go",
         "types.go",
     ],
+    importpath = "k8s.io/test-infra/prow/kube",
     deps = ["//vendor/github.com/ghodss/yaml:go_default_library"],
 )
 

--- a/prow/phony/BUILD
+++ b/prow/phony/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["phony.go"],
+    importpath = "k8s.io/test-infra/prow/phony",
     deps = ["//prow/github:go_default_library"],
 )
 

--- a/prow/pjutil/BUILD
+++ b/prow/pjutil/BUILD
@@ -11,6 +11,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["pjutil.go"],
+    importpath = "k8s.io/test-infra/prow/pjutil",
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",
@@ -35,6 +36,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["pjutil_test.go"],
+    importpath = "k8s.io/test-infra/prow/pjutil",
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = ["//prow/kube:go_default_library"],

--- a/prow/plank/BUILD
+++ b/prow/plank/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["controller_test.go"],
+    importpath = "k8s.io/test-infra/prow/plank",
     library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
@@ -22,6 +23,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["controller.go"],
+    importpath = "k8s.io/test-infra/prow/plank",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -12,6 +12,7 @@ go_test(
         "plugins_test.go",
         "respond_test.go",
     ],
+    importpath = "k8s.io/test-infra/prow/plugins",
     library = ":go_default_library",
     deps = ["//prow/github:go_default_library"],
 )
@@ -22,6 +23,7 @@ go_library(
         "plugins.go",
         "respond.go",
     ],
+    importpath = "k8s.io/test-infra/prow/plugins",
     deps = [
         "//prow/commentpruner:go_default_library",
         "//prow/config:go_default_library",

--- a/prow/plugins/assign/BUILD
+++ b/prow/plugins/assign/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["assign_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/assign",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -19,6 +20,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["assign.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/assign",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/blockade/BUILD
+++ b/prow/plugins/blockade/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["blockade.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/blockade",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -28,6 +29,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["blockade_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/blockade",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/cla/BUILD
+++ b/prow/plugins/cla/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["cla_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/cla",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -20,6 +21,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["cla.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/cla",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/close/BUILD
+++ b/prow/plugins/close/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["close_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/close",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -19,6 +20,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["close.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/close",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/docs-no-retest/BUILD
+++ b/prow/plugins/docs-no-retest/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["docs-no-retest.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/docs-no-retest",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -13,6 +14,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["docs-no-retest_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/docs-no-retest",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/golint/BUILD
+++ b/prow/plugins/golint/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["golint_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/golint",
     library = ":go_default_library",
     deps = [
         "//prow/git/localgit:go_default_library",
@@ -20,6 +21,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["golint.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/golint",
     deps = [
         "//prow/genfiles:go_default_library",
         "//prow/git:go_default_library",

--- a/prow/plugins/heart/BUILD
+++ b/prow/plugins/heart/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["heart.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/heart",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
@@ -32,6 +33,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["heart_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/heart",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/hold/BUILD
+++ b/prow/plugins/hold/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["hold.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/hold",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -14,6 +15,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["hold_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/hold",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/label/BUILD
+++ b/prow/plugins/label/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["label_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/label",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -20,6 +21,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["label.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/label",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/lgtm/BUILD
+++ b/prow/plugins/lgtm/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["lgtm_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/lgtm",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -20,6 +21,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["lgtm.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/lgtm",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/milestonestatus/BUILD
+++ b/prow/plugins/milestonestatus/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["milestonestatus.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/milestonestatus",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -28,6 +29,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["milestonestatus_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/milestonestatus",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/releasenote/BUILD
+++ b/prow/plugins/releasenote/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["releasenote_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/releasenote",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -20,6 +21,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["releasenote.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/releasenote",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/reopen/BUILD
+++ b/prow/plugins/reopen/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["reopen_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/reopen",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -19,6 +20,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["reopen.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/reopen",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/shrug/BUILD
+++ b/prow/plugins/shrug/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["shrug.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/shrug",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -28,6 +29,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["shurg_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/shrug",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/sigmention/BUILD
+++ b/prow/plugins/sigmention/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["sigmention.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/sigmention",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -14,6 +15,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["sigmention_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/sigmention",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/size/BUILD
+++ b/prow/plugins/size/BUILD
@@ -11,6 +11,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["size_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/size",
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
@@ -22,6 +23,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["size.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/size",
     tags = ["automanaged"],
     deps = [
         "//prow/genfiles:go_default_library",

--- a/prow/plugins/slackevents/BUILD
+++ b/prow/plugins/slackevents/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["slackevents_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/slackevents",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -22,6 +23,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["slackevents.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/slackevents",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/trigger/BUILD
+++ b/prow/plugins/trigger/BUILD
@@ -12,6 +12,7 @@ go_test(
         "ic_test.go",
         "pr_test.go",
     ],
+    importpath = "k8s.io/test-infra/prow/plugins/trigger",
     library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
@@ -30,6 +31,7 @@ go_library(
         "push.go",
         "trigger.go",
     ],
+    importpath = "k8s.io/test-infra/prow/plugins/trigger",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/updateconfig/BUILD
+++ b/prow/plugins/updateconfig/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["updateconfig_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/updateconfig",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -21,6 +22,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["updateconfig.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/updateconfig",
     deps = [
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/plugins/wip/BUILD
+++ b/prow/plugins/wip/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["wip-label.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/wip",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/github:go_default_library",
@@ -14,6 +15,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["wip-label_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/wip",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/yuks/BUILD
+++ b/prow/plugins/yuks/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["yuks_test.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/yuks",
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
@@ -20,6 +21,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["yuks.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/yuks",
     deps = [
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/report/BUILD
+++ b/prow/report/BUILD
@@ -11,6 +11,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["report_test.go"],
+    importpath = "k8s.io/test-infra/prow/report",
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
@@ -22,6 +23,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["report.go"],
+    importpath = "k8s.io/test-infra/prow/report",
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",

--- a/prow/slack/BUILD
+++ b/prow/slack/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["client.go"],
+    importpath = "k8s.io/test-infra/prow/slack",
 )
 
 filegroup(

--- a/prow/slack/fakeslack/BUILD
+++ b/prow/slack/fakeslack/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["fakeslack.go"],
+    importpath = "k8s.io/test-infra/prow/slack/fakeslack",
 )
 
 filegroup(

--- a/prow/tide/BUILD
+++ b/prow/tide/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["tide.go"],
+    importpath = "k8s.io/test-infra/prow/tide",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/config:go_default_library",
@@ -32,6 +33,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["tide_test.go"],
+    importpath = "k8s.io/test-infra/prow/tide",
     library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",

--- a/robots/issue-creator/BUILD
+++ b/robots/issue-creator/BUILD
@@ -38,6 +38,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/robots/issue-creator",
     visibility = ["//visibility:private"],
     deps = [
         "//robots/issue-creator/creator:go_default_library",
@@ -47,6 +48,7 @@ go_library(
 
 go_binary(
     name = "issue-creator",
+    importpath = "k8s.io/test-infra/robots/issue-creator",
     library = ":go_default_library",
     visibility = ["//visibility:public"],
 )

--- a/robots/issue-creator/creator/BUILD
+++ b/robots/issue-creator/creator/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["creator.go"],
+    importpath = "k8s.io/test-infra/robots/issue-creator/creator",
     visibility = ["//visibility:public"],
     deps = [
         "//ghclient:go_default_library",
@@ -15,6 +16,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["creator_test.go"],
+    importpath = "k8s.io/test-infra/robots/issue-creator/creator",
     library = ":go_default_library",
     deps = [
         "//robots/issue-creator/testowner:go_default_library",

--- a/robots/issue-creator/sources/BUILD
+++ b/robots/issue-creator/sources/BUILD
@@ -6,6 +6,7 @@ go_library(
         "flakyjob-reporter.go",
         "triage-filer.go",
     ],
+    importpath = "k8s.io/test-infra/robots/issue-creator/sources",
     visibility = ["//visibility:public"],
     deps = [
         "//mungegithub/mungers/mungerutil:go_default_library",
@@ -21,6 +22,7 @@ go_test(
         "flakyjob-reporter_test.go",
         "triage-filer_test.go",
     ],
+    importpath = "k8s.io/test-infra/robots/issue-creator/sources",
     library = ":go_default_library",
     deps = [
         "//robots/issue-creator/creator:go_default_library",

--- a/robots/issue-creator/testowner/BUILD
+++ b/robots/issue-creator/testowner/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["owner.go"],
+    importpath = "k8s.io/test-infra/robots/issue-creator/testowner",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )
@@ -10,6 +11,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["owner_test.go"],
+    importpath = "k8s.io/test-infra/robots/issue-creator/testowner",
     library = ":go_default_library",
 )
 

--- a/testgrid/config/BUILD
+++ b/testgrid/config/BUILD
@@ -21,6 +21,7 @@ genrule(
 
 go_binary(
     name = "config",
+    importpath = "k8s.io/test-infra/testgrid/config",
     library = ":go_default_library",
 )
 
@@ -31,6 +32,7 @@ go_test(
         "config.yaml",
         "//mungegithub:submit-queue/deployment/kubernetes/configmap.yaml",
     ],
+    importpath = "k8s.io/test-infra/testgrid/config",
     library = ":go_default_library",
     deps = [
         "//testgrid/config/yaml2proto:go_default_library",
@@ -41,6 +43,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/testgrid/config",
     deps = ["//testgrid/config/yaml2proto:go_default_library"],
 )
 

--- a/testgrid/config/pb/BUILD
+++ b/testgrid/config/pb/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["config.pb.go"],
+    importpath = "k8s.io/test-infra/testgrid/config/pb",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/testgrid/config/yaml2proto/BUILD
+++ b/testgrid/config/yaml2proto/BUILD
@@ -9,12 +9,14 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["yaml2proto_test.go"],
+    importpath = "k8s.io/test-infra/testgrid/config/yaml2proto",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["yaml2proto.go"],
+    importpath = "k8s.io/test-infra/testgrid/config/yaml2proto",
     deps = [
         "//testgrid/config/pb:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",

--- a/testgrid/jenkins_verify/BUILD
+++ b/testgrid/jenkins_verify/BUILD
@@ -8,12 +8,14 @@ load(
 
 go_binary(
     name = "jenkins_verify",
+    importpath = "k8s.io/test-infra/testgrid/jenkins_verify",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["jenkins_validate.go"],
+    importpath = "k8s.io/test-infra/testgrid/jenkins_verify",
     deps = [
         "//prow/config:go_default_library",
         "//testgrid/config/yaml2proto:go_default_library",

--- a/velodrome/fetcher/BUILD
+++ b/velodrome/fetcher/BUILD
@@ -9,6 +9,7 @@ load(
 
 go_binary(
     name = "fetcher",
+    importpath = "k8s.io/test-infra/velodrome/fetcher",
     library = ":go_default_library",
 )
 
@@ -21,6 +22,7 @@ go_test(
         "issue-events_test.go",
         "issues_test.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/fetcher",
     library = ":go_default_library",
     deps = [
         "//velodrome/sql:go_default_library",
@@ -39,6 +41,7 @@ go_library(
         "issue-events.go",
         "issues.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/fetcher",
     deps = [
         "//velodrome/sql:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/velodrome/sql/BUILD
+++ b/velodrome/sql/BUILD
@@ -12,6 +12,7 @@ go_test(
         "model_test.go",
         "mysql_test.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/sql",
     library = ":go_default_library",
 )
 
@@ -21,6 +22,7 @@ go_library(
         "model.go",
         "mysql.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/sql",
     deps = [
         "//vendor/github.com/jinzhu/gorm:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/velodrome/sql/testing/BUILD
+++ b/velodrome/sql/testing/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["sqlite_test.go"],
+    importpath = "k8s.io/test-infra/velodrome/sql/testing",
     library = ":go_default_library",
     deps = ["//velodrome/sql:go_default_library"],
 )
@@ -16,6 +17,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = ["sqlite.go"],
+    importpath = "k8s.io/test-infra/velodrome/sql/testing",
     deps = [
         "//velodrome/sql:go_default_library",
         "//vendor/github.com/jinzhu/gorm:go_default_library",

--- a/velodrome/token-counter/BUILD
+++ b/velodrome/token-counter/BUILD
@@ -8,6 +8,7 @@ load(
 
 go_binary(
     name = "token-counter",
+    importpath = "k8s.io/test-infra/velodrome/token-counter",
     library = ":go_default_library",
 )
 
@@ -17,6 +18,7 @@ go_library(
         "influx.go",
         "token-counter.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/token-counter",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/velodrome/transform/BUILD
+++ b/velodrome/transform/BUILD
@@ -9,6 +9,7 @@ load(
 
 go_binary(
     name = "transform",
+    importpath = "k8s.io/test-infra/velodrome/transform",
     library = ":go_default_library",
 )
 
@@ -18,6 +19,7 @@ go_test(
         "fetcher_test.go",
         "influx_test.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/transform",
     library = ":go_default_library",
     deps = [
         "//velodrome/sql:go_default_library",
@@ -32,6 +34,7 @@ go_library(
         "influx.go",
         "transform.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/transform",
     deps = [
         "//velodrome/sql:go_default_library",
         "//velodrome/transform/plugins:go_default_library",

--- a/velodrome/transform/plugins/BUILD
+++ b/velodrome/transform/plugins/BUILD
@@ -25,6 +25,7 @@ go_library(
         "states.go",
         "type_filter_wrapper.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/transform/plugins",
     deps = [
         "//velodrome/sql:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
@@ -66,6 +67,7 @@ go_test(
         "states_test.go",
         "type_filter_wrapper_test.go",
     ],
+    importpath = "k8s.io/test-infra/velodrome/transform/plugins",
     library = ":go_default_library",
     deps = [
         "//velodrome/sql:go_default_library",

--- a/vendor/bitbucket.org/ww/goautoneg/BUILD
+++ b/vendor/bitbucket.org/ww/goautoneg/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["autoneg.go"],
+    importpath = "bitbucket.org/ww/goautoneg",
 )
 
 filegroup(

--- a/vendor/cloud.google.com/go/compute/metadata/BUILD
+++ b/vendor/cloud.google.com/go/compute/metadata/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["metadata.go"],
+    importpath = "cloud.google.com/go/compute/metadata",
     deps = [
         "//vendor/cloud.google.com/go/internal:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",

--- a/vendor/cloud.google.com/go/internal/BUILD
+++ b/vendor/cloud.google.com/go/internal/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["cloud.go"],
+    importpath = "cloud.google.com/go/internal",
 )
 
 filegroup(

--- a/vendor/cloud.google.com/go/pubsub/BUILD
+++ b/vendor/cloud.google.com/go/pubsub/BUILD
@@ -19,6 +19,7 @@ go_library(
         "subscription.go",
         "topic.go",
     ],
+    importpath = "cloud.google.com/go/pubsub",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",

--- a/vendor/github.com/NYTimes/gziphandler/BUILD
+++ b/vendor/github.com/NYTimes/gziphandler/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["gzip.go"],
+    importpath = "github.com/NYTimes/gziphandler",
 )
 
 filegroup(

--- a/vendor/github.com/arbovm/levenshtein/BUILD
+++ b/vendor/github.com/arbovm/levenshtein/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["levenshtein.go"],
+    importpath = "github.com/arbovm/levenshtein",
 )
 
 filegroup(

--- a/vendor/github.com/beorn7/perks/quantile/BUILD
+++ b/vendor/github.com/beorn7/perks/quantile/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["stream.go"],
+    importpath = "github.com/beorn7/perks/quantile",
 )
 
 filegroup(

--- a/vendor/github.com/bwmarrin/snowflake/BUILD
+++ b/vendor/github.com/bwmarrin/snowflake/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["snowflake.go"],
+    importpath = "github.com/bwmarrin/snowflake",
 )
 
 filegroup(

--- a/vendor/github.com/ghodss/yaml/BUILD
+++ b/vendor/github.com/ghodss/yaml/BUILD
@@ -11,6 +11,7 @@ go_library(
         "fields.go",
         "yaml.go",
     ],
+    importpath = "github.com/ghodss/yaml",
     deps = ["//vendor/gopkg.in/yaml.v2:go_default_library"],
 )
 

--- a/vendor/github.com/go-sql-driver/mysql/BUILD
+++ b/vendor/github.com/go-sql-driver/mysql/BUILD
@@ -23,6 +23,7 @@ go_library(
         "transaction.go",
         "utils.go",
     ],
+    importpath = "github.com/go-sql-driver/mysql",
 )
 
 filegroup(

--- a/vendor/github.com/golang/glog/BUILD
+++ b/vendor/github.com/golang/glog/BUILD
@@ -11,6 +11,7 @@ go_library(
         "glog.go",
         "glog_file.go",
     ],
+    importpath = "github.com/golang/glog",
 )
 
 filegroup(

--- a/vendor/github.com/golang/lint/BUILD
+++ b/vendor/github.com/golang/lint/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["lint.go"],
+    importpath = "github.com/golang/lint",
     deps = ["//vendor/golang.org/x/tools/go/gcexportdata:go_default_library"],
 )
 

--- a/vendor/github.com/golang/mock/gomock/BUILD
+++ b/vendor/github.com/golang/mock/gomock/BUILD
@@ -13,6 +13,7 @@ go_library(
         "controller.go",
         "matchers.go",
     ],
+    importpath = "github.com/golang/mock/gomock",
 )
 
 filegroup(

--- a/vendor/github.com/golang/protobuf/proto/BUILD
+++ b/vendor/github.com/golang/protobuf/proto/BUILD
@@ -20,6 +20,7 @@ go_library(
         "text.go",
         "text_parser.go",
     ],
+    importpath = "github.com/golang/protobuf/proto",
 )
 
 filegroup(

--- a/vendor/github.com/google/btree/BUILD
+++ b/vendor/github.com/google/btree/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["btree.go"],
+    importpath = "github.com/google/btree",
 )
 
 filegroup(

--- a/vendor/github.com/google/go-github/github/BUILD
+++ b/vendor/github.com/google/go-github/github/BUILD
@@ -85,6 +85,7 @@ go_library(
         "users_keys.go",
         "without_appengine.go",
     ],
+    importpath = "github.com/google/go-github/github",
     deps = ["//vendor/github.com/google/go-querystring/query:go_default_library"],
 )
 

--- a/vendor/github.com/google/go-querystring/query/BUILD
+++ b/vendor/github.com/google/go-querystring/query/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["encode.go"],
+    importpath = "github.com/google/go-querystring/query",
 )
 
 filegroup(

--- a/vendor/github.com/google/gofuzz/BUILD
+++ b/vendor/github.com/google/gofuzz/BUILD
@@ -11,6 +11,7 @@ go_library(
         "doc.go",
         "fuzz.go",
     ],
+    importpath = "github.com/google/gofuzz",
 )
 
 filegroup(

--- a/vendor/github.com/gregjones/httpcache/BUILD
+++ b/vendor/github.com/gregjones/httpcache/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["httpcache.go"],
+    importpath = "github.com/gregjones/httpcache",
 )
 
 filegroup(

--- a/vendor/github.com/gregjones/httpcache/diskcache/BUILD
+++ b/vendor/github.com/gregjones/httpcache/diskcache/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["diskcache.go"],
+    importpath = "github.com/gregjones/httpcache/diskcache",
     deps = ["//vendor/github.com/peterbourgon/diskv:go_default_library"],
 )
 

--- a/vendor/github.com/inconshreveable/mousetrap/BUILD
+++ b/vendor/github.com/inconshreveable/mousetrap/BUILD
@@ -16,6 +16,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    importpath = "github.com/inconshreveable/mousetrap",
 )
 
 filegroup(

--- a/vendor/github.com/influxdata/influxdb/client/v2/BUILD
+++ b/vendor/github.com/influxdata/influxdb/client/v2/BUILD
@@ -11,6 +11,7 @@ go_library(
         "client.go",
         "udp.go",
     ],
+    importpath = "github.com/influxdata/influxdb/client/v2",
     deps = ["//vendor/github.com/influxdata/influxdb/models:go_default_library"],
 )
 

--- a/vendor/github.com/influxdata/influxdb/models/BUILD
+++ b/vendor/github.com/influxdata/influxdb/models/BUILD
@@ -16,6 +16,7 @@ go_library(
         "statistic.go",
         "time.go",
     ],
+    importpath = "github.com/influxdata/influxdb/models",
     deps = ["//vendor/github.com/influxdata/influxdb/pkg/escape:go_default_library"],
 )
 

--- a/vendor/github.com/influxdata/influxdb/pkg/escape/BUILD
+++ b/vendor/github.com/influxdata/influxdb/pkg/escape/BUILD
@@ -11,6 +11,7 @@ go_library(
         "bytes.go",
         "strings.go",
     ],
+    importpath = "github.com/influxdata/influxdb/pkg/escape",
 )
 
 filegroup(

--- a/vendor/github.com/jinzhu/gorm/BUILD
+++ b/vendor/github.com/jinzhu/gorm/BUILD
@@ -34,6 +34,7 @@ go_library(
         "search.go",
         "utils.go",
     ],
+    importpath = "github.com/jinzhu/gorm",
     deps = ["//vendor/github.com/jinzhu/inflection:go_default_library"],
 )
 

--- a/vendor/github.com/jinzhu/gorm/dialects/mysql/BUILD
+++ b/vendor/github.com/jinzhu/gorm/dialects/mysql/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["mysql.go"],
+    importpath = "github.com/jinzhu/gorm/dialects/mysql",
     deps = ["//vendor/github.com/go-sql-driver/mysql:go_default_library"],
 )
 

--- a/vendor/github.com/jinzhu/gorm/dialects/sqlite/BUILD
+++ b/vendor/github.com/jinzhu/gorm/dialects/sqlite/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["sqlite.go"],
+    importpath = "github.com/jinzhu/gorm/dialects/sqlite",
     deps = ["//vendor/github.com/mattn/go-sqlite3:go_default_library"],
 )
 

--- a/vendor/github.com/jinzhu/inflection/BUILD
+++ b/vendor/github.com/jinzhu/inflection/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["inflections.go"],
+    importpath = "github.com/jinzhu/inflection",
 )
 
 filegroup(

--- a/vendor/github.com/mattn/go-sqlite3/BUILD
+++ b/vendor/github.com/mattn/go-sqlite3/BUILD
@@ -45,6 +45,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    importpath = "github.com/mattn/go-sqlite3",
 )
 
 filegroup(

--- a/vendor/github.com/matttproud/golang_protobuf_extensions/pbutil/BUILD
+++ b/vendor/github.com/matttproud/golang_protobuf_extensions/pbutil/BUILD
@@ -12,6 +12,7 @@ go_library(
         "doc.go",
         "encode.go",
     ],
+    importpath = "github.com/matttproud/golang_protobuf_extensions/pbutil",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/github.com/peterbourgon/diskv/BUILD
+++ b/vendor/github.com/peterbourgon/diskv/BUILD
@@ -12,6 +12,7 @@ go_library(
         "diskv.go",
         "index.go",
     ],
+    importpath = "github.com/peterbourgon/diskv",
     deps = ["//vendor/github.com/google/btree:go_default_library"],
 )
 

--- a/vendor/github.com/prometheus/client_golang/prometheus/BUILD
+++ b/vendor/github.com/prometheus/client_golang/prometheus/BUILD
@@ -26,6 +26,7 @@ go_library(
         "value.go",
         "vec.go",
     ],
+    importpath = "github.com/prometheus/client_golang/prometheus",
     deps = [
         "//vendor/github.com/beorn7/perks/quantile:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",

--- a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/BUILD
+++ b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["http.go"],
+    importpath = "github.com/prometheus/client_golang/prometheus/promhttp",
     deps = [
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/common/expfmt:go_default_library",

--- a/vendor/github.com/prometheus/client_golang/prometheus/push/BUILD
+++ b/vendor/github.com/prometheus/client_golang/prometheus/push/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["push.go"],
+    importpath = "github.com/prometheus/client_golang/prometheus/push",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
@@ -14,6 +15,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["push_test.go"],
+    importpath = "github.com/prometheus/client_golang/prometheus/push",
     library = ":go_default_library",
     deps = [
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
@@ -24,6 +26,7 @@ go_test(
 go_test(
     name = "go_default_xtest",
     srcs = ["examples_test.go"],
+    importpath = "github.com/prometheus/client_golang/prometheus/push_test",
     deps = [
         ":go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",

--- a/vendor/github.com/prometheus/client_model/go/BUILD
+++ b/vendor/github.com/prometheus/client_model/go/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["metrics.pb.go"],
+    importpath = "github.com/prometheus/client_model/go",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/github.com/prometheus/common/expfmt/BUILD
+++ b/vendor/github.com/prometheus/common/expfmt/BUILD
@@ -15,6 +15,7 @@ go_library(
         "text_create.go",
         "text_parse.go",
     ],
+    importpath = "github.com/prometheus/common/expfmt",
     deps = [
         "//vendor/bitbucket.org/ww/goautoneg:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",

--- a/vendor/github.com/prometheus/common/model/BUILD
+++ b/vendor/github.com/prometheus/common/model/BUILD
@@ -19,6 +19,7 @@ go_library(
         "time.go",
         "value.go",
     ],
+    importpath = "github.com/prometheus/common/model",
 )
 
 filegroup(

--- a/vendor/github.com/prometheus/procfs/BUILD
+++ b/vendor/github.com/prometheus/procfs/BUILD
@@ -18,6 +18,7 @@ go_library(
         "proc_stat.go",
         "stat.go",
     ],
+    importpath = "github.com/prometheus/procfs",
 )
 
 filegroup(

--- a/vendor/github.com/satori/go.uuid/BUILD
+++ b/vendor/github.com/satori/go.uuid/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["uuid.go"],
+    importpath = "github.com/satori/go.uuid",
 )
 
 filegroup(

--- a/vendor/github.com/shurcooL/githubql/BUILD
+++ b/vendor/github.com/shurcooL/githubql/BUILD
@@ -9,6 +9,7 @@ go_library(
         "input.go",
         "scalar.go",
     ],
+    importpath = "github.com/shurcooL/githubql",
     visibility = ["//visibility:public"],
     deps = ["//vendor/github.com/shurcooL/graphql:go_default_library"],
 )

--- a/vendor/github.com/shurcooL/go/ctxhttp/BUILD
+++ b/vendor/github.com/shurcooL/go/ctxhttp/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["ctxhttp.go"],
+    importpath = "github.com/shurcooL/go/ctxhttp",
     visibility = ["//visibility:public"],
 )
 

--- a/vendor/github.com/shurcooL/graphql/BUILD
+++ b/vendor/github.com/shurcooL/graphql/BUILD
@@ -8,6 +8,7 @@ go_library(
         "query.go",
         "scalar.go",
     ],
+    importpath = "github.com/shurcooL/graphql",
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/shurcooL/go/ctxhttp:go_default_library",

--- a/vendor/github.com/shurcooL/graphql/ident/BUILD
+++ b/vendor/github.com/shurcooL/graphql/ident/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["ident.go"],
+    importpath = "github.com/shurcooL/graphql/ident",
     visibility = ["//visibility:public"],
 )
 

--- a/vendor/github.com/shurcooL/graphql/internal/jsonutil/BUILD
+++ b/vendor/github.com/shurcooL/graphql/internal/jsonutil/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["graphql.go"],
+    importpath = "github.com/shurcooL/graphql/internal/jsonutil",
     visibility = ["//vendor/github.com/shurcooL/graphql:__subpackages__"],
 )
 

--- a/vendor/github.com/sirupsen/logrus/BUILD
+++ b/vendor/github.com/sirupsen/logrus/BUILD
@@ -33,6 +33,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    importpath = "github.com/sirupsen/logrus",
 )
 
 filegroup(

--- a/vendor/github.com/spf13/cobra/BUILD
+++ b/vendor/github.com/spf13/cobra/BUILD
@@ -18,6 +18,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
+    importpath = "github.com/spf13/cobra",
     deps = [
         "//vendor/github.com/spf13/pflag:go_default_library",
     ] + select({

--- a/vendor/github.com/spf13/pflag/BUILD
+++ b/vendor/github.com/spf13/pflag/BUILD
@@ -30,6 +30,7 @@ go_library(
         "uint8.go",
         "uint_slice.go",
     ],
+    importpath = "github.com/spf13/pflag",
     visibility = ["//visibility:public"],
 )
 

--- a/vendor/golang.org/x/net/context/BUILD
+++ b/vendor/golang.org/x/net/context/BUILD
@@ -12,6 +12,7 @@ go_library(
         "go17.go",
         "pre_go17.go",
     ],
+    importpath = "golang.org/x/net/context",
 )
 
 filegroup(

--- a/vendor/golang.org/x/net/context/ctxhttp/BUILD
+++ b/vendor/golang.org/x/net/context/ctxhttp/BUILD
@@ -11,6 +11,7 @@ go_library(
         "ctxhttp.go",
         "ctxhttp_pre17.go",
     ],
+    importpath = "golang.org/x/net/context/ctxhttp",
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],
 )
 

--- a/vendor/golang.org/x/net/http2/BUILD
+++ b/vendor/golang.org/x/net/http2/BUILD
@@ -32,6 +32,7 @@ go_library(
         "writesched_priority.go",
         "writesched_random.go",
     ],
+    importpath = "golang.org/x/net/http2",
     deps = [
         "//vendor/golang.org/x/net/http2/hpack:go_default_library",
         "//vendor/golang.org/x/net/idna:go_default_library",

--- a/vendor/golang.org/x/net/http2/hpack/BUILD
+++ b/vendor/golang.org/x/net/http2/hpack/BUILD
@@ -13,6 +13,7 @@ go_library(
         "huffman.go",
         "tables.go",
     ],
+    importpath = "golang.org/x/net/http2/hpack",
 )
 
 filegroup(

--- a/vendor/golang.org/x/net/idna/BUILD
+++ b/vendor/golang.org/x/net/idna/BUILD
@@ -11,6 +11,7 @@ go_library(
         "idna.go",
         "punycode.go",
     ],
+    importpath = "golang.org/x/net/idna",
 )
 
 filegroup(

--- a/vendor/golang.org/x/net/internal/timeseries/BUILD
+++ b/vendor/golang.org/x/net/internal/timeseries/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["timeseries.go"],
+    importpath = "golang.org/x/net/internal/timeseries",
 )
 
 filegroup(

--- a/vendor/golang.org/x/net/lex/httplex/BUILD
+++ b/vendor/golang.org/x/net/lex/httplex/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["httplex.go"],
+    importpath = "golang.org/x/net/lex/httplex",
     deps = ["//vendor/golang.org/x/net/idna:go_default_library"],
 )
 

--- a/vendor/golang.org/x/net/trace/BUILD
+++ b/vendor/golang.org/x/net/trace/BUILD
@@ -12,6 +12,7 @@ go_library(
         "histogram.go",
         "trace.go",
     ],
+    importpath = "golang.org/x/net/trace",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/net/internal/timeseries:go_default_library",

--- a/vendor/golang.org/x/oauth2/BUILD
+++ b/vendor/golang.org/x/oauth2/BUILD
@@ -12,6 +12,7 @@ go_library(
         "token.go",
         "transport.go",
     ],
+    importpath = "golang.org/x/oauth2",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/oauth2/internal:go_default_library",

--- a/vendor/golang.org/x/oauth2/google/BUILD
+++ b/vendor/golang.org/x/oauth2/google/BUILD
@@ -14,6 +14,7 @@ go_library(
         "jwt.go",
         "sdk.go",
     ],
+    importpath = "golang.org/x/oauth2/google",
     deps = [
         "//vendor/cloud.google.com/go/compute/metadata:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",

--- a/vendor/golang.org/x/oauth2/internal/BUILD
+++ b/vendor/golang.org/x/oauth2/internal/BUILD
@@ -12,6 +12,7 @@ go_library(
         "token.go",
         "transport.go",
     ],
+    importpath = "golang.org/x/oauth2/internal",
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],
 )
 

--- a/vendor/golang.org/x/oauth2/jws/BUILD
+++ b/vendor/golang.org/x/oauth2/jws/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["jws.go"],
+    importpath = "golang.org/x/oauth2/jws",
 )
 
 filegroup(

--- a/vendor/golang.org/x/oauth2/jwt/BUILD
+++ b/vendor/golang.org/x/oauth2/jwt/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["jwt.go"],
+    importpath = "golang.org/x/oauth2/jwt",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",

--- a/vendor/golang.org/x/sys/unix/BUILD
+++ b/vendor/golang.org/x/sys/unix/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//conditions:default": [],
     }),
     cgo = True,
+    importpath = "golang.org/x/sys/unix",
 )
 
 filegroup(

--- a/vendor/golang.org/x/tools/go/gcexportdata/BUILD
+++ b/vendor/golang.org/x/tools/go/gcexportdata/BUILD
@@ -11,6 +11,7 @@ go_library(
         "gcexportdata.go",
         "importer.go",
     ],
+    importpath = "golang.org/x/tools/go/gcexportdata",
     deps = ["//vendor/golang.org/x/tools/go/gcimporter15:go_default_library"],
 )
 

--- a/vendor/golang.org/x/tools/go/gcimporter15/BUILD
+++ b/vendor/golang.org/x/tools/go/gcimporter15/BUILD
@@ -15,6 +15,7 @@ go_library(
         "isAlias18.go",
         "isAlias19.go",
     ],
+    importpath = "golang.org/x/tools/go/gcimporter15",
 )
 
 filegroup(

--- a/vendor/google.golang.org/api/gensupport/BUILD
+++ b/vendor/google.golang.org/api/gensupport/BUILD
@@ -18,6 +18,7 @@ go_library(
         "retry.go",
         "send.go",
     ],
+    importpath = "google.golang.org/api/gensupport",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/net/context/ctxhttp:go_default_library",

--- a/vendor/google.golang.org/api/googleapi/BUILD
+++ b/vendor/google.golang.org/api/googleapi/BUILD
@@ -11,6 +11,7 @@ go_library(
         "googleapi.go",
         "types.go",
     ],
+    importpath = "google.golang.org/api/googleapi",
     deps = ["//vendor/google.golang.org/api/googleapi/internal/uritemplates:go_default_library"],
 )
 

--- a/vendor/google.golang.org/api/googleapi/internal/uritemplates/BUILD
+++ b/vendor/google.golang.org/api/googleapi/internal/uritemplates/BUILD
@@ -11,6 +11,7 @@ go_library(
         "uritemplates.go",
         "utils.go",
     ],
+    importpath = "google.golang.org/api/googleapi/internal/uritemplates",
 )
 
 filegroup(

--- a/vendor/google.golang.org/api/internal/BUILD
+++ b/vendor/google.golang.org/api/internal/BUILD
@@ -11,6 +11,7 @@ go_library(
         "pool.go",
         "settings.go",
     ],
+    importpath = "google.golang.org/api/internal",
     deps = [
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",

--- a/vendor/google.golang.org/api/iterator/BUILD
+++ b/vendor/google.golang.org/api/iterator/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["iterator.go"],
+    importpath = "google.golang.org/api/iterator",
 )
 
 filegroup(

--- a/vendor/google.golang.org/api/option/BUILD
+++ b/vendor/google.golang.org/api/option/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["option.go"],
+    importpath = "google.golang.org/api/option",
     deps = [
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/google.golang.org/api/internal:go_default_library",

--- a/vendor/google.golang.org/api/pubsub/v1/BUILD
+++ b/vendor/google.golang.org/api/pubsub/v1/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["pubsub-gen.go"],
+    importpath = "google.golang.org/api/pubsub/v1",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/net/context/ctxhttp:go_default_library",

--- a/vendor/google.golang.org/api/transport/BUILD
+++ b/vendor/google.golang.org/api/transport/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["dial.go"],
+    importpath = "google.golang.org/api/transport",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",

--- a/vendor/google.golang.org/appengine/BUILD
+++ b/vendor/google.golang.org/appengine/BUILD
@@ -15,6 +15,7 @@ go_library(
         "namespace.go",
         "timeout.go",
     ],
+    importpath = "google.golang.org/appengine",
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",

--- a/vendor/google.golang.org/appengine/internal/BUILD
+++ b/vendor/google.golang.org/appengine/internal/BUILD
@@ -19,6 +19,7 @@ go_library(
         "net.go",
         "transaction.go",
     ],
+    importpath = "google.golang.org/appengine/internal",
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",

--- a/vendor/google.golang.org/appengine/internal/app_identity/BUILD
+++ b/vendor/google.golang.org/appengine/internal/app_identity/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["app_identity_service.pb.go"],
+    importpath = "google.golang.org/appengine/internal/app_identity",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/google.golang.org/appengine/internal/base/BUILD
+++ b/vendor/google.golang.org/appengine/internal/base/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["api_base.pb.go"],
+    importpath = "google.golang.org/appengine/internal/base",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/google.golang.org/appengine/internal/datastore/BUILD
+++ b/vendor/google.golang.org/appengine/internal/datastore/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["datastore_v3.pb.go"],
+    importpath = "google.golang.org/appengine/internal/datastore",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/google.golang.org/appengine/internal/log/BUILD
+++ b/vendor/google.golang.org/appengine/internal/log/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["log_service.pb.go"],
+    importpath = "google.golang.org/appengine/internal/log",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/google.golang.org/appengine/internal/modules/BUILD
+++ b/vendor/google.golang.org/appengine/internal/modules/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["modules_service.pb.go"],
+    importpath = "google.golang.org/appengine/internal/modules",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/google.golang.org/appengine/internal/remote_api/BUILD
+++ b/vendor/google.golang.org/appengine/internal/remote_api/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["remote_api.pb.go"],
+    importpath = "google.golang.org/appengine/internal/remote_api",
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/google.golang.org/grpc/BUILD
+++ b/vendor/google.golang.org/grpc/BUILD
@@ -19,6 +19,7 @@ go_library(
         "stream.go",
         "trace.go",
     ],
+    importpath = "google.golang.org/grpc",
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",

--- a/vendor/google.golang.org/grpc/codes/BUILD
+++ b/vendor/google.golang.org/grpc/codes/BUILD
@@ -11,6 +11,7 @@ go_library(
         "code_string.go",
         "codes.go",
     ],
+    importpath = "google.golang.org/grpc/codes",
 )
 
 filegroup(

--- a/vendor/google.golang.org/grpc/credentials/BUILD
+++ b/vendor/google.golang.org/grpc/credentials/BUILD
@@ -12,6 +12,7 @@ go_library(
         "credentials_util_go17.go",
         "credentials_util_pre_go17.go",
     ],
+    importpath = "google.golang.org/grpc/credentials",
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],
 )
 

--- a/vendor/google.golang.org/grpc/credentials/oauth/BUILD
+++ b/vendor/google.golang.org/grpc/credentials/oauth/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["oauth.go"],
+    importpath = "google.golang.org/grpc/credentials/oauth",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",

--- a/vendor/google.golang.org/grpc/grpclog/BUILD
+++ b/vendor/google.golang.org/grpc/grpclog/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["logger.go"],
+    importpath = "google.golang.org/grpc/grpclog",
 )
 
 filegroup(

--- a/vendor/google.golang.org/grpc/internal/BUILD
+++ b/vendor/google.golang.org/grpc/internal/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["internal.go"],
+    importpath = "google.golang.org/grpc/internal",
 )
 
 filegroup(

--- a/vendor/google.golang.org/grpc/metadata/BUILD
+++ b/vendor/google.golang.org/grpc/metadata/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["metadata.go"],
+    importpath = "google.golang.org/grpc/metadata",
     deps = ["//vendor/golang.org/x/net/context:go_default_library"],
 )
 

--- a/vendor/google.golang.org/grpc/naming/BUILD
+++ b/vendor/google.golang.org/grpc/naming/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["naming.go"],
+    importpath = "google.golang.org/grpc/naming",
 )
 
 filegroup(

--- a/vendor/google.golang.org/grpc/peer/BUILD
+++ b/vendor/google.golang.org/grpc/peer/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["peer.go"],
+    importpath = "google.golang.org/grpc/peer",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/google.golang.org/grpc/credentials:go_default_library",

--- a/vendor/google.golang.org/grpc/transport/BUILD
+++ b/vendor/google.golang.org/grpc/transport/BUILD
@@ -18,6 +18,7 @@ go_library(
         "pre_go16.go",
         "transport.go",
     ],
+    importpath = "google.golang.org/grpc/transport",
     deps = [
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",

--- a/vendor/gopkg.in/yaml.v2/BUILD
+++ b/vendor/gopkg.in/yaml.v2/BUILD
@@ -22,6 +22,7 @@ go_library(
         "yamlh.go",
         "yamlprivateh.go",
     ],
+    importpath = "gopkg.in/yaml.v2",
 )
 
 filegroup(

--- a/vendor/k8s.io/contrib/test-utils/utils/BUILD
+++ b/vendor/k8s.io/contrib/test-utils/utils/BUILD
@@ -11,6 +11,7 @@ go_library(
         "bucket.go",
         "utils.go",
     ],
+    importpath = "k8s.io/contrib/test-utils/utils",
     deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )
 

--- a/vendor/k8s.io/kubernetes/pkg/util/clock/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/clock/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["clock.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/clock",
 )
 
 filegroup(

--- a/vendor/k8s.io/kubernetes/pkg/util/errors/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/errors/BUILD
@@ -11,6 +11,7 @@ go_library(
         "doc.go",
         "errors.go",
     ],
+    importpath = "k8s.io/kubernetes/pkg/util/errors",
 )
 
 filegroup(

--- a/vendor/k8s.io/kubernetes/pkg/util/flag/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/flag/BUILD
@@ -11,6 +11,7 @@ go_library(
         "flags.go",
         "tristate.go",
     ],
+    importpath = "k8s.io/kubernetes/pkg/util/flag",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/vendor/k8s.io/kubernetes/pkg/util/sets/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/sets/BUILD
@@ -15,6 +15,7 @@ go_library(
         "int64.go",
         "string.go",
     ],
+    importpath = "k8s.io/kubernetes/pkg/util/sets",
 )
 
 filegroup(

--- a/vendor/k8s.io/kubernetes/pkg/util/yaml/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/yaml/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["decoder.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/yaml",
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/verify/update-bazel.sh
+++ b/verify/update-bazel.sh
@@ -22,18 +22,19 @@ TMP_GOPATH=$(mktemp -d)
 
 "${TESTINFRA_ROOT}/verify/go_install_from_commit.sh" \
   github.com/kubernetes/repo-infra/kazel \
-  e9d1a126ef355ff5d38e20612c889b07728225a4 \
+  e26fc85d14a1d3dc25569831acc06919673c545a \
   "${TMP_GOPATH}"
 
 # The gazelle commit should match the rules_go commit in the WORKSPACE file.
 "${TESTINFRA_ROOT}/verify/go_install_from_commit.sh" \
   github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-  43a3bda3eb97e7bcd86f564a1e0a4b008d6c407c \
+  c72631a220406c4fae276861ee286aaec82c5af2 \
   "${TMP_GOPATH}"
 
 "${TMP_GOPATH}/bin/gazelle" fix \
   -build_file_name=BUILD,BUILD.bazel \
   -external=vendored \
+  -proto=legacy \
   -mode=fix \
   -repo_root="${TESTINFRA_ROOT}"
 

--- a/verify/verify-bazel.sh
+++ b/verify/verify-bazel.sh
@@ -22,18 +22,19 @@ TMP_GOPATH=$(mktemp -d)
 
 "${TESTINFRA_ROOT}/verify/go_install_from_commit.sh" \
   github.com/kubernetes/repo-infra/kazel \
-  e9d1a126ef355ff5d38e20612c889b07728225a4 \
+  e26fc85d14a1d3dc25569831acc06919673c545a \
   "${TMP_GOPATH}"
 
 # The gazelle commit should match the rules_go commit in the WORKSPACE file.
 "${TESTINFRA_ROOT}/verify/go_install_from_commit.sh" \
   github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-  43a3bda3eb97e7bcd86f564a1e0a4b008d6c407c \
+  c72631a220406c4fae276861ee286aaec82c5af2 \
   "${TMP_GOPATH}"
 
 gazelle_diff=$("${TMP_GOPATH}/bin/gazelle" fix \
   -build_file_name=BUILD,BUILD.bazel \
   -external=vendored \
+  -proto=legacy \
   -mode=diff \
   -repo_root="${TESTINFRA_ROOT}")
 


### PR DESCRIPTION
Now that master of k/k is building under go1.9, this should update the go_rules and e2e image in test-infra to match.