### PR TITLE
Add support for ProwJob lifecycle hooks

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,23 +20,23 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.179
+HOOK_VERSION             ?= 0.180
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.22
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.60
+DECK_VERSION             ?= 0.61
 # SPLICE_VERSION is the version of the splice image
-SPLICE_VERSION           ?= 0.30
+SPLICE_VERSION           ?= 0.31
 # TOT_VERSION is the version of the tot image
 TOT_VERSION              ?= 0.5
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= 0.13
+HOROLOGIUM_VERSION       ?= 0.14
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= 0.58
+PLANK_VERSION            ?= 0.59
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= 0.55
+JENKINS-OPERATOR_VERSION ?= 0.56
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.10
+TIDE_VERSION             ?= 0.11
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.60
+        image: gcr.io/k8s-prow/deck:0.61
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.179
+        image: gcr.io/k8s-prow/hook:0.180
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.13
+        image: gcr.io/k8s-prow/horologium:0.14
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.55
+        image: gcr.io/k8s-prow/jenkins-operator:0.56
         ports:
         - name: logs
           containerPort: 8080

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.58
+        image: gcr.io/k8s-prow/plank:0.59
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.30
+        image: gcr.io/k8s-prow/splice:0.31
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.179
+        image: gcr.io/k8s-prow/hook:0.180
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.58
+        image: gcr.io/k8s-prow/plank:0.59
         args:
         - --dry-run=false
         volumeMounts:
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.60
+        image: gcr.io/k8s-prow/deck:0.61
         ports:
           - name: http
             containerPort: 8080
@@ -223,7 +223,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.13
+        image: gcr.io/k8s-prow/horologium:0.14
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.10
+        image: gcr.io/k8s-prow/tide:0.11
         args:
         - --dry-run=false
         ports:

--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -133,6 +133,27 @@ type Container struct {
 	Resources       Resources        `json:"resources,omitempty"`
 	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
 	VolumeMounts    []VolumeMount    `json:"volumeMounts,omitempty"`
+	Lifecycle       *Lifecycle       `json:"lifecycle,omitempty"`
+}
+
+// Lifecycle describes actions that the management system should take in response to container lifecycle
+// events. For the PostStart and PreStop lifecycle handlers, management of the container blocks
+// until the action is complete, unless the container process fails, in which case the handler is aborted.
+type Lifecycle struct {
+	PostStart *Handler `json:"postStart,omitempty"`
+	PreStop   *Handler `json:"preStop,omitempty"`
+}
+
+// Handler defines a specific action that should be taken
+// TODO: pass structured data to these actions, and document that data here.
+type Handler struct {
+	// Exec specifies the action to take.
+	Exec *ExecAction `json:"exec,omitempty"`
+}
+
+// ExecAction describes a "run in container" action.
+type ExecAction struct {
+	Command []string `json:"command,omitempty"`
 }
 
 type Port struct {


### PR DESCRIPTION
This PR adds support for specifying ProwJob lifecycle hooks.

We have started creating VMs within our CI jobs and need to ensure a `preStop` hook is run in order to clean up minikube/libvirt.
