### PR TITLE
make pull-kubernetes-e2e-gce-gpu required

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -20,6 +20,7 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce,\
+  pull-kubernetes-e2e-gce-gpu,\
   pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\

--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -16,6 +16,7 @@ required-retest-contexts: "\
   pull-kubernetes-bazel-build,\
   pull-kubernetes-bazel-test,\
   pull-kubernetes-e2e-gce,\
+  pull-kubernetes-e2e-gce-gpu,\
   pull-kubernetes-e2e-kops-aws,\
   pull-kubernetes-kubemark-e2e-gce,\
   pull-kubernetes-node-e2e,\


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/issues/4642

This job has been perfectly well-behaved and has maximum concurrency equal to other blocking presubmits (12), it also covers functionality not touched on by the other presubmits and we've already been running it (and reporting it) to all PRs in kubernetes/kubernetes.