### PR TITLE
Bump gcloud to 177.0.0 & kubekins to v20171027-35f67f55

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/bootstrap/Makefile
+++ b/images/bootstrap/Makefile
@@ -18,7 +18,7 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 all: build
 
 build:
-	docker build -t $(IMG):$(TAG) .
+	docker build --no-cache -t $(IMG):$(TAG) .
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with latest
 

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
 LABEL maintainer "beacham@google.com"
 
 RUN apt-get update && apt-get install -y \

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20171023-2aeb38db
+FROM gcr.io/k8s-testimages/bootstrap:v20171027-3ea22ce6
 LABEL maintainer "Sen Lu <senlu@google.com>"
 
 # install go

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -369,7 +369,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -468,7 +468,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -565,7 +565,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1483,7 +1483,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1582,7 +1582,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1679,7 +1679,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2933,7 +2933,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3051,7 +3051,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3094,7 +3094,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3137,7 +3137,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3255,7 +3255,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3298,7 +3298,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3640,7 +3640,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3683,7 +3683,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3726,7 +3726,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3769,7 +3769,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -17351,7 +17351,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -17470,7 +17470,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17515,7 +17515,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17632,7 +17632,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17677,7 +17677,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-fd39b094
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-8b67bb00
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -263,7 +263,7 @@ presubmits:
       trigger: "(?m)^/test( all| pull-cri-containerd-node-e2e),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
           args:
           - --root=/go/src
           - "--clean"
@@ -795,7 +795,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -858,7 +858,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -921,7 +921,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -968,7 +968,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1030,7 +1030,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1102,7 +1102,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1171,7 +1171,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1255,7 +1255,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1310,7 +1310,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -1365,7 +1365,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -1909,7 +1909,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1972,7 +1972,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2035,7 +2035,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2081,7 +2081,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2143,7 +2143,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2215,7 +2215,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2284,7 +2284,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2368,7 +2368,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2423,7 +2423,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -2478,7 +2478,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -3488,7 +3488,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --root=/go/src
       - "--clean"
@@ -3550,7 +3550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3583,7 +3583,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3826,7 +3826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3860,7 +3860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3894,7 +3894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3928,7 +3928,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3962,7 +3962,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3996,7 +3996,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4030,7 +4030,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4064,7 +4064,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4098,7 +4098,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4132,7 +4132,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4166,7 +4166,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4200,7 +4200,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4234,7 +4234,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4268,7 +4268,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4302,7 +4302,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4336,7 +4336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4370,7 +4370,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4404,7 +4404,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4438,7 +4438,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4509,7 +4509,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4545,7 +4545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4581,7 +4581,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4617,7 +4617,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4653,7 +4653,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4689,7 +4689,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4725,7 +4725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4761,7 +4761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4797,7 +4797,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4833,7 +4833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4869,7 +4869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4905,7 +4905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4941,7 +4941,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4977,7 +4977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5013,7 +5013,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5049,7 +5049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5085,7 +5085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5121,7 +5121,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5157,7 +5157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5193,7 +5193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5229,7 +5229,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5265,7 +5265,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5301,7 +5301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5337,7 +5337,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5373,7 +5373,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5409,7 +5409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5445,7 +5445,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5481,7 +5481,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5517,7 +5517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5553,7 +5553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5589,7 +5589,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5625,7 +5625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5661,7 +5661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5697,7 +5697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5733,7 +5733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5769,7 +5769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5805,7 +5805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5841,7 +5841,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5877,7 +5877,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5913,7 +5913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5947,7 +5947,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5981,7 +5981,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6015,7 +6015,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6049,7 +6049,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6083,7 +6083,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6117,7 +6117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6151,7 +6151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6185,7 +6185,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6219,7 +6219,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6253,7 +6253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6287,7 +6287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6321,7 +6321,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6355,7 +6355,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6389,7 +6389,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6423,7 +6423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6457,7 +6457,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6491,7 +6491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6525,7 +6525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6559,7 +6559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6593,7 +6593,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6627,7 +6627,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6661,7 +6661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6695,7 +6695,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6729,7 +6729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6763,7 +6763,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6797,7 +6797,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6831,7 +6831,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6865,7 +6865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6899,7 +6899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6933,7 +6933,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6967,7 +6967,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7001,7 +7001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7035,7 +7035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7069,7 +7069,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7103,7 +7103,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7137,7 +7137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7171,7 +7171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7205,7 +7205,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7239,7 +7239,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7273,7 +7273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7307,7 +7307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7341,7 +7341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7375,7 +7375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7409,7 +7409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7443,7 +7443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7477,7 +7477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7511,7 +7511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7580,7 +7580,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7614,7 +7614,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7648,7 +7648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7682,7 +7682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7716,7 +7716,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7750,7 +7750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7784,7 +7784,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7818,7 +7818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7852,7 +7852,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7886,7 +7886,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7920,7 +7920,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7954,7 +7954,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7988,7 +7988,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8022,7 +8022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8056,7 +8056,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8078,7 +8078,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -8115,7 +8115,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=240
@@ -8153,7 +8153,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -8190,7 +8190,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=240
@@ -8227,7 +8227,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -8264,7 +8264,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -8315,7 +8315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8351,7 +8351,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8387,7 +8387,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8423,7 +8423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8459,7 +8459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8495,7 +8495,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8531,7 +8531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8567,7 +8567,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8603,7 +8603,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8639,7 +8639,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8675,7 +8675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8711,7 +8711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8747,7 +8747,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8783,7 +8783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8819,7 +8819,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8855,7 +8855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8891,7 +8891,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8927,7 +8927,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8961,7 +8961,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8995,7 +8995,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9029,7 +9029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9063,7 +9063,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9097,7 +9097,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9131,7 +9131,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9165,7 +9165,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9199,7 +9199,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9233,7 +9233,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9267,7 +9267,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9301,7 +9301,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9335,7 +9335,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9369,7 +9369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9403,7 +9403,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9437,7 +9437,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9471,7 +9471,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9505,7 +9505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9539,7 +9539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9573,7 +9573,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9607,7 +9607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9641,7 +9641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9675,7 +9675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9709,7 +9709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9743,7 +9743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9777,7 +9777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9811,7 +9811,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9846,7 +9846,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9880,7 +9880,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9914,7 +9914,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9948,7 +9948,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9982,7 +9982,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10016,7 +10016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10050,7 +10050,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10084,7 +10084,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10118,7 +10118,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10152,7 +10152,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10186,7 +10186,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10220,7 +10220,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10254,7 +10254,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10288,7 +10288,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10322,7 +10322,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10356,7 +10356,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10390,7 +10390,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10424,7 +10424,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10458,7 +10458,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10492,7 +10492,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10526,7 +10526,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10560,7 +10560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10594,7 +10594,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10628,7 +10628,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10662,7 +10662,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10696,7 +10696,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10730,7 +10730,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10764,7 +10764,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10798,7 +10798,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10832,7 +10832,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10866,7 +10866,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10900,7 +10900,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10934,7 +10934,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10968,7 +10968,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11002,7 +11002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11036,7 +11036,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11070,7 +11070,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11104,7 +11104,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11138,7 +11138,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11172,7 +11172,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11206,7 +11206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11240,7 +11240,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11274,7 +11274,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11308,7 +11308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11342,7 +11342,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11376,7 +11376,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11410,7 +11410,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11444,7 +11444,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11478,7 +11478,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11512,7 +11512,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11546,7 +11546,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11580,7 +11580,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11614,7 +11614,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11648,7 +11648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11682,7 +11682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11716,7 +11716,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11785,7 +11785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11819,7 +11819,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11853,7 +11853,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11887,7 +11887,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11921,7 +11921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11955,7 +11955,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11989,7 +11989,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12023,7 +12023,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12057,7 +12057,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12091,7 +12091,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12125,7 +12125,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12159,7 +12159,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12193,7 +12193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12227,7 +12227,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12261,7 +12261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12295,7 +12295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12330,7 +12330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12364,7 +12364,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12398,7 +12398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12432,7 +12432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12466,7 +12466,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12500,7 +12500,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12534,7 +12534,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12568,7 +12568,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12602,7 +12602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12636,7 +12636,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12670,7 +12670,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12704,7 +12704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12738,7 +12738,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12772,7 +12772,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12806,7 +12806,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12840,7 +12840,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12874,7 +12874,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12908,7 +12908,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12942,7 +12942,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12976,7 +12976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13010,7 +13010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13044,7 +13044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13078,7 +13078,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13112,7 +13112,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13146,7 +13146,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13180,7 +13180,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13214,7 +13214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13248,7 +13248,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13282,7 +13282,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13316,7 +13316,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13350,7 +13350,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13384,7 +13384,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13418,7 +13418,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13452,7 +13452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13486,7 +13486,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13520,7 +13520,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13554,7 +13554,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13588,7 +13588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13622,7 +13622,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13656,7 +13656,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13690,7 +13690,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13724,7 +13724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13758,7 +13758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13792,7 +13792,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13826,7 +13826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13860,7 +13860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13894,7 +13894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13928,7 +13928,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13964,7 +13964,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14000,7 +14000,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14036,7 +14036,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14072,7 +14072,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14108,7 +14108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14144,7 +14144,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14180,7 +14180,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14216,7 +14216,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14252,7 +14252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14288,7 +14288,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14324,7 +14324,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14360,7 +14360,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14397,7 +14397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14433,7 +14433,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14469,7 +14469,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14505,7 +14505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14541,7 +14541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14577,7 +14577,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14613,7 +14613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14649,7 +14649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14685,7 +14685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14721,7 +14721,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14757,7 +14757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14793,7 +14793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14829,7 +14829,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14865,7 +14865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14901,7 +14901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14935,7 +14935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14971,7 +14971,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15102,7 +15102,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15145,7 +15145,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15188,7 +15188,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15231,7 +15231,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15274,7 +15274,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15317,7 +15317,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15358,7 +15358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15470,7 +15470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15509,7 +15509,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15548,7 +15548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15587,7 +15587,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15626,7 +15626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15665,7 +15665,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15704,7 +15704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15743,7 +15743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15782,7 +15782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15821,7 +15821,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15860,7 +15860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15899,7 +15899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15938,7 +15938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15977,7 +15977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16016,7 +16016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16055,7 +16055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16094,7 +16094,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16133,7 +16133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16172,7 +16172,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16211,7 +16211,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16250,7 +16250,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16289,7 +16289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16328,7 +16328,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16367,7 +16367,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16426,7 +16426,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16463,7 +16463,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16500,7 +16500,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16537,7 +16537,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16574,7 +16574,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -16611,7 +16611,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -16648,7 +16648,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.8
       args:
       - --repo=k8s.io/kubernetes=release-1.8
       - --timeout=90
@@ -16685,7 +16685,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -16722,7 +16722,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -16772,7 +16772,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16807,7 +16807,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16842,7 +16842,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16877,7 +16877,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16912,7 +16912,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16947,7 +16947,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16982,7 +16982,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17017,7 +17017,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17040,7 +17040,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -17076,7 +17076,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-bbb003a8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171027-35f67f55-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171027-bbb003a8-master'
+DEFAULT_KUBEKINS_TAG = 'v20171027-35f67f55-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
* add --no-cache option to bootstrap image, as it tend to use cached gcloud :-(
* ref https://github.com/kubernetes/test-infra/pull/5220, we need gcloud 177.0.0 for --region flag
* includes recent kubetest changes:
- https://github.com/kubernetes/test-infra/pull/5193
- https://github.com/kubernetes/test-infra/pull/4371

/hold
waiting for canaries
cc @wojtek-t 