### PR TITLE
Add rsync to gcloud image

### DIFF
--- a/images/gcloud/Dockerfile
+++ b/images/gcloud/Dockerfile
@@ -18,6 +18,7 @@ LABEL maintainer="senlu@google.com"
 
 RUN apt-get update && apt-get install -y \
     python \
+    rsync \
     wget && \
     apt-get clean
 

--- a/images/gcloud/Makefile
+++ b/images/gcloud/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.4
+VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 image:
 	docker build -t "gcr.io/k8s-testimages/gcloud-in-go:$(VERSION)" .


### PR DESCRIPTION
This is required by some of the federation verify checks (https://github.com/kubernetes/federation/pull/142).