### PR TITLE
Move scalability-release jobs to prow

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -93,32 +93,6 @@
         frequency: '' #manual
         trigger-job: ''
 
-    # gce scalability jobs
-    - kubernetes-e2e-gce-scalability-release-1-7:
-        job-name: ci-kubernetes-e2e-gce-scalability-release-1-7
-        jenkins-timeout: 240
-        timeout: 140
-        frequency: '@daily'
-        trigger-job: 'ci-kubernetes-build-1.7'
-
-    # gci-gce scalability jobs
-    - kubernetes-e2e-gci-gce-scalability-release-1-7:
-        job-name: ci-kubernetes-e2e-gci-gce-scalability-release-1-7
-        jenkins-timeout: 240
-        timeout: 140
-        frequency: '@daily'
-        trigger-job: 'ci-kubernetes-build-1.7'
-        use-blocker: true
-        blocker: 'ci-kubernetes-e2e-gci-gce-scalability-stable1'
-    - kubernetes-e2e-gci-gce-scalability-stable1:
-        job-name: ci-kubernetes-e2e-gci-gce-scalability-stable1
-        jenkins-timeout: 240
-        timeout: 140
-        frequency: '@daily'
-        trigger-job: 'ci-kubernetes-build-1.8'
-        use-blocker: true
-        blocker: 'ci-kubernetes-e2e-gci-gce-scalability-release-1-7'
-
     # gke high-scale tests #shyamjvs
     - kubernetes-e2e-gke-large-correctness:
         job-name: ci-kubernetes-e2e-gke-large-correctness

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2876,7 +2876,6 @@
       "--gcp-node-image=debian",
       "--gcp-project=k8s-e2e-gce-scalability-1-1",
       "--gcp-zone=us-east1-b",
-      "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --kube-api-content-type=application/vnd.kubernetes.protobuf --allowed-not-ready-nodes=1 --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--timeout=120m"
@@ -4036,7 +4035,6 @@
       "--gcp-node-image=gci",
       "--gcp-project=k8s-e2e-gci-gce-scale-1-4",
       "--gcp-zone=us-east1-b",
-      "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--timeout=120m"
@@ -4055,7 +4053,6 @@
       "--gcp-node-image=gci",
       "--gcp-project=k8s-e2e-gci-gce-scale-1-4",
       "--gcp-zone=us-east1-b",
-      "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --gather-logs-sizes=true --output-print-type=json --minStartupPods=8",
       "--timeout=120m"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -8897,6 +8897,41 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
+- cron: "0 */6 * * *" # every six hours
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gce-scalability-release-1-7
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
 - interval: 6h
   agent: kubernetes
   name: ci-kubernetes-e2e-gce-serial-release-1-6
@@ -10738,6 +10773,74 @@ periodics:
 - interval: 30m
   agent: kubernetes
   name: ci-kubernetes-e2e-gci-gce-scalability
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- cron: "0 3-21/6 * * *" # every six hours, disjoint with ci-kubernetes-e2e-gci-gce-scalability-stable1
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-scalability-release-1-7
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- cron: "0 0/6 * * *" # every six hours, disjoint with ci-kubernetes-e2e-gci-gce-scalability-release-1-7
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gci-gce-scalability-stable1
   spec:
     containers:
     - args:


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/issues/49820

http://k8s-testgrid.appspot.com/sig-testing-canaries#kubemark-canary-prow is using cron and the trigger part is working now, let's start with a few release branch jobs.

Also mimic the blocking behavior by schedule to different hours, since prow don't have that behavior.

For manual trigger jobs, we can set some cron trigger in the past maybe?

/area jobs

/assign @shyamjvs 