### PR TITLE
Add a Timeout result to junit_runner.xml

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -197,6 +197,18 @@ func validWorkingDirectory() error {
 }
 
 func writeXML(dump string, start time.Time) {
+	// Note whether timeout occurred
+	c := testCase{
+		Name:      "Timeout",
+		ClassName: "e2e.go",
+		Time:      timeout.Seconds(),
+	}
+	if isInterrupted() {
+		c.Failure = "kubetest --timeout triggered"
+		suite.Failures++
+	}
+	suite.Cases = append(suite.Cases, c)
+	// Write xml
 	suite.Time = time.Since(start).Seconds()
 	out, err := xml.MarshalIndent(&suite, "", "    ")
 	if err != nil {


### PR DESCRIPTION
/assign @Q-Lee 

Ensure that if I run `kubetest --timeout=foo` and this triggers that a line noting as much appears in testgrid.