### PR TITLE
bump test-infra to bazel 0.7.0

### DIFF
--- a/images/bazelbuild/Makefile
+++ b/images/bazelbuild/Makefile
@@ -15,7 +15,8 @@
 IMG = gcr.io/k8s-testimages/bazelbuild
 TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
-BAZEL_VERSIONS=0.5.2 0.5.4 0.6.1
+# TODO(bentheelder): retire 0.6.1 in favor of 0.7.0
+BAZEL_VERSIONS=0.5.2 0.5.4 0.6.1 0.7.0
 
 all: build
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2596,7 +2596,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-test-infra-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171013-53473ec5-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171020-b76ac241-0.7.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -3353,7 +3353,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171013-53473ec5-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171020-b76ac241-0.7.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17550,7 +17550,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171013-53473ec5-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171020-b76ac241-0.7.0
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -539,7 +539,9 @@ func TestBazelbuildArgs(t *testing.T) {
 		}
 	}
 	pinnedJobs := map[string]string{
-	//job: reason for pinning
+		//job: reason for pinning
+		"pull-test-infra-bazel": "testing test-infra with the shiniest bazel",
+		"ci-test-infra-bazel":   "testing test-infra with the shiniest bazel",
 	}
 	maxTag := ""
 	maxN := 0


### PR DESCRIPTION
0.7.0 has been a smooth upgrade so far locally, let's try it on test-infra.