### PR TITLE
Let gke canary job test against latest-staging to verify kubetest is working

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4977,11 +4977,11 @@
       "--check-leaked-resources",
       "--cluster=",
       "--deployment=gke",
-      "--extract=ci/latest",
+      "--extract=ci/gke-staging-latest",
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-b",
       "--ginkgo-parallel",
-      "--gke-environment=test",
+      "--gke-environment=staging",
       "--provider=gke",
       "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
       "--timeout=50m"


### PR DESCRIPTION
```
senlu-macbookpro:test-infra senlu$ gsutil cat gs://kubernetes-release-gke/release/gke-staging-latest.txt
1.8.2-gke.0
```
Let's use the canary job to verify it's working first

/assign @foxish 