### PR TITLE
Update node e2e benchmark test config

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -1,140 +1,124 @@
 ---
 images:
-  containervm-density1:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-1
-    tests:
-      - 'create 35 pods with 0s? interval \[Benchmark\]'
-  containervm-density2:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-1
-    tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
-  containervm-density2-qps60:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-1
-    tests:
-      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
-  containervm-density3:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-2
-    tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
-  containervm-density4:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-1
-    tests:
-      - 'create 105 pods with 100ms interval \[Benchmark\]'
-  containervm-resource1:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  containervm-resource2:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  containervm-resource3:
-    image: e2e-node-containervm-v20161208-image
-    project: kubernetes-node-e2e-images
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
   cosstable2-resource1:
-    image: cos-stable-59-9460-64-0
+    image: cos-stable-61-9765-89-0 
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable2-resource2:
-    image: cos-stable-59-9460-64-0
+    image: cos-stable-61-9765-89-0 
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable2-resource3:
-    image: cos-stable-59-9460-64-0
+    image: cos-stable-61-9765-89-0 
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
+
   cosstable1-resource1:
-    image: cos-stable-60-9592-76-0
+    image: cos-stable-62-9901-75-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable1-resource2:
-    image: cos-stable-60-9592-76-0
+    image: cos-stable-62-9901-75-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable1-resource3:
-    image: cos-stable-60-9592-76-0
+    image: cos-stable-62-9901-75-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
+
+  cosbeta-resource1:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 0 pods per node \[Benchmark\]'
+  cosbeta-resource2:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 35 pods per node \[Benchmark\]'
+  cosbeta-resource3:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 105 pods per node \[Benchmark\]'
+
+  cosbeta-density1:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-1
+    tests:
+      - 'create 35 pods with 0s? interval \[Benchmark\]'
+  cosbeta-density2:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-1
+    tests:
+      - 'create 105 pods with 0s? interval \[Benchmark\]'
+  cosbeta-density2-qps60:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-1
+    tests:
+      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
+  cosbeta-density3:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-2
+    tests:
+      - 'create 105 pods with 0s? interval \[Benchmark\]'
+  cosbeta-density4:
+    image: cos-beta-63-10032-32-0
+    project: cos-cloud
+    machine: n1-standard-1
+    tests:
+      - 'create 105 pods with 100ms interval \[Benchmark\]'
+
   cosdev-resource1:
-    image: cos-beta-61-9765-31-0
+    image: cos-dev-64-10112-0-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosdev-resource2:
-    image: cos-beta-61-9765-31-0
+    image: cos-dev-64-10112-0-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosdev-resource3:
-    image: cos-beta-61-9765-31-0
+    image: cos-dev-64-10112-0-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
-  cos-docker112-resource1:
-    image: cos-stable-60-9592-76-0
-    image_description: cos-stable-60-9592-76-0 with docker 1.12.6
-    project: cos-cloud
-    machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/cos-init-docker.yaml,gci-update-strategy=update_disabled,gci-docker-version=1.12.6"
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  cos-docker112-resource2:
-    image: cos-stable-60-9592-76-0
-    image_description: cos-stable-60-9592-76-0 with docker 1.12.6
-    project: cos-cloud
-    machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/cos-init-docker.yaml,gci-update-strategy=update_disabled,gci-docker-version=1.12.6"
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  cos-docker112-resource3:
-    image: cos-stable-60-9592-76-0
-    image_description: cos-stable-60-9592-76-0 with docker 1.12.6
-    project: cos-cloud
-    machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/cos-init-docker.yaml,gci-update-strategy=update_disabled,gci-docker-version=1.12.6"
-    tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+
   coreosalpha-resource1:
     image: coreos-alpha-1478-0-0-v20170719
     project: coreos-cloud
@@ -156,6 +140,7 @@ images:
     machine: n1-standard-1
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
+
   coreosstable-resource1:
     image: coreos-stable-1409-7-0-v20170719
     project: coreos-cloud
@@ -177,6 +162,7 @@ images:
     machine: n1-standard-1
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
+
   ubuntustable-resource1:
     image: ubuntu-gke-1604-xenial-v20170816-1
     project: ubuntu-os-gke-cloud
@@ -193,29 +179,5 @@ images:
     image: ubuntu-gke-1604-xenial-v20170816-1
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
-    tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
-  ubuntustable-docker112-resource1:
-    image: ubuntu-gke-1604-xenial-v20170816-1
-    image_description: ubuntu-gke-1604-xenial-v20170816-1 with docker 1.12.6
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/ubuntu-init-docker.yaml,ubuntu-docker-version=1.12.6"
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  ubuntustable-docker112-resource2:
-    image: ubuntu-gke-1604-xenial-v20170816-1
-    image_description: ubuntu-gke-1604-xenial-v20170816-1 with docker 1.12.6
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/ubuntu-init-docker.yaml,ubuntu-docker-version=1.12.6"
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  ubuntustable-docker112-resource3:
-    image: ubuntu-gke-1604-xenial-v20170816-1
-    image_description: ubuntu-gke-1604-xenial-v20170816-1 with docker 1.12.6
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/ubuntu-init-docker.yaml,ubuntu-docker-version=1.12.6"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'


### PR DESCRIPTION
1. Remove tests that explicitly use Docker 1.12. Those tests are used for debugging a memory issue in Ubuntu image. They are not needed anymore.
2. Remove container-vm tests since it has been deprecated.
3. Add density tests for cosbeta.
4. Update cos images.

/assign @krzyzacy @yujuhong
/cc @abgworrall @dchen1107