### PR TITLE
Fix --build-federation flag without value

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -611,7 +611,10 @@ def main(args):
         mode.add_k8s(os.path.dirname(k8s), 'kubernetes', 'release')
 
     if args.build_federation is not None:
-        runner_args.append('--build-federation=%s' % args.build_federation)
+        if args.build_federation == '':
+            runner_args.append('--build-federation')
+        else:
+            runner_args.append('--build-federation=%s' % args.build_federation)
         fed = os.getcwd()
         if not os.path.basename(fed) == 'federation':
             raise ValueError(fed)


### PR DESCRIPTION
This is a follow-up on https://github.com/kubernetes/test-infra/pull/5299
passing just `--build-federation=` flag fails in kubetest with the below error.
```
W1102 10:27:08.997] 2017/11/02 10:27:08 main.go:295: Flag parse failed: invalid argument "" for "--build-federation" flag: Bad build strategy:  (use: bazel, quick, release)
```
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/federation/112/pull-federation-e2e-gce/3/

/assign @krzyzacy 
/cc @irfanurrehman @marun 