### PR TITLE
Revert "Temporary disables custom network for pull-kuberntes-e2e-gce-gpu job"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10059,6 +10059,7 @@
   "pull-kubernetes-e2e-gce-gpu": {
     "args": [
       "--build=bazel",
+      "--check-leaked-resources",
       "--cluster=",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-e2e.env",

--- a/jobs/env/pull-kubernetes-e2e-gce-gpu.env
+++ b/jobs/env/pull-kubernetes-e2e-gce-gpu.env
@@ -1,6 +1,4 @@
 ### job-env
 KUBE_FEATURE_GATES=Accelerators=true
 NODE_ACCELERATORS=type=nvidia-tesla-k80,count=2
-
-# Temporary disabled until https://github.com/kubernetes/test-infra/issues/5019 is resolved
-# CREATE_CUSTOM_NETWORK=true
+CREATE_CUSTOM_NETWORK=true


### PR DESCRIPTION
Reverts kubernetes/test-infra#5021. xref https://github.com/kubernetes/test-infra/issues/4472.

Hey folks, now https://github.com/kubernetes/kubernetes/pull/54009 is in. Could we please try it again? :)

/assign @mindprince @krzyzacy 