### PR TITLE
upgrade test-infra to bazel 0.7 again

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2598,7 +2598,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-test-infra-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171013-53473ec5-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171020-844b54d7-0.7.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -3397,7 +3397,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171013-53473ec5-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171020-844b54d7-0.7.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -17672,7 +17672,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171013-53473ec5-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171020-844b54d7-0.7.0
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -541,6 +541,8 @@ func TestBazelbuildArgs(t *testing.T) {
 	pinnedJobs := map[string]string{
 		//job: reason for pinning
 		"pull-test-infra-bazel-canary": "canary testing the latest bazelbuild",
+		"pull-test-infra-bazel":        "test-infra dogfoods bazel upgrades first",
+		"ci-test-infra-bazel":          "test-infra dogfoods bazel upgrades first",
 	}
 	maxTag := ""
 	maxN := 0


### PR DESCRIPTION
The canary job has passed 3x now with `gcr.io/k8s-testimages/bazelbuild:latest-0.7.0` which should currently be equivalent to `gcr.io/k8s-testimages/bazelbuild:v20171020-844b54d7-0.7.0`.

Let's try to bump this again :fire:
/area bazel
/area jobs