### PR TITLE
Reduce kubemark-500 CI and PR jobs' timeouts

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins-pull/bootstrap-pull-json.yaml
@@ -84,7 +84,7 @@
         max-total: 12
         job-name: pull-kubernetes-kubemark-e2e-gce-big
         repo-name: 'k8s.io/kubernetes'
-        timeout: 160
+        timeout: 100
     - cadvisor-e2e:  # owner: stclair@google.com
         job-name: pull-cadvisor-e2e
         max-total: 5

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8249,7 +8249,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=120m"
+      "--timeout=70m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9407,7 +9407,7 @@
       "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce-big",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=140m"
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [


### PR DESCRIPTION
Ref https://github.com/kubernetes/test-infra/issues/5407

We don't need that much of a timeout for those jobs.

/cc @krzyzacy 