### PR TITLE
Revert "Migrate regional e2e tests to use gcloud beta"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -6250,7 +6250,7 @@
       "--gcp-project=k8s-jkns-e2e-regional",
       "--gcp-region=us-central1",
       "--ginkgo-parallel",
-      "--gke-command-group=beta",
+      "--gke-command-group=alpha",
       "--gke-environment=test",
       "--provider=gke",
       "--test_args=--gce-multizone=true --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",


### PR DESCRIPTION
Reverts kubernetes/test-infra#5214

Without updating gcloud, this causes tests to fail.

ref https://github.com/kubernetes/test-infra/issues/5218