### PR TITLE
Split jenkins list method to self-contained calls

### DIFF
--- a/prow/jenkins/BUILD
+++ b/prow/jenkins/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "controller.go",
+        "doc.go",
         "jenkins.go",
     ],
     importpath = "k8s.io/test-infra/prow/jenkins",

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -48,7 +48,7 @@ type kubeClient interface {
 
 type jenkinsClient interface {
 	Build(*kube.ProwJob) error
-	ListJenkinsBuilds(jobs map[string]struct{}) (map[string]JenkinsBuild, error)
+	ListBuilds(jobs []string) (map[string]JenkinsBuild, error)
 	Abort(job string, build *JenkinsBuild) error
 }
 
@@ -145,7 +145,7 @@ func (c *Controller) Sync() error {
 		}
 	}
 	pjs = jenkinsJobs
-	jbs, err := c.jc.ListJenkinsBuilds(getJenkinsJobs(pjs))
+	jbs, err := c.jc.ListBuilds(getJenkinsJobs(pjs))
 	if err != nil {
 		return fmt.Errorf("error listing jenkins builds: %v", err)
 	}
@@ -188,9 +188,9 @@ func (c *Controller) Sync() error {
 	return fmt.Errorf("errors syncing: %v, errors reporting: %v", syncErrs, reportErrs)
 }
 
-// getJenkinsJobs returns all the active Jenkins jobs for the provided
-// list of prowjobs.
-func getJenkinsJobs(pjs []kube.ProwJob) map[string]struct{} {
+// getJenkinsJobs returns all the Jenkins jobs for all active
+// prowjobs from the provided list. It handles deduplication.
+func getJenkinsJobs(pjs []kube.ProwJob) []string {
 	jenkinsJobs := make(map[string]struct{})
 	for _, pj := range pjs {
 		if pj.Complete() {
@@ -198,7 +198,11 @@ func getJenkinsJobs(pjs []kube.ProwJob) map[string]struct{} {
 		}
 		jenkinsJobs[pj.Spec.Job] = struct{}{}
 	}
-	return jenkinsJobs
+	var jobs []string
+	for job := range jenkinsJobs {
+		jobs = append(jobs, job)
+	}
+	return jobs
 }
 
 // terminateDupes aborts presubmits that have a newer version. It modifies pjs

--- a/prow/jenkins/doc.go
+++ b/prow/jenkins/doc.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jenkins includes a client and the operational logic for
+// managing Jenkins masters in prow. It has been used with the
+// following versions of Jenkins:
+//
+// * 2.60.3
+// * 2.73.2
+//
+// It should most likely work for all versions but use at your own
+// risk with a different version.
+package jenkins

--- a/prow/jenkins/jenkins_test.go
+++ b/prow/jenkins/jenkins_test.go
@@ -101,12 +101,12 @@ func intP(i int) *int {
 	return &i
 }
 
-func TestListJenkinsBuilds(t *testing.T) {
+func TestListBuilds(t *testing.T) {
 	tests := []struct {
 		name string
 
 		existingJobs  []string
-		requestedJobs map[string]struct{}
+		requestedJobs []string
 		builds        map[string][]JenkinsBuild
 		status        *int
 
@@ -117,7 +117,7 @@ func TestListJenkinsBuilds(t *testing.T) {
 			name: "missing job does not block",
 
 			existingJobs:  []string{"unit", "integration"},
-			requestedJobs: map[string]struct{}{"unit": {}, "integration": {}, "e2e": {}},
+			requestedJobs: []string{"unit", "integration", "e2e"},
 			builds: map[string][]JenkinsBuild{
 				"unit": {
 					{Number: 1, Result: strP(Succeess), Actions: []Action{{Parameters: []Parameter{{Name: buildID, Value: "first"}}}}},
@@ -142,7 +142,7 @@ func TestListJenkinsBuilds(t *testing.T) {
 			name: "bad error",
 
 			existingJobs:  []string{"unit"},
-			requestedJobs: map[string]struct{}{"unit": {}},
+			requestedJobs: []string{"unit"},
 			status:        intP(502),
 
 			expectedErr: fmt.Errorf("cannot list builds for job \"unit\": response not 2XX: 502 Bad Gateway"),
@@ -161,7 +161,7 @@ func TestListJenkinsBuilds(t *testing.T) {
 			baseURL: ts.URL,
 		}
 
-		builds, err := jc.ListJenkinsBuilds(test.requestedJobs)
+		builds, err := jc.ListBuilds(test.requestedJobs)
 		if !reflect.DeepEqual(err, test.expectedErr) {
 			t.Errorf("unexpected error: %v, expected: %v", err, test.expectedErr)
 		}


### PR DESCRIPTION
The self-contained calls will help in gathering metrics
about request latencies including unmarshalling in a clearer
fashion. This commit also contains some documentation
enhancements.

Closes https://github.com/kubernetes/test-infra/issues/4903

Signed-off-by: Michalis Kargakis <mkargaki@redhat.com>