### PR TITLE
prow: Remove pull-federation-bazel-build job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9173,13 +9173,6 @@
       "sig-node"
     ]
   },
-  "pull-federation-bazel-build": {
-    "args": [],
-    "scenario": "kubernetes_bazel",
-    "sigOwners": [
-      "sig-multicluster"
-    ]
-  },
   "pull-federation-bazel-test": {
     "args": [],
     "scenario": "kubernetes_bazel",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -151,47 +151,6 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
   kubernetes/federation:
-  - name: pull-federation-bazel-build
-    agent: kubernetes
-    context: pull-federation-bazel-build
-    always_run: true
-    rerun_command: "/test pull-federation-bazel-build"
-    trigger: "(?m)^/test( all| pull-federation-bazel-build),?(\\s+|$)"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171013-53473ec5-0.6.1
-        args:
-        - "--clean"
-        - "--git-cache=/root/.cache/git"
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--" # end bootstrap args, scenario args below
-        - "--build=//... -//vendor/..."
-        - "--release=//build/release-tars"
-        env:
-        - name: TEST_TMPDIR
-          value: /root/.cache/bazel
-        # Bazel needs privileged mode in order to sandbox builds.
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: service
-          mountPath: /etc/service-account
-          readOnly: true
-        - name: cache-ssd
-          mountPath: /root/.cache
-        ports:
-        - containerPort: 9999
-          hostPort: 9999
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
-      - name: cache-ssd
-        hostPath:
-          path: /mnt/disks/ssd0
   - name: pull-federation-bazel-test
     agent: kubernetes
     context: pull-federation-bazel-test

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1560,10 +1560,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-test-infra-verify-gofmt
   days_of_results: 1
   num_columns_recent: 20
-- name: pull-federation-bazel-build
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-federation-bazel-build
-  days_of_results: 1
-  num_columns_recent: 20
 - name: pull-federation-bazel-test
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-federation-bazel-test
   days_of_results: 1
@@ -3884,9 +3880,6 @@ dashboards:
 
 - name: presubmits-federation
   dashboard_tab:
-  - name: bazel-build
-    test_group_name: pull-federation-bazel-build
-    base_options: 'width=10'
   - name: bazel-test
     test_group_name: pull-federation-bazel-test
     base_options: 'width=10'


### PR DESCRIPTION
The job is broken against the proposed seed PR.  Since nothing is currently consuming the artifacts from the job, removing it seems expedient.

/area prow
/cc cjwager bentheelder