### PR TITLE
Enable the blockade plugin on k/k and disable the block-path munger.

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/block-path.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/block-path.yaml
@@ -1,8 +1,0 @@
-blockRegexp:
-  - ^docs/man
-  - ^docs/user-guide
-  - ^docs/yaml
-doNotBlockRegexp:
-  - ^docs/man/man1/.*\.1$
-  - ^docs/user-guide/kubectl/kubectl.*\.md$
-  - ^docs/yaml/kubectl/kubectl_.*\.yaml$

--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -5,7 +5,7 @@ organization: kubernetes
 project: kubernetes
 # Run blunderbuss before approval-handler, so that we can suggest approvers
 # based on assigned reviewer.
-pr-mungers: blunderbuss,approval-handler,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,path-label,stale-green-ci,block-path,comment-deleter,close-stale,sig-mention-handler,milestone-maintainer
+pr-mungers: blunderbuss,approval-handler,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,path-label,stale-green-ci,comment-deleter,close-stale,sig-mention-handler,milestone-maintainer
 state: open
 token-file: /etc/secret-volume/token
 period: 60s
@@ -28,7 +28,6 @@ required-retest-contexts: "\
 
 # munger specific options.
 path-label-config: "/etc/munge-config/path-label.txt"
-block-path-config: "/etc/munge-config/block-path.yaml"
 approval-requires-issue: true
 implicit-self-approval: true
 number-of-old-test-results: 5

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -16,6 +16,29 @@ approve:
   - kubernetes
   implicit_self_approve: true
 
+blockades:
+- repos:
+  - kubernetes/kubernetes
+  blockregexps:
+  - ^docs/man
+  exceptionregexps:
+  - ^docs/man/man1/.*\.1$
+  explanation: "Files under `docs/man` must be in the `man1` directory and have suffix `.1`."
+- repos:
+  - kubernetes/kubernetes
+  blockregexps:
+  - ^docs/user-guide
+  exceptionregexps:
+  - ^docs/user-guide/kubectl/kubectl.*\.md$
+  explanation: "Files under `docs/user-guide` must be in the `kubectl` directory and match pattern `kubectl*.md`."
+- repos:
+  - kubernetes/kubernetes
+  blockregexps:
+  - ^docs/yaml
+  exceptionregexps:
+  - ^docs/yaml/kubectl/kubectl_.*\.yaml$
+  explanation: "Files under `docs/yaml` must be in the `kubectl` directory and match pattern `kubectl_*.yaml`."
+
 heart:
   adorees:
   - k8s-merge-robot


### PR DESCRIPTION
/cc @cblecker 
I saw that you were the last person to make significant changes to the block-path config. Can you please validate that this config is still applicable and that the explanation messages I added are appropriate?
If there is a single explanation message that makes sense for all of the blockades I can combine them into one blockade like so:
```
blockades:
- repos:
  - kubernetes/kubernetes
  blockregexps:
  - ^docs/man
  - ^docs/user-guide
  - ^docs/yaml
  exceptionregexps:
  - ^docs/man/man1/.*\.1$
  - ^docs/user-guide/kubectl/kubectl.*\.md$
  - ^docs/yaml/kubectl/kubectl_.*\.yaml$
  explanation: "blah blah"
```