### PR TITLE
add mem-limit-range.yaml to build cluster

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -162,4 +162,7 @@ tide-image: git-image
 tide-deployment: get-cluster-credentials
 	kubectl apply -f cluster/tide_deployment.yaml
 
-.PHONY: hook-image hook-deployment hook-service sinker-image sinker-deployment deck-image deck-deployment deck-service splice-image splice-deployment tot-image tot-service tot-deployment horologium-image horologium-deployment plank-image plank-deployment jenkins-operator-image jenkins-operator-deployment tide-image tide-deployment
+mem-range-deployment: get-build-cluster-credentials
+	kubectl apply -f cluster/mem_limit_range.yaml
+
+.PHONY: hook-image hook-deployment hook-service sinker-image sinker-deployment deck-image deck-deployment deck-service splice-image splice-deployment tot-image tot-service tot-deployment horologium-image horologium-deployment plank-image plank-deployment jenkins-operator-image jenkins-operator-deployment tide-image tide-deployment mem-range-deployment

--- a/prow/cluster/mem_limit_range.yaml
+++ b/prow/cluster/mem_limit_range.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+  namespace: test-pods
+spec:
+  limits:
+  - defaultRequest:
+      memory: 1Gi
+    type: Container


### PR DESCRIPTION
start with a 1Gi request, no upper limit.

and we should add limits to each job require large memories.

/assign @BenTheElder @cjwagner 

xref https://github.com/kubernetes/test-infra/issues/5449