### PR TITLE
Use regexp instead of hard-coded string for "NONE"

### DIFF
--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -46,8 +46,7 @@ const (
 Please see: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed.`
 	parentReleaseNoteFormat = `All 'parent' PRs of a cherry-pick PR must have one of the %q or %q labels, or this PR must follow the standard/parent release note labeling requirement.`
 
-	noReleaseNoteComment = "none"
-	actionRequiredNote   = "action required"
+	actionRequiredNote = "action required"
 )
 
 var (
@@ -58,6 +57,7 @@ var (
 
 	noteMatcherRE = regexp.MustCompile(`(?s)(?:Release note\*\*:\s*(?:<!--[^<>]*-->\s*)?` + "```(?:release-note)?|```release-note)(.+?)```")
 	cpRe          = regexp.MustCompile(`Cherry pick of #([[:digit:]]+) on release-([[:digit:]]+\.[[:digit:]]+).`)
+	noneRe        = regexp.MustCompile(`(?i)^\W*NONE\W*$`)
 
 	allRNLabels = []string{
 		releaseNoteNone,
@@ -295,7 +295,7 @@ func determineReleaseNoteLabel(body string) string {
 	if composedReleaseNote == "" {
 		return releaseNoteLabelNeeded
 	}
-	if composedReleaseNote == noReleaseNoteComment {
+	if noneRe.MatchString(composedReleaseNote) {
 		return releaseNoteNone
 	}
 	if strings.Contains(composedReleaseNote, actionRequiredNote) {

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -493,7 +493,6 @@ func sliceDifference(a, b []string) []string {
 }
 
 func TestGetReleaseNote(t *testing.T) {
-
 	tests := []struct {
 		body                        string
 		expectedReleaseNote         string
@@ -532,6 +531,16 @@ func TestGetReleaseNote(t *testing.T) {
 		{
 			body:                        "```release-note\nNONE\n```",
 			expectedReleaseNote:         "NONE",
+			expectedReleaseNoteVariable: releaseNoteNone,
+		},
+		{
+			body:                        "```release-note\n`NONE`\n```",
+			expectedReleaseNote:         "`NONE`",
+			expectedReleaseNoteVariable: releaseNoteNone,
+		},
+		{
+			body:                        "```release-note\n`\"NONE\"`\n```",
+			expectedReleaseNote:         "`\"NONE\"`",
 			expectedReleaseNoteVariable: releaseNoteNone,
 		},
 		{

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -474,24 +474,6 @@ func TestReleaseNotePR(t *testing.T) {
 	}
 }
 
-// sliceDifference returns 'a' with all elems of 'b' removed.
-func sliceDifference(a, b []string) []string {
-	var out []string
-	for _, aa := range a {
-		found := false
-		for _, bb := range b {
-			if aa == bb {
-				found = true
-				break
-			}
-		}
-		if !found {
-			out = append(out, aa)
-		}
-	}
-	return out
-}
-
 func TestGetReleaseNote(t *testing.T) {
 	tests := []struct {
 		body                        string


### PR DESCRIPTION
If contributors fill release note block of PR template with below string (note the extra backticks), the PR will get a `release-note` label instead of `release-note-none`. This is incorrect.
```
`NONE`
```

See this happened in https://github.com/kubernetes/kubernetes/pull/48328#issuecomment-312274073

/cc @cjwagner @roycaihw 