### PR TITLE
Fix missing metadata

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -346,6 +346,7 @@ class GSUtil(object):
         if not os.path.isdir(artifacts):
             logging.warning('Artifacts dir %s is missing.', artifacts)
             return
+        original_artifacts = artifacts
         try:
             # If remote path exists, it will create .../_artifacts subdir instead
             gsutil.ls(path)
@@ -367,6 +368,11 @@ class GSUtil(object):
             artifacts, path,
         ]
         self.call(cmd)
+
+        # rename the artifacts dir back
+        # other places still references the original artifacts dir
+        if original_artifacts != artifacts:
+            os.rename(artifacts, original_artifacts)
 
 
 def append_result(gsutil, path, build, version, passed):


### PR DESCRIPTION
This will make https://github.com/kubernetes/test-infra/issues/5357 happier

Basically when using logexporter, the local artifacts dir was renamed, however outside calls still references the old artifacts dir. Simply rename it back so that outside can still recognize the artifacts dir.

/assign @BenTheElder @shyamjvs 
cc @porridge 