### PR TITLE
cleanup / add bazel canary jobs

### DIFF
--- a/images/bazelbuild/Makefile
+++ b/images/bazelbuild/Makefile
@@ -15,19 +15,27 @@
 IMG = gcr.io/k8s-testimages/bazelbuild
 TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
-BAZEL_VERSIONS=0.5.2 0.5.4 0.6.1
+# TODO(bentheelder): retire some of these as they become unnecessary
+LATEST_BAZEL_VERSION=0.7.0
+BAZEL_VERSIONS=0.5.2 0.5.4 0.6.1 $(LATEST_BAZEL_VERSION)
 
 all: build
 
 do_build = \
 	docker build --pull --build-arg BAZEL_VERSION=$(VERSION) -t $(IMG):$(TAG)-$(VERSION) .;\
 	docker tag $(IMG):$(TAG)-$(VERSION) $(IMG):latest-$(VERSION);\
-	echo Built $(IMG):$(TAG)-$(VERSION) and tagged with latest-$(VERSION);
+	echo Built $(IMG):$(TAG)-$(VERSION) and tagged with latest-$(VERSION);\
+	[ "$(VERSION)" == "$(LATEST_BAZEL_VERSION)" ] &&\
+	docker tag $(IMG):$(TAG)-$(VERSION) $(IMG):latest-latest &&\
+	echo tagged $(IMG) with latest-latest tag;
 
 do_push = \
 	gcloud docker -- push $(IMG):$(TAG)-$(VERSION);\
 	gcloud docker -- push $(IMG):latest-$(VERSION);\
-	echo Pushed $(IMG) with $(TAG)-$(VERSION) and latest-$(VERSION) tags;
+	echo Pushed $(IMG) with $(TAG)-$(VERSION) and latest-$(VERSION) tags;\
+	[ "$(VERSION)" == "$(LATEST_BAZEL_VERSION)" ] &&\
+	gcloud docker -- push $(IMG):latest-latest &&\
+	echo Pushed $(IMG) with latest-latest tag;
 
 build:
 	@$(foreach VERSION,$(BAZEL_VERSIONS),$(do_build))

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9371,7 +9371,21 @@
       "sig-testing"
     ]
   },
+  "pull-kubernetes-bazel-build-canary": {
+    "args": [],
+    "scenario": "kubernetes_bazel",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "pull-kubernetes-bazel-test": {
+    "args": [],
+    "scenario": "kubernetes_bazel",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
+  "pull-kubernetes-bazel-test-canary": {
     "args": [],
     "scenario": "kubernetes_bazel",
     "sigOwners": [
@@ -9632,25 +9646,14 @@
     ]
   },
   "pull-test-infra-bazel": {
-    "args": [
-      "--build=//...",
-      "--install=gubernator/test_requirements.txt",
-      "--test=//... //verify:verify-all",
-      "--test-args=--test_output=errors"
-    ],
+    "args": [],
     "scenario": "kubernetes_bazel",
     "sigOwners": [
       "sig-testing"
     ]
   },
   "pull-test-infra-bazel-canary": {
-    "args": [
-      "--batch",
-      "--build=//...",
-      "--install=gubernator/test_requirements.txt",
-      "--test=//... //verify:verify-all",
-      "--test-args=--test_output=errors"
-    ],
+    "args": [],
     "scenario": "kubernetes_bazel",
     "sigOwners": [
       "sig-testing"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -606,6 +606,53 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+
+  - name: pull-kubernetes-bazel-build-canary
+    agent: kubernetes
+    context: pull-kubernetes-bazel-build-canary
+    always_run: false
+    rerun_command: "/test pull-kubernetes-bazel-build-canary"
+    trigger: "(?m)^/test pull-kubernetes-bazel-build-canary,?(\\s+|$)"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+        imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
+        - "--build=//... -//vendor/..."
+        - "--release=//build/release-tars"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   - name: pull-kubernetes-bazel-test
     agent: kubernetes
     context: pull-kubernetes-bazel-test
@@ -746,6 +793,56 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+
+  - name: pull-kubernetes-bazel-test-canary
+    agent: kubernetes
+    context: pull-kubernetes-bazel-test-canary
+    always_run: false
+    rerun_command: "/test pull-kubernetes-bazel-test-canary"
+    trigger: "(?m)^/test pull-kubernetes-bazel-test-canary,?(\\s+|$)"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+        imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
+        - "--test=//... -//build/... -//vendor/..."
+        - "--manual-test=//hack:verify-all"
+        - "--test-args=--build_tag_filters=-e2e,-integration"
+        - "--test-args=--test_tag_filters=-e2e,-integration"
+        - "--test-args=--flaky_test_attempts=3"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   - name: pull-kubernetes-cross
     agent: jenkins
     context: pull-kubernetes-cross
@@ -1720,6 +1817,51 @@ presubmits:
         - name: cache-ssd
           hostPath:
             path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-bazel-build-canary
+    agent: kubernetes
+    context: pull-securitykubernetes-bazel-build-canary
+    always_run: false
+    rerun_command: "/test pull-security-kubernetes-bazel-build-canary"
+    trigger: "(?m)^/test pull-security-kubernetes-bazel-build-canary,?(\\s+|$)"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+        imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
+        - "--build=//... -//vendor/..."
+        - "--release=//build/release-tars"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
   - name: pull-security-kubernetes-bazel-test
     agent: kubernetes
     context: pull-security-kubernetes-bazel-test
@@ -1860,6 +2002,55 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-bazel-test-canary
+    agent: kubernetes
+    context: pull-security-kubernetes-bazel-test-canary
+    always_run: false
+    rerun_command: "/test pull-security-kubernetes-bazel-test-canary"
+    trigger: "(?m)^/test pull-security-kubernetes-bazel-test-canary,?(\\s+|$)"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
+        imagePullPolicy: Always
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
+        - "--test=//... -//build/... -//vendor/..."
+        - "--manual-test=//hack:verify-all"
+        - "--test-args=--build_tag_filters=-e2e,-integration"
+        - "--test-args=--test_tag_filters=-e2e,-integration"
+        - "--test-args=--flaky_test_attempts=3"
+        env:
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+
   - name: pull-security-kubernetes-cross
     agent: jenkins
     context: pull-security-kubernetes-cross
@@ -2554,6 +2745,11 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--build=//..."
+        - "--install=gubernator/test_requirements.txt"
+        - "--test=//... //verify:verify-all"
+        - "--test-args=--test_output=errors"
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
@@ -2587,7 +2783,7 @@ presubmits:
     trigger: "(?m)^/test pull-test-infra-bazel-canary,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:latest-0.7.0
+      - image: gcr.io/k8s-testimages/bazelbuild:latest-latest
         imagePullPolicy: Always
         args:
         - "--clean"
@@ -2596,6 +2792,12 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--" # end bootstrap args, scenario args below
+        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
+        - "--build=//..."
+        - "--install=gubernator/test_requirements.txt"
+        - "--test=//... //verify:verify-all"
+        - "--test-args=--test_output=errors"
         env:
         - name: TEST_TMPDIR
           value: /root/.cache/bazel

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1819,7 +1819,7 @@ presubmits:
             path: /mnt/disks/ssd0
   - name: pull-security-kubernetes-bazel-build-canary
     agent: kubernetes
-    context: pull-securitykubernetes-bazel-build-canary
+    context: pull-security-kubernetes-bazel-build-canary
     always_run: false
     rerun_command: "/test pull-security-kubernetes-bazel-build-canary"
     trigger: "(?m)^/test pull-security-kubernetes-bazel-build-canary,?(\\s+|$)"

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -540,7 +540,9 @@ func TestBazelbuildArgs(t *testing.T) {
 	}
 	pinnedJobs := map[string]string{
 		//job: reason for pinning
-		"pull-test-infra-bazel-canary": "canary testing the latest bazelbuild",
+		"pull-test-infra-bazel-canary":       "canary testing the latest bazel",
+		"pull-kubernetes-bazel-build-canary": "canary testing the latest bazel",
+		"pull-kubernetes-bazel-test-canary":  "canary testing the latest bazel",
 	}
 	maxTag := ""
 	maxN := 0

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -544,6 +544,12 @@ func TestBazelbuildArgs(t *testing.T) {
 		"pull-kubernetes-bazel-build-canary": "canary testing the latest bazel",
 		"pull-kubernetes-bazel-test-canary":  "canary testing the latest bazel",
 	}
+	// auto insert pull-security-kubernetes-*
+	for job, reason := range pinnedJobs {
+		if strings.HasPrefix(job, "pull-kubernetes") {
+			pinnedJobs[strings.Replace(job, "pull-kubernetes", "pull-security-kubernetes", 1)] = reason
+		}
+	}
 	maxTag := ""
 	maxN := 0
 	for t, js := range tags {

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1471,12 +1471,20 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
+- name: pull-kubernetes-bazel-build-canary
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-build-canary
+  days_of_results: 1
+  num_columns_recent: 20
 - name: pull-kubernetes-bazel-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-test
   days_of_results: 1
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
+- name: pull-kubernetes-bazel-test-canary
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-bazel-test-canary
+  days_of_results: 1
+  num_columns_recent: 20
 - name: pull-kubernetes-cross
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-cross
   days_of_results: 1
@@ -3773,6 +3781,14 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-scalability-canary
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: test-infra-bazel-canary
+    test_group_name: pull-test-infra-bazel-canary
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: bazel-build-canary
+    test_group_name: pull-kubernetes-bazel-build-canary
+  - name: bazel-test-canary
+    test_group_name: pull-kubernetes-bazel-test-canary
 
 - name: sig-ui
   dashboard_tab:


### PR DESCRIPTION
This also tags the latest and greatest bazel-version-image with `latest-latest` so the canary jobs can always use that tag.