### PR TITLE
Tune up kubemark and aws canaries

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7229,6 +7229,24 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-e2e-kops-aws-cncf-canary": {
+    "args": [
+      "--aws",
+      "--aws-cluster-domain=test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-canary",
+      "--env-file=jobs/platform/kops_aws.env",
+      "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-canary.env",
+      "--extract=ci/latest",
+      "--ginkgo-parallel",
+      "--provider=aws",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-testing"
+    ]
+  },
   "ci-kubernetes-e2e-kops-aws-newrunner": {
     "args": [
       "--cluster=e2e-kops-aws-newrunner.test-aws.k8s.io",
@@ -8221,7 +8239,7 @@
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest",
       "--extract-source",
-      "--gcp-project=k8s-jenkins-gci-kubemark",
+      "--gcp-project=sen-lu-test",
       "--gcp-zone=us-central1-f",
       "--kubemark",
       "--kubemark-nodes=5",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -15379,6 +15379,50 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
+        secretName: aws-cred
+
+- interval: 2h
+  agent: kubernetes
+  name: ci-kubernetes-e2e-kops-aws-cncf-canary
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_AWS_CREDENTIALS_FILE
+        value: /etc/aws-cred/credentials
+      - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/aws-ssh
+        name: aws-ssh
+        readOnly: true
+      - mountPath: /etc/aws-cred
+        name: aws-cred
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: aws-ssh
+      secret:
+        defaultMode: 256
+        secretName: aws-ssh-key-secret
+    - name: aws-cred
+      secret:
+        defaultMode: 256
         secretName: aws-cred-new
 
 - interval: 1h

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -99,6 +99,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws
 - name: ci-kubernetes-e2e-kops-aws-canary
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-canary
+- name: ci-kubernetes-e2e-kops-aws-cncf-canary
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-cncf-canary
 - name: ci-kubernetes-e2e-kops-aws-sig-cli
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-sig-cli
 - name: ci-kubernetes-e2e-kops-aws-release-1-6
@@ -3776,6 +3778,10 @@ dashboards:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: kops-aws-canary
     test_group_name: ci-kubernetes-e2e-kops-aws-canary
+    code_search_url_template:
+      url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
+  - name: kops-aws-cncf-canary
+    test_group_name: ci-kubernetes-e2e-kops-aws-cncf-canary
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
   - name: prow-canary


### PR DESCRIPTION
Tune up for two canary job:
- make kubemark-5-prow-canary use a different project for now, as it's sharing project with the other canary job and I cannot tell which kubemark image the job is actually using - cc @shyamjvs 
- create an explicit cncf-aws job, as it might take a while to configure everything properly

/assign @BenTheElder 