### PR TITLE
Expose the ProwJob spec through environment

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -221,6 +221,7 @@ the build.
 
 Variable | Periodic | Postsubmit | Batch | Presubmit | Description | Example
 --- |:---:|:---:|:---:|:---:| --- | ---
+`PROW_JOB_SPEC` | ✓ | ✓ | ✓ | ✓ | Serialized JSON of the `ProwJobSpec`. | `n/a`
 `JOB_NAME` | ✓ | ✓ | ✓ | ✓ | Name of the job. | `pull-test-infra-bazel`
 `BUILD_NUMBER` | ✓ | ✓ | ✓ | ✓ | Unique build number for each run. | `12345`
 `REPO_OWNER` | | ✓ | ✓ | ✓ | GitHub org that triggered the job. | `kubernetes`

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/kube"
+	"encoding/json"
 )
 
 // NewProwJob initializes a ProwJob out of a ProwJobSpec.
@@ -174,6 +175,15 @@ func EnvForSpec(spec kube.ProwJobSpec) map[string]string {
 	env := map[string]string{
 		"JOB_NAME": spec.Job,
 	}
+
+	rawSpecData, err := json.Marshal(spec)
+	if err != nil {
+		// there should be no point at which these objects
+		// cannot be serialized, or we couldn't store them
+		// in the apiserver in the first place
+		panic(err)
+	}
+	env["PROW_JOB_SPEC"] = string(rawSpecData)
 
 	if spec.Type == kube.PeriodicJob {
 		return env


### PR DESCRIPTION
When building tools that run in the test pod or in test jobs, it is
critical to be able to determine the ProwJob specification that was used
to trigger the job in order to determine where the appropriate GCS
bucket is, which repositories need to be checked out, etc. In addition
to providing this data in a disparate set of environment variables, we
should also just provide the ProwJob spec in serialized form so that Go
programs importing test-infra can simply unmarshal it and go from there.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @kargakis @spxtr @cjwagner @fejta 
/assign @kargakis @cjwagner 

This patch came out of me trying to simplify some of our code that we run in the logging sidecar -- there is no good reason for us to juggle around environment variables, etc, to get at _e.g._ the type of job we are running. Much simpler to write a method to determine the correct place to push in GCS given a `ProwJobSpec`.