### PR TITLE
Ensure all release-master-blocking jobs have a sigOwner

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3495,7 +3495,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-alpha-features": {
@@ -3512,7 +3512,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-alpha-features-release-1-6": {
@@ -3896,7 +3896,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-reboot-release-1-6": {
@@ -4071,7 +4071,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-serial-release-1-6": {
@@ -4158,7 +4158,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-slow-release-1-6": {
@@ -4263,7 +4263,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-alpha-features": {
@@ -4497,7 +4497,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-reboot-release-1-6": {
@@ -4613,7 +4613,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-serial-release-1-6": {
@@ -4710,7 +4710,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-slow-release-1-6": {
@@ -8639,7 +8639,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-soak-gci-gce-stable1": {
@@ -8735,7 +8735,7 @@
     ],
     "scenario": "kubernetes_verify",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "ci-kubernetes-test-go-release-1.6": {
@@ -8776,7 +8776,7 @@
     ],
     "scenario": "kubernetes_verify",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "ci-kubernetes-verify-release-1.6": {

--- a/jobs/validOwners.json
+++ b/jobs/validOwners.json
@@ -11,6 +11,7 @@
    "sig-contributor-experience",
    "sig-docs",
    "sig-multicluster",
+   "sig-gcp",
    "sig-instrumentation",
    "sig-network",
    "sig-node",


### PR DESCRIPTION
This is a total first guess for kubernetes/test-infra#5303

The owners for these should be first point of contact if they're repeatedly failing. Most often for these jobs that encompass test cases owned by a _lot_ of sigs, the owner is going to route to the appropriate sig.

Rationale for assignments:
- sig-testing owns verify because these are basically more tests
- sig-testing owns test-go because running unit tests is a thing we want to support
- sig-gcp owns any gci-gce or gci-gke job that's not using a sig-specific feature (eg: sig-auth's auth job), because it's their cloud provider

I'm open to feedback. I avoided multiple sigs so there's just one point of contact.  sig-gcp still hasn't had their first meeting AFAIK, historically I have gone to sig-cluster-lifecycle first for these sorts of things.

WDYT @kubernetes/sig-release-maintainers @kubernetes/sig-gcp-test-failures @kuberentes/sig-testing-test-failures @kubernetes/sig-cluster-lifecycle-test-failures