### PR TITLE
Create a downward API struct for ProwJobs

### DIFF
--- a/experiment/manual-trigger/manual-trigger.go
+++ b/experiment/manual-trigger/manual-trigger.go
@@ -177,7 +177,8 @@ func main() {
 
 	if err = jc.BuildFromSpec(&spec, o.jobName); err != nil {
 		log.Println("Submitting the following to Jenkins:")
-		for k, v := range pjutil.EnvForSpec(spec) {
+		env, _ := pjutil.EnvForSpec(pjutil.NewJobSpec(spec, "0"))
+		for k, v := range env {
 			log.Printf("  %s=%s\n", k, v)
 		}
 		log.Fatalf("for %s/%s#%d resulted in an error: %v", o.org, o.repo, o.num, err)

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -32,9 +32,9 @@ TOT_VERSION              ?= 0.5
 # HOROLOGIUM_VERSION is the version of the horologium image
 HOROLOGIUM_VERSION       ?= 0.11
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= 0.54
+PLANK_VERSION            ?= 0.55
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= 0.50
+JENKINS-OPERATOR_VERSION ?= 0.51
 # TIDE_VERSION is the version of the tide image
 TIDE_VERSION             ?= 0.8
 

--- a/prow/README.md
+++ b/prow/README.md
@@ -29,6 +29,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 6, 2017* `plank:0.55` provides `Pods` with the `$BUILD_ID` variable
+   as well as the `$BUILD_NUMBER` variable. The latter is deprecated and will be
+   removed in a future version.
  - *November 3, 2017* Added `EmptyDir` volume type. To update to `hook:0.176+`
    or `horologium:0.11+` the following components must have the associated
    minimum versions: `deck:0.58+`, `plank:0.54+`, `jenkins-operator:0.50+`.
@@ -231,6 +234,9 @@ the build.
 Variable | Periodic | Postsubmit | Batch | Presubmit | Description | Example
 --- |:---:|:---:|:---:|:---:| --- | ---
 `JOB_NAME` | ✓ | ✓ | ✓ | ✓ | Name of the job. | `pull-test-infra-bazel`
+`JOB_TYPE` | ✓ | ✓ | ✓ | ✓ | Type of job. | `presubmit`
+`JOB_SPEC` | ✓ | ✓ | ✓ | ✓ | JSON-encoded job specification. | see below
+`BUILD_ID` | ✓ | ✓ | ✓ | ✓ | Unique build number for each run. | `12345`
 `BUILD_NUMBER` | ✓ | ✓ | ✓ | ✓ | Unique build number for each run. | `12345`
 `REPO_OWNER` | | ✓ | ✓ | ✓ | GitHub org that triggered the job. | `kubernetes`
 `REPO_NAME` | | ✓ | ✓ | ✓ | GitHub repo that triggered the job. | `test-infra`
@@ -242,6 +248,30 @@ Variable | Periodic | Postsubmit | Batch | Presubmit | Description | Example
 
 Note: to not overwrite the Jenkins `$BUILD_NUMBER` variable, the build identifier
 will be passed as `$buildId` to Jenkins jobs.
+
+Note: Use of `$BUILD_NUMBER` is deprecated. Please use `$BUILD_ID` instead.
+
+Note: Examples of the JSON-encoded job specification follow for the different
+job types:
+
+Periodic Job:
+```json
+{"type":"periodic","job":"job-name","buildid":"0","refs":{}}
+```
+
+Postsubmit Job:
+```json
+{"type":"postsubmit","job":"job-name","buildid":"0","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha"}}```
+
+Presubmit Job:
+```json
+{"type":"presubmit","job":"job-name","buildid":"0","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}]}}
+```
+
+Batch Job:
+```json
+{"type":"batch","job":"job-name","buildid":"0","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"},{"number":2,"author":"other-author-name","sha":"second-pull-sha"}]}}
+```
 
 ## Bots home
 

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.50
+        image: gcr.io/k8s-prow/jenkins-operator:0.51
         ports:
         - name: logs
           containerPort: 8080

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.54
+        image: gcr.io/k8s-prow/plank:0.55
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.54
+        image: gcr.io/k8s-prow/plank:0.55
         args:
         - --dry-run=false
         volumeMounts:

--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -238,8 +238,10 @@ func (c *Client) BuildFromSpec(spec *kube.ProwJobSpec, buildId string) error {
 	if err != nil {
 		return err
 	}
-	env := pjutil.EnvForSpec(*spec)
-	env[buildID] = buildId
+	env, err := pjutil.EnvForSpec(pjutil.NewJobSpec(*spec, buildId))
+	if err != nil {
+		return err
+	}
 
 	q := u.Query()
 	for key, value := range env {

--- a/prow/pjutil/BUILD
+++ b/prow/pjutil/BUILD
@@ -10,7 +10,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["pjutil.go"],
+    srcs = [
+        "jobspec.go",
+        "pjutil.go",
+    ],
     importpath = "k8s.io/test-infra/prow/pjutil",
     tags = ["automanaged"],
     deps = [
@@ -35,7 +38,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["pjutil_test.go"],
+    srcs = [
+        "jobspec_test.go",
+        "pjutil_test.go",
+    ],
     importpath = "k8s.io/test-infra/prow/pjutil",
     library = ":go_default_library",
     tags = ["automanaged"],

--- a/prow/pjutil/jobspec.go
+++ b/prow/pjutil/jobspec.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pjutil
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"fmt"
+
+	"k8s.io/test-infra/prow/kube"
+)
+
+// JobSpec is the full downward API that we expose to
+// jobs that realize a ProwJob. We will provide this
+// data to jobs with environment variables in two ways:
+//  - the full spec, in serialized JSON in one variable
+//  - individual fields of the spec in their own variables
+type JobSpec struct {
+	Type    kube.ProwJobType `json:"type,omitempty"`
+	Job     string           `json:"job,omitempty"`
+	BuildId string           `json:"buildid,omitempty"`
+
+	Refs kube.Refs `json:"refs,omitempty"`
+
+	// we need to keep track of the agent until we
+	// migrate everyone away from using the $BUILD_NUMBER
+	// environment variable
+	agent kube.ProwJobAgent
+}
+
+func NewJobSpec(spec kube.ProwJobSpec, buildId string) JobSpec {
+	return JobSpec{
+		Type:    spec.Type,
+		Job:     spec.Job,
+		BuildId: buildId,
+		Refs:    spec.Refs,
+		agent:   spec.Agent,
+	}
+}
+
+// EnvForSpec returns a mapping of environment variables
+// to their values that should be available for a job spec
+func EnvForSpec(spec JobSpec) (map[string]string, error) {
+	env := map[string]string{
+		"JOB_NAME": spec.Job,
+		"BUILD_ID": spec.BuildId,
+		"JOB_TYPE": string(spec.Type),
+	}
+
+	// for backwards compatibility, we provide the build ID
+	// in both $BUILD_ID and $BUILD_NUMBER for Prow agents
+	if spec.agent == kube.KubernetesAgent {
+		env["BUILD_NUMBER"] = spec.BuildId
+	}
+
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return env, fmt.Errorf("failed to marshal job spec: %v", err)
+	}
+	env["JOB_SPEC"] = string(raw)
+
+	if spec.Type == kube.PeriodicJob {
+		return env, nil
+	}
+	env["REPO_OWNER"] = spec.Refs.Org
+	env["REPO_NAME"] = spec.Refs.Repo
+	env["PULL_BASE_REF"] = spec.Refs.BaseRef
+	env["PULL_BASE_SHA"] = spec.Refs.BaseSHA
+	env["PULL_REFS"] = spec.Refs.String()
+
+	if spec.Type == kube.PostsubmitJob || spec.Type == kube.BatchJob {
+		return env, nil
+	}
+	env["PULL_NUMBER"] = strconv.Itoa(spec.Refs.Pulls[0].Number)
+	env["PULL_PULL_SHA"] = spec.Refs.Pulls[0].SHA
+	return env, nil
+}

--- a/prow/pjutil/jobspec_test.go
+++ b/prow/pjutil/jobspec_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pjutil
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/test-infra/prow/kube"
+)
+
+func TestEnvironmentForSpec(t *testing.T) {
+	var tests = []struct {
+		name     string
+		spec     JobSpec
+		expected map[string]string
+	}{
+		{
+			name: "periodic job",
+			spec: JobSpec{
+				Type:    kube.PeriodicJob,
+				Job:     "job-name",
+				BuildId: "0",
+			},
+			expected: map[string]string{
+				"JOB_NAME": "job-name",
+				"BUILD_ID": "0",
+				"JOB_TYPE": "periodic",
+				"JOB_SPEC": `{"type":"periodic","job":"job-name","buildid":"0","refs":{}}`,
+			},
+		},
+		{
+			name: "postsubmit job",
+			spec: JobSpec{
+				Type:    kube.PostsubmitJob,
+				Job:     "job-name",
+				BuildId: "0",
+				Refs: kube.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+				},
+			},
+			expected: map[string]string{
+				"JOB_NAME":      "job-name",
+				"BUILD_ID":      "0",
+				"JOB_TYPE":      "postsubmit",
+				"JOB_SPEC":      `{"type":"postsubmit","job":"job-name","buildid":"0","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha"}}`,
+				"REPO_OWNER":    "org-name",
+				"REPO_NAME":     "repo-name",
+				"PULL_BASE_REF": "base-ref",
+				"PULL_BASE_SHA": "base-sha",
+				"PULL_REFS":     "base-ref:base-sha",
+			},
+		},
+		{
+			name: "batch job",
+			spec: JobSpec{
+				Type:    kube.BatchJob,
+				Job:     "job-name",
+				BuildId: "0",
+				Refs: kube.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []kube.Pull{{
+						Number: 1,
+						Author: "author-name",
+						SHA:    "pull-sha",
+					}, {
+						Number: 2,
+						Author: "other-author-name",
+						SHA:    "second-pull-sha",
+					}},
+				},
+			},
+			expected: map[string]string{
+				"JOB_NAME":      "job-name",
+				"BUILD_ID":      "0",
+				"JOB_TYPE":      "batch",
+				"JOB_SPEC":      `{"type":"batch","job":"job-name","buildid":"0","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"},{"number":2,"author":"other-author-name","sha":"second-pull-sha"}]}}`,
+				"REPO_OWNER":    "org-name",
+				"REPO_NAME":     "repo-name",
+				"PULL_BASE_REF": "base-ref",
+				"PULL_BASE_SHA": "base-sha",
+				"PULL_REFS":     "base-ref:base-sha,1:pull-sha,2:second-pull-sha",
+			},
+		},
+		{
+			name: "presubmit job",
+			spec: JobSpec{
+				Type:    kube.PresubmitJob,
+				Job:     "job-name",
+				BuildId: "0",
+				Refs: kube.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []kube.Pull{{
+						Number: 1,
+						Author: "author-name",
+						SHA:    "pull-sha",
+					}},
+				},
+			},
+			expected: map[string]string{
+				"JOB_NAME":      "job-name",
+				"BUILD_ID":      "0",
+				"JOB_TYPE":      "presubmit",
+				"JOB_SPEC":      `{"type":"presubmit","job":"job-name","buildid":"0","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}]}}`,
+				"REPO_OWNER":    "org-name",
+				"REPO_NAME":     "repo-name",
+				"PULL_BASE_REF": "base-ref",
+				"PULL_BASE_SHA": "base-sha",
+				"PULL_REFS":     "base-ref:base-sha,1:pull-sha",
+				"PULL_NUMBER":   "1",
+				"PULL_PULL_SHA": "pull-sha",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		env, err := EnvForSpec(test.spec)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+		}
+		if actual, expected := env, test.expected; !reflect.DeepEqual(actual, expected) {
+			t.Errorf("%s: got environment:\n\t%v\n\tbut expected:\n\t%v", test.name, actual, expected)
+		}
+	}
+}

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -17,115 +17,10 @@ limitations under the License.
 package pjutil
 
 import (
-	"reflect"
 	"testing"
 
 	"k8s.io/test-infra/prow/kube"
 )
-
-func TestEnvironmentForSpec(t *testing.T) {
-	var tests = []struct {
-		name     string
-		spec     kube.ProwJobSpec
-		expected map[string]string
-	}{
-		{
-			name: "periodic job",
-			spec: kube.ProwJobSpec{
-				Type: kube.PeriodicJob,
-				Job:  "job-name",
-			},
-			expected: map[string]string{
-				"JOB_NAME": "job-name",
-			},
-		},
-		{
-			name: "postsubmit job",
-			spec: kube.ProwJobSpec{
-				Type: kube.PostsubmitJob,
-				Job:  "job-name",
-				Refs: kube.Refs{
-					Org:     "org-name",
-					Repo:    "repo-name",
-					BaseRef: "base-ref",
-					BaseSHA: "base-sha",
-				},
-			},
-			expected: map[string]string{
-				"JOB_NAME":      "job-name",
-				"REPO_OWNER":    "org-name",
-				"REPO_NAME":     "repo-name",
-				"PULL_BASE_REF": "base-ref",
-				"PULL_BASE_SHA": "base-sha",
-				"PULL_REFS":     "base-ref:base-sha",
-			},
-		},
-		{
-			name: "batch job",
-			spec: kube.ProwJobSpec{
-				Type: kube.BatchJob,
-				Job:  "job-name",
-				Refs: kube.Refs{
-					Org:     "org-name",
-					Repo:    "repo-name",
-					BaseRef: "base-ref",
-					BaseSHA: "base-sha",
-					Pulls: []kube.Pull{{
-						Number: 1,
-						Author: "author-name",
-						SHA:    "pull-sha",
-					}, {
-						Number: 2,
-						Author: "other-author-name",
-						SHA:    "second-pull-sha",
-					}},
-				},
-			},
-			expected: map[string]string{
-				"JOB_NAME":      "job-name",
-				"REPO_OWNER":    "org-name",
-				"REPO_NAME":     "repo-name",
-				"PULL_BASE_REF": "base-ref",
-				"PULL_BASE_SHA": "base-sha",
-				"PULL_REFS":     "base-ref:base-sha,1:pull-sha,2:second-pull-sha",
-			},
-		},
-		{
-			name: "presubmit job",
-			spec: kube.ProwJobSpec{
-				Type: kube.PresubmitJob,
-				Job:  "job-name",
-				Refs: kube.Refs{
-					Org:     "org-name",
-					Repo:    "repo-name",
-					BaseRef: "base-ref",
-					BaseSHA: "base-sha",
-					Pulls: []kube.Pull{{
-						Number: 1,
-						Author: "author-name",
-						SHA:    "pull-sha",
-					}},
-				},
-			},
-			expected: map[string]string{
-				"JOB_NAME":      "job-name",
-				"REPO_OWNER":    "org-name",
-				"REPO_NAME":     "repo-name",
-				"PULL_BASE_REF": "base-ref",
-				"PULL_BASE_SHA": "base-sha",
-				"PULL_REFS":     "base-ref:base-sha,1:pull-sha",
-				"PULL_NUMBER":   "1",
-				"PULL_PULL_SHA": "pull-sha",
-			},
-		},
-	}
-
-	for _, test := range tests {
-		if actual, expected := EnvForSpec(test.spec), test.expected; !reflect.DeepEqual(actual, expected) {
-			t.Errorf("%s: got environment:\n\t%v\n\tbut expected:\n\t%v", test.name, actual, expected)
-		}
-	}
-}
 
 func TestProwJobToPod(t *testing.T) {
 	tests := []struct {
@@ -141,8 +36,9 @@ func TestProwJobToPod(t *testing.T) {
 			buildID: "blabla",
 			labels:  map[string]string{"needstobe": "inherited"},
 			pjSpec: kube.ProwJobSpec{
-				Type: kube.PresubmitJob,
-				Job:  "job-name",
+				Type:  kube.PresubmitJob,
+				Job:   "job-name",
+				Agent: kube.KubernetesAgent,
 				Refs: kube.Refs{
 					Org:     "org-name",
 					Repo:    "repo-name",
@@ -188,6 +84,9 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "MY_ENV", Value: "rocks"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "JOB_NAME", Value: "job-name"},
+								{Name: "JOB_TYPE", Value: "presubmit"},
+								{Name: "BUILD_ID", Value: "blabla"},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}]}}`},
 								{Name: "PULL_BASE_REF", Value: "base-ref"},
 								{Name: "REPO_OWNER", Value: "org-name"},
 								{Name: "REPO_NAME", Value: "repo-name"},
@@ -206,7 +105,10 @@ func TestProwJobToPod(t *testing.T) {
 	for i, test := range tests {
 		t.Logf("test run #%d", i)
 		pj := kube.ProwJob{Metadata: kube.ObjectMeta{Name: test.podName, Labels: test.labels}, Spec: test.pjSpec}
-		got := ProwJobToPod(pj, test.buildID)
+		got, err := ProwJobToPod(pj, test.buildID)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 		// TODO: For now I am just comparing fields manually, eventually we
 		// should port the semantic.DeepEqual helper from the api-machinery
 		// repo, which is basically a fork of the reflect package.

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -401,7 +401,10 @@ func (c *Controller) startPod(pj kube.ProwJob) (string, string, error) {
 		return "", "", fmt.Errorf("error getting build ID: %v", err)
 	}
 
-	pod := pjutil.ProwJobToPod(pj, buildID)
+	pod, err := pjutil.ProwJobToPod(pj, buildID)
+	if err != nil {
+		return "", "", err
+	}
 
 	actual, err := c.pkc.CreatePod(*pod)
 	if err != nil {


### PR DESCRIPTION
In order to be more clear about the API that Prow will provide to the
agents that realize `ProwJobs`, the `pjutil.JobSpec` struct serializes
the full API and the `EnvForSpec()` utility now exposes all of the
fields in the struct as environment variables as well as exposing the
full JSON-encoded struct as `$JOB_SPEC`. Job code running on an agent
can opt to use either the JSON-encoded data or the more fine-grained
environment variables and can be certain they will never drift.

The `plank` controller will now provide the build identifier through the
`$BUILD_ID` environment variable to containers in `Pod`s in addition to
continuing to provide it as `$BUILD_NUMBER`. Job code that expects
`$BUILD_NUMBER` should migrate to the newer environment variable
whenever possible. In the future, client code should not make use of
`$BUILD_NUMBER` in any way as this is not a field that Prow can control
in Jenkins-agent jobs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @kargakis @spxtr @cjwagner 
supersedes https://github.com/kubernetes/test-infra/pull/5307