### PR TITLE
make bazel scenario automatically exclude manual targets

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -505,7 +505,8 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--test=//... //hack:verify-all -//build/... -//vendor/... -//examples/..."
+        - "--test=//... -//build/... -//vendor/..."
+        - "--manual-test=//hack:verify-all"
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
@@ -551,7 +552,8 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/..."
+        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //vendor/k8s.io/..."
+        - "--manual-test=//hack:verify-all"
         - "--test-args=--test_tag_filters=-integration"
         - "--test-args=--flaky_test_attempts=3"
         env:
@@ -596,7 +598,8 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
         # -//pkg/kubelet/config:go_default_test because: https://github.com/kubernetes/kubernetes/issues/53016
-        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all -//pkg/kubelet/config:go_default_test"
+        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... -//pkg/kubelet/config:go_default_test"
+        - "--manual-test=//hack:verify-all"
         - "--test-args=--test_tag_filters=-integration"
         - "--test-args=--flaky_test_attempts=3"
         env:
@@ -1705,7 +1708,8 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--test=//... //hack:verify-all -//build/... -//vendor/... -//examples/..."
+        - "--test=//... -//build/... -//vendor/..."
+        - "--manual-test=//hack:verify-all"
         - "--test-args=--build_tag_filters=-e2e,-integration"
         - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
@@ -1751,7 +1755,8 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/..."
+        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //vendor/k8s.io/..."
+        - "--manual-test=//hack:verify-all"
         - "--test-args=--test_tag_filters=-integration"
         - "--test-args=--flaky_test_attempts=3"
         env:
@@ -1796,7 +1801,8 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
         # -//pkg/kubelet/config:go_default_test because: https://github.com/kubernetes/kubernetes/issues/53016
-        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all -//pkg/kubelet/config:go_default_test"
+        - "--test=//cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... -//pkg/kubelet/config:go_default_test"
+        - "--manual-test=//hack:verify-all"
         - "--test-args=--test_tag_filters=-integration"
         - "--test-args=--flaky_test_attempts=3"
         env:

--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -98,11 +98,12 @@ def query(kind, selected_pkgs, changed_pkgs):
     if changed_pkgs:
         changes = 'set(%s)' % ' '.join(changed_pkgs)
 
+    query_pat = 'kind(%s, rdeps(%s, %s)) except attr(\'tags\', \'manual\', //...)'
     return filter(None, check_output(
         'bazel', 'query',
         '--keep_going',
         '--noshow_progress',
-        'kind(%s, rdeps(%s, %s))' % (kind, selection, changes)
+        query_pat % (kind, selection, changes)
     ).split('\n'))
 
 
@@ -133,16 +134,22 @@ def main(args):
                 raise ValueError('PULL_BASE_SHA must be set!')
             affected = get_changed(base, pull)
 
-        build_pkgs = None
-        test_pkgs = None
+        build_pkgs = []
+        manual_build_targets = []
+        test_pkgs = []
+        manual_test_targets = []
         if args.build:
             build_pkgs = args.build.split(' ')
+        if args.manual_build:
+            manual_build_targets = args.manual_build.split(' ')
         if args.test:
             test_pkgs = args.test.split(' ')
+        if args.manual_test:
+            manual_test_targets = args.manual_test.split(' ')
 
         buildables = []
-        if build_pkgs or affected:
-            buildables = query('.*_binary', build_pkgs, affected)
+        if build_pkgs or manual_build_targets or affected:
+            buildables = query('.*_binary', build_pkgs, affected) + manual_build_targets
 
         if buildables:
             check('bazel', 'build', *buildables)
@@ -156,8 +163,8 @@ def main(args):
         if args.release:
             check('bazel', 'build', *args.release.split(' '))
 
-        if test_pkgs or affected:
-            tests = query('test', test_pkgs, affected)
+        if test_pkgs or manual_test_targets or affected:
+            tests = query('test', test_pkgs, affected) + manual_test_targets
             if tests:
                 if args.test_args:
                     tests = args.test_args + tests
@@ -198,7 +205,11 @@ def create_parser():
         '--affected', action='store_true',
         help='If build/test affected targets. Filtered by --build and --test flags.')
     parser.add_argument(
-        '--build', help='Bazel build targets, split by one space')
+        '--build', help='Bazel build target patterns, split by one space')
+    parser.add_argument(
+        '--manual-build',
+        help='Bazel build targets that should always be manually included, split by one space'
+    )
     # TODO(krzyzacy): Convert to bazel build rules
     parser.add_argument(
         '--install', action="append", help='Python dependency(s) that need to be installed')
@@ -209,7 +220,11 @@ def create_parser():
         default="gs://kubernetes-jenkins/shared-results/",
         help='If $PULL_REFS is set push build location to this bucket')
     parser.add_argument(
-        '--test', help='Bazel test targets, split by one space')
+        '--test', help='Bazel test target patterns, split by one space')
+    parser.add_argument(
+        '--manual-test',
+        help='Bazel test targets that should always be manually included, split by one space'
+    )
     parser.add_argument(
         '--test-args', action="append", help='Bazel test args')
     parser.add_argument(

--- a/scenarios/kubernetes_bazel_test.py
+++ b/scenarios/kubernetes_bazel_test.py
@@ -142,7 +142,11 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         # temporarily un-stub query
         with Stub(kubernetes_bazel, 'query', self.boiler['query'].old):
             def check_query(*cmd):
-                self.assertIn('kind(.*_binary, rdeps(//b/... -//b/bb/... +//c/..., //...))', cmd)
+                self.assertIn(
+                    'kind(.*_binary, rdeps(//b/... -//b/bb/... +//c/..., //...))'
+                    ' except attr(\'tags\', \'manual\', //...)',
+                    cmd
+                )
                 return '//b/aa/...\n//c/...'
             with Stub(kubernetes_bazel, 'check_output', check_query):
                 kubernetes_bazel.main(args)


### PR DESCRIPTION
[bazel actually does this in their CI scripts](https://bazel-review.googlesource.com/c/bazel/+/1800/4/scripts/ci/ci.sh)

This change means we don't have to manually exclude manual targets in our build/test target patterns in CI, when we query we will automatically exclude them, however in case we want to go ahead and run some manual target, I added new flags `--manual-build` and `--manual-test` to support this.