### PR TITLE
Fix the prefix for mlkube presubmit jobs.

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1517,7 +1517,7 @@ test_groups:
 - name: mlkube-build-periodic
   gcs_prefix: kubernetes-jenkins/logs/mlkube-build-periodic
 - name: mlkube-build-presubmit
-  gcs_prefix: kubernetes-jenkins/logs/mlkube-build-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/mlkube-build-presubmit
 - name: mlkube-build-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/mlkube-build-postsubmit
 # kube-proxy daemonset migration jobs

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1518,6 +1518,7 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/mlkube-build-periodic
 - name: mlkube-build-presubmit
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/mlkube-build-presubmit
+  num_columns_recent: 30
 - name: mlkube-build-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/mlkube-build-postsubmit
 # kube-proxy daemonset migration jobs


### PR DESCRIPTION
* Results for the presubmit test aren't showing up in the test grid.
  * I think its because we have the GCS prefix for presubmits.

Fixes jlewi/mlkube.io#75