### PR TITLE
Let gcloud beta use v1beta1 API

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -141,9 +141,9 @@ func newGKE(provider, project, zone, region, network, image, cluster string, tes
 	}
 
 	g.commandGroup = strings.Fields(*gkeCommandGroup)
-	if *gkeCommandGroup == "alpha" {
-		// By default gcloud alpha container is using v1 alpha api.
-		// If we want to use v1alpha1 we need to force it.
+	if *gkeCommandGroup == "alpha" || *gkeCommandGroup == "beta" {
+		// By default gcloud {alpha,beta} container is using v1 api.
+		// If we want to use v1alpha1/v1beta1 we need to force it.
 		if err := finishRunning(exec.Command("gcloud", "config", "set", "container/use_v1_api_client", "False")); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
No tests affected right now. This is a prerequisite for testing anything in v1beta1 API.