### PR TITLE
add rpm tooling to planter, also normalize image tags to match bazel …

### DIFF
--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     python \
     python-pip \
+    rpm \
     unzip \
     wget \
     zip \

--- a/planter/Makefile
+++ b/planter/Makefile
@@ -16,7 +16,7 @@
 # this should be bazel version - planter sub version
 BAZEL_VERSION = 0.7.0
 IMAGE_NAME = gcr.io/k8s-testimages/planter
-TAG = $(BAZEL_VERSION)-1
+TAG = $(BAZEL_VERSION)
 
 image:
 	docker build --build-arg BAZEL_VERSION=$(BAZEL_VERSION) -t "$(IMAGE_NAME):$(TAG)" . --pull

--- a/planter/README.md
+++ b/planter/README.md
@@ -20,7 +20,8 @@ Then from `$GOPATH/src/k8s.io/kubernetes/` run:
 Planter repects the following environment variables:
 
  - `TAG`: the planter image tag, this will default to the current stable version
- used to build kubernetes, but you may override it with EG `TAG=0.6.1-1`
+ used to build kubernetes, but you may override it with EG `TAG=0.6.1`
+   - These should now match bazel release versions eg `0.8.0rc2`
  - `DRY_RUN`: if set planter will only echo the docker command that would have been run
 
  - `HOME`: your home directory, this will be mounted in to the container

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -19,7 +19,7 @@
 set -o errexit
 set -o nounset
 IMAGE_NAME="gcr.io/k8s-testimages/planter"
-TAG="${TAG:-0.7.0-1}"
+TAG="${TAG:-0.7.0}"
 IMAGE="${IMAGE_NAME}:${TAG}"
 # run our docker image as the host user with bazel cache and current repo dir
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
@@ -28,9 +28,9 @@ VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --tmpfs /tmp:exec,mode=777"
 GID="$(id -g ${USER})"
 ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
 # the final command to run
-CMD="docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}"
+CMD="docker pull ${IMAGE} && docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}"
 if [ -n "${DRY_RUN+set}" ]; then
     echo "${CMD}"
 else
-    ${CMD}
+    eval ${CMD}
 fi


### PR DESCRIPTION
…versions

new tags available:
- `0.6.1`
- `0.7.0`
- `0.8.0rc2`

`0.7.0` is now the default tag

`docker pull ${IMAGE}` is now run before running the image to keep things up to date.