### PR TITLE
add EmtpyDir Volumes to prow kube types

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,7 +20,7 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.175
+HOOK_VERSION             ?= 0.176
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.21
 # DECK_VERSION is the version of the deck image
@@ -30,7 +30,7 @@ SPLICE_VERSION           ?= 0.28
 # TOT_VERSION is the version of the tot image
 TOT_VERSION              ?= 0.5
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= 0.10
+HOROLOGIUM_VERSION       ?= 0.11
 # PLANK_VERSION is the version of the plank image
 PLANK_VERSION            ?= 0.53
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-oprator image

--- a/prow/README.md
+++ b/prow/README.md
@@ -29,6 +29,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 3, 2017* Added `EmptyDir` volume type. To update to `hook:0.176+`
+   or `horologium:0.11+` the following components must have the associated
+   minimum versions: `deck:0.57+`, `plank:0.53+`, `jenkins-operator:0.49+`.
  - *November 2, 2017* `plank:0.53` changes the `type` label key to `prow.k8s.io/type`
    and the `job` annotation key to `prow.k8s.io/job` added in pods.
  - *October 13, 2017* `hook:0.174`, `plank:0.50`, and `jenkins-operator:0.47`

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.175
+        image: gcr.io/k8s-prow/hook:0.176
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.10
+        image: gcr.io/k8s-prow/horologium:0.11
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.175
+        image: gcr.io/k8s-prow/hook:0.176
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -223,7 +223,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.10
+        image: gcr.io/k8s-prow/horologium:0.11
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -75,15 +75,18 @@ type PodStatus struct {
 }
 
 type Volume struct {
-	Name        string             `json:"name,omitempty"`
-	Secret      *SecretSource      `json:"secret,omitempty"`
-	DownwardAPI *DownwardAPISource `json:"downwardAPI,omitempty"`
-	HostPath    *HostPathSource    `json:"hostPath,omitempty"`
-	ConfigMap   *ConfigMapSource   `json:"configMap,omitempty"`
+	Name         string `json:"name,omitempty"`
+	VolumeSource `json:",inline"`
 }
 
-type ConfigMapSource struct {
-	Name string `json:"name,omitempty"`
+// VolumeSource represents the source location of a volume to mount.
+// Only one of its members may be specified.
+type VolumeSource struct {
+	HostPath    *HostPathSource       `json:"hostPath,omitempty"`
+	EmptyDir    *EmptyDirVolumeSource `json:"emptyDir,omitemtpy"`
+	Secret      *SecretSource         `json:"secret,omitempty"`
+	DownwardAPI *DownwardAPISource    `json:"downwardAPI,omitempty"`
+	ConfigMap   *ConfigMapSource      `json:"configMap,omitempty"`
 }
 
 type HostPathSource struct {
@@ -93,6 +96,14 @@ type HostPathSource struct {
 type SecretSource struct {
 	Name        string `json:"secretName,omitempty"`
 	DefaultMode int32  `json:"defaultMode,omitempty"`
+}
+
+type EmptyDirVolumeSource struct {
+	// NOTE: fields ommitted here as Prow does not currently use them
+}
+
+type ConfigMapSource struct {
+	Name string `json:"name,omitempty"`
 }
 
 type DownwardAPISource struct {


### PR DESCRIPTION
Needed for https://github.com/kubernetes/test-infra/pull/5327, this brings `EmptyDir` support to Prow.

I also reorganized the `Volume` members to match the upstream `types.go` a little bit more.