### PR TITLE
Use 1.6 kubekins-e2e image for 1.6 tests

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -791,7 +791,7 @@ jobs:
     interval: 2h
     sigOwners: ['sig-gcp']
   ci-kubernetes-e2e-gce-cos-k8sstable3-reboot:
-    interval: 6h˙
+    interval: 6h
     sigOwners: ['sig-gcp']
   ci-kubernetes-e2e-gce-cos-k8sstable2-reboot:
     interval: 2h
@@ -1009,19 +1009,24 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
   beta:
     args:
     # Run against HEAD since there's currently no Kubernetes beta release.
     - --repo=k8s.io/kubernetes=master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.8
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.7
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.6
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.6
 
 nodeTestSuites:
   default:

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -16750,7 +16750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16789,7 +16789,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16828,7 +16828,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16867,7 +16867,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16906,7 +16906,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16945,7 +16945,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17140,7 +17140,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17179,7 +17179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17218,7 +17218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17257,7 +17257,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17296,7 +17296,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17335,7 +17335,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17452,7 +17452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17491,7 +17491,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17530,7 +17530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17569,7 +17569,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17686,7 +17686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17725,7 +17725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17764,7 +17764,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17803,7 +17803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2enode-cosbeta-k8sstable3-default/54 timed out because of https://github.com/kubernetes/kubernetes/issues/43534.

We should use the 1.6 kubekins-e2e image for 1.6 tests.

/assign @krzyzacy @BenTheElder 
/cc @yujuhong 