### PR TITLE
Include build tag into kubetest binary

### DIFF
--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -38,7 +38,7 @@ endif
 all: build
 
 kubetest:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubetest ../../kubetest
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o kubetest -ldflags "-X main.BuildTag=${TAG}" ../../kubetest
 
 build: kubetest
 	@echo Building with go:$(GO) and bazel:$(BAZEL)

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -11,6 +11,9 @@ go_binary(
     name = "kubetest",
     importpath = "k8s.io/test-infra/kubetest",
     library = ":go_default_library",
+    x_defs = {
+        "main.BuildTag": "{DOCKER_TAG}",  # keep
+    },
 )
 
 go_library(

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -42,6 +42,12 @@ import (
 const defaultGinkgoParallel = 25
 
 var (
+	// BuildTag is set by the build process to diagnostic information to identify the build,
+	// ideally including the git SHA
+	BuildTag = ""
+)
+
+var (
 	artifacts = filepath.Join(os.Getenv("WORKSPACE"), "_artifacts")
 	interrupt = time.NewTimer(time.Duration(0)) // interrupt testing at this time.
 	terminate = time.NewTimer(time.Duration(0)) // terminate testing at this time.
@@ -287,6 +293,8 @@ func validateFlags(o *options) error {
 }
 
 func main() {
+	fmt.Fprintf(os.Stderr, "kubetest (tag:%s)\n", BuildTag)
+
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
 	o := defineFlags()


### PR DESCRIPTION
And print it at start.  Should appear in build messages, and make any
kubetest-skew issues very obvious.