### PR TITLE
Support extract tarball directly from kubetest, make kubemark prow job extract k8s src tarball as well

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8416,6 +8416,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest",
+      "--extract-source",
       "--gcp-project=k8s-jenkins-gci-kubemark",
       "--gcp-zone=us-central1-f",
       "--kubemark",

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -74,7 +74,7 @@ func TestGetKube(t *testing.T) {
 		if err := ioutil.WriteFile("./get-kube.sh", bytes, 0700); err != nil {
 			t.Fatal(err)
 		}
-		err := getKube("url", "version")
+		err := getKube("url", "version", false)
 		if tc.success && err != nil {
 			t.Errorf("%s did not succeed: %s", tc.name, err)
 		}
@@ -130,7 +130,7 @@ func TestExtractStrategies(t *testing.T) {
 	// arguments.
 	oldGetKube := getKube
 	defer func() { getKube = oldGetKube }()
-	getKube = func(url, version string) error {
+	getKube = func(url, version string, _ bool) error {
 		gotURL = url
 		gotVersion = version
 		// This is needed or else Extract() will think that getKube failed.


### PR DESCRIPTION
Let kubetest support extract k8s-src at the same version of the test tarball, which we can have bazel workspace at the same version.

/assign @shyamjvs 

