### PR TITLE
Bump kubekins to v20171026-4fad18a0

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
 LABEL maintainer "beacham@google.com"
 
 RUN apt-get update && apt-get install -y \

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -263,7 +263,7 @@ presubmits:
       trigger: "(?m)^/test( all| pull-cri-containerd-node-e2e),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
           args:
           - --root=/go/src
           - "--clean"
@@ -795,7 +795,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -858,7 +858,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -921,7 +921,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -968,7 +968,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1030,7 +1030,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1102,7 +1102,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1171,7 +1171,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1255,7 +1255,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1310,7 +1310,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -1365,7 +1365,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -1909,7 +1909,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1972,7 +1972,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2035,7 +2035,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2081,7 +2081,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2143,7 +2143,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2215,7 +2215,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2284,7 +2284,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2368,7 +2368,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2423,7 +2423,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -2478,7 +2478,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -3488,7 +3488,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --root=/go/src
       - "--clean"
@@ -3550,7 +3550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3583,7 +3583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3826,7 +3826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3860,7 +3860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3894,7 +3894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3928,7 +3928,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3962,7 +3962,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3996,7 +3996,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4030,7 +4030,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4064,7 +4064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4098,7 +4098,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4132,7 +4132,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4166,7 +4166,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4200,7 +4200,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4234,7 +4234,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4268,7 +4268,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4302,7 +4302,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4336,7 +4336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4370,7 +4370,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4404,7 +4404,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4438,7 +4438,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4509,7 +4509,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4545,7 +4545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4581,7 +4581,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4617,7 +4617,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4653,7 +4653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4689,7 +4689,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4725,7 +4725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4761,7 +4761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4797,7 +4797,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4833,7 +4833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4869,7 +4869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4905,7 +4905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4941,7 +4941,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4977,7 +4977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5013,7 +5013,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5049,7 +5049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5085,7 +5085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5121,7 +5121,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5157,7 +5157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5193,7 +5193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5229,7 +5229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5265,7 +5265,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5301,7 +5301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5337,7 +5337,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5373,7 +5373,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5409,7 +5409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5445,7 +5445,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5481,7 +5481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5517,7 +5517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5553,7 +5553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5589,7 +5589,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5625,7 +5625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5661,7 +5661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5697,7 +5697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5733,7 +5733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5769,7 +5769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5805,7 +5805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5841,7 +5841,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5877,7 +5877,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5913,7 +5913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5947,7 +5947,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5981,7 +5981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6015,7 +6015,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6049,7 +6049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6083,7 +6083,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6117,7 +6117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6151,7 +6151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6185,7 +6185,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6219,7 +6219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6253,7 +6253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6287,7 +6287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6321,7 +6321,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6355,7 +6355,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6389,7 +6389,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6423,7 +6423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6457,7 +6457,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6491,7 +6491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6525,7 +6525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6559,7 +6559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6593,7 +6593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6627,7 +6627,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6661,7 +6661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6695,7 +6695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6729,7 +6729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6763,7 +6763,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6797,7 +6797,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6831,7 +6831,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6865,7 +6865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6899,7 +6899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6933,7 +6933,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6967,7 +6967,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7001,7 +7001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7035,7 +7035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7069,7 +7069,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7103,7 +7103,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7137,7 +7137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7171,7 +7171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7205,7 +7205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7239,7 +7239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7273,7 +7273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7307,7 +7307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7341,7 +7341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7375,7 +7375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7409,7 +7409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7443,7 +7443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7477,7 +7477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7511,7 +7511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7545,7 +7545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7579,7 +7579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7648,7 +7648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7682,7 +7682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7716,7 +7716,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7750,7 +7750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7784,7 +7784,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7818,7 +7818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7852,7 +7852,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7886,7 +7886,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7920,7 +7920,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7954,7 +7954,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7988,7 +7988,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8022,7 +8022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8056,7 +8056,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8090,7 +8090,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8124,7 +8124,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8146,7 +8146,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -8183,7 +8183,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=240
@@ -8221,7 +8221,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -8258,7 +8258,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=240
@@ -8295,7 +8295,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -8332,7 +8332,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -8383,7 +8383,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8419,7 +8419,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8455,7 +8455,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8491,7 +8491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8527,7 +8527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8563,7 +8563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8599,7 +8599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8635,7 +8635,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8671,7 +8671,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8707,7 +8707,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8743,7 +8743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8779,7 +8779,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8815,7 +8815,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8851,7 +8851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8887,7 +8887,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8923,7 +8923,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8959,7 +8959,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8995,7 +8995,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9029,7 +9029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9063,7 +9063,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9097,7 +9097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9131,7 +9131,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9165,7 +9165,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9199,7 +9199,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9233,7 +9233,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9267,7 +9267,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9301,7 +9301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9335,7 +9335,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9369,7 +9369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9403,7 +9403,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9437,7 +9437,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9471,7 +9471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9505,7 +9505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9539,7 +9539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9573,7 +9573,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9607,7 +9607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9641,7 +9641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9675,7 +9675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9709,7 +9709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9743,7 +9743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9777,7 +9777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9811,7 +9811,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9845,7 +9845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9879,7 +9879,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9914,7 +9914,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9948,7 +9948,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9982,7 +9982,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10016,7 +10016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10050,7 +10050,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10084,7 +10084,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10118,7 +10118,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10152,7 +10152,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10186,7 +10186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10220,7 +10220,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10254,7 +10254,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10288,7 +10288,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10322,7 +10322,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10356,7 +10356,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10390,7 +10390,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10424,7 +10424,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10458,7 +10458,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10492,7 +10492,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10526,7 +10526,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10560,7 +10560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10594,7 +10594,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10628,7 +10628,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10662,7 +10662,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10696,7 +10696,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10730,7 +10730,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10764,7 +10764,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10798,7 +10798,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10832,7 +10832,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10866,7 +10866,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10900,7 +10900,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10934,7 +10934,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10968,7 +10968,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11002,7 +11002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11036,7 +11036,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11070,7 +11070,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11104,7 +11104,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11138,7 +11138,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11172,7 +11172,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11206,7 +11206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11240,7 +11240,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11274,7 +11274,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11308,7 +11308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11342,7 +11342,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11376,7 +11376,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11410,7 +11410,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11444,7 +11444,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11478,7 +11478,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11512,7 +11512,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11546,7 +11546,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11580,7 +11580,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11614,7 +11614,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11648,7 +11648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11682,7 +11682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11716,7 +11716,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11750,7 +11750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11784,7 +11784,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11853,7 +11853,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11887,7 +11887,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11921,7 +11921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11955,7 +11955,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11989,7 +11989,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12023,7 +12023,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12057,7 +12057,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12091,7 +12091,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12125,7 +12125,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12159,7 +12159,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12193,7 +12193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12227,7 +12227,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12261,7 +12261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12295,7 +12295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12329,7 +12329,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12363,7 +12363,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12397,7 +12397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12431,7 +12431,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12465,7 +12465,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12499,7 +12499,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12533,7 +12533,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12567,7 +12567,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12602,7 +12602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12636,7 +12636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12670,7 +12670,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12704,7 +12704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12738,7 +12738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12772,7 +12772,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12806,7 +12806,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12840,7 +12840,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12874,7 +12874,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12908,7 +12908,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12942,7 +12942,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12976,7 +12976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13010,7 +13010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13044,7 +13044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13078,7 +13078,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13112,7 +13112,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13146,7 +13146,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13180,7 +13180,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13214,7 +13214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13248,7 +13248,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13282,7 +13282,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13316,7 +13316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13350,7 +13350,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13384,7 +13384,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13418,7 +13418,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13452,7 +13452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13486,7 +13486,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13520,7 +13520,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13554,7 +13554,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13588,7 +13588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13622,7 +13622,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13656,7 +13656,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13690,7 +13690,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13724,7 +13724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13758,7 +13758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13792,7 +13792,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13826,7 +13826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13860,7 +13860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13894,7 +13894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13928,7 +13928,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13962,7 +13962,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13996,7 +13996,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14030,7 +14030,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14064,7 +14064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14098,7 +14098,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14132,7 +14132,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14166,7 +14166,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14200,7 +14200,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14236,7 +14236,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14272,7 +14272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14308,7 +14308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14344,7 +14344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14380,7 +14380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14416,7 +14416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14452,7 +14452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14488,7 +14488,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14524,7 +14524,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14560,7 +14560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14596,7 +14596,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14632,7 +14632,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14669,7 +14669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14705,7 +14705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14741,7 +14741,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14777,7 +14777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14813,7 +14813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14849,7 +14849,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14885,7 +14885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14921,7 +14921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14957,7 +14957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14993,7 +14993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15029,7 +15029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15065,7 +15065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15101,7 +15101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15137,7 +15137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15173,7 +15173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15207,7 +15207,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15243,7 +15243,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15330,7 +15330,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15373,7 +15373,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15416,7 +15416,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15459,7 +15459,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15502,7 +15502,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15545,7 +15545,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15586,7 +15586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-4f12da13-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15698,7 +15698,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15737,7 +15737,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15776,7 +15776,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15815,7 +15815,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15854,7 +15854,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15893,7 +15893,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15932,7 +15932,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15971,7 +15971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16010,7 +16010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16049,7 +16049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16088,7 +16088,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16127,7 +16127,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16166,7 +16166,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16205,7 +16205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16244,7 +16244,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16283,7 +16283,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16322,7 +16322,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16361,7 +16361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16400,7 +16400,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16439,7 +16439,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16478,7 +16478,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16517,7 +16517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16556,7 +16556,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16595,7 +16595,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16654,7 +16654,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16691,7 +16691,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16728,7 +16728,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16765,7 +16765,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16802,7 +16802,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -16839,7 +16839,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -16876,7 +16876,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.8
       args:
       - --repo=k8s.io/kubernetes=release-1.8
       - --timeout=90
@@ -16913,7 +16913,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -16950,7 +16950,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -17000,7 +17000,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17035,7 +17035,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17070,7 +17070,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17105,7 +17105,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17140,7 +17140,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17175,7 +17175,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17210,7 +17210,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17245,7 +17245,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171024-74d82dbc-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17268,7 +17268,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -17304,7 +17304,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -369,7 +369,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -468,7 +468,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -565,7 +565,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1483,7 +1483,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1582,7 +1582,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1679,7 +1679,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2933,7 +2933,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3051,7 +3051,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3094,7 +3094,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3137,7 +3137,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3255,7 +3255,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3298,7 +3298,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3640,7 +3640,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3683,7 +3683,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3726,7 +3726,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3769,7 +3769,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -17579,7 +17579,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -17698,7 +17698,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17743,7 +17743,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17860,7 +17860,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17905,7 +17905,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171023-10ade723
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171026-a4097c34
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171023-364289b6-master'
+DEFAULT_KUBEKINS_TAG = 'v20171026-4fad18a0-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
includes various of kubetest changes recently:

https://github.com/kubernetes/test-infra/pull/5144
https://github.com/kubernetes/test-infra/pull/5121
https://github.com/kubernetes/test-infra/pull/4764

mainly for kops and federation

/hold
watching canaries