### PR TITLE
Use context.Context to support test timeout

### DIFF
--- a/kubetest/kubernetes.go
+++ b/kubetest/kubernetes.go
@@ -26,7 +26,7 @@ import (
 
 // kubectlGetNodes lists nodes by executing kubectl get nodes, parsing the output into a nodeList object
 func kubectlGetNodes() (*nodeList, error) {
-	o, err := output(exec.Command("kubectl", "get", "nodes", "-ojson"))
+	o, err := output(exec.CommandContext(kubetestContext, "kubectl", "get", "nodes", "-ojson"))
 	if err != nil {
 		log.Printf("kubectl get nodes failed: %s\n%s", wrapError(err).Error(), string(o))
 		return nil, err

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -48,6 +49,9 @@ var (
 	verbose   = false
 	timeout   = time.Duration(0)
 	boskos    = client.NewClient(os.Getenv("JOB_NAME"), "http://boskos")
+
+	// kubetestContext is the Context that should be used for timeout / cancellation
+	kubetestContext context.Context
 )
 
 type options struct {
@@ -320,10 +324,28 @@ func complete(o *options) error {
 		<-interrupt.C // Drain value
 	}
 
+	ctx := context.Background()
+	var cancel context.CancelFunc
+
 	if timeout > 0 {
 		log.Printf("Limiting testing to %s", timeout)
 		interrupt.Reset(timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
 	}
+
+	{
+		// Exit the kubetest context on a signal
+		sigChannel := make(chan os.Signal, 1)
+		signal.Notify(sigChannel, os.Interrupt)
+		go func() {
+			<-sigChannel
+			log.Println("got Interrupt signal; cancelling execution")
+			cancel()
+		}()
+	}
+	kubetestContext = ctx
 
 	if o.dump != "" {
 		defer writeMetadata(o.dump, o.metadataSources)


### PR DESCRIPTION
We create a global context.Context object, which we can then cancel on a
timeout.