### PR TITLE
Fix path in cri-containerd e2e.

### DIFF
--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -10,8 +10,8 @@ TEST_ETCD_VERSION=2.2.1
 ENABLE_POD_SECURITY_POLICY=true
 
 # Envs for cri-containerd.
-KUBE_MASTER_EXTRA_METADATA=user-data=/go/src/github.com/kubernetes-incubator/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/go/src/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
-KUBE_NODE_EXTRA_METADATA=user-data=/go/src/github.com/kubernetes-incubator/cri-containerd/test/e2e/node.yaml,cri-containerd-configure-sh=/go/src/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
+KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/kubernetes-incubator/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/workspace/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
+KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/kubernetes-incubator/cri-containerd/test/e2e/node.yaml,cri-containerd-configure-sh=/workspace/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
 KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/var/run/cri-containerd.sock
 KUBE_LOAD_IMAGE_COMMAND=/home/cri-containerd/usr/local/bin/cri-containerd load


### PR DESCRIPTION
From the test log, it seems that current directory is `/workspace`.
Use relative path now.