### PR TITLE
Ensure Jenkins jobs get a backwards compatible environment set

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -18,7 +18,7 @@ not make any attempt to preserve backwards compatibility.
 * `cmd/horologium` starts periodic jobs when necessary.
 * `cmd/mkpj` creates `ProwJobs`.
 
-See also: [Life of a Prow Job](./architecture.md) 
+See also: [Life of a Prow Job](./architecture.md)
 
 ## Announcements
 
@@ -29,6 +29,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 7, 2017* `jenkins-operator:0.51` provides jobs with the `$BUILD_ID`
+   variable as well as the `$buildId` variable. The latter is deprecated and will
+   be removed in a future version.
  - *November 6, 2017* `plank:0.55` provides `Pods` with the `$BUILD_ID` variable
    as well as the `$BUILD_NUMBER` variable. The latter is deprecated and will be
    removed in a future version.
@@ -51,7 +54,7 @@ used when updating deployments.
    handled in the `milestonestatus` plugin instead of the `label` plugin, the
    team ID is stored at key `milestonestatus`>>`maintainers_id`.
    - The sigmention and milestonestatus plugins must be enabled on any repos
-   that require them since their functionality is no longer included in the 
+   that require them since their functionality is no longer included in the
    label plugin.
  - *September 3, 2017* `sinker:0.17` now deletes pods labeled by `plank:0.42` in
    order to avoid cleaning up unrelated pods that happen to be found in the
@@ -114,10 +117,10 @@ number.
 ## How to update the cluster
 
 Any modifications to Go code will require redeploying the affected binaries.
-Fortunately, this should result in no downtime for the system. Run `./bump.sh <program-name>` 
+Fortunately, this should result in no downtime for the system. Run `./bump.sh <program-name>`
 to bump the relevant version number in the makefile as well as in the `cluster` manifest,
-then run the image and deployment make targets on a branch which has the 
-changes. For instance, if you bumped the hook version, run 
+then run the image and deployment make targets on a branch which has the
+changes. For instance, if you bumped the hook version, run
 `make hook-image && make hook-deployment`.
 
 **Please ensure that your git tree is up to date before updating anything.**
@@ -138,10 +141,10 @@ plugin to mimic.
 
 ## How to enable a plugin on a repo
 
-Add an entry to [plugins.yaml](plugins.yaml). If you misspell the name then a 
-unit test will fail. If you have [update-config](plugins/updateconfig) plugin 
-deployed then the config will be automatically updated once the PR is merged, 
-else you will need to run `make update-plugins`. This does not require 
+Add an entry to [plugins.yaml](plugins.yaml). If you misspell the name then a
+unit test will fail. If you have [update-config](plugins/updateconfig) plugin
+deployed then the config will be automatically updated once the PR is merged,
+else you will need to run `make update-plugins`. This does not require
 redeploying the binaries, and will take effect within a minute.
 
 Note that Github events triggered by the account that is managing the plugins
@@ -151,10 +154,10 @@ second account is `tide` or the `submit-queue` munger.
 
 ## How to add new jobs
 
-To add a new job you'll need to add an entry into [config.yaml](config.yaml). 
-If you have [update-config](plugins/updateconfig) plugin deployed then the 
-config will be automatically updated once the PR is merged, else you will need 
-to run `make update-config`. This does not require redeploying any binaries, 
+To add a new job you'll need to add an entry into [config.yaml](config.yaml).
+If you have [update-config](plugins/updateconfig) plugin deployed then the
+config will be automatically updated once the PR is merged, else you will need
+to run `make update-config`. This does not require redeploying any binaries,
 and will take effect within a minute.
 
 Periodic config looks like so:
@@ -279,4 +282,4 @@ Batch Job:
 [@k8s-bot](https://github.com/k8s-bot) both live here as triggers to GitHub
 messages defined in [config.yaml](config.yaml). Here is a
 [command list](https://github.com/kubernetes/test-infra/blob/master/commands.md)
-for them. 
+for them.

--- a/prow/pjutil/jobspec.go
+++ b/prow/pjutil/jobspec.go
@@ -64,8 +64,11 @@ func EnvForSpec(spec JobSpec) (map[string]string, error) {
 
 	// for backwards compatibility, we provide the build ID
 	// in both $BUILD_ID and $BUILD_NUMBER for Prow agents
+	// and in both $buildId and $BUILD_NUMBER for Jenkins
 	if spec.agent == kube.KubernetesAgent {
 		env["BUILD_NUMBER"] = spec.BuildId
+	} else if spec.agent == kube.JenkinsAgent {
+		env["buildId"] = spec.BuildId
 	}
 
 	raw, err := json.Marshal(spec)

--- a/prow/pjutil/jobspec_test.go
+++ b/prow/pjutil/jobspec_test.go
@@ -134,6 +134,38 @@ func TestEnvironmentForSpec(t *testing.T) {
 				"PULL_PULL_SHA": "pull-sha",
 			},
 		},
+		{
+			name: "kubernetes agent",
+			spec: JobSpec{
+				Type:    kube.PeriodicJob,
+				Job:     "job-name",
+				BuildId: "0",
+				agent:   kube.KubernetesAgent,
+			},
+			expected: map[string]string{
+				"JOB_NAME":     "job-name",
+				"BUILD_ID":     "0",
+				"BUILD_NUMBER": "0",
+				"JOB_TYPE":     "periodic",
+				"JOB_SPEC":     `{"type":"periodic","job":"job-name","buildid":"0","refs":{}}`,
+			},
+		},
+		{
+			name: "jenkins agent",
+			spec: JobSpec{
+				Type:    kube.PeriodicJob,
+				Job:     "job-name",
+				BuildId: "0",
+				agent:   kube.JenkinsAgent,
+			},
+			expected: map[string]string{
+				"JOB_NAME": "job-name",
+				"BUILD_ID": "0",
+				"buildId":  "0",
+				"JOB_TYPE": "periodic",
+				"JOB_SPEC": `{"type":"periodic","job":"job-name","buildid":"0","refs":{}}`,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When migrating away from the old `$buildId` variable to the new
`$BUILD_ID` variable that both Jenkins and Kubernetes jobs can share, we
need to ensure the migration happens in a backwards compatible manner so
that dependent jobs can migrate at their own pace. This means passing
the old variable as well as the new one for now.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/kind bug
/area prow
/cc @kargakis @cjwagner 

Sorry about README edits, opened in an editor that chomps whitespace. I can revert  that if we feel strongly about it. Backwards compat for k8s jobs was already present, just forgot Jenkins.