### PR TITLE
planter DRY_RUN and documentation

### DIFF
--- a/planter/README.md
+++ b/planter/README.md
@@ -14,3 +14,16 @@ Then from `$GOPATH/src/k8s.io/kubernetes/` run:
  `./../planter/planter.sh make bazel-build`.
 
  For `test-infra` you can run eg `./planter/planter.sh bazel test //...`.
+
+## Options
+
+Planter repects the following environment variables:
+
+ - `TAG`: the planter image tag, this will default to the current stable version
+ used to build kubernetes, but you may override it with EG `TAG=0.6.1-1`
+ - `DRY_RUN`: if set planter will only echo the docker command that would have been run
+
+ - `HOME`: your home directory, this will be mounted in to the container
+ - `PWD`: will be set to the working directory in the image
+ - `USER`: used to run the image as the current user
+

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -27,4 +27,10 @@ REPO=${REPO:-${PWD}}
 VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --tmpfs /tmp:exec,mode=777"
 GID="$(id -g ${USER})"
 ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
-docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}
+# the final command to run
+CMD="docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}"
+if [ -n "${DRY_RUN+set}" ]; then
+    echo "${CMD}"
+else
+    ${CMD}
+fi


### PR DESCRIPTION
Adds a new `DRY_RUN= planter/planter.sh ...` mode which will only echo the constructed docker command.

Also documents the environment variables respected by planter.

/area planter