### PR TITLE
Create custom network for pull-kubernetes-e2e-gce

### DIFF
--- a/jobs/env/pull-kubernetes-e2e-gce.env
+++ b/jobs/env/pull-kubernetes-e2e-gce.env
@@ -6,3 +6,5 @@ ENABLE_CACHE_MUTATION_DETECTOR=true
 # Enable the PodSecurityPolicy in tests.
 # TODO: Enable this by default in the test environment.
 ENABLE_POD_SECURITY_POLICY=true
+
+CREATE_CUSTOM_NETWORK=true


### PR DESCRIPTION
From https://github.com/kubernetes/test-infra/issues/4472.

Enable `CREATE_CUSTOM_NETWORK` on the first blocking PR job `pull-kubernetes-e2e-gce`.

Context: `pull-kubernetes-e2e-gke-gpu` has been successfully running with `CREATE_CUSTOM_NETWORK=true` for a while.

/assign @krzyzacy @BenTheElder 

Any more folks we should notify?