### PR TITLE
Log dump: support for dumping additional IPs

### DIFF
--- a/kubetest/dump_test.go
+++ b/kubetest/dump_test.go
@@ -376,3 +376,71 @@ func (m *mockSSHClient) ExecPiped(ctx context.Context, command string, stdout io
 
 	return fmt.Errorf("unexpected command: %s", command)
 }
+
+func TestFindInstancesNotDumped(t *testing.T) {
+	n1 := &node{
+		Status: nodeStatus{
+			Addresses: []nodeAddress{{Address: "10.0.0.1"}},
+		},
+	}
+
+	n2 := &node{
+		Status: nodeStatus{
+			Addresses: []nodeAddress{{Address: "10.0.0.2"}},
+		},
+	}
+	n3 := &node{
+		Status: nodeStatus{
+			Addresses: []nodeAddress{
+				{Address: "10.0.0.3"},
+				{Address: "10.0.3.3"},
+			},
+		},
+	}
+
+	grid := []struct {
+		ips      []string
+		dumped   []*node
+		expected []string
+	}{
+		{
+			ips:      nil,
+			dumped:   nil,
+			expected: nil,
+		},
+		{
+			ips:      []string{"10.0.0.1"},
+			dumped:   nil,
+			expected: []string{"10.0.0.1"},
+		},
+		{
+			ips:      []string{"10.0.0.1"},
+			dumped:   []*node{n1},
+			expected: nil,
+		},
+		{
+			ips:      []string{"10.0.0.1", "10.0.0.2"},
+			dumped:   []*node{n1},
+			expected: []string{"10.0.0.2"},
+		},
+		{
+			ips:      []string{"10.0.0.1", "10.0.0.2", "10.0.3.3"},
+			dumped:   []*node{n1, n2, n3},
+			expected: nil,
+		},
+		{
+			ips:      []string{"10.0.0.1", "10.0.0.2", "10.0.3.3"},
+			dumped:   []*node{n1, n2},
+			expected: []string{"10.0.3.3"},
+		},
+	}
+
+	for _, g := range grid {
+		actual := findInstancesNotDumped(g.ips, g.dumped)
+
+		if !reflect.DeepEqual(actual, g.expected) {
+			t.Errorf("unexpected result from findInstancesNotDumped.  actual=%v, expected=%v", actual, g.expected)
+			continue
+		}
+	}
+}

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -344,7 +345,7 @@ func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
 
 	finished := make(chan error)
 	go func() {
-		finished <- logDumper.DumpAllNodes(ctx)
+		finished <- k.dumpAllNodes(ctx, logDumper)
 	}()
 
 	for {
@@ -355,6 +356,32 @@ func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
 			return err
 		}
 	}
+}
+
+// dumpAllNodes connects to every node and dumps the logs
+func (k *kops) dumpAllNodes(ctx context.Context, d *logDumper) error {
+	var additionalIPs []string
+	dump, err := runKopsDump(k.cluster)
+	if err != nil {
+		log.Printf("unable to get cluster status from kops: %v", err)
+	} else {
+		for _, instance := range dump.Instances {
+			name := instance.Name
+
+			if len(instance.PublicAddresses) == 0 {
+				log.Printf("ignoring instance in kops status with no public address: %v", name)
+				continue
+			}
+
+			additionalIPs = append(additionalIPs, instance.PublicAddresses[0])
+		}
+	}
+
+	if err := d.DumpAllNodes(ctx, additionalIPs); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (k kops) TestSetup() error {
@@ -386,4 +413,41 @@ func (k kops) Down() error {
 
 func (k kops) GetClusterCreated(gcpProject string) (time.Time, error) {
 	return time.Time{}, errors.New("not implemented")
+}
+
+// kopsDump is the format of data as dumped by `kops toolbox dump -ojson`
+type kopsDump struct {
+	Instances []*kopsDumpInstance `json:"instances"`
+}
+
+// String implements fmt.Stringer
+func (o *kopsDump) String() string {
+	return jsonForDebug(o)
+}
+
+// kopsDumpInstance is the format of an instance (machine) in a kops dump
+type kopsDumpInstance struct {
+	Name            string   `json:"name"`
+	PublicAddresses []string `json:"publicAddresses"`
+}
+
+// String implements fmt.Stringer
+func (o *kopsDumpInstance) String() string {
+	return jsonForDebug(o)
+}
+
+// runKopsDump runs a kops toolbox dump to dump the status of the cluster
+func runKopsDump(clusterName string) (*kopsDump, error) {
+	o, err := output(exec.Command("kops", "toolbox", "dump", "--name", clusterName, "-ojson"))
+	if err != nil {
+		log.Printf("error running kops toolbox dump: %s\n%s", wrapError(err).Error(), string(o))
+		return nil, err
+	}
+
+	dump := &kopsDump{}
+	if err := json.Unmarshal(o, dump); err != nil {
+		return nil, fmt.Errorf("error parsing kops toolbox dump output: %v", err)
+	}
+
+	return dump, nil
 }

--- a/kubetest/util.go
+++ b/kubetest/util.go
@@ -531,3 +531,16 @@ func getLatestClusterUpTime(gcloudJSON string) (time.Time, error) {
 	// this returns time.Time{} if no ig exists, which will always force a new cluster
 	return latest, nil
 }
+
+// jsonForDebug returns a json representation of the value, or a string representation of an error
+// It is useful for an easy implementation of fmt.Stringer
+func jsonForDebug(o interface{}) string {
+	if o == nil {
+		return "nil"
+	}
+	v, err := json.Marshal(o)
+	if err != nil {
+		return fmt.Sprintf("error[%v]", err)
+	}
+	return string(v)
+}


### PR DESCRIPTION
DumpAllNodes now takes an additional list of IP addresses.  Dumping
through kubectl get nodes is still preferred, but if an IP address is
specified that was not found in that list of nodes, then that IP address
will be dumped also.

This allows for the installation tool to provide an additional list of
IPs that is finds e.g. via cloud APIs, and that thus log dumping will
still work for nodes that fail to register with the cluster (or even if
the entire cluster fails to come up)