### PR TITLE
k8s-multicluster-ingress: mount coveralls secret token in job.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9886,7 +9886,10 @@
   "pull-kubernetes-multicluster-ingress-test": {
     "args": [
       "make",
-      "test"
+      "-j",
+      "2",
+      "test",
+      "coveralls"
     ],
     "scenario": "execute",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -174,10 +174,16 @@ presubmits:
         - name: service
           mountPath: /etc/service-account
           readOnly: true
+        - name: coveralls
+          mountPath: /etc/coveralls-token
+          readOnly: true
       volumes:
       - name: service
         secret:
           secretName: service-account
+      - name: coveralls
+        secret:
+          secretName: k8s-multicluster-ingress-coveralls-token
   kubernetes/federation:
   - name: pull-federation-bazel-test
     agent: kubernetes


### PR DESCRIPTION
We need the coveralls repo token so that coveralls knows how to attach the coverage results we upload to the right repo.
cc @nikhiljindal @BenTheElder 