### PR TITLE
Assign sigOwners to all remaining jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3620,6 +3620,7 @@
     ]
   },
   "ci-kubernetes-e2e-gci-gce-garbage": {
+    "_comment": "TODO: remove this job, kubernetes/kubernetes#49262 removed the Feature:GarbageCollector tag",
     "args": [
       "--check-leaked-resources",
       "--cluster=gc-feature",
@@ -3633,7 +3634,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-api-machinery"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-ingress": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2926,7 +2926,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-instrumentation"
     ]
   },
   "ci-kubernetes-e2e-gce-taint-evict": {
@@ -6255,7 +6255,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-instrumentation"
     ]
   },
   "ci-kubernetes-e2e-gke-staging-default-latest-upgrade-cluster": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2206,7 +2206,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-cluster-lifecycle"
     ]
   },
   "ci-kubernetes-e2e-gce-large-correctness": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2942,7 +2942,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-apps"
     ]
   },
   "ci-kubernetes-e2e-gce-ubuntudev-k8sbeta-default": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1849,7 +1849,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-cluster-lifecycle"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-latest-upgrade-etcd": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -288,7 +288,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-apps"
     ]
   },
   "ci-kubernetes-cross-build": {
@@ -9029,7 +9029,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-apps"
     ]
   },
   "pull-cluster-registry-bazel": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5505,7 +5505,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-cli"
     ]
   },
   "ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3566,7 +3566,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-instrumentation"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-etcd3": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9219,7 +9219,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "pull-kubernetes-e2e-gce-device-plugin-gpu": {
@@ -9291,7 +9291,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "pull-kubernetes-e2e-kops-aws": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7,7 +7,7 @@
     ],
     "scenario": "canarypush",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "ci-cadvisor-node-kubelet": {
@@ -16,7 +16,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "ci-cri-containerd-build": {
@@ -9020,7 +9020,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "pull-charts-e2e": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -1737,7 +1737,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-federation-release-1-7": {
@@ -1796,7 +1796,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-ci-serial-master": {
@@ -1812,7 +1812,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-ci-slow-master": {
@@ -1829,7 +1829,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-latest-rollback-etcd": {
@@ -1887,7 +1887,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-m61": {
@@ -1904,7 +1904,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-m62": {
@@ -1921,7 +1921,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-m63": {
@@ -1938,7 +1938,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-master": {
@@ -1955,7 +1955,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m60": {
@@ -1972,7 +1972,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m61": {
@@ -1988,7 +1988,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m62": {
@@ -2004,7 +2004,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-m63": {
@@ -2020,7 +2020,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-serial-master": {
@@ -2035,7 +2035,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-m60": {
@@ -2053,7 +2053,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-m61": {
@@ -2070,7 +2070,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-m62": {
@@ -2087,7 +2087,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-m63": {
@@ -2104,7 +2104,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-qa-slow-master": {
@@ -2121,7 +2121,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-gci-serial-sig-cli": {
@@ -2403,7 +2403,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew": {
@@ -3583,7 +3583,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-etcd3-sig-cli": {
@@ -3616,7 +3616,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-garbage": {
@@ -4334,7 +4334,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-prod": {
@@ -4354,7 +4354,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-prod-parallel": {
@@ -4375,7 +4375,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-prod-smoke": {
@@ -4396,7 +4396,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-reboot": {
@@ -4727,7 +4727,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-test": {
@@ -4745,7 +4745,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gci-gke-updown": {
@@ -4764,7 +4764,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-1-6-1-7-cvm-kubectl-skew": {
@@ -5357,7 +5357,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster": {
@@ -5918,7 +5918,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-prod-parallel": {
@@ -5938,7 +5938,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-prod-smoke": {
@@ -5958,7 +5958,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-reboot-release-1-6": {
@@ -6014,7 +6014,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-release-1-6": {
@@ -6339,7 +6339,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-staging-default-serial": {
@@ -6359,7 +6359,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-staging-latest-device-plugin-gpu": {
@@ -6399,7 +6399,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-staging-latest-serial": {
@@ -6418,7 +6418,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-subnet": {
@@ -6438,7 +6438,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-test": {
@@ -6456,7 +6456,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-gke-ubuntustable1-k8sdev-alphafeatures": {
@@ -7190,7 +7190,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-gcp"
     ]
   },
   "ci-kubernetes-e2e-kops-aws": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -271,7 +271,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-release"
     ]
   },
   "ci-kubernetes-charts-gce": {
@@ -299,7 +299,7 @@
     ],
     "scenario": "kubernetes_build",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-release"
     ]
   },
   "ci-kubernetes-e2e-cos-docker-validation": {
@@ -9184,7 +9184,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-release"
     ]
   },
   "pull-kubernetes-dns-test": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8730,7 +8730,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-scalability"
     ]
   },
   "ci-perf-tests-kubemark-100-benchmark": {
@@ -8739,7 +8739,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-scalability"
     ]
   },
   "ci-test-infra-bazel": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9446,7 +9446,7 @@
     ],
     "scenario": "kubernetes_verify",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "pull-kubernetes-verify": {
@@ -9456,7 +9456,7 @@
     ],
     "scenario": "kubernetes_verify",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "pull-kubernetes-verify-prow": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -146,7 +146,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-aws"
     ]
   },
   "ci-kubernetes-bazel-build": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8845,7 +8845,7 @@
     ],
     "scenario": "execute",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-testing"
     ]
   },
   "periodic-kubernetes-bazel-build-1-6": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3796,7 +3796,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-api-machinery"
     ]
   },
   "ci-kubernetes-e2e-gci-gce-reboot": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4161,7 +4161,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-apps"
     ]
   },
   "ci-kubernetes-e2e-gci-gke": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -318,7 +318,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "ci-kubernetes-e2e-cos-docker-validation-serial": {
@@ -336,7 +336,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "ci-kubernetes-e2e-cos-docker-validation-slow": {
@@ -355,7 +355,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "ci-kubernetes-e2e-gce-1-6-1-7-cvm-kubectl-skew": {
@@ -8477,7 +8477,7 @@
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-node"
     ]
   },
   "ci-kubernetes-soak-gce-1-6": {

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9121,7 +9121,7 @@
   "pull-heapster-e2e": {
     "scenario": "kubernetes_heapster",
     "sigOwners": [
-      "UNKNOWN"
+      "sig-instrumentation"
     ]
   },
   "pull-kops-e2e-kubernetes-aws": {

--- a/jobs/validOwners.json
+++ b/jobs/validOwners.json
@@ -1,5 +1,4 @@
 [
-   "UNKNOWN",
    "sig-api-machinery",
    "sig-apps",
    "sig-auth",


### PR DESCRIPTION
Fixes kubernetes/test-infra#5350

Broken into commit(s) per sig, with rationale in the commit message

I've removed UNKNOWN from validOwners because it's not a valid owner anymore :tada:

@kubernetes/sig-api-machinery-test-failures
@kubernetes/sig-apps-test-failures
@kubernetes/sig-aws-test-failures
@kubernetes/sig-cli-test-failures
@kubernetes/sig-cluster-lifecycle-test-failures
@kubernetes/sig-gcp-test-failures
@kubernetes/sig-instrumentation-test-failures
@kubernetes/sig-node-test-failures
@kubernetes/sig-release-test-failures
@kubernetes/sig-scalability-test-failures
@kubernetes/sig-testing-test-failures
Please comment with suggestions for an alternate sig if you feel I have mis-assigned your sig