### PR TITLE
Revert "disable batch on test-infra-bazel-canary to verify that it fails agai…"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2793,6 +2793,7 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
+        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
         - "--build=//..."
         - "--install=gubernator/test_requirements.txt"
         - "--test=//... //verify:verify-all"


### PR DESCRIPTION
Reverts kubernetes/test-infra#5261

I think I [proved the point](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/test-infra/5137/pull-test-infra-bazel-canary/45/). We should consider migrating test-infra to 0.7 again now that we have a functioning work-around for the server abort.