### PR TITLE
Approve plugin touch ups

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -92,7 +92,7 @@ func handleGenericCommentEvent(pc plugins.PluginClient, ce github.GenericComment
 }
 
 func handleGenericComment(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, config *plugins.Configuration, ce *github.GenericCommentEvent) error {
-	if ce.Action != github.GenericCommentActionCreated || !ce.IsPR {
+	if ce.Action != github.GenericCommentActionCreated || !ce.IsPR || ce.IssueState == "closed" {
 		return nil
 	}
 
@@ -143,7 +143,7 @@ func handlePullRequest(log *logrus.Entry, ghc githubClient, repo approvers.RepoI
 		return err
 	}
 	if pre.Action == github.PullRequestActionLabeled &&
-		(pre.Label.Name != approvedLabel || pre.Sender.Login == botName) {
+		(pre.Label.Name != approvedLabel || pre.Sender.Login == botName || pre.PullRequest.State == "closed") {
 		return nil
 	}
 

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -84,19 +84,10 @@ func init() {
 }
 
 func handleGenericCommentEvent(pc plugins.PluginClient, ce github.GenericCommentEvent) error {
-	ro, err := pc.OwnersClient.LoadRepoOwners(ce.Repo.Owner.Login, ce.Repo.Name)
-	if err != nil {
-		return err
-	}
-	return handleGenericComment(pc.Logger, pc.GitHubClient, ro, pc.PluginConfig, &ce)
-}
-
-func handleGenericComment(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, config *plugins.Configuration, ce *github.GenericCommentEvent) error {
 	if ce.Action != github.GenericCommentActionCreated || !ce.IsPR || ce.IssueState == "closed" {
 		return nil
 	}
-
-	botName, err := ghc.BotName()
+	botName, err := pc.GitHubClient.BotName()
 	if err != nil {
 		return err
 	}
@@ -105,6 +96,14 @@ func handleGenericComment(log *logrus.Entry, ghc githubClient, repo approvers.Re
 		return nil
 	}
 
+	ro, err := pc.OwnersClient.LoadRepoOwners(ce.Repo.Owner.Login, ce.Repo.Name)
+	if err != nil {
+		return err
+	}
+	return handleGenericComment(pc.Logger, pc.GitHubClient, ro, pc.PluginConfig, &ce)
+}
+
+func handleGenericComment(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, config *plugins.Configuration, ce *github.GenericCommentEvent) error {
 	return handle(
 		log,
 		ghc,
@@ -123,22 +122,13 @@ func handleGenericComment(log *logrus.Entry, ghc githubClient, repo approvers.Re
 }
 
 func handlePullRequestEvent(pc plugins.PluginClient, pre github.PullRequestEvent) error {
-	ro, err := pc.OwnersClient.LoadRepoOwners(pre.Repo.Owner.Login, pre.Repo.Name)
-	if err != nil {
-		return err
-	}
-	return handlePullRequest(pc.Logger, pc.GitHubClient, ro, pc.PluginConfig, &pre)
-}
-
-func handlePullRequest(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, config *plugins.Configuration, pre *github.PullRequestEvent) error {
 	if pre.Action != github.PullRequestActionOpened &&
 		pre.Action != github.PullRequestActionReopened &&
 		pre.Action != github.PullRequestActionSynchronize &&
 		pre.Action != github.PullRequestActionLabeled {
 		return nil
 	}
-
-	botName, err := ghc.BotName()
+	botName, err := pc.GitHubClient.BotName()
 	if err != nil {
 		return err
 	}
@@ -147,6 +137,14 @@ func handlePullRequest(log *logrus.Entry, ghc githubClient, repo approvers.RepoI
 		return nil
 	}
 
+	ro, err := pc.OwnersClient.LoadRepoOwners(pre.Repo.Owner.Login, pre.Repo.Name)
+	if err != nil {
+		return err
+	}
+	return handlePullRequest(pc.Logger, pc.GitHubClient, ro, pc.PluginConfig, &pre)
+}
+
+func handlePullRequest(log *logrus.Entry, ghc githubClient, repo approvers.RepoInterface, config *plugins.Configuration, pre *github.PullRequestEvent) error {
 	return handle(
 		log,
 		ghc,


### PR DESCRIPTION
Make approve plugin ignore closed PRs until they are reopened:
If a PR is closed we shouldn't change the approval notification or apply or remove the `approved` label. Instead the approve plugin should wait until the PR is reopened to react to any `/approve` or `/lgtm` commands that change the approval state. This will save API tokens and discourage users to reopen a PR if work is still being done on it.

Make approve plugin check if an event is relevant before loading repo owners:
I just moved these checks so that irrelevant events are ignored before `LoadRepoOwners` is called.
/cc @rmmh 