### PR TITLE
Fix testgrid for tensorflow/k8s postsubmit results.

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1437,7 +1437,7 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/tf-k8s-presubmit
   num_columns_recent: 30
 - name: tf-k8s-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/tf-k8s-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/tensorflow_k8s/tf-k8s-postsubmit
 # kube-proxy daemonset migration jobs
 - name: ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds

--- a/testgrid/config/config_test.go
+++ b/testgrid/config/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 	"k8s.io/test-infra/testgrid/config/yaml2proto"
+	"path/filepath"
 )
 
 type SQConfig struct {
@@ -85,10 +86,13 @@ func TestConfig(t *testing.T) {
 			t.Errorf("Testgroup %v: UseKubernetesClient should always be true!", testgroup.Name)
 		}
 
-		// All testgroup from kubernetes must have testgroup name match its bucket name
 		if strings.HasPrefix(testgroup.GcsPrefix, "kubernetes-jenkins/logs/") {
-			if strings.TrimPrefix(testgroup.GcsPrefix, "kubernetes-jenkins/logs/") != testgroup.Name {
-				t.Errorf("Kubernetes Testgroup %v, name does not match GCS Bucket %v", testgroup.Name, testgroup.GcsPrefix)
+			// The expectation is that testgroup.Name is the name of a Prow job and the GCSPrefix
+			// follows the convention kubernetes-jenkins/logs/.../jobName
+			// The final part of the prefix should be the job name.
+			expected := filepath.Join(filepath.Dir(testgroup.GcsPrefix), testgroup.Name)
+			if expected != testgroup.GcsPrefix {
+				t.Errorf("Kubernetes Testgroup %v GcsPrefix; Got %v; Want %v", testgroup.Name, testgroup.GcsPrefix, expected)
 			}
 		}
 

--- a/testgrid/jenkins_verify/jenkins_validate.go
+++ b/testgrid/jenkins_verify/jenkins_validate.go
@@ -103,7 +103,8 @@ func main() {
 	testgroups := make(map[string]bool)
 	for _, testgroup := range config.TestGroups {
 		if strings.Contains(testgroup.GcsPrefix, "kubernetes-jenkins/logs/") {
-			job := strings.TrimPrefix(testgroup.GcsPrefix, "kubernetes-jenkins/logs/")
+			// The convention is that the job name is the final part of the GcsPrefix
+			job := filepath.Base(testgroup.GcsPrefix)
 			testgroups[job] = false
 		}
 


### PR DESCRIPTION
* No results are showing up in testgrid for the postsubmit results.
* It looks like the problem is that the actual GCS artifacts are in
  kubernetes-jenkins/logs/tensorflow_k8s/tf-k8s-postsubmit
  but the testgrid was using
  kubernetes-jenkins/logs/tf-k8s-postsubmit
  so we update the testgrid config to include the repo name in the GCS path.

* Fixes tensorflow/k8s#113