### PR TITLE
Migrate regional e2e tests to use gcloud beta again

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -6076,7 +6076,7 @@
       "--gcp-project=k8s-jkns-e2e-regional",
       "--gcp-region=us-central1",
       "--ginkgo-parallel",
-      "--gke-command-group=alpha",
+      "--gke-command-group=beta",
       "--gke-environment=test",
       "--provider=gke",
       "--test_args=--gce-multizone=true --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",


### PR DESCRIPTION
(Reverts kubernetes/test-infra#5219)

Now that https://github.com/kubernetes/test-infra/pull/5226 is merged, gcloud is at 177.0.0, so this change should no longer be breaking.

/cc @wojtek-t 