### PR TITLE
Fix --ginkgo.focus for cosbeta-nosnat

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -788,7 +788,7 @@ testSuites:
   nosnat:
     args:
     - --timeout=20m
-    - --test_args=--ginkgo.focus=\\[Feature:NoSNAT\\] --minStartupPods=8
+    - --test_args=--ginkgo.focus=\[Feature:NoSNAT\] --minStartupPods=8
     - --ginkgo-parallel=1
 
 # The following settings are used by node e2e tests.

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -767,7 +767,7 @@
       "--image-family=cos-beta",
       "--image-project=cos-cloud",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=\\\\[Feature:NoSNAT\\\\] --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:NoSNAT\\] --minStartupPods=8",
       "--timeout=20m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
From https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cosbeta-k8sdev-nosnat/281/, seems like the `--ginkgo.focus` for `ci-kubernetes-e2e-gce-cosbeta-k8sdev-nosnat` isn't configured properly so that it fails to include the [no-SNAT test](https://github.com/kubernetes/kubernetes/blob/ee4d54c70c98d89e06d66142345791db852f8278/test/e2e/network/no_snat.go#L136).

P.S. I saw this comment, but still think it isn't correct...:
```
"_comment": "AUTO-GENERATED by experiment/generate_tests.py - DO NOT EDIT."
```

/assign @krzyzacy 