### PR TITLE
Bump image for ci-kubernetes-e2e-kops-aws-newrunner

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15330,7 +15330,8 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
We want the --kops-version support in kubetest