### PR TITLE
Add ipvs e2e test job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3808,6 +3808,24 @@
       "sig-network"
     ]
   },
+  "ci-kubernetes-e2e-gci-gce-ipvs": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-gci-gce-ipvs.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[sig-network\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=60m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds": {
     "args": [
       "--check-leaked-resources",

--- a/jobs/env/ci-kubernetes-e2e-gci-gce-ipvs.env
+++ b/jobs/env/ci-kubernetes-e2e-gci-gce-ipvs.env
@@ -1,0 +1,4 @@
+### job-env
+# Use proxy mode IPVS
+KUBE_FEATURE_GATES=SupportIPVSProxyMode=true
+KUBEPROXY_TEST_ARGS=--proxy-mode=ipvs

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -9792,6 +9792,40 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
+- interval: 1h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-ipvs
+  spec:
+    containers:
+    - args:
+      - --timeout=80
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -207,6 +207,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability
 - name: ci-kubernetes-e2e-gci-gce-ip-alias
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ip-alias
+- name: ci-kubernetes-e2e-gci-gce-ipvs
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ipvs
 - name: ci-kubernetes-e2e-gce-alpha-api
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-alpha-api
 - name: ci-kubernetes-e2e-gci-gce-serial
@@ -1852,6 +1854,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-scalability-release-1-7
   - name: gci-gce-ip-alias
     test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
+  - name: gci-gce-ipvs
+    test_group_name: ci-kubernetes-e2e-gci-gce-ipvs
   - name: gce-alpha-api
     test_group_name: ci-kubernetes-e2e-gce-alpha-api
   - name: gci-gce-serial
@@ -3262,6 +3266,10 @@ dashboards:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gci-gce-ip-alias
     test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: gci-gce-ipvs
+    test_group_name: ci-kubernetes-e2e-gci-gce-ipvs
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gce-alpha-api


### PR DESCRIPTION
We were working on move IPVS outside of alpha for the 1.9 release. see this issue: https://github.com/kubernetes/kubernetes/issues/51602.
This pr is about to create a new e2e test job for IPVS, which mentioned in this issue: https://github.com/kubernetes/kubernetes/issues/52834.