### PR TITLE
Add test that prow jobs specify an imagePullPolicy

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -217,7 +217,7 @@ func TestJobDoesNotHaveDockerSocket(t *testing.T) {
 	for _, periodic := range c.Periodics {
 		if periodic.Spec != nil {
 			if err := CheckDockerSocketVolumes(periodic.Spec.Volumes); err != nil {
-				t.Errorf("Error in postsubmit: %v", err)
+				t.Errorf("Error in periodic: %v", err)
 			}
 		}
 	}
@@ -796,6 +796,65 @@ func TestPullKubernetesCross(t *testing.T) {
 		if got != test.expected {
 			t.Errorf("expected changes (%s) to run cross job: %t, got: %t",
 				test.changedFile, test.expected, got)
+		}
+	}
+}
+
+// CheckLatestUsesImagePullPolicy returns an error if an image is a `latest-.*` tag,
+// but doesn't have imagePullPolicy: Always
+func CheckLatestUsesImagePullPolicy(spec *kube.PodSpec) error {
+	for _, container := range spec.Containers {
+		if strings.Contains(container.Image, ":latest-") {
+			// If the job doesn't specify imagePullPolicy: Always,
+			// we aren't guaranteed to check for the latest version of the image.
+			if container.ImagePullPolicy == "" || container.ImagePullPolicy != "Always" {
+				return errors.New("job uses latest- tag, but does not specify imagePullPolicy: Always")
+			}
+		}
+		if strings.HasSuffix(container.Image, ":latest") {
+			// The k8s default for `:latest` images is `imagePullPolicy: Always`
+			// Check the job didn't override
+			if container.ImagePullPolicy != "" && container.ImagePullPolicy != "Always" {
+				return errors.New("job uses latest tag, but does not specify imagePullPolicy: Always")
+			}
+		}
+
+	}
+	return nil
+}
+
+// Make sure jobs that use `latest-*` tags specify `imagePullPolicy: Always`
+func TestLatestUsesImagePullPolicy(t *testing.T) {
+	c, err := Load("../config.yaml")
+	if err != nil {
+		t.Fatalf("Could not load config: %v", err)
+	}
+
+	for _, pres := range c.Presubmits {
+		for _, presubmit := range pres {
+			if presubmit.Spec != nil {
+				if err := CheckLatestUsesImagePullPolicy(presubmit.Spec); err != nil {
+					t.Errorf("Error in presubmit %q: %v", presubmit.Name, err)
+				}
+			}
+		}
+	}
+
+	for _, posts := range c.Postsubmits {
+		for _, postsubmit := range posts {
+			if postsubmit.Spec != nil {
+				if err := CheckLatestUsesImagePullPolicy(postsubmit.Spec); err != nil {
+					t.Errorf("Error in postsubmit %q: %v", postsubmit.Name, err)
+				}
+			}
+		}
+	}
+
+	for _, periodic := range c.Periodics {
+		if periodic.Spec != nil {
+			if err := CheckLatestUsesImagePullPolicy(periodic.Spec); err != nil {
+				t.Errorf("Error in periodic %q: %v", periodic.Name, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
When a prow job specifies a mutable tag (e.g. `latest-.*`), we check
that it also specifies an imagePullPolicy of Always.