### PR TITLE
Let kubetest save cluster state regardless of test failures

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -268,6 +268,15 @@ func run(deploy deployer, o options) error {
 		}))
 	}
 
+	// Save the state if we upped a new cluster without downing it
+	// or we are turning up federated clusters without turning up
+	// the federation control plane.
+	if o.save != "" && ((!o.down && o.up) || (!o.federation && o.up && o.deployment != "none")) {
+		errs = appendError(errs, xmlWrap("Save Cluster State", func() error {
+			return saveState(o.save)
+		}))
+	}
+
 	if o.checkLeaks {
 		log.Print("Sleeping for 30 seconds...") // Wait for eventually consistent listing
 		time.Sleep(30 * time.Second)

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -405,15 +405,6 @@ func complete(o *options) error {
 		return err
 	}
 
-	// Save the state if we upped a new cluster without downing it
-	// or we are turning up federated clusters without turning up
-	// the federation control plane.
-	if o.save != "" && ((!o.down && o.up) || (!o.federation && o.up && o.deployment != "none")) {
-		if err := saveState(o.save); err != nil {
-			return err
-		}
-	}
-
 	// Publish the successfully tested version when requested
 	if o.publish != "" {
 		if err := publish(o.publish); err != nil {


### PR DESCRIPTION
ref #5253 moved the save logic into e2e.go

Current code path will skip saving kubeconfig if we up the cluster but fail the e2e test, and the following runs will not be able to find the previous soak cluster.

We should still save the cluster state regardless of test passed or failed.

/assign @fejta @wojtek-t @BenTheElder 