### PR TITLE
Make pull-kubernetes-kubemark-e2e-gce create custom network

### DIFF
--- a/jobs/env/pull-kubernetes-kubemark-e2e-gce.env
+++ b/jobs/env/pull-kubernetes-kubemark-e2e-gce.env
@@ -4,6 +4,7 @@ KUBE_FASTBUILD=true
 ### cluster-env
 NUM_NODES=1
 NODE_SIZE=n1-standard-2
+CREATE_CUSTOM_NETWORK=true
 
 ### kubernetes-env
 KUBELET_TEST_LOG_LEVEL=--v=4


### PR DESCRIPTION
Fix https://github.com/kubernetes/test-infra/issues/4472.

Looks like PR jobs were well-behaved over the weekend with custom network: 
- https://k8s-testgrid.appspot.com/presubmits-kubernetes#pull-kubernetes-e2e-gce
- https://k8s-testgrid.appspot.com/presubmits-kubernetes#pull-kubernetes-e2e-gce-gpu

What about proceeding to other PR jobs as well?
(Seems like this is the last PR job we need to tweak, other jobs don't seem to be creating networks.)

/assign @krzyzacy @BenTheElder 
cc @shyamjvs 