### PR TITLE
Remove unused func from subset of wip plugin's *github.Client methods.

### DIFF
--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -57,7 +57,6 @@ type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
-	CreateComment(org, repo string, number int, comment string) error
 }
 
 func handlePullRequest(pc plugins.PluginClient, pe github.PullRequestEvent) error {


### PR DESCRIPTION
wip plugin no longer comments. ref: #4490