### PR TITLE
Add missed staging flag for federation e2e pull job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9196,6 +9196,7 @@
       "--multiple-federations",
       "--provider=gce",
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
+      "--stage=gs://kubernetes-release-pull/ci/pull-federation-e2e-gce",
       "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
       "--timeout=90m"
     ],


### PR DESCRIPTION
This pr adds the missed staging flag to federation e2e presubmit job. If we do not stage, we are unable to consume the release. below is the error
```
W1103 03:23:56.345] 2017/11/03 03:23:56 util.go:157: Step 'make -C /go/src/k8s.io/federation quick-release' finished in 7m23.446217767s
W1103 03:23:56.346] 2017/11/03 03:23:56 main.go:245: Saved XML output to /workspace/_artifacts/junit_runner.xml.
W1103 03:23:56.346] 2017/11/03 03:23:56 main.go:311: Something went wrong: failed to acquire federation binaries: open /go/src/k8s.io/federation/_output/gcs-stage: no such file or directory
```
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/federation/113/pull-federation-e2e-gce/8/

/assign @krzyzacy 
/cc @irfanurrehman @marun 

p.s: hope this is the final fix before the federation e2e pull job starts working.