### PR TITLE
Use new build script in cri-containerd test.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -21,7 +21,7 @@
   },
   "ci-cri-containerd-build": {
     "args": [
-      "./test/e2e_node/build.sh"
+      "./test/build.sh"
     ],
     "scenario": "execute",
     "sigOwners": [
@@ -9150,7 +9150,7 @@
   },
   "pull-cri-containerd-build": {
     "args": [
-      "./test/e2e_node/build.sh"
+      "./test/build.sh"
     ],
     "scenario": "execute",
     "sigOwners": [


### PR DESCRIPTION
The build script is moving to `test/build.sh`.