### PR TITLE
Add pod.spec.hostNetwork field to Prow job spec

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,23 +20,23 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.176
+HOOK_VERSION             ?= 0.177
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.21
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.58
+DECK_VERSION             ?= 0.59
 # SPLICE_VERSION is the version of the splice image
-SPLICE_VERSION           ?= 0.28
+SPLICE_VERSION           ?= 0.29
 # TOT_VERSION is the version of the tot image
 TOT_VERSION              ?= 0.5
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= 0.11
+HOROLOGIUM_VERSION       ?= 0.12
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= 0.55
+PLANK_VERSION            ?= 0.56
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= 0.51
+JENKINS-OPERATOR_VERSION ?= 0.52
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.8
+TIDE_VERSION             ?= 0.9
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.58
+        image: gcr.io/k8s-prow/deck:0.59
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.176
+        image: gcr.io/k8s-prow/hook:0.177
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.11
+        image: gcr.io/k8s-prow/horologium:0.12
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.51
+        image: gcr.io/k8s-prow/jenkins-operator:0.52
         ports:
         - name: logs
           containerPort: 8080

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.55
+        image: gcr.io/k8s-prow/plank:0.56
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.28
+        image: gcr.io/k8s-prow/splice:0.29
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.176
+        image: gcr.io/k8s-prow/hook:0.177
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.55
+        image: gcr.io/k8s-prow/plank:0.56
         args:
         - --dry-run=false
         volumeMounts:
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.58
+        image: gcr.io/k8s-prow/deck:0.59
         ports:
           - name: http
             containerPort: 8080
@@ -223,7 +223,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.11
+        image: gcr.io/k8s-prow/horologium:0.12
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.8
+        image: gcr.io/k8s-prow/tide:0.9
         args:
         - --dry-run=false
         ports:

--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -47,6 +47,7 @@ type Pod struct {
 }
 
 type PodSpec struct {
+	HostNetwork   bool              `json:"hostNetwork,omitempty"`
 	Volumes       []Volume          `json:"volumes,omitempty"`
 	Containers    []Container       `json:"containers,omitempty"`
 	RestartPolicy string            `json:"restartPolicy,omitempty"`


### PR DESCRIPTION
We're using the test-infra repository for some of our own repos, and have a requirement to use hostNetwork (so we can run virtualbox within a container).

This PR adds the `pod.spec.hostNetwork` field in order to allow this. I think I'll also need to update some image tags in the Makefile and `cluster` deployment examples.

As an aside - now that we have `k8s.io/api`, could we potentially stop writing these types ourselves and instead depend upon that? Or will it still introduce some circular dependency?