### PR TITLE
Only allow one container per PodSpec for ProwJobs

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -207,8 +207,14 @@ func parseConfig(c *Config) error {
 		name := v.Name
 		agent := v.Agent
 		// Ensure that k8s presubmits have a pod spec.
-		if agent == string(kube.KubernetesAgent) && v.Spec == nil {
-			return fmt.Errorf("job %s has no spec", name)
+		if agent == string(kube.KubernetesAgent) {
+			if v.Spec == nil {
+				return fmt.Errorf("job %s has no spec", name)
+			} else {
+				if len(v.Spec.Containers) > 1 {
+					return fmt.Errorf("job %s has more than one container; see https://github.com/kubernetes/test-infra/pull/5403 for discussion on this restriction", name)
+				}
+			}
 		}
 		// Ensure agent is a known value.
 		if agent != string(kube.KubernetesAgent) && agent != string(kube.JenkinsAgent) {
@@ -225,9 +231,14 @@ func parseConfig(c *Config) error {
 	for _, j := range c.AllPostsubmits(nil) {
 		name := j.Name
 		agent := j.Agent
-		// Ensure that k8s postsubmits have a pod spec.
-		if agent == string(kube.KubernetesAgent) && j.Spec == nil {
-			return fmt.Errorf("job %s has no spec", name)
+		if agent == string(kube.KubernetesAgent) {
+			if j.Spec == nil {
+				return fmt.Errorf("job %s has no spec", name)
+			} else {
+				if len(j.Spec.Containers) > 1 {
+					return fmt.Errorf("job %s has more than one container; see https://github.com/kubernetes/test-infra/pull/5403 for discussion on this restriction", name)
+				}
+			}
 		}
 		// Ensure agent is a known value.
 		if agent != string(kube.KubernetesAgent) && agent != string(kube.JenkinsAgent) {
@@ -244,8 +255,14 @@ func parseConfig(c *Config) error {
 	for _, p := range c.AllPeriodics() {
 		name := p.Name
 		agent := p.Agent
-		if agent == string(kube.KubernetesAgent) && p.Spec == nil {
-			return fmt.Errorf("job %s has no spec", name)
+		if agent == string(kube.KubernetesAgent) {
+			if p.Spec == nil {
+				return fmt.Errorf("job %s has no spec", name)
+			} else {
+				if len(p.Spec.Containers) > 1 {
+					return fmt.Errorf("job %s has more than one container; see https://github.com/kubernetes/test-infra/pull/5403 for discussion on this restriction", name)
+				}
+			}
 		}
 		if agent != string(kube.KubernetesAgent) && agent != string(kube.JenkinsAgent) {
 			return fmt.Errorf("job %s has invalid agent (%s), it needs to be one of the following: %s %s",


### PR DESCRIPTION
Today, no jobs use more than one container and it is generally undefined
behavior to have more than one container in a Prow test pod. We should
enforce this through validation on Prow PodSpec configuration.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @kargakis @fejta @cjwagner 
/area prow

Background: when we are dynamically adding a logging sidecar it only makes sense today to do it if there is one container in a pod that the user gives us, otherwise the user would need to tell us which container to log. In  any case today this behavior is undefined so I feel like we can tighten validation to enforce it and loosen later when we decide how we want to handle it. This impacts no current jobs.