### PR TITLE
Flip verbose to be default true

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -163,7 +163,7 @@ func defineFlags() *options {
 	flag.BoolVar(&o.up, "up", false, "If true, start the the e2e cluster. If cluster is already up, recreate it.")
 	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests")
 
-	flag.BoolVar(&verbose, "v", false, "If true, print all command output.")
+	flag.BoolVar(&verbose, "v", true, "If true, print all command output.")
 
 	// go flag does not support StringArrayVar
 	pflag.StringArrayVar(&o.testCmdArgs, "test-cmd-args", []string{}, "args for test-cmd")


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/5426

and many other kubetest user are confused at the beginning without specify `-v` when running it locally
/assign @BenTheElder 
/area kubetest