### PR TITLE
enable admissionregistration/v1alpha1 by default in pull-e2e-gce/gke

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10047,6 +10047,7 @@
       "--ginkgo-parallel=30",
       "--mode=docker",
       "--provider=gce",
+      "--runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true",
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=65m"
@@ -10117,6 +10118,7 @@
       "--gke-shape={\"default\":{\"Nodes\":4,\"MachineType\":\"n1-standard-2\"}}",
       "--mode=docker",
       "--provider=gke",
+      "--runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true",
       "--stage=gs://kubernetes-release-dev/ci",
       "--stage-suffix=pull-gke-gci",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",


### PR DESCRIPTION
We plan to promote the API to beta in 1.9. We need to enforce queue-blocking e2e test to prevent breaking changes.

Tested in https://github.com/kubernetes/kubernetes/pull/54169/files, it's safe to enable the API.