### PR TITLE
Update who can use /status in commands.md

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -33,4 +33,4 @@ Command | Implemented By | Who can run it | Description
 `/release-note` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note` label
 `/release-note-action-required` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-action-required` label
 `/release-note-none` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-none` label
-`/status [label1 label2 ...]` | prow [label](./prow/plugins/label) | anyone | adds a status/<> label(s) if it exists
+`/status [label1 label2 ...]` | prow [label](./prow/plugins/label) | members of the [kubernetes-milestone-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers/members) github team | adds a status/<> label(s) if it exists

--- a/commands.md
+++ b/commands.md
@@ -33,4 +33,4 @@ Command | Implemented By | Who can run it | Description
 `/release-note` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note` label
 `/release-note-action-required` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-action-required` label
 `/release-note-none` | prow [releasenote](./prow/plugins/releasenote) | authors and kubernetes org members | adds the `release-note-none` label
-`/status [label1 label2 ...]` | prow [label](./prow/plugins/label) | members of the [kubernetes-milestone-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers/members) github team | adds a status/<> label(s) if it exists
+`/status [label1 label2 ...]` | prow [milestonestatus](./prow/plugins/milestonestatus) | members of the [kubernetes-milestone-maintainers](https://github.com/orgs/kubernetes/teams/kubernetes-milestone-maintainers/members) github team | adds a status/<> label(s) if it exists


### PR DESCRIPTION
It's technically whatever is configured in plugins.yaml, but I'm
hardcoding in the common kubernetes case until we have dynamic docs
served up from deck

Fixes #5270