### PR TITLE
auto s̶p̶a̶m̶ assign bentheelder and krzyzacy for job changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@ bootstrap/** @bentheelder
 boskos/** @krzyzacy
 gubernator/** @rmmh
 jenkins/bootstrap* @bentheelder @krzyzacy
+jobs/** @bentheelder @krzyzacy
 kettle/** @rmmh
 kubetest/** @krzyzacy
 logexporter/** @shyamjvs


### PR DESCRIPTION
We already do this for `prow/config.yaml`, but sometimes tweaks only go into `jobs/config.json` or `jobs/**.env`, missing changes to these has left some breakage in the past with some of the more interesting setups EG: https://github.com/kubernetes/test-infra/pull/5281 / https://github.com/kubernetes/test-infra/issues/5280