### PR TITLE
log `bazel version` in the bazel scenario

### DIFF
--- a/scenarios/kubernetes_bazel.py
+++ b/scenarios/kubernetes_bazel.py
@@ -123,6 +123,7 @@ def main(args):
                 raise ValueError('Invalid install path: %s' % install)
             check('pip', 'install', '-r', install)
 
+    check('bazel', 'version')
     check('bazel', 'clean', '--expunge')
     res = 0
     try:


### PR DESCRIPTION
We can tell this by looking at deck's rerun button and checking the image version, but it would be nice to be able to verify which bazel version was used much later by reading the build log.

/area bazel
/area scenarios