### PR TITLE
Fix typo in community repo mungegithub config.

### DIFF
--- a/mungegithub/submit-queue/deployment/community/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/community/configmap.yaml
@@ -6,7 +6,7 @@ project: community
 # Otherwise it's going to take an extra-cycle to detect the label change.
 # Run blunderbuss before approval-handler, so that we can suggest approvers
 # based on assigned reviewer.
-pr-mungers: blunderbuss,close-stale,comment-deleter,lgtm-after-commit,needs-rebase,owner-labels,sig-mention-handler,submit-queue
+pr-mungers: blunderbuss,close-stale,comment-deleter,lgtm-after-commit,needs-rebase,owner-label,sig-mention-handler,submit-queue
 state: open
 token-file: /etc/secret-volume/token
 period: 5m


### PR DESCRIPTION
Oops, I should have noticed that.
I deployed the config with this change.
/cc @cblecker 
ref #5207 