### PR TITLE
Set GOBIN in go_install_from_commit.sh

### DIFF
--- a/verify/go_install_from_commit.sh
+++ b/verify/go_install_from_commit.sh
@@ -20,6 +20,7 @@ set -o pipefail
 PKG=$1
 COMMIT=$2
 export GOPATH=$3
+export GOBIN="$GOPATH/bin"
 
 go get -d -u "${PKG}"
 cd "${GOPATH}/src/${PKG}"


### PR DESCRIPTION
Got below error when running `verify-bazel.sh`:
```
$ verify/verify-bazel.sh 
verify/verify-bazel.sh: line 39: /tmp/tmp.E9ANvSeWuU/bin/gazelle: No such file or directory
```

This is because I set GOBIN in my env var. The PR set expected GOBIN by the script.

/cc @ixdy 