### PR TITLE
kubetest kops: reuse cluster flag from GKE

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -225,7 +225,7 @@ func getDeployer(o *options) (deployer, error) {
 	case "gke":
 		return newGKE(o.provider, o.gcpProject, o.gcpZone, o.gcpRegion, o.gcpNetwork, o.gcpNodeImage, o.cluster, &o.testArgs, &o.upgradeArgs)
 	case "kops":
-		return newKops(o.provider, o.gcpProject)
+		return newKops(o.provider, o.gcpProject, o.cluster)
 	case "kubernetes-anywhere":
 		if o.multiClusters.Enabled() {
 			return newKubernetesAnywhereMultiCluster(o.gcpProject, o.gcpZone, o.multiClusters)


### PR DESCRIPTION
We can hopefully remove `--kops-cluster`