### PR TITLE
Add trigger plugin to k8s.io/community

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -44,6 +44,9 @@ plugins:
   kubernetes/cluster-registry:
   - trigger
 
+  kubernetes/community:
+  - trigger
+
   kubernetes/federation:
   - trigger
 


### PR DESCRIPTION
Missed one more piece for #3034. Have to enable the trigger plugin now that there is a prowjob to trigger.