### PR TITLE
Move sig-cli gce etcd3 tests into their own job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3689,6 +3689,23 @@
       "UNKNOWN"
     ]
   },
+  "ci-kubernetes-e2e-gci-gce-etcd3-sig-cli": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=25",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[sig-cli\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cli"
+    ]
+  },
   "ci-kubernetes-e2e-gci-gce-flaky": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8903,6 +8903,40 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
+- interval: 2h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171018-fb8014bc-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-flaky

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -228,6 +228,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-gci-serial-sig-cli
 - name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-serial-sig-cli
+- name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
 - name: ci-kubernetes-e2e-gci-gce-serial-release-1-5
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial-release-1-5
 - name: ci-kubernetes-e2e-gci-gce-slow
@@ -3273,8 +3275,7 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
     description: 'kubectl gke serial e2e tests for master branch'
   - name: gce-etcd3
-    test_group_name: ci-kubernetes-e2e-gci-gce-etcd3
-    base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'
+    test_group_name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
     description: 'e2e tests run against a cluster with an etcd3 instance'
   - name: aws
     test_group_name: ci-kubernetes-e2e-kops-aws

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -3277,6 +3277,8 @@ dashboards:
   - name: gce-etcd3
     test_group_name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
     description: 'e2e tests run against a cluster with an etcd3 instance'
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall+alerts@gmail.com'
   - name: aws
     test_group_name: ci-kubernetes-e2e-kops-aws
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'


### PR DESCRIPTION
also send alert emails to the mailing list 'kubernetes-sig-cli-oncall+alerts@gmail.com'