### PR TITLE
put release-1.6 presubmit e2e back on jenkins

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -775,7 +775,7 @@ def job_script(job, extra_job_args):
         config = json.loads(fp.read())
     job_config = config[job]
     cmd = test_infra('scenarios/%s.py' % job_config['scenario'])
-    return [cmd] + job_args(extra_job_args + job_config.get('args', []))
+    return [cmd] + job_args(job_config.get('args', []) + extra_job_args)
 
 
 def gubernator_uri(paths):

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -65,6 +65,11 @@
         job-name: pull-kubernetes-e2e-gke-gci
         repo-name: 'k8s.io/kubernetes'
         timeout: 75
+    - kubernetes-e2e-gce:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gce
+        repo-name: 'k8s.io/kubernetes'
+        timeout: 85
     - kubernetes-federation-e2e-gce:
         max-total: 12
         job-name: pull-kubernetes-federation-e2e-gce

--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-security-pull.yaml
@@ -71,6 +71,11 @@
         job-name: pull-kubernetes-cross
         repo-name: 'github.com/kubernetes-security/kubernetes'
         timeout: 90
+    - kubernetes-e2e-gce:
+        max-total: 12
+        job-name: pull-kubernetes-e2e-gce
+        repo-name: 'github.com/kubernetes-security/kubernetes'
+        timeout: 85
     - kubernetes-e2e-kops-aws:
         max-total: 12
         job-name: pull-kubernetes-e2e-kops-aws

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9960,7 +9960,7 @@
   },
   "pull-kubernetes-e2e-gce": {
     "args": [
-      "--build=bazel",
+      "--build",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",
@@ -9970,6 +9970,7 @@
       "--gcp-project=k8s-jkns-pr-gce-etcd3",
       "--gcp-zone=us-central1-f",
       "--ginkgo-parallel=30",
+      "--mode=docker",
       "--provider=gce",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -460,6 +460,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -518,6 +523,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -576,6 +586,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -616,64 +631,16 @@ presubmits:
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
+  # bazel build works for 1.6 but not bazel-release :-(
   - name: pull-kubernetes-e2e-gce
-    agent: kubernetes
+    agent: jenkins
     context: pull-kubernetes-e2e-gce
     rerun_command: "/test pull-kubernetes-e2e-gce"
     trigger: "(?m)^/test (all|pull-kubernetes-e2e-gce),?(\\s+|$)"
     always_run: true
     branches:
     - release-1.6
-    spec:
-      containers:
-      - args:
-        - --root=/go/src
-        - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/release
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
-        - --clean
-        - --timeout=90
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        - name: USER
-          value: prow
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171018-fb8014bc-1.6
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
+
   - name: pull-kubernetes-e2e-gce-gpu
     agent: kubernetes
     skip_branches:
@@ -1541,6 +1508,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+         # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1599,6 +1571,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1657,6 +1634,11 @@ presubmits:
         - --git-cache=/root/.cache/git
         - --clean
         - --timeout=90
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
@@ -1697,64 +1679,15 @@ presubmits:
       - hostPath:
           path: /mnt/disks/ssd0
         name: cache-ssd
+  # bazel build works for 1.6 but not bazel-release :-(
   - name: pull-security-kubernetes-e2e-gce
-    agent: kubernetes
+    agent: jenkins
     context: pull-security-kubernetes-e2e-gce
     rerun_command: "/test pull-security-kubernetes-e2e-gce"
     trigger: "(?m)^/test (all|pull-security-kubernetes-e2e-gce),?(\\s+|$)"
     always_run: true
     branches:
     - release-1.6
-    spec:
-      containers:
-      - args:
-        - --root=/go/src
-        - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/release
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --git-cache=/root/.cache/git
-        - --clean
-        - --timeout=90
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/service-account/service-account.json
-        - name: USER
-          value: prow
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
-        # Make Bazel use shared cache for its root
-        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171018-fb8014bc-1.6
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
-          readOnly: true
-        - mountPath: /root/.cache
-          name: cache-ssd
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
-      - hostPath:
-          path: /mnt/disks/ssd0
-        name: cache-ssd
   - name: pull-security-kubernetes-e2e-gce-gpu
     agent: kubernetes
     skip_branches:


### PR DESCRIPTION
this overrides the job args in prow to not be jenkins like and moves the release-1.6 `pull-kubernetes-e2e-gce` to dockerized builds on jenkins since push build is broken for release-1.6

TODO: clean this up after release-1.6 is dropped, 1.7 forward should work fine.