### PR TITLE
add docker-in-docker bootstrap variant

### DIFF
--- a/images/bootstrap-dind/Dockerfile
+++ b/images/bootstrap-dind/Dockerfile
@@ -1,0 +1,65 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a build environment for building and running kubernetes
+# unit and integration tests
+
+ARG BOOTSTRAP_TAG
+FROM gcr.io/k8s-testimages/bootstrap:${BOOTSTRAP_TAG}
+LABEL maintainer="Benjamin Elder <bentheelder@google.com>"
+
+#
+# BEGIN: DOCKER IN DOCKER SETUP
+#
+
+# docker deps, some of these are already installed in the base image but
+# that's fine since they won't re-install and we can reuse the code below
+# for another image someday
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg2 \
+        software-properties-common \
+        lsb-release
+
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add -
+
+RUN add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+    $(lsb_release -cs) \
+    stable"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce
+
+# Move Docker's storage location
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --graph=/docker-graph"' | \
+        tee --append /etc/default/docker
+# NOTE this should be mounted in from the host ideally (!)
+# We will make a fake one now just in case
+RUN mkdir /docker-graph
+
+# Add a runner that wraps the original runner with a script that also runs:
+# `service docker start`
+# before running the original runner.
+ADD ["dind-runner", \
+    "/workspace/"]
+
+ENTRYPOINT ["/workspace/dind-runner"]
+
+#
+# END: DOCKER IN DOCKER SETUP
+#

--- a/images/bootstrap-dind/Makefile
+++ b/images/bootstrap-dind/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMG = gcr.io/k8s-testimages/bootstrap-dind
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+all: build
+
+build:
+	make -C ./../bootstrap push
+	docker build --no-cache -t $(IMG):$(TAG) --build-arg BOOTSTRAP_TAG=$(TAG) .
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	@echo Built $(IMG):$(TAG) and tagged with latest
+
+push: build
+	gcloud docker -- push $(IMG):$(TAG)
+	gcloud docker -- push $(IMG):latest
+	@echo Pushed $(IMG) with :latest and :$(TAG) tags

--- a/images/bootstrap-dind/dind-runner
+++ b/images/bootstrap-dind/dind-runner
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# start docker
+service docker start
+
+# run the normal bootstrap runner
+/workspace/runner


### PR DESCRIPTION
TODO: fold this into bootstrap once we no longer need a docker 1.9 binary for Jenkins jobs.

This adds an image that takes bootstrap and adds docker-in-docker support so that we can migrate docker-at-runtime dependent jobs to Prow.

/area images