### PR TITLE
Fix not stored cronstr in cron

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -30,7 +30,7 @@ SPLICE_VERSION           ?= 0.32
 # TOT_VERSION is the version of the tot image
 TOT_VERSION              ?= 0.5
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= 0.16
+HOROLOGIUM_VERSION       ?= 0.17
 # PLANK_VERSION is the version of the plank image
 PLANK_VERSION            ?= 0.60
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image

--- a/prow/README.md
+++ b/prow/README.md
@@ -35,6 +35,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 14, 2017* `horologium:0.17` fixes cron job not being scheduled.
  - *November 10, 2017* If you want to use cron feature in prow, you need to bump to:
  `hook:0.181`, `sinker:0.23`, `deck:0.62`, `splice:0.32`, `horologium:0.15`
  `plank:0.60`, `jenkins-operator:0.57` and `tide:0.12` to avoid error spamming from

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.16
+        image: gcr.io/k8s-prow/horologium:0.17
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -223,7 +223,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.16
+        image: gcr.io/k8s-prow/horologium:0.17
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cron/cron.go
+++ b/prow/cron/cron.go
@@ -161,6 +161,7 @@ func (c *Cron) addJob(name, cron string) error {
 
 	c.jobs[name] = &jobStatus{
 		entryID: id,
+		cronStr: cron,
 		// try to kick of a periodic trigger right away
 		triggered: strings.HasPrefix(cron, "@every"),
 	}

--- a/prow/cron/cron_test.go
+++ b/prow/cron/cron_test.go
@@ -77,8 +77,11 @@ func TestSync(t *testing.T) {
 		t.Error("1st sync, should not have job 'interval'")
 	}
 
+	var cronID cron.EntryID
 	if !c.HasJob("cron") {
 		t.Error("1st sync, should have job 'cron'")
+	} else {
+		cronID = c.jobs["cron"].entryID
 	}
 
 	if err := c.SyncConfig(addAndUpdate); err != nil {
@@ -87,9 +90,13 @@ func TestSync(t *testing.T) {
 
 	if !c.HasJob("cron") {
 		t.Error("2nd sync, should have job 'cron'")
+	} else {
+		newCronID := c.jobs["cron"].entryID
+		if newCronID != cronID {
+			t.Errorf("2nd sync, entryID for 'cron' should not be updated")
+		}
 	}
 
-	var cronID cron.EntryID
 	if !c.HasJob("cron-2") {
 		t.Error("2nd sync, should have job 'cron-2'")
 	} else {
@@ -109,7 +116,7 @@ func TestSync(t *testing.T) {
 	} else {
 		newCronID := c.jobs["cron-2"].entryID
 		if newCronID == cronID {
-			t.Errorf("3rd sync, cron-2 should be updated")
+			t.Errorf("3rd sync, entryID for 'cron-2' should be updated")
 		}
 	}
 }


### PR DESCRIPTION
welp log helps

```
{"client":"cron","level":"info","msg":"Triggering cron job ci-kubernetes-kubemark-5-prow-canary.","time":"2017-11-14T22:00:00Z"}
{"client":"cron","level":"info","msg":"Removed previous cron job ci-kubernetes-kubemark-5-prow-canary.","time":"2017-11-14T22:00:30Z"}
{"client":"cron","level":"info","msg":"Added new cron job ci-kubernetes-kubemark-5-prow-canary with trigger 0 * * * *.","time":"2017-11-14T22:00:30Z"}
```

/shrug
/assign @cjwagner 