### PR TITLE
update planter default tag for bazel 0.7

### DIFF
--- a/planter/Makefile
+++ b/planter/Makefile
@@ -14,7 +14,7 @@
 
 # note: sync this with planter.sh!
 # this should be bazel version - planter sub version
-BAZEL_VERSION = 0.5.4
+BAZEL_VERSION = 0.7.0
 IMAGE_NAME = gcr.io/k8s-testimages/planter
 TAG = $(BAZEL_VERSION)-1
 

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -19,7 +19,7 @@
 set -o errexit
 set -o nounset
 IMAGE_NAME="gcr.io/k8s-testimages/planter"
-TAG="${TAG:-0.5.4-1}"
+TAG="${TAG:-0.7.0-1}"
 IMAGE="${IMAGE_NAME}:${TAG}"
 # run our docker image as the host user with bazel cache and current repo dir
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)


### PR DESCRIPTION
0.7.0 seems to work fine for kubernetes master, but 0.5.4 is too old, so we should update the default.

/area planter