### PR TITLE
Adds tolerations, serviceAccountName and initContainers to PodSpec

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,23 +20,23 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.187
+HOOK_VERSION             ?= 0.188
 # SINKER_VERSION is the version of the sinker image
-SINKER_VERSION           ?= 0.24
+SINKER_VERSION           ?= 0.25
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.69
+DECK_VERSION             ?= 0.70
 # SPLICE_VERSION is the version of the splice image
-SPLICE_VERSION           ?= 0.33
+SPLICE_VERSION           ?= 0.34
 # TOT_VERSION is the version of the tot image
 TOT_VERSION              ?= 0.6
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= 0.19
+HOROLOGIUM_VERSION       ?= 0.20
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= 0.61
+PLANK_VERSION            ?= 0.62
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= 0.59
+JENKINS-OPERATOR_VERSION ?= 0.60
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.14
+TIDE_VERSION             ?= 0.15
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.69
+        image: gcr.io/k8s-prow/deck:0.70
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.187
+        image: gcr.io/k8s-prow/hook:0.188
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.19
+        image: gcr.io/k8s-prow/horologium:0.20
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.59
+        image: gcr.io/k8s-prow/jenkins-operator:0.60
         ports:
         - name: logs
           containerPort: 8080

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.61
+        image: gcr.io/k8s-prow/plank:0.62
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
-        image: gcr.io/k8s-prow/sinker:0.24
+        image: gcr.io/k8s-prow/sinker:0.25
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.33
+        image: gcr.io/k8s-prow/splice:0.34
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.187
+        image: gcr.io/k8s-prow/hook:0.188
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.61
+        image: gcr.io/k8s-prow/plank:0.62
         args:
         - --dry-run=false
         volumeMounts:
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.24
+        image: gcr.io/k8s-prow/sinker:0.25
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.69
+        image: gcr.io/k8s-prow/deck:0.70
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:
@@ -225,7 +225,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.19
+        image: gcr.io/k8s-prow/horologium:0.20
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.14
+        image: gcr.io/k8s-prow/tide:0.15
         args:
         - --dry-run=false
         ports:

--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -47,11 +47,14 @@ type Pod struct {
 }
 
 type PodSpec struct {
-	HostNetwork   bool              `json:"hostNetwork,omitempty"`
-	Volumes       []Volume          `json:"volumes,omitempty"`
-	Containers    []Container       `json:"containers,omitempty"`
-	RestartPolicy string            `json:"restartPolicy,omitempty"`
-	NodeSelector  map[string]string `json:"nodeSelector,omitempty"`
+	HostNetwork        bool              `json:"hostNetwork,omitempty"`
+	Volumes            []Volume          `json:"volumes,omitempty"`
+	InitContainers     []Container       `json:"initContainers,omitempty"`
+	Containers         []Container       `json:"containers,omitempty"`
+	RestartPolicy      string            `json:"restartPolicy,omitempty"`
+	ServiceAccountName string            `json:"serviceAccountName,omitempty"`
+	Tolerations        []Toleration      `json:"tolerations,omitempty"`
+	NodeSelector       map[string]string `json:"nodeSelector,omitempty"`
 }
 
 type PodPhase string
@@ -200,3 +203,15 @@ type ConfigMap struct {
 	Metadata ObjectMeta        `json:"metadata,omitempty"`
 	Data     map[string]string `json:"data,omitempty"`
 }
+
+type Toleration struct {
+	Key               string             `json:"key,omitempty"`
+	Operator          TolerationOperator `json:"operator,omitempty"`
+	Value             string             `json:"value,omitempty"`
+	Effect            TaintEffect        `json:"effect,omitempty"`
+	TolerationSeconds *int64             `json:"tolerationSeconds,omitempty"`
+}
+
+type TaintEffect string
+
+type TolerationOperator string


### PR DESCRIPTION
As @munnerz already explained in #5381, we are using test-infra for our public repo's testing.

W would like to make use of initContainers and tolerations as we'd like certain jobs to be running on certain hosts and have some more privileged initContianer. I agree that #1986 should be implemented to get in the end all types from the core project. It would help use meanwhile to extend the PodSpec a bit more :slightly_smiling_face: 