### PR TITLE
Add cluster e2e for cri-containerd.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -28,6 +28,45 @@
       "sig-node"
     ]
   },
+  "ci-cri-containerd-e2e-gci-gce": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "ci-cri-containerd-e2e-ubuntu-gce": {
+    "args": [
+      "--check-leaked-resources",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=ci/latest",
+      "--gcp-node-image=ubuntu",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--image-family=ubuntu-gke-1604-lts",
+      "--image-project=ubuntu-os-gke-cloud",
+      "--provider=gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=50m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "ci-cri-containerd-node-e2e": {
     "args": [
       "--deployment=node",

--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -1,0 +1,20 @@
+### job-env
+# This list should match the list in kubernetes-pull-build-test-e2e-gce.
+NUM_NODES=4
+# For now explicitly test etcd v2 mode in this suite.
+STORAGE_BACKEND=etcd2
+TEST_ETCD_IMAGE=2.2.1
+TEST_ETCD_VERSION=2.2.1
+
+# Enable the PodSecurityPolicy in tests.
+ENABLE_POD_SECURITY_POLICY=true
+
+# Envs for cri-containerd.
+KUBE_MASTER_EXTRA_METADATA=user-data=/go/src/github.com/kubernetes-incubator/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/go/src/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
+KUBE_NODE_EXTRA_METADATA=user-data=/go/src/github.com/kubernetes-incubator/cri-containerd/test/e2e/node.yaml,cri-containerd-configure-sh=/go/src/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
+KUBE_CONTAINER_RUNTIME=remote
+KUBE_CONTAINER_RUNTIME_ENDPOINT=/var/run/cri-containerd.sock
+KUBE_LOAD_IMAGE_COMMAND=/home/cri-containerd/usr/local/bin/cri-containerd load
+NETWORK_POLICY_PROVIDER=calico
+# TODO(random-liu): Enable this after kubernetes/kubernetes#55141 is fixed.
+PREPULL_E2E_IMAGES=false

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3744,6 +3744,74 @@ periodics:
       secret:
         secretName: service-account
 
+- interval: 1h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-gci-gce
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/kubernetes-incubator/cri-containerd=master"
+      - "--timeout=70"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 1h
+  agent: kubernetes
+  name: ci-cri-containerd-e2e-ubuntu-gce
+  spec:
+    containers:
+    - args:
+      - "--repo=github.com/kubernetes-incubator/cri-containerd=master"
+      - "--timeout=70"
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171030-bcf1a6a2-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
 - name: ci-cri-containerd-node-e2e
   interval: 1h
   agent: kubernetes

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -76,6 +76,10 @@ test_groups:
     name_format: '%s [%s]'
 - name: ci-cri-containerd-build
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-build
+- name: ci-cri-containerd-e2e-gci-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce
+- name: ci-cri-containerd-e2e-ubuntu-gce
+  gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-e2e-ubuntu-gce
 - name: ci-cri-containerd-node-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-node-e2e
   test_name_config:
@@ -3355,6 +3359,10 @@ dashboards:
     test_group_name: ci-cri-containerd-build
   - name: node-e2e
     test_group_name: ci-cri-containerd-node-e2e
+  - name: e2e-gci
+    test_group_name: ci-cri-containerd-e2e-gci-gce
+  - name: e2e-ubuntu
+    test_group_name: ci-cri-containerd-e2e-ubuntu-gce
 
 - name: sig-node-rkt
   dashboard_tab:


### PR DESCRIPTION
Add e2e test for cri-containerd.

This depends on https://github.com/kubernetes/kubernetes/issues/54962.
We can get this merged first, but the test will keep failing until https://github.com/kubernetes/kubernetes/issues/54962 is fixed.

For https://github.com/kubernetes/features/issues/286.