### PR TITLE
Delete gke subnet tests which have not passed in 150 days

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4713,25 +4713,6 @@
       "sig-gcp"
     ]
   },
-  "ci-kubernetes-e2e-gci-gke-subnet": {
-    "args": [
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--cluster=auto-subnet",
-      "--deployment=gke",
-      "--extract=gke",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
-      "--gcp-node-image=gci",
-      "--gcp-zone=us-central1-f",
-      "--gke-environment=test",
-      "--provider=gke",
-      "--timeout=480m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-gcp"
-    ]
-  },
   "ci-kubernetes-e2e-gci-gke-test": {
     "args": [
       "--check-leaked-resources",
@@ -6697,26 +6678,6 @@
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\] --ginkgo.skip=\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=600m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-gcp"
-    ]
-  },
-  "ci-kubernetes-e2e-gke-subnet": {
-    "args": [
-      "--check-leaked-resources",
-      "--check-version-skew=false",
-      "--cluster=auto-subnet",
-      "--deployment=gke",
-      "--extract=gke",
-      "--gcp-cloud-sdk=gs://cloud-sdk-testing/rc",
-      "--gcp-node-image=gci",
-      "--gcp-project=k8s-jkns-e2e-gke-subnet",
-      "--gcp-zone=us-central1-f",
-      "--gke-environment=test",
-      "--provider=gke",
-      "--timeout=480m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11694,40 +11694,6 @@ periodics:
 
 - interval: 30m
   agent: kubernetes
-  name: ci-kubernetes-e2e-gci-gke-subnet
-  spec:
-    containers:
-    - args:
-      - --timeout=500
-      - --bare
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: USER
-        value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
-
-- interval: 30m
-  agent: kubernetes
   name: ci-kubernetes-e2e-gci-gke-test
   spec:
     containers:
@@ -14645,40 +14611,6 @@ periodics:
     containers:
     - args:
       - --timeout=620
-      - --bare
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/service-account/service-account.json
-      - name: USER
-        value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
-      volumeMounts:
-      - mountPath: /etc/service-account
-        name: service
-        readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
-    volumes:
-    - name: service
-      secret:
-        secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
-
-- interval: 30m
-  agent: kubernetes
-  name: ci-kubernetes-e2e-gke-subnet
-  spec:
-    containers:
-    - args:
-      - --timeout=500
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -320,10 +320,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu
   alert_stale_results_hours: 24
   num_failures_to_alert: 12 # Runs every 2h. Alert when it's been failing for a day.
-- name: ci-kubernetes-e2e-gke-subnet
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-subnet
-- name: ci-kubernetes-e2e-gci-gke-subnet
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-subnet
 - name: ci-kubernetes-e2e-gke-test
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-test
 - name: ci-kubernetes-e2e-gci-gke-test
@@ -2061,10 +2057,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-regional
   - name: gci-gke-reboot
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-  - name: gke-subnet
-    test_group_name: ci-kubernetes-e2e-gke-subnet
-  - name: gci-gke-subnet
-    test_group_name: ci-kubernetes-e2e-gci-gke-subnet
   - name: gke-test
     test_group_name: ci-kubernetes-e2e-gke-test
   - name: gci-gke-test
@@ -3982,12 +3974,6 @@ dashboards:
     - configuration_value: infra-commit
   - name: gci-gke-reboot
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-    column_header:
-    - configuration_value: node_os_image
-    - configuration_value: Commit
-    - configuration_value: infra-commit
-  - name: gci-gke-subnet
-    test_group_name: ci-kubernetes-e2e-gci-gke-subnet
     column_header:
     - configuration_value: node_os_image
     - configuration_value: Commit


### PR DESCRIPTION
FYI @kubernetes/sig-network-test-failures @kubernetes/sig-gcp-test-failures 

These tests failed every time they failed for the past 150 days: http://velodrome.k8s.io/dashboard/db/bigquery-metrics?orgId=1

/assign @krzyzacy @bowei 

