### PR TITLE
Create AWS job not using kops-e2e-runner.sh

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7397,6 +7397,23 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-e2e-kops-aws-newrunner": {
+    "args": [
+      "--cluster=e2e-kops-aws-newrunner.test-aws.k8s.io",
+      "--deployment=kops",
+      "--env-file=jobs/platform/kops_aws.env",
+      "--extract=ci/latest",
+      "--ginkgo-parallel",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
+      "--provider=aws",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-aws"
+    ]
+  },
   "ci-kubernetes-e2e-kops-aws-release-1-6": {
     "args": [
       "--aws",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15238,6 +15238,49 @@ periodics:
         defaultMode: 256
         secretName: aws-cred
 
+- interval: 1h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-kops-aws-newrunner
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_AWS_CREDENTIALS_FILE
+        value: /etc/aws-cred/credentials
+      - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171023-364289b6-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/aws-ssh
+        name: aws-ssh
+        readOnly: true
+      - mountPath: /etc/aws-cred
+        name: aws-cred
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: aws-ssh
+      secret:
+        defaultMode: 256
+        secretName: aws-ssh-key-secret
+    - name: aws-cred
+      secret:
+        defaultMode: 256
+        secretName: aws-cred
+
 - interval: 24h
   agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-release-1-6

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1046,6 +1046,8 @@ test_groups:
   - configuration_value: node_os_image
   - configuration_value: Commit
   - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-kops-aws-newrunner
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-newrunner
 - name: ci-kubernetes-e2e-kops-aws-release-1-7
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-release-1-7
 - name: ci-kubernetes-e2e-gce-slow-release-1-7
@@ -1784,6 +1786,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-aws-updown
   - name: kops-aws-weave
     test_group_name: ci-kubernetes-e2e-kops-aws-weave
+  - name: kops-aws-newrunner
+    test_group_name: ci-kubernetes-e2e-kops-aws-newrunner
 
 - name: google-docker
   dashboard_tab:


### PR DESCRIPTION
Once this job is stable, it can replace the kops-e2e-runner jobs and we
can remove them.

The --aws flag selects the kops-e2e-runner, and will be considered
legacy.  --deployment=kops --provider=aws selects the new runner,
and is consistent with kops/GCE testing.  (And this also allows for
other deployment tools to target AWS)