### PR TITLE
Bump everything for config parsing change

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,23 +20,23 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.180
+HOOK_VERSION             ?= 0.181
 # SINKER_VERSION is the version of the sinker image
-SINKER_VERSION           ?= 0.22
+SINKER_VERSION           ?= 0.23
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.61
+DECK_VERSION             ?= 0.62
 # SPLICE_VERSION is the version of the splice image
-SPLICE_VERSION           ?= 0.31
+SPLICE_VERSION           ?= 0.32
 # TOT_VERSION is the version of the tot image
 TOT_VERSION              ?= 0.5
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= 0.14
+HOROLOGIUM_VERSION       ?= 0.15
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= 0.59
+PLANK_VERSION            ?= 0.60
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= 0.56
+JENKINS-OPERATOR_VERSION ?= 0.57
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.11
+TIDE_VERSION             ?= 0.12
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/README.md
+++ b/prow/README.md
@@ -34,6 +34,10 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 10, 2017* If you want to use cron feature in prow, you need to bump to:
+ `hook:0.181`, `sinker:0.23`, `deck:0.62`, `splice:0.32`, `horologium:0.15`
+ `plank:0.60`, `jenkins-operator:0.57` and `tide:0.12` to avoid error spamming from
+ the config parser.
  - *November 7, 2017* `plank:0.56` fixes bug introduced in `plank:0.53` that
    affects controllers using an empty kubernetes selector.
  - *November 7, 2017* `jenkins-operator:0.51` provides jobs with the `$BUILD_ID`

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.61
+        image: gcr.io/k8s-prow/deck:0.62
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.180
+        image: gcr.io/k8s-prow/hook:0.181
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.14
+        image: gcr.io/k8s-prow/horologium:0.15
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.56
+        image: gcr.io/k8s-prow/jenkins-operator:0.57
         ports:
         - name: logs
           containerPort: 8080

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.59
+        image: gcr.io/k8s-prow/plank:0.60
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
-        image: gcr.io/k8s-prow/sinker:0.22
+        image: gcr.io/k8s-prow/sinker:0.23
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.31
+        image: gcr.io/k8s-prow/splice:0.32
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.180
+        image: gcr.io/k8s-prow/hook:0.181
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.59
+        image: gcr.io/k8s-prow/plank:0.60
         args:
         - --dry-run=false
         volumeMounts:
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.22
+        image: gcr.io/k8s-prow/sinker:0.23
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.61
+        image: gcr.io/k8s-prow/deck:0.62
         ports:
           - name: http
             containerPort: 8080
@@ -223,7 +223,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.14
+        image: gcr.io/k8s-prow/horologium:0.15
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.11
+        image: gcr.io/k8s-prow/tide:0.12
         args:
         - --dry-run=false
         ports:


### PR DESCRIPTION
of course the old config agent does not like the cron

got 
```
{"error":"cannot parse duration for ci-kubernetes-e2e-kops-aws-cncf-canary: time: invalid duration ","level":"error","msg":"Error loading config.","path":"/etc/config/config","time":"2017-11-10T23:47:45Z"}
```
everywhere
/shrug
/area prow

/assign @BenTheElder @cjwagner 