### PR TITLE
Remove soak-gce-gci from sig-release-master-blocking

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2523,8 +2523,6 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-reboot
   - name: gci-gke-reboot
     test_group_name: ci-kubernetes-e2e-gci-gke-reboot
-  - name: soak-gce-gci
-    test_group_name: ci-kubernetes-soak-gce-gci
   - name: kubeadm-gce
     test_group_name: ci-kubernetes-e2e-kubeadm-gce
 


### PR DESCRIPTION
This job was failing during the run up to v1.9.0-alpha.2 (kubernetes/sig-release#22)
and is also failing as we look to cut v1.9.0-alpha.3 (kubernetes/sig-release#27).

https://github.com/kubernetes/kubernetes/issues/55196

This job has historically gone red and not been actively maintained.

If we get this job to a point where it meets the criteria to be established at kubernetes/sig-release#24 we can PR it back in.

/hold
for discussion

@kubernetes/sig-gcp-test-failures
@kubernetes/sig-release-test-failures