### PR TITLE
Move back to goflags, only use pflag for StringArrayVar

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,8 +28,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-
-	flag "github.com/spf13/pflag"
 )
 
 const defaultKubeadmCNI = "weave"

--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -31,8 +32,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	flag "github.com/spf13/pflag"
 )
 
 const (

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,8 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	flag "github.com/spf13/pflag"
 )
 
 var (


### PR DESCRIPTION
And let pflag parsing spill out errors rather than failing silently

/assign @BenTheElder 