### PR TITLE
remove gci-gke jobs from sig-release-master-blocking

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2485,8 +2485,6 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet
   - name: gci-gce
     test_group_name: ci-kubernetes-e2e-gci-gce
-  - name: gci-gke
-    test_group_name: ci-kubernetes-e2e-gci-gke
   - name: aws
     test_group_name: ci-kubernetes-e2e-kops-aws
   - name: gce-gpu
@@ -2499,12 +2497,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-p100
   - name: gci-gce-slow
     test_group_name: ci-kubernetes-e2e-gci-gce-slow
-  - name: gci-gke-slow
-    test_group_name: ci-kubernetes-e2e-gci-gke-slow
   - name: gci-gce-serial
     test_group_name: ci-kubernetes-e2e-gci-gce-serial
-  - name: gci-gke-serial
-    test_group_name: ci-kubernetes-e2e-gci-gke-serial
   - name: gci-gce-alpha-features
     test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
   - name: gci-gce-audit
@@ -2517,12 +2511,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gce-scale-performance
   - name: gci-gce-ingress
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
-  - name: gci-gke-ingress
-    test_group_name: ci-kubernetes-e2e-gci-gke-ingress
   - name: gci-gce-reboot
     test_group_name: ci-kubernetes-e2e-gci-gce-reboot
-  - name: gci-gke-reboot
-    test_group_name: ci-kubernetes-e2e-gci-gke-reboot
   - name: soak-gce-gci
     test_group_name: ci-kubernetes-soak-gce-gci
   - name: kubeadm-gce


### PR DESCRIPTION
They have been failing for about two weeks now.  The vast majority of failures holding back v1.9.0-alpha.3 (https://github.com/kubernetes/sig-release/issues/27) are all GKE jobs:
- https://github.com/kubernetes/kubernetes/issues/55189
- https://github.com/kubernetes/kubernetes/issues/55190
- https://github.com/kubernetes/kubernetes/issues/55192
- https://github.com/kubernetes/kubernetes/issues/55193
- https://github.com/kubernetes/kubernetes/issues/55195

If the jobs get to a point where they meet the criteria to be established at https://github.com/kubernetes/sig-release/issues/24 we can PR them back in.  But right now, history is showing me we're not being responsive enough in preventing these from going red, nor in bringing them back to green.

I'd like for us to have a discussion here about whether we're OK with this, or whether more resources need to be mobilized to prevent this from happening.  My intent is for sig-gcp and sig-release to have final say on whether this is OK.

/hold
for discussion

@kubernetes/sig-gcp-test-failures
@kubernetes/sig-release-test-failures