### PR TITLE
Build untrusted PR once when it is approved.

### DIFF
--- a/prow/plugins/trigger/pr.go
+++ b/prow/plugins/trigger/pr.go
@@ -60,8 +60,8 @@ func handlePR(c client, trustedOrg string, pr github.PullRequestEvent) error {
 			return buildAll(c, pr.PullRequest)
 		}
 	case github.PullRequestActionLabeled:
-		// When a PR is LGTMd, if it is untrusted then build it once.
-		if pr.Label.Name == lgtmLabel {
+		// When a PR is approved or LGTMd, if it is untrusted then build it once.
+		if pr.Label.Name == approvedLabel || pr.Label.Name == lgtmLabel {
 			trusted, err := trustedPullRequest(c.GitHubClient, pr.PullRequest, trustedOrg)
 			if err != nil {
 				return fmt.Errorf("could not validate PR: %s", err)

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	pluginName = "trigger"
-	lgtmLabel  = "lgtm"
+	pluginName    = "trigger"
+	lgtmLabel     = "lgtm"
+	approvedLabel = "approved"
 )
 
 func init() {


### PR DESCRIPTION
When an untrusted PR is approved, allow it to test once, as what is done for untrusted lgtm'd PR.
/cc @cjwagner
WDYT?