### PR TITLE
fix verify-prow a bit more

### DIFF
--- a/images/prow-test-image/Makefile
+++ b/images/prow-test-image/Makefile
@@ -23,7 +23,7 @@ do_build = \
 	$(eval VERSION_PARTS := $(subst :, ,$(v))) \
 	$(eval K8S := $(firstword $(VERSION_PARTS))) \
 	$(eval GO := $(lastword $(VERSION_PARTS))) \
-	docker build --build-arg GO_VERSION=$(GO) -f ./Dockerfile -t $(IMG):$(TAG)-$(K8S) . &&\
+	docker build --no-cache --build-arg GO_VERSION=$(GO) -f ./Dockerfile -t $(IMG):$(TAG)-$(K8S) . &&\
 	docker tag $(IMG):$(TAG)-$(K8S) $(IMG):latest-$(K8S) &&\
 	echo Built $(IMG):$(TAG)-$(K8S) and tagged with $(IMG):latest-$(K8S) ;
 

--- a/images/prow-test-image/runner
+++ b/images/prow-test-image/runner
@@ -17,7 +17,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+set -x
 service docker start
+echo "Ignore 'cgroup is already mounted' errors here :-)"
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
     --job=${JOB_NAME} \

--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -135,7 +135,7 @@ def main(branch, script, force, on_prow):
             # mimic k8s.io/kubernetes/hack/jenkins/verify-dockerized.sh
             # but patched slightly to work appropriately on prow
             path_prefix = os.environ['GOPATH'] + '/bin'
-            path_prefix += ':' + os.getcwd() + '/third_party/etcd:/usr/local/go/bin'
+            path_prefix += ':' + k8s + '/third_party/etcd:/usr/local/go/bin'
             os.environ['PATH'] = path_prefix + ':' + os.environ['PATH']
             os.environ['ARTIFACTS_DIR'] = os.environ['WORKSPACE'] + '/artifacts'
             os.environ['LOG_LEVEL'] = '4'


### PR DESCRIPTION
- don't cache the docker build because this causes problems with stale images
- echo that [some errors](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/52755/pull-kubernetes-verify-prow/84/) are ok :-)
- don't use getcwd right after chdir to a fixed path...

/area images
/area jobs