### PR TITLE
Add external PR status refresh plugin

### DIFF
--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -29,6 +29,7 @@ filegroup(
         "//experiment/cherrypicker:all-srcs",
         "//experiment/commenter:all-srcs",
         "//experiment/manual-trigger:all-srcs",
+        "//experiment/refresh:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/experiment/refresh/BUILD
+++ b/experiment/refresh/BUILD
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+        "server.go",
+    ],
+    importpath = "k8s.io/test-infra/experiment/refresh",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/hook:go_default_library",
+        "//prow/kube:go_default_library",
+        "//prow/pjutil:go_default_library",
+        "//prow/report:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "refresh",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/experiment/refresh",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/refresh/Dockerfile
+++ b/experiment/refresh/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-prow/alpine:0.1
+LABEL maintainer="mkargaki@redhat.com"
+
+COPY refresh /refresh
+ENTRYPOINT ["/refresh"]

--- a/experiment/refresh/OWNERS
+++ b/experiment/refresh/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- kargakis
+- stevekuznetsov

--- a/experiment/refresh/main.go
+++ b/experiment/refresh/main.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Refresh retries Github status updates for stale PR statuses.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+)
+
+var (
+	configPath        = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
+	port              = flag.Int("port", 8888, "Port to listen on.")
+	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
+	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	prowURL           = flag.String("prow-url", "", "Prow frontend URL.")
+)
+
+func validateFlags() error {
+	if *prowURL == "" {
+		return errors.New("--prow-url needs to be specified")
+	}
+	_, err := url.Parse(*githubEndpoint)
+	return err
+}
+
+func main() {
+	flag.Parse()
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+
+	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
+	// We'll get SIGTERM first and then SIGKILL after our graceful termination
+	// deadline.
+	signal.Ignore(syscall.SIGTERM)
+
+	if err := validateFlags(); err != nil {
+		logrus.WithError(err).Fatal("Error validating flags.")
+	}
+
+	configAgent := &config.Agent{}
+	if err := configAgent.Start(*configPath); err != nil {
+		logrus.WithError(err).Fatal("Error starting config agent.")
+	}
+
+	webhookSecretRaw, err := ioutil.ReadFile(*webhookSecretFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read webhook secret file.")
+	}
+	webhookSecret := bytes.TrimSpace(webhookSecretRaw)
+
+	oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read oauth secret file.")
+	}
+	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
+
+	ghc := github.NewClient(oauthSecret, *githubEndpoint)
+	if *dryRun {
+		ghc = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+	}
+
+	server := NewServer(oauthSecret, webhookSecret, ghc, *prowURL, configAgent)
+
+	http.Handle("/", server)
+	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
+}

--- a/experiment/refresh/server.go
+++ b/experiment/refresh/server.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/hook"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/report"
+)
+
+const pluginName = "refresh"
+
+var refreshRe = regexp.MustCompile(`(?mi)^/refresh\s*$`)
+
+type Server struct {
+	hmacSecret  []byte
+	credentials string
+	prowURL     string
+	configAgent *config.Agent
+	ghc         *github.Client
+	log         *logrus.Entry
+}
+
+func NewServer(creds string, hmac []byte, ghc *github.Client, prowURL string, configAgent *config.Agent) *Server {
+	return &Server{
+		hmacSecret:  hmac,
+		credentials: creds,
+		prowURL:     prowURL,
+		configAgent: configAgent,
+		ghc:         ghc,
+		log:         logrus.StandardLogger().WithField("plugin", "refresh"),
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	eventType, eventGUID, payload, ok := hook.ValidateWebhook(w, r, s.hmacSecret)
+	if !ok {
+		return
+	}
+	fmt.Fprint(w, "Event received. Have a nice day.")
+
+	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
+		logrus.WithError(err).Error("Error parsing event.")
+	}
+}
+
+func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
+	switch eventType {
+	case "issue_comment":
+		var ic github.IssueCommentEvent
+		if err := json.Unmarshal(payload, &ic); err != nil {
+			return err
+		}
+		go func() {
+			if err := s.handleIssueComment(ic); err != nil {
+				s.log.WithError(err).Info("Refreshing github statuses failed.")
+			}
+		}()
+	default:
+		return fmt.Errorf("received an event of type %q but didn't ask for it", eventType)
+	}
+	return nil
+}
+
+func (s *Server) handleIssueComment(ic github.IssueCommentEvent) error {
+	if !ic.Issue.IsPullRequest() || ic.Action != github.IssueCommentActionCreated || ic.Issue.State == "closed" {
+		return nil
+	}
+
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	num := ic.Issue.Number
+
+	if !refreshRe.MatchString(ic.Comment.Body) {
+		return nil
+	}
+	s.log.Infof("Requested a status refresh for PR %s/%s#%d", org, repo, num)
+
+	// TODO: Retries
+	resp, err := http.Get(s.prowURL + "/prowjobs.js")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("status code not 2XX: %v", resp.Status)
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var list struct {
+		PJs []kube.ProwJob `json:"items"`
+	}
+	if err := json.Unmarshal(data, &list); err != nil {
+		return fmt.Errorf("cannot unmarshal data from deck: %v", err)
+	}
+
+	pr, err := s.ghc.GetPullRequest(org, repo, num)
+	if err != nil {
+		return err
+	}
+
+	var presubmits []kube.ProwJob
+	for _, pj := range list.PJs {
+		if pj.Spec.Type != "presubmit" {
+			continue
+		}
+		if !pj.Spec.Report {
+			continue
+		}
+		if pj.Spec.Refs.Pulls[0].Number != num {
+			continue
+		}
+		if pj.Spec.Refs.Pulls[0].SHA != pr.Head.SHA {
+			continue
+		}
+		presubmits = append(presubmits, pj)
+	}
+
+	if len(presubmits) == 0 {
+		s.log.Infof("No prowjobs found for %s/%s#%d", org, repo, num)
+		return nil
+	}
+
+	jenkinsReport := s.configAgent.Config().JenkinsOperator.ReportTemplate
+	kubeReport := s.configAgent.Config().Plank.ReportTemplate
+	for _, pj := range pjutil.GetLatestProwJobs(presubmits, kube.PresubmitJob) {
+		s.log.Infof("Refreshing the status of job %q in PR %s/%s#%d (pj: %s)", pj.Spec.Job, org, repo, num, pj.Metadata.Name)
+		reportTemplate := jenkinsReport
+		if pj.Spec.Agent == "kubernetes" {
+			reportTemplate = kubeReport
+		}
+		if err := report.Report(s.ghc, reportTemplate, pj); err != nil {
+			logrus.WithError(err).Info("Failed report.")
+		}
+	}
+	return nil
+}

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -73,7 +73,7 @@ func sync(kc kubeClient, cfg *config.Config, cr cronClient, now time.Time) error
 	if err != nil {
 		return fmt.Errorf("error listing prow jobs: %v", err)
 	}
-	latestJobs := pjutil.GetLatestPeriodics(jobs)
+	latestJobs := pjutil.GetLatestProwJobs(jobs, kube.PeriodicJob)
 
 	// TODO(krzyzacy): retire the interval check, migrate everything to use cron
 	if err := cr.SyncConfig(cfg); err != nil {

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -128,7 +128,7 @@ func (c *controller) clean() {
 	}
 	// Get the jobs that we need to retain so horologium can continue working
 	// as intended.
-	latestPeriodics := pjutil.GetLatestPeriodics(prowJobs)
+	latestPeriodics := pjutil.GetLatestProwJobs(prowJobs, kube.PeriodicJob)
 	for _, prowJob := range prowJobs {
 		if prowJob.Spec.Type != kube.PeriodicJob {
 			continue

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -198,12 +198,12 @@ func PartitionPending(pjs []kube.ProwJob) (pending, nonPending chan kube.ProwJob
 	return pending, nonPending
 }
 
-// GetLatestPeriodics filters through the provided prowjobs and returns
-// a map of periodic jobs to their latest prowjobs.
-func GetLatestPeriodics(pjs []kube.ProwJob) map[string]kube.ProwJob {
+// GetLatestProwJobs filters through the provided prowjobs and returns
+// a map of jobType jobs to their latest prowjobs.
+func GetLatestProwJobs(pjs []kube.ProwJob, jobType kube.ProwJobType) map[string]kube.ProwJob {
 	latestJobs := make(map[string]kube.ProwJob)
 	for _, j := range pjs {
-		if j.Spec.Type != kube.PeriodicJob {
+		if j.Spec.Type != jobType {
 			continue
 		}
 		name := j.Spec.Job


### PR DESCRIPTION
This is an external prow plugin that helps updating stale Github
contexts in PRs. We had these so far because plank and the
Jenkins operator were not respecting termination signals but that
was a separate issue that got [fixed](https://github.com/kubernetes/test-infra/pull/5076) and stale contexts are still
a possibility in case Github breaks down.