### PR TITLE
change alert email address for sig-cli failing tests

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -3290,27 +3290,27 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-sig-cli
     description: 'kubectl gce e2e tests for master branch'
     alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall+alerts@gmail.com'
+      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall@gmail.com'
   - name: gke
     test_group_name: ci-kubernetes-e2e-gci-gke-sig-cli
     description: 'kubectl gke e2e tests for master branch'
     alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall+alerts@gmail.com'
+      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall@gmail.com'
   - name: gce-serial
     test_group_name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
     description: 'kubectl gce serial e2e tests for master branch'
     alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall+alerts@gmail.com'
+      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall@gmail.com'
   - name: gke-serial
     test_group_name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
     description: 'kubectl gke serial e2e tests for master branch'
     alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall+alerts@gmail.com'
+      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall@gmail.com'
   - name: gce-etcd3
     test_group_name: ci-kubernetes-e2e-gci-gce-etcd3-sig-cli
     description: 'e2e tests run against a cluster with an etcd3 instance'
     alert_options:
-      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall+alerts@gmail.com'
+      alert_mail_to_addresses: 'kubernetes-sig-cli-oncall@gmail.com'
   - name: aws
     test_group_name: ci-kubernetes-e2e-kops-aws
     base_options: 'include-filter-by-regex=Kubectl%7Ckubectl'


### PR DESCRIPTION
Since "+alerts" causes emails not to reach the mailing list.