### PR TITLE
Fix pull-federation-e2e-gce job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -166,10 +166,10 @@ presubmits:
           path: /mnt/disks/ssd0
   - name: pull-federation-e2e-gce
     agent: jenkins
-    always_run: false
+    always_run: true
     context: pull-federation-e2e-gce
     rerun_command: "/test pull-federation-e2e-gce"
-    trigger: "(?m)^/test pull-federation-e2e-gce,?(\\s+|$)"
+    trigger: "(?m)^/test( all| pull-federation-e2e-gce),?(\\s+|$)"
   kubernetes/heapster:
   - name: pull-heapster-e2e
     agent: jenkins

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -552,7 +552,7 @@ def main(args):
 
     container = '%s-%s' % (os.environ.get('JOB_NAME'), os.environ.get('BUILD_NUMBER'))
     if args.mode == 'docker':
-        sudo = args.docker_in_docker or args.build is not None
+        sudo = args.docker_in_docker or args.build or args.build_federation is not None
         mode = DockerMode(container, artifacts, sudo, args.tag, args.mount_paths)
     elif args.mode == 'local':
         mode = LocalMode(workspace, artifacts)  # pylint: disable=bad-option-value
@@ -609,6 +609,13 @@ def main(args):
         if not os.path.basename(k8s) == 'kubernetes':
             raise ValueError(k8s)
         mode.add_k8s(os.path.dirname(k8s), 'kubernetes', 'release')
+
+    if args.build_federation is not None:
+        runner_args.append('--build-federation=%s' % args.build_federation)
+        fed = os.getcwd()
+        if not os.path.basename(fed) == 'federation':
+            raise ValueError(fed)
+        mode.add_k8s(os.path.dirname(fed), 'federation', 'release')
 
     if args.kops_build:
         build_kops(os.getcwd(), mode)
@@ -735,6 +742,9 @@ def create_parser():
     parser.add_argument(
         '--build', nargs='?', default=None, const='',
         help='Build kubernetes binaries if set, optionally specifying strategy')
+    parser.add_argument(
+        '--build-federation', nargs='?', default=None, const='',
+        help='Build federation binaries if set, optionally specifying strategy')
     parser.add_argument(
         '--use-shared-build', nargs='?', default=None, const='',
         help='Use prebuilt kubernetes binaries if set, optionally specifying strategy')


### PR DESCRIPTION
We are trying to run federation pull job from k/f repo. It seems there is an issue in kubernetes_e2e scenario as the `--build-federation` flag need to be handled to add volume to docker container.

here is the failure log https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/federation/112/pull-federation-e2e-gce/2/

/assign @krzyzacy 
/cc @marun, @irfanurrehman @kubernetes/sig-multicluster-bugs 