### PR TITLE
Make hook serve plugin help information for normal and external plugins.

### DIFF
--- a/prow/BUILD
+++ b/prow/BUILD
@@ -41,6 +41,7 @@ filegroup(
         "//prow/phony:all-srcs",
         "//prow/pjutil:all-srcs",
         "//prow/plank:all-srcs",
+        "//prow/pluginhelp:all-srcs",
         "//prow/plugins:all-srcs",
         "//prow/repoowners:all-srcs",
         "//prow/report:all-srcs",

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//prow/hook:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/metrics:go_default_library",
+        "//prow/pluginhelp/hook:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -48,10 +48,14 @@ func TestHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Marshalling ICE: %v", err)
 	}
-	plugins.RegisterIssueHandler("baz", func(pc plugins.PluginClient, ie github.IssueEvent) error {
-		called <- true
-		return nil
-	})
+	plugins.RegisterIssueHandler(
+		"baz",
+		func(pc plugins.PluginClient, ie github.IssueEvent) error {
+			called <- true
+			return nil
+		},
+		nil,
+	)
 	pa := &plugins.PluginAgent{}
 	pa.Set(&plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}

--- a/prow/pluginhelp/BUILD
+++ b/prow/pluginhelp/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pluginhelp.go"],
+    importpath = "k8s.io/test-infra/prow/pluginhelp",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//prow/pluginhelp/externalplugins:all-srcs",
+        "//prow/pluginhelp/hook:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/pluginhelp/externalplugins/BUILD
+++ b/prow/pluginhelp/externalplugins/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["externalplugins.go"],
+    importpath = "k8s.io/test-infra/prow/pluginhelp/externalplugins",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/pluginhelp:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/pluginhelp/externalplugins/externalplugins.go
+++ b/prow/pluginhelp/externalplugins/externalplugins.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package externalplugins provides the plugin help components to be compiled into external plugin binaries.
+// Since external plugins only need to serve a "/help" endpoint this package just provides an
+// http.HandlerFunc that wraps an ExternalPluginHelpProvider function.
+package externalplugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/pluginhelp"
+)
+
+// ExternalPluginHelpProvider is a func type that returns a PluginHelp struct for an external
+// plugin based on the specified enabledRepos.
+type ExternalPluginHelpProvider func(enabledRepos []string) (*pluginhelp.PluginHelp, error)
+
+// ServeExternalPluginHelp returns a HandlerFunc that serves plugin help information that is
+// providied by the specified ExternalPluginHelpProvider.
+func ServeExternalPluginHelp(log *logrus.Entry, provider ExternalPluginHelpProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache")
+
+		serverError := func(action string, err error) {
+			log.WithError(err).Errorf("Error %s.", action)
+			msg := fmt.Sprintf("500 Internal server error %s: %v", action, err)
+			http.Error(w, msg, http.StatusInternalServerError)
+		}
+
+		if r.Method != http.MethodPost {
+			log.Errorf("Invalid request method: %v.", r.Method)
+			http.Error(w, "405 Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			serverError("reading request body", err)
+			return
+		}
+		var enabledRepos []string
+		if err := json.Unmarshal(b, &enabledRepos); err != nil {
+			serverError("unmarshaling request body", err)
+			return
+		}
+		if provider == nil {
+			serverError("generating plugin help", errors.New("help provider is nil"))
+			return
+		}
+		help, err := provider(enabledRepos)
+		if err != nil {
+			serverError("generating plugin help", err)
+			return
+		}
+		b, err = json.Marshal(help)
+		if err != nil {
+			serverError("marshaling plugin help", err)
+			return
+		}
+
+		fmt.Fprint(w, string(b))
+	}
+}

--- a/prow/pluginhelp/hook/BUILD
+++ b/prow/pluginhelp/hook/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -27,4 +27,19 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["hook_test.go"],
+    importpath = "k8s.io/test-infra/prow/pluginhelp/hook",
+    library = ":go_default_library",
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/pluginhelp/externalplugins:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+    ],
 )

--- a/prow/pluginhelp/hook/BUILD
+++ b/prow/pluginhelp/hook/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hook.go"],
+    importpath = "k8s.io/test-infra/prow/pluginhelp/hook",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/pluginhelp/externalplugins:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/pluginhelp/hook/hook.go
+++ b/prow/pluginhelp/hook/hook.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hook provides the plugin help components to be compiled into the hook binary.
+// This includes the code to fetch help from normal and external plugins and the code to build and
+// serve a pluginhelp.Help struct.
+package hook
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+// TODO: unit test to ensure that external plugins with the same name have the same endpoint and events.
+
+const (
+	// newRepoDetectionLimit is the maximum allowable time before a repo will appear in the help
+	// information if it is a new repo that is only referenced via its parent org in the config.
+	// (i.e. max time before help is available for brand new "kubernetes/foo" repo if only
+	// "kubernetes" is listed in the config)
+	newRepoDetectionLimit = time.Hour
+)
+
+type pluginAgent interface {
+	Config() *plugins.Configuration
+}
+
+type githubClient interface {
+	GetRepos(org string, isUser bool) ([]github.Repo, error)
+}
+
+type HelpAgent struct {
+	log *logrus.Entry
+	pa  pluginAgent
+	oa  *orgAgent
+}
+
+func NewHelpAgent(pa pluginAgent, ghc githubClient) *HelpAgent {
+	l := logrus.WithField("client", "plugin-help")
+	return &HelpAgent{
+		log: l,
+		pa:  pa,
+		oa:  newOrgAgent(l, ghc, newRepoDetectionLimit),
+	}
+}
+
+func (ha *HelpAgent) generateNormalPluginHelp(config *plugins.Configuration, revMap map[string][]string) (allPlugins []string, pluginHelp map[string]pluginhelp.PluginHelp) {
+	pluginHelp = map[string]pluginhelp.PluginHelp{}
+	for name, provider := range plugins.HelpProviders() {
+		allPlugins = append(allPlugins, name)
+		if provider == nil {
+			ha.log.Warnf("No help is provided for plugin %q.", name)
+			continue
+		}
+		help, err := provider(config, revMap[name])
+		if err != nil {
+			ha.log.WithError(err).Errorf("Generating help from normal plugin %q.", name)
+			continue
+		}
+		help.Events = plugins.EventsForPlugin(name)
+		pluginHelp[name] = *help
+	}
+	return
+}
+
+func (ha *HelpAgent) generateExternalPluginHelp(config *plugins.Configuration, revMap map[string][]string) (allPlugins []string, pluginHelp map[string]pluginhelp.PluginHelp) {
+	externals := map[string]plugins.ExternalPlugin{}
+	for _, exts := range config.ExternalPlugins {
+		for _, ext := range exts {
+			externals[ext.Name] = ext
+		}
+	}
+
+	type externalResult struct {
+		name string
+		help *pluginhelp.PluginHelp
+	}
+	externalResultChan := make(chan externalResult, len(externals))
+	for _, ext := range externals {
+		allPlugins = append(allPlugins, ext.Name)
+		go func(ext plugins.ExternalPlugin) {
+			help, err := externalHelpProvider(ha.log, ext.Endpoint)(revMap[ext.Name])
+			if err != nil {
+				ha.log.WithError(err).Errorf("Getting help from external plugin %q.", ext.Name)
+				help = nil
+			} else {
+				help.Events = ext.Events
+			}
+			externalResultChan <- externalResult{name: ext.Name, help: help}
+		}(ext)
+	}
+
+	pluginHelp = map[string]pluginhelp.PluginHelp{}
+	for result := range externalResultChan {
+		if result.help == nil {
+			continue
+		}
+		pluginHelp[result.name] = *result.help
+	}
+	return
+}
+
+// GeneratePluginHelp compiles and returns the help information for all plugins.
+func (ha *HelpAgent) GeneratePluginHelp() *pluginhelp.Help {
+	config := ha.pa.Config()
+	orgToRepos := ha.oa.orgToReposMap(config)
+
+	normalRevMap, externalRevMap := reversePluginMaps(config, orgToRepos)
+
+	allPlugins, pluginHelp := ha.generateNormalPluginHelp(config, normalRevMap)
+	allExternalPlugins, externalPluginHelp := ha.generateExternalPluginHelp(config, externalRevMap)
+
+	// Load repo->plugins maps from config
+	repoPlugins := map[string][]string{
+		"": allPlugins,
+	}
+	for repo, plugins := range config.Plugins {
+		repoPlugins[repo] = plugins
+	}
+	repoExternalPlugins := map[string][]string{
+		"": allExternalPlugins,
+	}
+	for repo, exts := range config.ExternalPlugins {
+		for _, ext := range exts {
+			repoExternalPlugins[repo] = append(repoExternalPlugins[repo], ext.Name)
+		}
+	}
+
+	return &pluginhelp.Help{
+		AllRepos:            allRepos(config, orgToRepos),
+		RepoPlugins:         repoPlugins,
+		RepoExternalPlugins: repoExternalPlugins,
+		PluginHelp:          pluginHelp,
+		ExternalPluginHelp:  externalPluginHelp,
+	}
+}
+
+func allRepos(config *plugins.Configuration, orgToRepos map[string]sets.String) []string {
+	all := sets.NewString()
+	for repo := range config.Plugins {
+		all.Insert(repo)
+	}
+	for repo := range config.ExternalPlugins {
+		all.Insert(repo)
+	}
+
+	flattened := sets.NewString()
+	for repo := range all {
+		if strings.Contains(repo, "/") {
+			flattened.Insert(repo)
+			continue
+		}
+		flattened = flattened.Union(orgToRepos[repo])
+	}
+	return flattened.List()
+}
+
+func externalHelpProvider(log *logrus.Entry, endpoint string) externalplugins.ExternalPluginHelpProvider {
+	return func(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+		url, err := url.Parse(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing url: %s err: %v", endpoint, err)
+		}
+		url.Path = path.Join(url.Path, "/help")
+		b, err := json.Marshal(enabledRepos)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling enabled repos: %q, err: %v", enabledRepos, err)
+		}
+
+		// Don't retry because user is waiting for response to their browser.
+		// If there is an error the user can refresh to get the plugin info that failed to load.
+		urlString := url.String()
+		resp, err := http.Post(urlString, "application/json", bytes.NewReader(b))
+		if err != nil {
+			return nil, fmt.Errorf("error posting to %s err: %v", urlString, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			return nil, fmt.Errorf("post to %s failed with status %d: %s", urlString, resp.StatusCode, resp.Status)
+		}
+		var help pluginhelp.PluginHelp
+		if err := json.NewDecoder(resp.Body).Decode(&help); err != nil {
+			return nil, fmt.Errorf("failed to decode json response from %s err: %v", urlString, err)
+		}
+		return &help, nil
+	}
+}
+
+// reversePluginMaps inverts the Configuration.Plugins and Configuration.ExternalPlugins maps and
+// expands any org strings to org/repo strings.
+// The returned values map plugin names to the set of org/repo strings they are enabled on.
+func reversePluginMaps(config *plugins.Configuration, orgToRepos map[string]sets.String) (normal, external map[string][]string) {
+	normal = map[string][]string{}
+	for repo, plugins := range config.Plugins {
+		var repos []string
+		if flattened, ok := orgToRepos[repo]; ok {
+			repos = flattened.List()
+		} else {
+			repos = []string{repo}
+		}
+		for _, plugin := range plugins {
+			normal[plugin] = append(normal[plugin], repos...)
+		}
+	}
+	external = map[string][]string{}
+	for repo, plugins := range config.ExternalPlugins {
+		var repos []string
+		if flattened, ok := orgToRepos[repo]; ok {
+			repos = flattened.List()
+		} else {
+			repos = []string{repo}
+		}
+		for _, plugin := range plugins {
+			external[plugin.Name] = append(external[plugin.Name], repos...)
+		}
+	}
+	return
+}
+
+// orgAgent provides a cached mapping of orgs to the repos that are in that org.
+// Caching is necessary to prevent excessive github API token usage.
+type orgAgent struct {
+	log *logrus.Entry
+	ghc githubClient
+
+	syncPeriod time.Duration
+
+	lock       sync.Mutex
+	nextSync   time.Time
+	orgs       sets.String
+	orgToRepos map[string]sets.String
+}
+
+func newOrgAgent(log *logrus.Entry, ghc githubClient, syncPeriod time.Duration) *orgAgent {
+	return &orgAgent{
+		log:        log,
+		ghc:        ghc,
+		syncPeriod: syncPeriod,
+	}
+}
+
+func (oa *orgAgent) orgToReposMap(config *plugins.Configuration) map[string]sets.String {
+	oa.lock.Lock()
+	defer oa.lock.Unlock()
+	// Only need to sync if either:
+	// - the sync period has passed (we sync periodically to pick up new repos in known orgs)
+	//  or
+	// - new org(s) have been added in the config
+	var syncReason string
+	if time.Now().After(oa.nextSync) {
+		syncReason = "the sync period elapsed"
+	} else if diff := orgsInConfig(config).Difference(oa.orgs); diff.Len() > 0 {
+		syncReason = fmt.Sprintf("the following orgs were added to the config: %q", diff.List())
+	}
+	if syncReason != "" {
+		oa.log.Infof("Syncing org to repos mapping because %s.")
+		oa.sync(config)
+	}
+	return oa.orgToRepos
+}
+
+func (oa *orgAgent) sync(config *plugins.Configuration) {
+
+	// QUESTION: If we fail to list repos for a single org should we reuse the old orgToRepos or just
+	// log the error and omit the org from orgToRepos as is done now?
+	// I could remove the failed org from 'orgs' to force a resync the next time it is called, but
+	// that could waste tokens if the call continues to fail for some reason.
+
+	orgs := orgsInConfig(config)
+	orgToRepos := map[string]sets.String{}
+	for _, org := range orgs.List() {
+		repos, err := oa.ghc.GetRepos(org, false /*isUser*/)
+		if err != nil {
+			oa.log.WithError(err).Errorf("Getting repos in org: %s.", org)
+			// Remove 'org' from 'orgs' here to force future resync?
+			continue
+		}
+		repoSet := sets.NewString()
+		for _, repo := range repos {
+			repoSet.Insert(repo.FullName)
+		}
+		orgToRepos[org] = repoSet
+	}
+
+	oa.orgs = orgs
+	oa.orgToRepos = orgToRepos
+	oa.nextSync = time.Now().Add(oa.syncPeriod)
+}
+
+// orgsInConfig gets all the org strings (not org/repo) in config.Plugins and config.ExternalPlugins.
+func orgsInConfig(config *plugins.Configuration) sets.String {
+	orgs := sets.NewString()
+	for repo := range config.Plugins {
+		if !strings.Contains(repo, "/") {
+			orgs.Insert(repo)
+		}
+	}
+	for repo := range config.ExternalPlugins {
+		if !strings.Contains(repo, "/") {
+			orgs.Insert(repo)
+		}
+	}
+	return orgs
+}
+
+func (ha *HelpAgent) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-cache")
+
+	serverError := func(action string, err error) {
+		ha.log.WithError(err).Errorf("Error %s.", action)
+		msg := fmt.Sprintf("500 Internal server error %s: %v", action, err)
+		http.Error(w, msg, http.StatusInternalServerError)
+	}
+
+	if r.Method != http.MethodGet {
+		ha.log.Errorf("Invalid request method: %v.", r.Method)
+		http.Error(w, "405 Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		serverError("reading request body", err)
+		return
+	}
+	help := ha.GeneratePluginHelp()
+	b, err = json.Marshal(help)
+	if err != nil {
+		serverError("marshaling plugin help", err)
+		return
+	}
+
+	fmt.Fprint(w, string(b))
+}

--- a/prow/pluginhelp/hook/hook_test.go
+++ b/prow/pluginhelp/hook/hook_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hook
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+type fakeGithubClient map[string][]string
+
+func (fghc fakeGithubClient) GetRepos(org string, _ bool) ([]github.Repo, error) {
+	var repos []github.Repo
+	for _, repo := range fghc[org] {
+		repos = append(repos, github.Repo{FullName: fmt.Sprintf("%s/%s", org, repo)})
+	}
+	return repos, nil
+}
+
+type fakePluginAgent plugins.Configuration
+
+func (fpa fakePluginAgent) Config() *plugins.Configuration {
+	config := plugins.Configuration(fpa)
+	return &config
+}
+
+func TestGeneratePluginHelp(t *testing.T) {
+	orgToRepos := map[string][]string{"org1": {"repo1", "repo2", "repo3"}, "org2": {"repo1"}}
+	fghc := fakeGithubClient(orgToRepos)
+
+	normalHelp := map[string]pluginhelp.PluginHelp{
+		"org-plugin": {Description: "org-plugin", Config: map[string]string{"": "overall config"}},
+		"repo-plugin1": {
+			Description: "repo-plugin1",
+			Config: map[string]string{
+				"org1/repo1": "repo1 config",
+				"org1/repo2": "repo2 config",
+			},
+		},
+		"repo-plugin2": {Description: "repo-plugin2", Config: map[string]string{}},
+		"repo-plugin3": {Description: "repo-plugin3", Config: map[string]string{}},
+	}
+	helpfulExternalHelp := pluginhelp.PluginHelp{Description: "helpful-external"}
+	noHelpSever := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "404 Not Found", http.StatusNotFound)
+	}))
+	defer noHelpSever.Close()
+	helpfulServer := httptest.NewServer(externalplugins.ServeExternalPluginHelp(
+		logrus.WithField("plugin", "helpful-external"),
+		func(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+			if got, expected := enabledRepos, []string{"org1/repo1"}; !reflect.DeepEqual(got, expected) {
+				t.Errorf("Plugin 'helpful-external' expected to be enabled on repos %q, but got %q.", expected, got)
+			}
+			return &helpfulExternalHelp, nil
+		},
+	))
+	defer helpfulServer.Close()
+
+	config := &plugins.Configuration{
+		Plugins: map[string][]string{
+			"org1":       {"org-plugin"},
+			"org1/repo1": {"repo-plugin1", "no-help-plugin"},
+			"org1/repo2": {"repo-plugin1", "repo-plugin2"},
+			"org2/repo1": {"repo-plugin3"},
+		},
+		ExternalPlugins: map[string][]plugins.ExternalPlugin{
+			"org1/repo1": {
+				{Name: "no-endpoint-external", Endpoint: "http://no-endpoint-external", Events: []string{"issue_comment"}},
+				{Name: "no-help-external", Endpoint: noHelpSever.URL, Events: []string{"issue_comment"}},
+				{Name: "helpful-external", Endpoint: helpfulServer.URL, Events: []string{"pull_request", "issue"}},
+			},
+		},
+	}
+	fpa := fakePluginAgent(*config)
+
+	expectedAllRepos := []string{"org1/repo1", "org1/repo2", "org1/repo3", "org2/repo1"}
+
+	normalExpectedReposForPlugin := map[string][]string{
+		"org-plugin":     {"org1/repo1", "org1/repo2", "org1/repo3"},
+		"repo-plugin1":   {"org1/repo1", "org1/repo2"},
+		"repo-plugin2":   {"org1/repo2"},
+		"repo-plugin3":   {"org2/repo1"},
+		"no-help-plugin": {"org1/repo1"},
+	}
+	normalExpectedPluginsForRepo := map[string][]string{
+		"":           {"org-plugin", "repo-plugin1", "repo-plugin2", "repo-plugin3", "no-help-plugin"},
+		"org1":       {"org-plugin"},
+		"org1/repo1": {"repo-plugin1", "no-help-plugin"},
+		"org1/repo2": {"repo-plugin1", "repo-plugin2"},
+		"org2/repo1": {"repo-plugin3"},
+	}
+	normalExpectedEvents := map[string][]string{
+		"org-plugin":     {"issue_comment"},
+		"repo-plugin1":   {"issue"},
+		"repo-plugin2":   {"pull_request"},
+		"repo-plugin3":   {"pull_request_review", "pull_request_review_comment"},
+		"no-help-plugin": {"issue_comment"},
+	}
+
+	externalExpectedPluginsForRepo := map[string][]string{
+		"":           {"no-endpoint-external", "no-help-external", "helpful-external"},
+		"org1/repo1": {"no-endpoint-external", "no-help-external", "helpful-external"},
+	}
+	externalExpectedEvents := map[string][]string{
+		"no-endpoint-external": {"issue_comment"},
+		"no-help-external":     {"issue_comment"},
+		"helpful-external":     {"pull_request", "issue"},
+	}
+
+	registerNormalPlugins(t, normalExpectedEvents, normalHelp, normalExpectedReposForPlugin)
+
+	help := NewHelpAgent(fpa, fghc).GeneratePluginHelp()
+	if help == nil {
+		t.Fatal("HelpAgent returned nil Help struct pointer.")
+	}
+	if got, expected := sets.NewString(help.AllRepos...), sets.NewString(expectedAllRepos...); !got.Equal(expected) {
+		t.Errorf("Expected 'AllRepos' to be %q, but got %q.", expected.List(), got.List())
+	}
+	checkPluginsForRepo := func(expected, got map[string][]string) {
+		for _, plugins := range expected {
+			sort.Strings(plugins)
+		}
+		for _, plugins := range got {
+			sort.Strings(plugins)
+		}
+		if !reflect.DeepEqual(expected, got) {
+			t.Errorf("Expected repo->plugin map %v, but got %v.", expected, got)
+		}
+	}
+	checkPluginsForRepo(normalExpectedPluginsForRepo, help.RepoPlugins)
+	checkPluginsForRepo(externalExpectedPluginsForRepo, help.RepoExternalPlugins)
+
+	checkPluginHelp := func(plugin string, expected, got pluginhelp.PluginHelp, eventsForPlugin []string) {
+		sort.Strings(eventsForPlugin)
+		sort.Strings(got.Events)
+		if expected, got := eventsForPlugin, got.Events; !reflect.DeepEqual(expected, got) {
+			t.Errorf("Expected plugin '%s' to subscribe to events %q, but got %q.", plugin, expected, got)
+		}
+		// Events field is correct, everything else should match the input exactly.
+		got.Events = nil
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("Expected plugin '%s' to have help: %v, but got %v.", plugin, expected, got)
+		}
+	}
+
+	for plugin, expected := range normalHelp {
+		checkPluginHelp(plugin, expected, help.PluginHelp[plugin], normalExpectedEvents[plugin])
+	}
+	checkPluginHelp("helpful-external", helpfulExternalHelp, help.ExternalPluginHelp["helpful-external"], externalExpectedEvents["helpful-external"])
+}
+
+func registerNormalPlugins(t *testing.T, pluginsToEvents map[string][]string, pluginHelp map[string]pluginhelp.PluginHelp, expectedRepos map[string][]string) {
+	for plugin, events := range pluginsToEvents {
+		plugin := plugin
+		helpProvider := func(_ *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+			if got, expected := sets.NewString(enabledRepos...), sets.NewString(expectedRepos[plugin]...); !got.Equal(expected) {
+				t.Errorf("Plugin '%s' expected to be enabled on repos %q, but got %q.", plugin, expected.List(), got.List())
+			}
+			help := pluginHelp[plugin]
+			return &help, nil
+		}
+		for _, event := range events {
+			switch event {
+			case "issue_comment":
+				plugins.RegisterIssueCommentHandler(plugin, nil, helpProvider)
+			case "issue":
+				plugins.RegisterIssueHandler(plugin, nil, helpProvider)
+			case "pull_request":
+				plugins.RegisterPullRequestHandler(plugin, nil, helpProvider)
+			case "pull_request_review":
+				plugins.RegisterReviewEventHandler(plugin, nil, helpProvider)
+			case "pull_request_review_comment":
+				plugins.RegisterReviewCommentEventHandler(plugin, nil, helpProvider)
+			default:
+				t.Fatalf("Invalid test! Unknown event type '%s' for plugin '%s'.", event, plugin)
+			}
+		}
+	}
+}

--- a/prow/pluginhelp/pluginhelp.go
+++ b/prow/pluginhelp/pluginhelp.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pluginhelp defines structures that represent plugin help information.
+// These structs are used by sub-packages 'hook' and 'externalplugins'.
+package pluginhelp
+
+// PluginHelp is a serializable representation of the help information for a single plugin.
+// This includes repo specific configuration for every repo that the plugin is enabled for.
+type PluginHelp struct {
+	// Description is a description of what the plugin does and what purpose it achieves.
+	Description string
+	// WhoCanUse is a description of the permissions/role/authorization required to use the plugin.
+	// This is usually specified as a github permissions, but it can also be a github team, an
+	// OWNERS file alias, etc.
+	WhoCanUse string
+	// Usage is a usage string for the plugin. Leave empty if not applicable.
+	Usage string
+	// Examples is a list of usage examples for the plugin. Leave empty if not applicable.
+	Examples []string
+	// Config is a map from org/repo strings to a string describing the configuration for that repo.
+	// The key "" should map to a string describing configuration that applies to all repos if any.
+	Config map[string]string
+
+	// Events is a slice containing the events that are handled by the plugin.
+	// NOTE: Plugins do not need to populate this. Hook populates it on their behalf.
+	Events []string
+}
+
+// Help is a serializable representation of all plugin help information.
+type Help struct {
+	// AllRepos is a flatten (all org/repo, no org strings) list of the repos that use plugins.
+	AllRepos []string
+	// RepoPlugins maps org and org/repo strings to the plugins configured for that scope.
+	// NOTE: The key "" maps to the list of all existing plugins (including failed help providers).
+	// A mix of org or org/repo strings is desirable over the flattened form (all org/repo) that
+	// 'AllRepos' uses because it matches the plugin configuration and is more human readable.
+	RepoPlugins         map[string][]string
+	RepoExternalPlugins map[string][]string
+	// PluginHelp is maps plugin names to their help info.
+	PluginHelp         map[string]PluginHelp
+	ExternalPluginHelp map[string]PluginHelp
+}

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/pluginhelp:go_default_library",
         "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -79,8 +79,8 @@ type state struct {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequestEvent)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, nil)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequestEvent, nil)
 }
 
 func handleGenericCommentEvent(pc plugins.PluginClient, ce github.GenericCommentEvent) error {

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -35,7 +35,7 @@ var (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/blockade/blockade.go
+++ b/prow/plugins/blockade/blockade.go
@@ -54,7 +54,7 @@ type pruneClient interface {
 }
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
 }
 
 type blockCalc func([]github.PullRequestChange, []blockade) summary

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -54,7 +54,7 @@ It may take a couple minutes for the CLA signature to be fully registered; after
 )
 
 func init() {
-	plugins.RegisterStatusEventHandler(pluginName, handleStatusEvent)
+	plugins.RegisterStatusEventHandler(pluginName, handleStatusEvent, nil)
 }
 
 type gitHubClient interface {

--- a/prow/plugins/close/close.go
+++ b/prow/plugins/close/close.go
@@ -31,7 +31,7 @@ const pluginName = "close"
 var closeRe = regexp.MustCompile(`(?mi)^/close\s*$`)
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/docs-no-retest/docs-no-retest.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest.go
@@ -40,7 +40,7 @@ var (
 )
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
 }
 
 func handlePullRequest(pc plugins.PluginClient, pe github.PullRequestEvent) error {

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -43,7 +43,7 @@ const (
 var lintRe = regexp.MustCompile(`(?mi)^/lint\s*$`)
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/heart/heart.go
+++ b/prow/plugins/heart/heart.go
@@ -42,8 +42,8 @@ var reactions = []string{
 }
 
 func init() {
-	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment, nil)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -41,7 +41,7 @@ var (
 type hasLabelFunc func(label string, issueLabels []github.Label) bool
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -36,7 +36,7 @@ var (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -35,7 +35,7 @@ var (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -46,7 +46,7 @@ type githubClient interface {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -74,8 +74,8 @@ var (
 )
 
 func init() {
-	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment, nil)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/reopen/reopen.go
+++ b/prow/plugins/reopen/reopen.go
@@ -31,7 +31,7 @@ const pluginName = "reopen"
 var reopenRe = regexp.MustCompile(`(?mi)^/reopen\s*$`)
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/shrug/shrug.go
+++ b/prow/plugins/shrug/shrug.go
@@ -47,7 +47,7 @@ type event struct {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/sigmention/sigmention.go
+++ b/prow/plugins/sigmention/sigmention.go
@@ -54,7 +54,7 @@ type githubClient interface {
 }
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -33,7 +33,7 @@ import (
 const pluginName = "size"
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
 }
 
 func handlePullRequest(pc plugins.PluginClient, pe github.PullRequestEvent) error {

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -45,8 +45,8 @@ type client struct {
 }
 
 func init() {
-	plugins.RegisterPushEventHandler(pluginName, handlePush)
-	plugins.RegisterGenericCommentHandler(pluginName, handleComment)
+	plugins.RegisterPushEventHandler(pluginName, handlePush, nil)
+	plugins.RegisterGenericCommentHandler(pluginName, handleComment, nil)
 }
 
 func handleComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -31,9 +31,9 @@ const (
 )
 
 func init() {
-	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment)
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
-	plugins.RegisterPushEventHandler(pluginName, handlePush)
+	plugins.RegisterIssueCommentHandler(pluginName, handleIssueComment, nil)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
+	plugins.RegisterPushEventHandler(pluginName, handlePush, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -31,7 +31,7 @@ const (
 )
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
 }
 
 type githubClient interface {

--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -49,7 +49,7 @@ type event struct {
 }
 
 func init() {
-	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, nil)
 }
 
 // Strict subset of *github.Client methods.

--- a/prow/plugins/yuks/yuks.go
+++ b/prow/plugins/yuks/yuks.go
@@ -41,7 +41,7 @@ const (
 )
 
 func init() {
-	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment)
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, nil)
 }
 
 type githubClient interface {


### PR DESCRIPTION
This still needs:
- [x] tests
- [x] deck endpoint to expose the help information (`/plugin-help.js`)
- [x] deck endpoint to display the help information (`/plugin-help`)

I can make the last two items a separate PR.

Additionally, the plugins will need to actually register real help information instead of just passing nil at registration time.