### PR TITLE
Add a integration test trigger to dns, ingress-gce

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9282,6 +9282,15 @@
       "UNKNOWN"
     ]
   },
+  "pull-kubernetes-dns-test": {
+    "args": [
+      "make"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "pull-kubernetes-e2e-gce": {
     "_comment1": "NOTE: THESE ARE THE JENKINS ARGS / COMMON ARGS (!)",
     "_comment2": "PLEASE PUT ARGS THAT WILL WORK FOR 1.6 HERE",
@@ -9441,6 +9450,15 @@
     "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-cluster-lifecycle"
+    ]
+  },
+  "pull-kubernetes-ingress-gce-test": {
+    "args": [
+      "make"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-network"
     ]
   },
   "pull-kubernetes-kubemark-e2e-gce": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -78,6 +78,78 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  kubernetes/dns:
+  - name: pull-kubernetes-dns-test
+    agent: kubernetes
+    context: pull-kubernetes-dns-test
+    branches:
+    - master
+    rerun_command: "/test pull-kubernetes-dns-test"
+    trigger: "(?m)^/test( all| pull-kubernetes-dns-test),?(\\s+|$)"
+    always_run: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:0.4
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--clean"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  kubernetes/ingress-gce:
+  - name: pull-kubernetes-ingress-gce-test
+    agent: kubernetes
+    context: pull-kubernetes-ingress-gce-test
+    branches:
+    - master
+    rerun_command: "/test pull-kubernetes-ingress-gce-test"
+    trigger: "(?m)^/test( all| pull-kubernetes-ingress-gce-test),?(\\s+|$)"
+    always_run: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:0.4
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--clean"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
   kubernetes/federation:
   - name: pull-federation-bazel-build
     agent: kubernetes

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -52,6 +52,12 @@ plugins:
   kubernetes/community:
   - trigger
 
+  kubernetes/dns:
+  - trigger
+
+  kubernetes/ingress-gce:
+  - trigger
+
   kubernetes/federation:
   - trigger
 


### PR DESCRIPTION
This adds a webhook for integration tests. Right now it's just a stub to validate that the hooks are functional.