### PR TITLE
Use --stage-federation flag instead of --stage for federation presubmit

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9196,7 +9196,7 @@
       "--multiple-federations",
       "--provider=gce",
       "--save=gs://kubernetes-jenkins/federation/ci-kubernetes-pull-gce-federation-deploy",
-      "--stage=gs://kubernetes-release-pull/ci/pull-federation-e2e-gce",
+      "--stage-federation=gs://kubernetes-release-pull/ci/pull-federation-e2e-gce",
       "--test_args=--ginkgo.focus=\\[Feature:Federation\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[NoCluster\\] --minStartupPods=8",
       "--timeout=90m"
     ],


### PR DESCRIPTION
This is the follow-up of the https://github.com/kubernetes/test-infra/pull/5328
we should have used `--stage-federation` instead of `--stage` for this job.
Sorry for this mistake :), i have tested the `--extract-federation` and `--build-federation` separately but while integrating all this in pull job is causing all silly mistakes.

/assign @krzyzacy 