### PR TITLE
Switch Go binaries destined for containers to pure Go mode

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,7 +21,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.9.1",
+    go_version = "1.9.2",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,18 +6,20 @@ http_archive(
 )
 
 load("@io_kubernetes_build//defs:bazel_version.bzl", "check_version")
+
 # Ensure minimum supported bazel version
 check_version("0.6.0")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "c72631a220406c4fae276861ee286aaec82c5af2",
+    commit = "b655527ae7769bdf5ac0b772c844f322bdd65b34",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
+
 go_register_toolchains(
     go_version = "1.9.1",
 )
@@ -42,8 +44,8 @@ docker_pull(
 
 git_repository(
     name = "org_dropbox_rules_node",
-    remote = "https://github.com/dropbox/rules_node.git",
     commit = "4fe6494f3f8d1a272d47d32ecc66698f6c43ed09",
+    remote = "https://github.com/dropbox/rules_node.git",
 )
 
 load("@org_dropbox_rules_node//node:defs.bzl", "node_repositories")

--- a/bootstrap/BUILD
+++ b/bootstrap/BUILD
@@ -16,8 +16,8 @@ go_library(
 
 go_binary(
     name = "bootstrap",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/bootstrap",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 
@@ -43,6 +43,6 @@ go_test(
         "paths_test.go",
         "repos_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/bootstrap",
-    library = ":go_default_library",
 )

--- a/boskos/BUILD
+++ b/boskos/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "boskos",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/boskos/BUILD
+++ b/boskos/BUILD
@@ -9,16 +9,16 @@ load(
 
 go_binary(
     name = "boskos",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos",
-    library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["boskos_test.go"],
     data = ["resources.json"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos",
-    library = ":go_default_library",
     deps = [
         "//boskos/common:go_default_library",
         "//boskos/ranch:go_default_library",

--- a/boskos/client/BUILD
+++ b/boskos/client/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["client_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/client",
-    library = ":go_default_library",
     deps = ["//boskos/common:go_default_library"],
 )
 

--- a/boskos/janitor/BUILD
+++ b/boskos/janitor/BUILD
@@ -9,8 +9,8 @@ load(
 
 go_binary(
     name = "janitor",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/janitor",
-    library = ":go_default_library",
 )
 
 go_library(
@@ -40,7 +40,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["janitor_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/janitor",
-    library = ":go_default_library",
     deps = ["//boskos/common:go_default_library"],
 )

--- a/boskos/janitor/BUILD
+++ b/boskos/janitor/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "janitor",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/janitor",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/boskos/metrics/BUILD
+++ b/boskos/metrics/BUILD
@@ -12,6 +12,8 @@ go_binary(
     name = "metrics",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/metrics",
+    pure = "on",
+    race = "off",
     tags = ["automanaged"],
 )
 

--- a/boskos/metrics/BUILD
+++ b/boskos/metrics/BUILD
@@ -10,8 +10,8 @@ load(
 
 go_binary(
     name = "metrics",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/metrics",
-    library = ":go_default_library",
     tags = ["automanaged"],
 )
 

--- a/boskos/ranch/BUILD
+++ b/boskos/ranch/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["ranch_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/ranch",
-    library = ":go_default_library",
     deps = ["//boskos/common:go_default_library"],
 )
 

--- a/boskos/reaper/BUILD
+++ b/boskos/reaper/BUILD
@@ -10,6 +10,8 @@ go_binary(
     name = "reaper",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/reaper",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/boskos/reaper/BUILD
+++ b/boskos/reaper/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "reaper",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/reaper",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/experiment/cherrypicker/BUILD
+++ b/experiment/cherrypicker/BUILD
@@ -21,8 +21,8 @@ go_library(
 
 go_binary(
     name = "cherrypicker",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/experiment/cherrypicker",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 
@@ -43,8 +43,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["server_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/experiment/cherrypicker",
-    library = ":go_default_library",
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",

--- a/experiment/commenter/BUILD
+++ b/experiment/commenter/BUILD
@@ -41,8 +41,8 @@ load(
 
 go_binary(
     name = "commenter",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/experiment/commenter",
-    library = ":go_default_library",
 )
 
 go_library(
@@ -68,7 +68,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/experiment/commenter",
-    library = ":go_default_library",
     deps = ["//prow/github:go_default_library"],
 )

--- a/experiment/manual-trigger/BUILD
+++ b/experiment/manual-trigger/BUILD
@@ -15,8 +15,8 @@ go_library(
 
 go_binary(
     name = "manual-trigger",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/experiment/manual-trigger",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 

--- a/gcsweb/cmd/gcsweb/BUILD
+++ b/gcsweb/cmd/gcsweb/BUILD
@@ -10,6 +10,8 @@ go_binary(
     name = "gcsweb",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/gcsweb/cmd/gcsweb/BUILD
+++ b/gcsweb/cmd/gcsweb/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "gcsweb",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/ghclient/BUILD
+++ b/ghclient/BUILD
@@ -12,8 +12,8 @@ go_test(
         "core_test.go",
         "wrappers_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/ghclient",
-    library = ":go_default_library",
     tags = ["automanaged"],
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -34,7 +34,7 @@ find ${TESTINFRA_ROOT}/vendor/ -name "*_test.go" -delete
 # The gazelle commit should match the rules_go commit in the WORKSPACE file.
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-  c72631a220406c4fae276861ee286aaec82c5af2 \
+  b655527ae7769bdf5ac0b772c844f322bdd65b34 \
   "${TMP_GOPATH}"
 
 touch "${TESTINFRA_ROOT}/vendor/BUILD"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -28,7 +28,7 @@ TMP_GOPATH=$(mktemp -d)
 # The gazelle commit should match the rules_go commit in the WORKSPACE file.
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-  c72631a220406c4fae276861ee286aaec82c5af2 \
+  b655527ae7769bdf5ac0b772c844f322bdd65b34 \
   "${TMP_GOPATH}"
 
 touch "${TESTINFRA_ROOT}/vendor/BUILD"

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "kubetest",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/kubetest",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -9,8 +9,8 @@ load(
 
 go_binary(
     name = "kubetest",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/kubetest",
-    library = ":go_default_library",
 )
 
 go_library(
@@ -65,6 +65,6 @@ go_test(
         "main_test.go",
         "util_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/kubetest",
-    library = ":go_default_library",
 )

--- a/label_sync/BUILD
+++ b/label_sync/BUILD
@@ -11,8 +11,8 @@ load(
 
 go_binary(
     name = "label_sync",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/label_sync",
-    library = ":go_default_library",
     tags = ["automanaged"],
 )
 
@@ -22,8 +22,8 @@ go_test(
     data = [
         "//label_sync:test_examples",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/label_sync",
-    library = ":go_default_library",
     tags = ["automanaged"],
 )
 

--- a/label_sync/BUILD
+++ b/label_sync/BUILD
@@ -13,6 +13,8 @@ go_binary(
     name = "label_sync",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/label_sync",
+    pure = "on",
+    race = "off",
     tags = ["automanaged"],
 )
 

--- a/logexporter/cmd/BUILD
+++ b/logexporter/cmd/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "cmd",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/logexporter/cmd",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/logexporter/cmd/BUILD
+++ b/logexporter/cmd/BUILD
@@ -10,6 +10,8 @@ go_binary(
     name = "cmd",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/logexporter/cmd",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/maintenance/migratestatus/BUILD
+++ b/maintenance/migratestatus/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "migratestatus",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/maintenance/migratestatus",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/maintenance/migratestatus/migrator/BUILD
+++ b/maintenance/migratestatus/migrator/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["migrator_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/maintenance/migratestatus/migrator",
-    library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/BUILD
+++ b/mungegithub/BUILD
@@ -10,6 +10,8 @@ go_binary(
     name = "mungegithub",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/mungegithub/BUILD
+++ b/mungegithub/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "mungegithub",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/mungegithub/example-one-off/BUILD
+++ b/mungegithub/example-one-off/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "example-one-off",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/example-one-off",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/mungegithub/features/BUILD
+++ b/mungegithub/features/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["repo-updates_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/features",
-    library = ":go_default_library",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/github/BUILD
+++ b/mungegithub/github/BUILD
@@ -12,8 +12,8 @@ go_test(
         "github_test.go",
         "status_change_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/github",
-    library = ":go_default_library",
     deps = [
         "//mungegithub/github/testing:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/mungegithub/mungers/BUILD
+++ b/mungegithub/mungers/BUILD
@@ -25,9 +25,9 @@ go_test(
     data = [
         "//mungegithub:configs",
     ],
+    embed = [":go_default_library"],
     features = ["-race"],
     importpath = "k8s.io/test-infra/mungegithub/mungers",
-    library = ":go_default_library",
     deps = [
         "//mungegithub/features:go_default_library",
         "//mungegithub/github:go_default_library",

--- a/mungegithub/mungers/BUILD
+++ b/mungegithub/mungers/BUILD
@@ -26,8 +26,8 @@ go_test(
         "//mungegithub:configs",
     ],
     embed = [":go_default_library"],
-    features = ["-race"],
     importpath = "k8s.io/test-infra/mungegithub/mungers",
+    race = "off",  # kubernetes/test-infra/issues/3639
     deps = [
         "//mungegithub/features:go_default_library",
         "//mungegithub/github:go_default_library",

--- a/mungegithub/mungers/approvers/BUILD
+++ b/mungegithub/mungers/approvers/BUILD
@@ -12,8 +12,8 @@ go_test(
         "approvers_test.go",
         "owners_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/mungers/approvers",
-    library = ":go_default_library",
     deps = ["//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library"],
 )
 

--- a/mungegithub/mungers/e2e/BUILD
+++ b/mungegithub/mungers/e2e/BUILD
@@ -12,8 +12,8 @@ go_test(
         "e2e_test.go",
         "resolved_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/mungers/e2e",
-    library = ":go_default_library",
     deps = [
         "//mungegithub/options:go_default_library",
         "//vendor/k8s.io/contrib/test-utils/utils:go_default_library",

--- a/mungegithub/mungers/flakesync/BUILD
+++ b/mungegithub/mungers/flakesync/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["cache_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/mungers/flakesync",
-    library = ":go_default_library",
     deps = ["//vendor/github.com/google/gofuzz:go_default_library"],
 )
 

--- a/mungegithub/mungers/matchers/BUILD
+++ b/mungegithub/mungers/matchers/BUILD
@@ -17,8 +17,8 @@ go_test(
     data = [
         "//mungegithub:configs",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/mungers/matchers",
-    library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/mungers/matchers/comment/BUILD
+++ b/mungegithub/mungers/matchers/comment/BUILD
@@ -17,8 +17,8 @@ go_test(
         "operators_test.go",
         "pinger_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/comment",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/mungegithub/mungers/matchers/event/BUILD
+++ b/mungegithub/mungers/matchers/event/BUILD
@@ -12,8 +12,8 @@ go_test(
         "event_test.go",
         "finder_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/mungers/matchers/event",
-    library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/mungers/mungerutil/BUILD
+++ b/mungegithub/mungers/mungerutil/BUILD
@@ -12,8 +12,8 @@ go_test(
         "time_cache_test.go",
         "util_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/mungers/mungerutil",
-    library = ":go_default_library",
     deps = ["//vendor/github.com/google/go-github/github:go_default_library"],
 )
 

--- a/mungegithub/options/BUILD
+++ b/mungegithub/options/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["options_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub/options",
-    library = ":go_default_library",
     deps = ["//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library"],
 )
 

--- a/prow/cmd/config/BUILD
+++ b/prow/cmd/config/BUILD
@@ -15,8 +15,8 @@ go_library(
 go_binary(
     name = "config",
     data = ["//prow:configs"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/config",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/deck/BUILD
+++ b/prow/cmd/deck/BUILD
@@ -9,8 +9,8 @@ load(
 
 go_binary(
     name = "deck",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/deck",
-    library = ":go_default_library",
 )
 
 go_test(
@@ -19,8 +19,8 @@ go_test(
         "jobs_test.go",
         "main_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/deck",
-    library = ":go_default_library",
     deps = [
         "//prow/kube:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/cmd/deck/BUILD
+++ b/prow/cmd/deck/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "deck",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/deck",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -12,8 +12,8 @@ go_binary(
     data = [
         "//prow:configs",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/hook",
-    library = ":go_default_library",
 )
 
 go_test(
@@ -22,8 +22,8 @@ go_test(
     data = [
         "//prow:configs",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/hook",
-    library = ":go_default_library",
     deps = ["//prow/plugins:go_default_library"],
 )
 

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -14,6 +14,8 @@ go_binary(
     ],
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/hook",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/prow/cmd/horologium/BUILD
+++ b/prow/cmd/horologium/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "horologium",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/horologium",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/prow/cmd/horologium/BUILD
+++ b/prow/cmd/horologium/BUILD
@@ -9,8 +9,8 @@ load(
 
 go_binary(
     name = "horologium",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/horologium",
-    library = ":go_default_library",
 )
 
 go_library(
@@ -42,8 +42,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/horologium",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/jenkins-operator/BUILD
+++ b/prow/cmd/jenkins-operator/BUILD
@@ -44,7 +44,7 @@ filegroup(
 
 go_binary(
     name = "jenkins-operator",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
-    library = ":go_default_library",
     tags = ["automanaged"],
 )

--- a/prow/cmd/jenkins-operator/BUILD
+++ b/prow/cmd/jenkins-operator/BUILD
@@ -46,5 +46,7 @@ go_binary(
     name = "jenkins-operator",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
+    pure = "on",
+    race = "off",
     tags = ["automanaged"],
 )

--- a/prow/cmd/mkpj/BUILD
+++ b/prow/cmd/mkpj/BUILD
@@ -10,8 +10,8 @@ go_binary(
     name = "mkpj",
     args = ["--config-path=$(location //prow:config.yaml)"],
     data = ["//prow:config.yaml"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/mkpj",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/prow/cmd/phony/BUILD
+++ b/prow/cmd/phony/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "phony",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/phony",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/prow/cmd/plank/BUILD
+++ b/prow/cmd/plank/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "plank",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/plank",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/prow/cmd/plank/BUILD
+++ b/prow/cmd/plank/BUILD
@@ -10,6 +10,8 @@ go_binary(
     name = "plank",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/plank",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/prow/cmd/sinker/BUILD
+++ b/prow/cmd/sinker/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "sinker",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/sinker",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/prow/cmd/sinker/BUILD
+++ b/prow/cmd/sinker/BUILD
@@ -9,15 +9,15 @@ load(
 
 go_binary(
     name = "sinker",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/sinker",
-    library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/sinker",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/splice/BUILD
+++ b/prow/cmd/splice/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "splice",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/splice",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/prow/cmd/splice/BUILD
+++ b/prow/cmd/splice/BUILD
@@ -9,15 +9,15 @@ load(
 
 go_binary(
     name = "splice",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/splice",
-    library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/splice",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/cmd/tide/BUILD
+++ b/prow/cmd/tide/BUILD
@@ -17,8 +17,8 @@ go_library(
 
 go_binary(
     name = "tide",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tide",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/tide/BUILD
+++ b/prow/cmd/tide/BUILD
@@ -19,6 +19,8 @@ go_binary(
     name = "tide",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tide",
+    pure = "on",
+    race = "off",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/tot/BUILD
+++ b/prow/cmd/tot/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "tot",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tot",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/prow/cmd/tot/BUILD
+++ b/prow/cmd/tot/BUILD
@@ -9,15 +9,15 @@ load(
 
 go_binary(
     name = "tot",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tot",
-    library = ":go_default_library",
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tot",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/prow/commentpruner/BUILD
+++ b/prow/commentpruner/BUILD
@@ -14,8 +14,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["commentpruner_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/commentpruner",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/config/BUILD
+++ b/prow/config/BUILD
@@ -18,8 +18,8 @@ go_test(
         "//prow:configs",
         "//scenarios",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/config",
-    library = ":go_default_library",
     deps = [
         "//prow/kube:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",

--- a/prow/cron/BUILD
+++ b/prow/cron/BUILD
@@ -15,8 +15,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["cron_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cron",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//vendor/github.com/robfig/cron:go_default_library",

--- a/prow/genfiles/BUILD
+++ b/prow/genfiles/BUILD
@@ -11,8 +11,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["genfiles_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/genfiles",
-    library = ":go_default_library",
 )
 
 filegroup(

--- a/prow/github/BUILD
+++ b/prow/github/BUILD
@@ -14,8 +14,8 @@ go_test(
         "links_test.go",
         "types_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/github",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -12,8 +12,8 @@ go_test(
         "hook_test.go",
         "server_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/hook",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/jenkins/BUILD
+++ b/prow/jenkins/BUILD
@@ -46,8 +46,8 @@ go_test(
         "controller_test.go",
         "jenkins_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/jenkins",
-    library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
         "//prow/config:go_default_library",

--- a/prow/kube/BUILD
+++ b/prow/kube/BUILD
@@ -12,8 +12,8 @@ go_test(
         "client_test.go",
         "prowjob_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/kube",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/prow/kube/labels/BUILD
+++ b/prow/kube/labels/BUILD
@@ -22,8 +22,8 @@ go_test(
         "selector_test.go",
         "validation_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/kube/labels",
-    library = ":go_default_library",
     deps = ["//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library"],
 )
 

--- a/prow/pjutil/BUILD
+++ b/prow/pjutil/BUILD
@@ -42,8 +42,8 @@ go_test(
         "jobspec_test.go",
         "pjutil_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/pjutil",
-    library = ":go_default_library",
     tags = ["automanaged"],
     deps = ["//prow/kube:go_default_library"],
 )

--- a/prow/plank/BUILD
+++ b/prow/plank/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["controller_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plank",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/pluginhelp/hook/BUILD
+++ b/prow/pluginhelp/hook/BUILD
@@ -32,8 +32,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["hook_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/pluginhelp/hook",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -12,8 +12,8 @@ go_test(
         "plugins_test.go",
         "respond_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins",
-    library = ":go_default_library",
     deps = ["//prow/github:go_default_library"],
 )
 

--- a/prow/plugins/approve/BUILD
+++ b/prow/plugins/approve/BUILD
@@ -19,8 +19,8 @@ go_test(
     data = [
         "//prow:configs",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/approve",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/approve/approvers/BUILD
+++ b/prow/plugins/approve/approvers/BUILD
@@ -17,8 +17,8 @@ go_test(
         "approvers_test.go",
         "owners_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/approve/approvers",
-    library = ":go_default_library",
     deps = [
         "//vendor/github.com/sirupsen/logrus:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",

--- a/prow/plugins/assign/BUILD
+++ b/prow/plugins/assign/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["assign_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/assign",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plugins/blockade/BUILD
+++ b/prow/plugins/blockade/BUILD
@@ -29,8 +29,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["blockade_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/blockade",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/blunderbuss/BUILD
+++ b/prow/plugins/blunderbuss/BUILD
@@ -31,8 +31,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["blunderbuss_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/blunderbuss",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plugins/cla/BUILD
+++ b/prow/plugins/cla/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["cla_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/cla",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/close/BUILD
+++ b/prow/plugins/close/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["close_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/close",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plugins/docs-no-retest/BUILD
+++ b/prow/plugins/docs-no-retest/BUILD
@@ -14,8 +14,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["docs-no-retest_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/docs-no-retest",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/util/sets:go_default_library",

--- a/prow/plugins/golint/BUILD
+++ b/prow/plugins/golint/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["golint_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/golint",
-    library = ":go_default_library",
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/heart/BUILD
+++ b/prow/plugins/heart/BUILD
@@ -33,8 +33,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["heart_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/heart",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/hold/BUILD
+++ b/prow/plugins/hold/BUILD
@@ -15,8 +15,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["hold_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/hold",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/label/BUILD
+++ b/prow/plugins/label/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["label_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/label",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/lgtm/BUILD
+++ b/prow/plugins/lgtm/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["lgtm_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/lgtm",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/milestonestatus/BUILD
+++ b/prow/plugins/milestonestatus/BUILD
@@ -29,8 +29,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["milestonestatus_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/milestonestatus",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/releasenote/BUILD
+++ b/prow/plugins/releasenote/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["releasenote_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/releasenote",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/reopen/BUILD
+++ b/prow/plugins/reopen/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["reopen_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/reopen",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",

--- a/prow/plugins/shrug/BUILD
+++ b/prow/plugins/shrug/BUILD
@@ -29,8 +29,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["shurg_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/shrug",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/sigmention/BUILD
+++ b/prow/plugins/sigmention/BUILD
@@ -15,8 +15,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["sigmention_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/sigmention",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/size/BUILD
+++ b/prow/plugins/size/BUILD
@@ -11,8 +11,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["size_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/size",
-    library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",

--- a/prow/plugins/slackevents/BUILD
+++ b/prow/plugins/slackevents/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["slackevents_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/slackevents",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/trigger/BUILD
+++ b/prow/plugins/trigger/BUILD
@@ -12,8 +12,8 @@ go_test(
         "ic_test.go",
         "pr_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/trigger",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/updateconfig/BUILD
+++ b/prow/plugins/updateconfig/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["updateconfig_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/updateconfig",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/wip/BUILD
+++ b/prow/plugins/wip/BUILD
@@ -15,8 +15,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["wip-label_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/wip",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/yuks/BUILD
+++ b/prow/plugins/yuks/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["yuks_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/plugins/yuks",
-    library = ":go_default_library",
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/repoowners/BUILD
+++ b/prow/repoowners/BUILD
@@ -17,8 +17,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["repoowners_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/repoowners",
-    library = ":go_default_library",
     deps = [
         "//prow/git/localgit:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/report/BUILD
+++ b/prow/report/BUILD
@@ -11,8 +11,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["report_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/report",
-    library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
         "//prow/github:go_default_library",

--- a/prow/tide/BUILD
+++ b/prow/tide/BUILD
@@ -33,8 +33,8 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["tide_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/tide",
-    library = ":go_default_library",
     deps = [
         "//prow/config:go_default_library",
         "//prow/git/localgit:go_default_library",

--- a/robots/issue-creator/BUILD
+++ b/robots/issue-creator/BUILD
@@ -48,8 +48,8 @@ go_library(
 
 go_binary(
     name = "issue-creator",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/robots/issue-creator",
-    library = ":go_default_library",
     visibility = ["//visibility:public"],
 )
 

--- a/robots/issue-creator/creator/BUILD
+++ b/robots/issue-creator/creator/BUILD
@@ -16,8 +16,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["creator_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/robots/issue-creator/creator",
-    library = ":go_default_library",
     deps = [
         "//robots/issue-creator/testowner:go_default_library",
         "//vendor/github.com/google/go-github/github:go_default_library",

--- a/robots/issue-creator/sources/BUILD
+++ b/robots/issue-creator/sources/BUILD
@@ -22,8 +22,8 @@ go_test(
         "flakyjob-reporter_test.go",
         "triage-filer_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/robots/issue-creator/sources",
-    library = ":go_default_library",
     deps = [
         "//robots/issue-creator/creator:go_default_library",
         "//robots/issue-creator/testowner:go_default_library",

--- a/robots/issue-creator/testowner/BUILD
+++ b/robots/issue-creator/testowner/BUILD
@@ -11,8 +11,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["owner_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/robots/issue-creator/testowner",
-    library = ":go_default_library",
 )
 
 filegroup(

--- a/testgrid/config/BUILD
+++ b/testgrid/config/BUILD
@@ -21,8 +21,8 @@ genrule(
 
 go_binary(
     name = "config",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/testgrid/config",
-    library = ":go_default_library",
 )
 
 go_test(
@@ -32,8 +32,8 @@ go_test(
         "config.yaml",
         "//mungegithub:submit-queue/deployment/kubernetes/configmap.yaml",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/testgrid/config",
-    library = ":go_default_library",
     deps = [
         "//testgrid/config/yaml2proto:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",

--- a/testgrid/config/yaml2proto/BUILD
+++ b/testgrid/config/yaml2proto/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["yaml2proto_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/testgrid/config/yaml2proto",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/testgrid/jenkins_verify/BUILD
+++ b/testgrid/jenkins_verify/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "jenkins_verify",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/testgrid/jenkins_verify",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/velodrome/fetcher/BUILD
+++ b/velodrome/fetcher/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "fetcher",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/fetcher",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/velodrome/fetcher/BUILD
+++ b/velodrome/fetcher/BUILD
@@ -9,8 +9,8 @@ load(
 
 go_binary(
     name = "fetcher",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/fetcher",
-    library = ":go_default_library",
 )
 
 go_test(
@@ -22,8 +22,8 @@ go_test(
         "issue-events_test.go",
         "issues_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/fetcher",
-    library = ":go_default_library",
     deps = [
         "//velodrome/sql:go_default_library",
         "//velodrome/sql/testing:go_default_library",

--- a/velodrome/sql/BUILD
+++ b/velodrome/sql/BUILD
@@ -12,8 +12,8 @@ go_test(
         "model_test.go",
         "mysql_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/sql",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/velodrome/sql/testing/BUILD
+++ b/velodrome/sql/testing/BUILD
@@ -9,8 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = ["sqlite_test.go"],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/sql/testing",
-    library = ":go_default_library",
     deps = ["//velodrome/sql:go_default_library"],
 )
 

--- a/velodrome/token-counter/BUILD
+++ b/velodrome/token-counter/BUILD
@@ -10,6 +10,8 @@ go_binary(
     name = "token-counter",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/token-counter",
+    pure = "on",
+    race = "off",
 )
 
 go_library(

--- a/velodrome/token-counter/BUILD
+++ b/velodrome/token-counter/BUILD
@@ -8,8 +8,8 @@ load(
 
 go_binary(
     name = "token-counter",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/token-counter",
-    library = ":go_default_library",
 )
 
 go_library(

--- a/velodrome/transform/BUILD
+++ b/velodrome/transform/BUILD
@@ -11,6 +11,8 @@ go_binary(
     name = "transform",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/transform",
+    pure = "on",
+    race = "off",
 )
 
 go_test(

--- a/velodrome/transform/BUILD
+++ b/velodrome/transform/BUILD
@@ -9,8 +9,8 @@ load(
 
 go_binary(
     name = "transform",
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/transform",
-    library = ":go_default_library",
 )
 
 go_test(
@@ -19,8 +19,8 @@ go_test(
         "fetcher_test.go",
         "influx_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/transform",
-    library = ":go_default_library",
     deps = [
         "//velodrome/sql:go_default_library",
         "//velodrome/sql/testing:go_default_library",

--- a/velodrome/transform/plugins/BUILD
+++ b/velodrome/transform/plugins/BUILD
@@ -67,8 +67,8 @@ go_test(
         "states_test.go",
         "type_filter_wrapper_test.go",
     ],
+    embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/transform/plugins",
-    library = ":go_default_library",
     deps = [
         "//velodrome/sql:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/vendor/github.com/inconshreveable/mousetrap/BUILD
+++ b/vendor/github.com/inconshreveable/mousetrap/BUILD
@@ -2,9 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "trap_others.go",
-    ] + select({
+    srcs = select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "trap_others.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "trap_others.go",
+        ],
         "@io_bazel_rules_go//go/platform:windows_amd64": [
             "trap_windows.go",
             "trap_windows_1.4.go",

--- a/vendor/github.com/mattn/go-sqlite3/BUILD
+++ b/vendor/github.com/mattn/go-sqlite3/BUILD
@@ -11,9 +11,14 @@ go_library(
         "sqlite3-binding.c",
         "sqlite3-binding.h",
         "sqlite3_load_extension.go",
-        "sqlite3_other.go",
         "sqlite3ext.h",
     ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "sqlite3_other.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "sqlite3_other.go",
+        ],
         "@io_bazel_rules_go//go/platform:windows_amd64": [
             "sqlite3_windows.go",
         ],
@@ -33,8 +38,13 @@ go_library(
         "-std=gnu99",
         "-DSQLITE_ENABLE_RTREE -DSQLITE_THREADSAFE",
         "-DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4_UNICODE61",
-        "-Ivendor/github.com/mattn/go-sqlite3",
     ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "-Ivendor/github.com/mattn/go-sqlite3",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "-Ivendor/github.com/mattn/go-sqlite3",
+        ],
         "@io_bazel_rules_go//go/platform:windows_amd64": [
             "-Ivendor/github.com/mattn/go-sqlite3 -fno-stack-check -fno-stack-protector -mno-stack-arg-probe",
         ],

--- a/vendor/github.com/spf13/cobra/BUILD
+++ b/vendor/github.com/spf13/cobra/BUILD
@@ -6,8 +6,13 @@ go_library(
         "bash_completions.go",
         "cobra.go",
         "command.go",
-        "command_notwin.go",
     ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "command_notwin.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "command_notwin.go",
+        ],
         "@io_bazel_rules_go//go/platform:windows_amd64": [
             "command_win.go",
         ],

--- a/vendor/golang.org/x/crypto/curve25519/BUILD
+++ b/vendor/golang.org/x/crypto/curve25519/BUILD
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "curve25519.go",
         "doc.go",
     ] + select({
         "@io_bazel_rules_go//go/platform:darwin_amd64": [

--- a/vendor/k8s.io/kubernetes/pkg/util/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/BUILD
@@ -7,9 +7,14 @@ go_library(
         "string_flag.go",
         "template.go",
         "trace.go",
-        "umask.go",
         "util.go",
     ] + select({
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [
+            "umask.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "umask.go",
+        ],
         "@io_bazel_rules_go//go/platform:windows_amd64": [
             "umask_windows.go",
         ],


### PR DESCRIPTION
This PR also bumps rules_go, which brings in some autogenerated BUILD changes across the entire tree.

It seems like this works properly, though switching back and forth between `bazel build` and `bazel test` causes a bunch of stuff to be rebuilt, probably due to the race/pure mode incompatibilities.

I'm not sure if that sort of performance hit is expected.

/assign @BenTheElder @spxtr 
cc @mattmoor 