### PR TITLE
Bump kubekins to v20171030-bcf1a6a2

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
 LABEL maintainer "beacham@google.com"
 
 RUN apt-get update && apt-get install -y \

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -369,7 +369,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -468,7 +468,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -565,7 +565,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1580,7 +1580,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1679,7 +1679,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -1776,7 +1776,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -3135,7 +3135,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3253,7 +3253,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3296,7 +3296,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3339,7 +3339,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3457,7 +3457,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3500,7 +3500,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -3842,7 +3842,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3885,7 +3885,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3928,7 +3928,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -3971,7 +3971,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -17587,7 +17587,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -17706,7 +17706,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17751,7 +17751,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -17868,7 +17868,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -17913,7 +17913,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171029-aade2840
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171030-e52272c1
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -263,7 +263,7 @@ presubmits:
       trigger: "(?m)^/test( all| pull-cri-containerd-node-e2e),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
           args:
           - --root=/go/src
           - "--clean"
@@ -892,7 +892,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -955,7 +955,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1018,7 +1018,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1065,7 +1065,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1127,7 +1127,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1199,7 +1199,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1268,7 +1268,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1352,7 +1352,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1407,7 +1407,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -1462,7 +1462,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -2100,7 +2100,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2163,7 +2163,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2226,7 +2226,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2272,7 +2272,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2334,7 +2334,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2406,7 +2406,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2475,7 +2475,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-kops-aws-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2559,7 +2559,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2614,7 +2614,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -2669,7 +2669,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -3690,7 +3690,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --root=/go/src
       - "--clean"
@@ -3752,7 +3752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -3785,7 +3785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4028,7 +4028,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4062,7 +4062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4096,7 +4096,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4130,7 +4130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4164,7 +4164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4198,7 +4198,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4232,7 +4232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4266,7 +4266,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4300,7 +4300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4334,7 +4334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4368,7 +4368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4402,7 +4402,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4436,7 +4436,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4470,7 +4470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4504,7 +4504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4538,7 +4538,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4572,7 +4572,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4606,7 +4606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4640,7 +4640,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4711,7 +4711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4747,7 +4747,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4783,7 +4783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4819,7 +4819,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4855,7 +4855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4891,7 +4891,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4927,7 +4927,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4963,7 +4963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4999,7 +4999,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5035,7 +5035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5071,7 +5071,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5107,7 +5107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5143,7 +5143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5179,7 +5179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5215,7 +5215,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5251,7 +5251,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5287,7 +5287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5323,7 +5323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5359,7 +5359,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5395,7 +5395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5431,7 +5431,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5467,7 +5467,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5503,7 +5503,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5539,7 +5539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5575,7 +5575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5611,7 +5611,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5647,7 +5647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5683,7 +5683,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5719,7 +5719,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5755,7 +5755,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5791,7 +5791,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5827,7 +5827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5863,7 +5863,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5899,7 +5899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5935,7 +5935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5971,7 +5971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6007,7 +6007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6043,7 +6043,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6079,7 +6079,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6115,7 +6115,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6149,7 +6149,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6183,7 +6183,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6217,7 +6217,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6251,7 +6251,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6285,7 +6285,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6319,7 +6319,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6353,7 +6353,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6387,7 +6387,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6421,7 +6421,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6455,7 +6455,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6489,7 +6489,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6523,7 +6523,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6557,7 +6557,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6591,7 +6591,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6625,7 +6625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6659,7 +6659,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6693,7 +6693,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6727,7 +6727,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6761,7 +6761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6795,7 +6795,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6829,7 +6829,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6863,7 +6863,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6897,7 +6897,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6931,7 +6931,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6965,7 +6965,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6999,7 +6999,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7033,7 +7033,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7067,7 +7067,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7101,7 +7101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7135,7 +7135,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7169,7 +7169,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7203,7 +7203,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7237,7 +7237,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7271,7 +7271,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7305,7 +7305,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7339,7 +7339,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7373,7 +7373,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7407,7 +7407,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7441,7 +7441,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7475,7 +7475,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7509,7 +7509,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7543,7 +7543,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7577,7 +7577,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7611,7 +7611,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7645,7 +7645,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7679,7 +7679,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7713,7 +7713,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7782,7 +7782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7816,7 +7816,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7850,7 +7850,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7884,7 +7884,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7918,7 +7918,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7952,7 +7952,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7986,7 +7986,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8020,7 +8020,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8054,7 +8054,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8088,7 +8088,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8122,7 +8122,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8156,7 +8156,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8190,7 +8190,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8224,7 +8224,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8258,7 +8258,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8280,7 +8280,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -8317,7 +8317,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=240
@@ -8355,7 +8355,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -8392,7 +8392,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=240
@@ -8429,7 +8429,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -8466,7 +8466,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -8517,7 +8517,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8553,7 +8553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8589,7 +8589,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8625,7 +8625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8661,7 +8661,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8697,7 +8697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8733,7 +8733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8769,7 +8769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8805,7 +8805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8841,7 +8841,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8877,7 +8877,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8913,7 +8913,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8949,7 +8949,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8985,7 +8985,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9021,7 +9021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9057,7 +9057,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9093,7 +9093,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9129,7 +9129,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9163,7 +9163,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9197,7 +9197,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9231,7 +9231,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9265,7 +9265,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9299,7 +9299,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9333,7 +9333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9367,7 +9367,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9401,7 +9401,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9435,7 +9435,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9469,7 +9469,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9503,7 +9503,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9537,7 +9537,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9571,7 +9571,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9605,7 +9605,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9639,7 +9639,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9673,7 +9673,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9707,7 +9707,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9741,7 +9741,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9775,7 +9775,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9809,7 +9809,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171026-4fad18a0-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9843,7 +9843,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9877,7 +9877,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9911,7 +9911,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9945,7 +9945,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9979,7 +9979,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10013,7 +10013,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10047,7 +10047,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10082,7 +10082,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10116,7 +10116,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10150,7 +10150,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10184,7 +10184,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10218,7 +10218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10252,7 +10252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10286,7 +10286,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10320,7 +10320,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10354,7 +10354,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10388,7 +10388,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10422,7 +10422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10456,7 +10456,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10490,7 +10490,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10524,7 +10524,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10558,7 +10558,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10592,7 +10592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10626,7 +10626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10660,7 +10660,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10694,7 +10694,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10728,7 +10728,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10762,7 +10762,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10796,7 +10796,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10830,7 +10830,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10864,7 +10864,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10898,7 +10898,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10932,7 +10932,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10966,7 +10966,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11000,7 +11000,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11034,7 +11034,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11068,7 +11068,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11102,7 +11102,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11136,7 +11136,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11170,7 +11170,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11204,7 +11204,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11238,7 +11238,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11272,7 +11272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11306,7 +11306,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11340,7 +11340,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11374,7 +11374,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11408,7 +11408,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11442,7 +11442,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11476,7 +11476,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11510,7 +11510,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11544,7 +11544,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11578,7 +11578,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11612,7 +11612,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11646,7 +11646,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11680,7 +11680,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11714,7 +11714,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11748,7 +11748,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11782,7 +11782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11816,7 +11816,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11850,7 +11850,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11884,7 +11884,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11918,7 +11918,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11952,7 +11952,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12021,7 +12021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12055,7 +12055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12089,7 +12089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12123,7 +12123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12157,7 +12157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12191,7 +12191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12225,7 +12225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12259,7 +12259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12293,7 +12293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12327,7 +12327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12361,7 +12361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12395,7 +12395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12429,7 +12429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12463,7 +12463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12497,7 +12497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12531,7 +12531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12566,7 +12566,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12600,7 +12600,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12634,7 +12634,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12668,7 +12668,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12702,7 +12702,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12736,7 +12736,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12770,7 +12770,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12804,7 +12804,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12838,7 +12838,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12872,7 +12872,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12906,7 +12906,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12940,7 +12940,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12974,7 +12974,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13008,7 +13008,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13042,7 +13042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13076,7 +13076,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13110,7 +13110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13144,7 +13144,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13178,7 +13178,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13212,7 +13212,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13246,7 +13246,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13280,7 +13280,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13314,7 +13314,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13348,7 +13348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13382,7 +13382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13416,7 +13416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13450,7 +13450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13484,7 +13484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13518,7 +13518,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13552,7 +13552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13586,7 +13586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13620,7 +13620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13654,7 +13654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13688,7 +13688,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13722,7 +13722,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13756,7 +13756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13790,7 +13790,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13824,7 +13824,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13858,7 +13858,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13892,7 +13892,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13926,7 +13926,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13960,7 +13960,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13994,7 +13994,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14028,7 +14028,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14062,7 +14062,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14096,7 +14096,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14130,7 +14130,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14164,7 +14164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14200,7 +14200,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14236,7 +14236,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14272,7 +14272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14308,7 +14308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14344,7 +14344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14380,7 +14380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14416,7 +14416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14452,7 +14452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14488,7 +14488,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14524,7 +14524,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14560,7 +14560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14596,7 +14596,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14633,7 +14633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14669,7 +14669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14705,7 +14705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14741,7 +14741,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14777,7 +14777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14813,7 +14813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14849,7 +14849,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14885,7 +14885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14921,7 +14921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14957,7 +14957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14993,7 +14993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15029,7 +15029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15065,7 +15065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15101,7 +15101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15137,7 +15137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15171,7 +15171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15207,7 +15207,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15338,7 +15338,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15381,7 +15381,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15424,7 +15424,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15467,7 +15467,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15510,7 +15510,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15553,7 +15553,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15594,7 +15594,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15706,7 +15706,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15745,7 +15745,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15784,7 +15784,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15823,7 +15823,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15862,7 +15862,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15901,7 +15901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15940,7 +15940,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15979,7 +15979,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16018,7 +16018,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16057,7 +16057,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16096,7 +16096,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16135,7 +16135,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16174,7 +16174,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16213,7 +16213,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16252,7 +16252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16291,7 +16291,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16330,7 +16330,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16369,7 +16369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16408,7 +16408,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16447,7 +16447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16486,7 +16486,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16525,7 +16525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16564,7 +16564,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16603,7 +16603,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16662,7 +16662,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16699,7 +16699,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16736,7 +16736,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16773,7 +16773,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -16810,7 +16810,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -16847,7 +16847,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -16884,7 +16884,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.8
       args:
       - --repo=k8s.io/kubernetes=release-1.8
       - --timeout=90
@@ -16921,7 +16921,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -16958,7 +16958,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -17008,7 +17008,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17043,7 +17043,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17078,7 +17078,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17113,7 +17113,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17148,7 +17148,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17183,7 +17183,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17218,7 +17218,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17253,7 +17253,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17276,7 +17276,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -17312,7 +17312,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171029-c4db3be8-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171029-c4db3be8-master'
+DEFAULT_KUBEKINS_TAG = 'v20171030-bcf1a6a2-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
includes https://github.com/kubernetes/test-infra/pull/5255

Bump for all jobs since it might affect the overall behavior, but should be no-op except for jobs needs soaking behavior.

/hold