### PR TITLE
Add quotes to stop spamming kubernetes maintainers

### DIFF
--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -31,7 +31,7 @@ const pluginName = "milestonestatus"
 
 var (
 	statusRegex   = regexp.MustCompile(`(?m)^/status\s+(.+)$`)
-	mustBeSigLead = "You must be a member of the @kubernetes/kubernetes-milestone-maintainers github team to add status labels."
+	mustBeSigLead = "You must be a member of the `@kubernetes/kubernetes-milestone-maintainers` github team to add status labels."
 	statusMap     = map[string]string{
 		"approved-for-milestone": "status/approved-for-milestone",
 		"in-progress":            "status/in-progress",


### PR DESCRIPTION
The quotes prevent github from notifying groups/people.

#5271

