### PR TITLE
Fix boskos config upload job

### DIFF
--- a/boskos/update_prow_config.sh
+++ b/boskos/update_prow_config.sh
@@ -28,7 +28,15 @@ if [[ -a "${PROW_SERVICE_ACCOUNT:-}" ]] ; then
 	gcloud auth activate-service-account --key-file="${PROW_SERVICE_ACCOUNT}"
 fi
 
+if ! [ -x "$(command -v kubectl)" ]; then
+	gcloud components install kubectl 
+fi
 
 pushd "${TREE}/boskos"
 make update-config
 popd
+
+# switch back to default service account for uploading logs
+if [[ -a "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] ; then
+	gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+fi


### PR DESCRIPTION
Current status: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/maintenance-boskos-config-upload/731

This fixes two issue:
- kubectl does not exist in gcloud-in-go image yet
- we need to switch back to kubekins to upload logs after done with prow service account

/assign @BenTheElder 