### PR TITLE
🎡 Remove k8s.io/kubernetes dependency

### DIFF
--- a/mungegithub/BUILD
+++ b/mungegithub/BUILD
@@ -25,8 +25,8 @@ go_library(
         "//mungegithub/reports:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/flag:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
     ],
 )
 

--- a/mungegithub/example-one-off/BUILD
+++ b/mungegithub/example-one-off/BUILD
@@ -21,7 +21,7 @@ go_library(
         "//mungegithub/options:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/flag:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
     ],
 )
 

--- a/mungegithub/example-one-off/main.go
+++ b/mungegithub/example-one-off/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	utilflag "k8s.io/kubernetes/pkg/util/flag"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
 )

--- a/mungegithub/features/BUILD
+++ b/mungegithub/features/BUILD
@@ -14,7 +14,7 @@ go_test(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -37,8 +37,8 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/yaml:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
     ],
 )
 

--- a/mungegithub/features/branch-protection.go
+++ b/mungegithub/features/branch-protection.go
@@ -17,7 +17,7 @@ limitations under the License.
 package features
 
 import (
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/features/features.go
+++ b/mungegithub/features/features.go
@@ -19,7 +19,7 @@ package features
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
 

--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -26,8 +26,8 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/util/yaml"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
 

--- a/mungegithub/features/repo-updates_test.go
+++ b/mungegithub/features/repo-updates_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/go-github/github"
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (

--- a/mungegithub/features/server.go
+++ b/mungegithub/features/server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/github/BUILD
+++ b/mungegithub/github/BUILD
@@ -36,7 +36,7 @@ go_library(
         "//vendor/github.com/gregjones/httpcache/diskcache:go_default_library",
         "//vendor/github.com/peterbourgon/diskv:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/mungegithub/github/github.go
+++ b/mungegithub/github/github.go
@@ -33,7 +33,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/options"
 
 	"github.com/golang/glog"

--- a/mungegithub/github/status_change.go
+++ b/mungegithub/github/status_change.go
@@ -19,7 +19,7 @@ package github
 import (
 	"sync"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // StatusChange keeps track of issue/commit for status changes

--- a/mungegithub/mungegithub.go
+++ b/mungegithub/mungegithub.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"time"
 
-	utilflag "k8s.io/kubernetes/pkg/util/flag"
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/test-infra/mungegithub/features"
 	github_util "k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"

--- a/mungegithub/mungeopts/BUILD
+++ b/mungegithub/mungeopts/BUILD
@@ -11,7 +11,7 @@ go_library(
     importpath = "k8s.io/test-infra/mungegithub/mungeopts",
     deps = [
         "//mungegithub/options:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/mungegithub/mungeopts/mungeopts.go
+++ b/mungegithub/mungeopts/mungeopts.go
@@ -19,7 +19,7 @@ package mungeopts
 import (
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/options"
 )
 

--- a/mungegithub/mungers/BUILD
+++ b/mungegithub/mungers/BUILD
@@ -41,9 +41,9 @@ go_test(
         "//mungegithub/sharedmux:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/contrib/test-utils/utils:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/clock:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -102,10 +102,10 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/contrib/test-utils/utils:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/util/clock:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/yaml:go_default_library",
     ],
 )
 

--- a/mungegithub/mungers/approval-handler.go
+++ b/mungegithub/mungers/approval-handler.go
@@ -23,7 +23,7 @@ import (
 
 	githubapi "github.com/google/go-github/github"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/approvers"

--- a/mungegithub/mungers/approvers/BUILD
+++ b/mungegithub/mungers/approvers/BUILD
@@ -14,7 +14,7 @@ go_test(
     ],
     importpath = "k8s.io/test-infra/mungegithub/mungers/approvers",
     library = ":go_default_library",
-    deps = ["//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
 )
 
 go_library(
@@ -23,7 +23,7 @@ go_library(
     importpath = "k8s.io/test-infra/mungegithub/mungers/approvers",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/mungegithub/mungers/approvers/approvers_test.go
+++ b/mungegithub/mungers/approvers/approvers_test.go
@@ -21,7 +21,7 @@ import (
 
 	"reflect"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestUnapprovedFiles(t *testing.T) {

--- a/mungegithub/mungers/approvers/owners.go
+++ b/mungegithub/mungers/approvers/owners.go
@@ -27,7 +27,7 @@ import (
 	"text/template"
 
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (

--- a/mungegithub/mungers/approvers/owners_test.go
+++ b/mungegithub/mungers/approvers/owners_test.go
@@ -19,7 +19,7 @@ package approvers
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"path/filepath"
 	"reflect"

--- a/mungegithub/mungers/assign-fixes.go
+++ b/mungegithub/mungers/assign-fixes.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mungers
 
 import (
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/block_paths.go
+++ b/mungegithub/mungers/block_paths.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"regexp"
 
-	"k8s.io/kubernetes/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/util/yaml"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/blunderbuss.go
+++ b/mungegithub/mungers/blunderbuss.go
@@ -20,7 +20,7 @@ import (
 	"math"
 	"math/rand"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/check-labels.go
+++ b/mungegithub/mungers/check-labels.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/kubernetes/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/util/yaml"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/test-infra/mungegithub/features"
 	githubhelper "k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"

--- a/mungegithub/mungers/cherrypick-auto-approve.go
+++ b/mungegithub/mungers/cherrypick-auto-approve.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/cherrypick-clear-after-merge.go
+++ b/mungegithub/mungers/cherrypick-clear-after-merge.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/cherrypick-label-unapproved.go
+++ b/mungegithub/mungers/cherrypick-label-unapproved.go
@@ -19,7 +19,7 @@ package mungers
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/cherrypick-must-have-milestone.go
+++ b/mungegithub/mungers/cherrypick-must-have-milestone.go
@@ -19,7 +19,7 @@ package mungers
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/cherrypick-queue.go
+++ b/mungegithub/mungers/cherrypick-queue.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/close-stale.go
+++ b/mungegithub/mungers/close-stale.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"

--- a/mungegithub/mungers/comment-deleter.go
+++ b/mungegithub/mungers/comment-deleter.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mungers
 
 import (
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/e2e/BUILD
+++ b/mungegithub/mungers/e2e/BUILD
@@ -31,8 +31,8 @@ go_library(
         "//mungegithub/mungers/flakesync:go_default_library",
         "//mungegithub/options:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/contrib/test-utils/utils:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/mungegithub/mungers/e2e/e2e.go
+++ b/mungegithub/mungers/e2e/e2e.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/contrib/test-utils/utils"
-	"k8s.io/kubernetes/pkg/util/sets"
 	cache "k8s.io/test-infra/mungegithub/mungers/flakesync"
 	"k8s.io/test-infra/mungegithub/options"
 

--- a/mungegithub/mungers/inactive-review-handler.go
+++ b/mungegithub/mungers/inactive-review-handler.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	githubapi "github.com/google/go-github/github"
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/matchers"

--- a/mungegithub/mungers/issue-categorizer.go
+++ b/mungegithub/mungers/issue-categorizer.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/lgtm_after_commit.go
+++ b/mungegithub/mungers/lgtm_after_commit.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/mungerutil"

--- a/mungegithub/mungers/milestone-maintainer.go
+++ b/mungegithub/mungers/milestone-maintainer.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/approvers"

--- a/mungegithub/mungers/milestone-maintainer_test.go
+++ b/mungegithub/mungers/milestone-maintainer_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/github"
 	github_test "k8s.io/test-infra/mungegithub/github/testing"
 	c "k8s.io/test-infra/mungegithub/mungers/matchers/comment"

--- a/mungegithub/mungers/mungers.go
+++ b/mungegithub/mungers/mungers.go
@@ -19,7 +19,7 @@ package mungers
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/mungerutil/BUILD
+++ b/mungegithub/mungers/mungerutil/BUILD
@@ -29,7 +29,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/mungegithub/mungers/mungerutil/util.go
+++ b/mungegithub/mungers/mungerutil/util.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/google/go-github/github"
 )

--- a/mungegithub/mungers/nag-flake-issues.go
+++ b/mungegithub/mungers/nag-flake-issues.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/github"
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	mgh "k8s.io/test-infra/mungegithub/github"
 	c "k8s.io/test-infra/mungegithub/mungers/matchers/comment"

--- a/mungegithub/mungers/needs_rebase.go
+++ b/mungegithub/mungers/needs_rebase.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/old-test-getter.go
+++ b/mungegithub/mungers/old-test-getter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungers/e2e"

--- a/mungegithub/mungers/owner-label.go
+++ b/mungegithub/mungers/owner-label.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mungers
 
 import (
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/owner-label_test.go
+++ b/mungegithub/mungers/owner-label_test.go
@@ -26,7 +26,7 @@ import (
 	github_test "k8s.io/test-infra/mungegithub/github/testing"
 
 	"github.com/google/go-github/github"
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type testOwnerLabeler struct{}

--- a/mungegithub/mungers/path_label.go
+++ b/mungegithub/mungers/path_label.go
@@ -23,7 +23,7 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/publisher.go
+++ b/mungegithub/mungers/publisher.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/sig-mention-handler.go
+++ b/mungegithub/mungers/sig-mention-handler.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"

--- a/mungegithub/mungers/stale-green-ci.go
+++ b/mungegithub/mungers/stale-green-ci.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"

--- a/mungegithub/mungers/stale-pending-ci.go
+++ b/mungegithub/mungers/stale-pending-ci.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/features"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/mungeopts"

--- a/mungegithub/mungers/submit-queue.go
+++ b/mungegithub/mungers/submit-queue.go
@@ -30,8 +30,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilclock "k8s.io/kubernetes/pkg/util/clock"
-	"k8s.io/kubernetes/pkg/util/sets"
 
 	"k8s.io/contrib/test-utils/utils"
 	"k8s.io/test-infra/mungegithub/features"

--- a/mungegithub/mungers/submit-queue_test.go
+++ b/mungegithub/mungers/submit-queue_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	utilclock "k8s.io/kubernetes/pkg/util/clock"
+	utilclock "k8s.io/apimachinery/pkg/util/clock"
 
 	"k8s.io/contrib/test-utils/utils"
 	"k8s.io/test-infra/mungegithub/features"

--- a/mungegithub/options/BUILD
+++ b/mungegithub/options/BUILD
@@ -11,7 +11,7 @@ go_test(
     srcs = ["options_test.go"],
     importpath = "k8s.io/test-infra/mungegithub/options",
     library = ":go_default_library",
-    deps = ["//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library"],
 )
 
 go_library(
@@ -21,7 +21,7 @@ go_library(
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/mungegithub/options/options.go
+++ b/mungegithub/options/options.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"

--- a/mungegithub/options/options_test.go
+++ b/mungegithub/options/options_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (

--- a/mungegithub/reports/BUILD
+++ b/mungegithub/reports/BUILD
@@ -13,7 +13,7 @@ go_library(
         "//mungegithub/github:go_default_library",
         "//mungegithub/options:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/mungegithub/reports/reports.go
+++ b/mungegithub/reports/reports.go
@@ -19,7 +19,7 @@ package reports
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/mungegithub/github"
 	"k8s.io/test-infra/mungegithub/options"
 

--- a/prow/plugins/approve/BUILD
+++ b/prow/plugins/approve/BUILD
@@ -27,7 +27,7 @@ go_test(
         "//prow/plugins:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/plugins"

--- a/prow/plugins/approve/approvers/BUILD
+++ b/prow/plugins/approve/approvers/BUILD
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -21,7 +21,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -23,7 +23,7 @@ import (
 
 	"reflect"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestUnapprovedFiles(t *testing.T) {

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (

--- a/prow/plugins/approve/approvers/owners_test.go
+++ b/prow/plugins/approve/approvers/owners_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"path/filepath"
 	"reflect"

--- a/prow/plugins/docs-no-retest/BUILD
+++ b/prow/plugins/docs-no-retest/BUILD
@@ -18,7 +18,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/docs-no-retest/docs-no-retest_test.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
 )
 

--- a/prow/plugins/releasenote/BUILD
+++ b/prow/plugins/releasenote/BUILD
@@ -26,7 +26,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )

--- a/prow/repoowners/BUILD
+++ b/prow/repoowners/BUILD
@@ -10,7 +10,7 @@ go_library(
         "//prow/github:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 
@@ -23,7 +23,7 @@ go_test(
         "//prow/git/localgit:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
 )

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github/fakegithub"
 )


### PR DESCRIPTION
We don't need to vendor k8s.io/kubernetes anymore as the package we use have been split up