### PR TITLE
kubetest kops: pass kubernetes version

### DIFF
--- a/kubetest/extract.go
+++ b/kubetest/extract.go
@@ -209,7 +209,7 @@ var (
 	sleep = time.Sleep
 )
 
-// Calls KUBERNETES_RELASE_URL=url KUBERNETES_RELEASE=version get-kube.sh.
+// Calls KUBERNETES_RELEASE_URL=url KUBERNETES_RELEASE=version get-kube.sh.
 // This will download version from the specified url subdir and extract
 // the tarballs.
 var getKube = func(url, version string) error {

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -173,6 +173,19 @@ func (k kops) isGoogleCloud() bool {
 }
 
 func (k kops) Up() error {
+	// If we downloaded kubernetes, pass that version to kops
+	if k.kubeVersion == "" {
+		// TODO(justinsb): figure out a refactor that allows us to get this from acquireKubernetes cleanly
+		kubeReleaseUrl := os.Getenv("KUBERNETES_RELEASE_URL")
+		kubeRelease := os.Getenv("KUBERNETES_RELEASE")
+		if kubeReleaseUrl != "" && kubeRelease != "" {
+			if !strings.HasSuffix(kubeReleaseUrl, "/") {
+				kubeReleaseUrl += "/"
+			}
+			k.kubeVersion = kubeReleaseUrl + kubeRelease
+		}
+	}
+
 	var featureFlags []string
 
 	createArgs := []string{


### PR DESCRIPTION
Unless explictly set by a flag, we populate it from the version kubetest
downloaded.