### PR TITLE
add NON_MASQUERADE_CIDR="0.0.0.0/0"

### DIFF
--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -16,5 +16,6 @@ KUBE_CONTAINER_RUNTIME=remote
 KUBE_CONTAINER_RUNTIME_ENDPOINT=/var/run/cri-containerd.sock
 KUBE_LOAD_IMAGE_COMMAND=/home/cri-containerd/usr/local/bin/cri-containerd load
 NETWORK_POLICY_PROVIDER=calico
+NON_MASQUERADE_CIDR=0.0.0.0/0
 # TODO(random-liu): Enable this after kubernetes/kubernetes#55141 is fixed.
 PREPULL_E2E_IMAGES=false


### PR DESCRIPTION
This is newly added in https://github.com/kubernetes/kubernetes/pull/55178, and we need this to make cri-containerd e2e test work.