### PR TITLE
don't test deprecated //examples/... in k/k

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -466,7 +466,7 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--test=//... //hack:verify-all -//build/... -//vendor/..."
+        - "--test=//... //hack:verify-all -//build/... -//vendor/... -//examples/..."
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
@@ -1666,7 +1666,7 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--test=//... //hack:verify-all -//build/... -//vendor/..."
+        - "--test=//... //hack:verify-all -//build/... -//vendor/... -//examples/..."
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"


### PR DESCRIPTION
followup x2 to https://github.com/kubernetes/test-infra/pull/4983

Since we construct the target list ourself bazel thinks we are enabling these "manual" targets manually. This test really shouldn't ever be run and is for a deprecated subdir anyhow, so this disables it.
