### PR TITLE
Trust a PR if it doesn't have "needs-ok-to-test"

### DIFF
--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -48,6 +48,7 @@ type githubClient interface {
 	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 	RemoveLabel(org, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }
 
 type kubeClient interface {


### PR DESCRIPTION
cblecker wrote here: https://github.com/kubernetes/test-infra/issues/5239#issuecomment-340206865
>A similar situation can occur if you delete an "/ok-to-test" comment.. then the bots don't know that the PR is "trusted".

IMO, if the `/ok-to-test` is deleted, we can still think the PR to be trusted. If the `needs-ok-to-test` label is removed by maintainer manually, the PR also can be truested.

@cblecker @cjwagner WDYT?