### PR TITLE
Add checks for unexpected github event actions to hook.

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -447,6 +447,9 @@ const (
 // - pull_request_review_comment events
 // - pull_request events with action in ["opened", "edited"]
 // - issue events with action in ["opened", "edited"]
+//
+// Issue and PR "closed" events are not coerced to the "deleted" Action and do not trigger
+// a GenericCommentEvent because these events don't actually remove the comment content from GH.
 type GenericCommentEvent struct {
 	IsPR         bool
 	Action       GenericCommentEventAction

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//prow/plugins/yuks:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This makes hook log error if it receives events with unexpected `Action`s which is important in case a new event action is added by github that should be handled as a `GenericCommentEvent`.

/cc @BenTheElder 