### PR TITLE
Disable pod security policy. It is not finished yet, and doesn't work with calico addons.

### DIFF
--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -7,7 +7,8 @@ TEST_ETCD_IMAGE=2.2.1
 TEST_ETCD_VERSION=2.2.1
 
 # Enable the PodSecurityPolicy in tests.
-ENABLE_POD_SECURITY_POLICY=true
+# TODO(random-liu): Re-enable this after the pod security policy feature is finished.
+# ENABLE_POD_SECURITY_POLICY=true
 
 # Envs for cri-containerd.
 KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/kubernetes-incubator/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/workspace/github.com/kubernetes-incubator/cri-containerd/test/configure.sh


### PR DESCRIPTION
Disable pod security policy.
It is not finished yet, and doesn't work with calico addons.

/cc @timstclair 