### PR TITLE
Apply retest-not-required-docs-only for LICENSE changes

### DIFF
--- a/prow/plugins/docs-no-retest/docs-no-retest.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest.go
@@ -34,8 +34,9 @@ const (
 )
 
 var (
-	docFilesRegex    = regexp.MustCompile(`^.*\.(md|png|svg|dia)$`)
-	ownersFilesRegex = regexp.MustCompile(`^OWNERS$`)
+	docFilesRegex     = regexp.MustCompile(`^.*\.(md|png|svg|dia)$`)
+	ownersFilesRegex  = regexp.MustCompile(`^OWNERS$`)
+	licenseFilesRegex = regexp.MustCompile(`^LICENSE$`)
 )
 
 func init() {
@@ -79,6 +80,9 @@ func handlePR(gc githubClient, pe github.PullRequestEvent) error {
 			continue
 		}
 		if ownersFilesRegex.MatchString(basename) {
+			continue
+		}
+		if licenseFilesRegex.MatchString(basename) {
 			continue
 		}
 		docsOnly = false

--- a/prow/plugins/docs-no-retest/docs-no-retest_test.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest_test.go
@@ -111,6 +111,17 @@ func TestHandlePR(t *testing.T) {
 			shouldSkipRetest: true,
 		},
 		{
+			name:   "change LICENSE, no label, needs label",
+			labels: sets.NewString(),
+			prChanges: []github.PullRequestChange{
+				{
+					Filename: "/path/to/file/LICENSE",
+				},
+			},
+			action:           github.PullRequestActionOpened,
+			shouldSkipRetest: true,
+		},
+		{
 			name:   "change non doc, no label, needs no label",
 			labels: sets.NewString(),
 			prChanges: []github.PullRequestChange{
@@ -164,6 +175,17 @@ func TestHandlePR(t *testing.T) {
 			prChanges: []github.PullRequestChange{
 				{
 					Filename: "/path/to/file/OWNERS",
+				},
+			},
+			action:           github.PullRequestActionOpened,
+			shouldSkipRetest: true,
+		},
+		{
+			name:   "change LICENSE, has label, needs label",
+			labels: sets.NewString(labelSkipRetest),
+			prChanges: []github.PullRequestChange{
+				{
+					Filename: "/path/to/file/LICENSE",
 				},
 			},
 			action:           github.PullRequestActionOpened,


### PR DESCRIPTION
As discussed on Slack, we should apply the `retest-not-required-docs-only` label for LICENSE file changes.

Came across this in https://github.com/kubernetes/kubernetes/pull/54399.

/cc @stevekuznetsov 