### PR TITLE
Set imagePullPolicy:Always for jobs use :latest images

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -23,7 +23,7 @@ DECK_VERSION             ?= 0.53
 SPLICE_VERSION           ?= 0.28
 TOT_VERSION              ?= 0.5
 HOROLOGIUM_VERSION       ?= 0.9
-PLANK_VERSION            ?= 0.50
+PLANK_VERSION            ?= 0.51
 JENKINS-OPERATOR_VERSION ?= 0.48
 TIDE_VERSION             ?= 0.7
 

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.50
+        image: gcr.io/k8s-prow/plank:0.51
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.50
+        image: gcr.io/k8s-prow/plank:0.51
         args:
         - --dry-run=false
         volumeMounts:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2736,6 +2736,7 @@ presubmits:
       containers:
       # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
       - image: gcr.io/mlkube-testing/builder:latest
+        imagePullPolicy: Always
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -3409,6 +3410,7 @@ postsubmits:
       containers:
       # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
       - image: gcr.io/mlkube-testing/builder:latest
+        imagePullPolicy: Always
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
@@ -4407,6 +4409,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7614,7 +7617,8 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12090,6 +12094,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15659,6 +15664,7 @@ periodics:
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16032,6 +16038,7 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=110
@@ -16069,6 +16076,7 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       args:
       - --bare
       - --timeout=85
@@ -17687,6 +17695,7 @@ periodics:
     containers:
     # TODO(jlewi): Replace latest with a specific tag once the images stabilize.
     - image: gcr.io/mlkube-testing/builder:latest
+      imagePullPolicy: Always
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json

--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -109,13 +109,14 @@ type ObjectFieldSelector struct {
 }
 
 type Container struct {
-	Name    string   `json:"name,omitempty"`
-	Image   string   `json:"image,omitempty"`
-	Command []string `json:"command,omitempty"`
-	Args    []string `json:"args,omitempty"`
-	WorkDir string   `json:"workingDir,omitempty"`
-	Env     []EnvVar `json:"env,omitempty"`
-	Ports   []Port   `json:"ports,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Image           string   `json:"image,omitempty"`
+	ImagePullPolicy string   `json:"imagePullPolicy,omitempty"`
+	Command         []string `json:"command,omitempty"`
+	Args            []string `json:"args,omitempty"`
+	WorkDir         string   `json:"workingDir,omitempty"`
+	Env             []EnvVar `json:"env,omitempty"`
+	Ports           []Port   `json:"ports,omitempty"`
 
 	Resources       Resources        `json:"resources,omitempty"`
 	SecurityContext *SecurityContext `json:"securityContext,omitempty"`


### PR DESCRIPTION
ref http://k8s-testgrid.appspot.com/sig-testing-canaries#kops-aws-canary

Our canary jobs is super flaky, and after investigation I figured they are running with non-latest `:latest` images :-( add `imagePullPolicy` so jobs depend on `:latest` tag will always use the latest image.

/assign @cjwagner  @BenTheElder 