### PR TITLE
Improve scale jobs schedule to get better signal

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -58,27 +58,27 @@
     # gce high-scale tests #shyamjvs
     - kubernetes-e2e-gce-large-correctness:
         job-name: ci-kubernetes-e2e-gce-large-correctness
-        jenkins-timeout: 720
-        timeout: 620
-        frequency: '1 3 * * 6' # Run at 03:01 to avoid start-up clash with gke-large-performance
+        jenkins-timeout: 520
+        timeout: 420
+        frequency: '1 22 * * 1,3,5' # Run at 22:01 on odd days (except sunday)
         trigger-job: ''
     - kubernetes-e2e-gce-large-performance:
         job-name: ci-kubernetes-e2e-gce-large-performance
-        jenkins-timeout: 1020
-        timeout: 920
-        frequency: '1 0 * * 7' # Run at 00:01 to avoid start-up clash with gke-large-correctness
+        jenkins-timeout: 640
+        timeout: 540
+        frequency: '1 5 * * 2,4,6' # Run at 5:01 on even days
         trigger-job: ''
     - kubernetes-e2e-gce-scale-correctness:
         job-name: ci-kubernetes-e2e-gce-scale-correctness
-        jenkins-timeout: 1120
-        timeout: 1020
-        frequency: '1 0 * * 2,4' # Run at 00:01 on even weekdays
+        jenkins-timeout: 700
+        timeout: 600
+        frequency: '1 14 * * 2,4,6' # Run at 14:01 on even days
         trigger-job: ''
     - kubernetes-e2e-gce-scale-performance:
         job-name: ci-kubernetes-e2e-gce-scale-performance
         jenkins-timeout: 1420
         timeout: 1320
-        frequency: '1 0 * * 1,3,5' # Run at 00:01 on odd weekdays
+        frequency: '1 0 * * 1,3,5' # Run at 00:01 on odd days (except sunday)
         trigger-job: ''
     - kubernetes-e2e-gce-large-manual-up:
         job-name: ci-kubernetes-e2e-gce-large-manual-up
@@ -96,15 +96,21 @@
     # gke high-scale tests #shyamjvs
     - kubernetes-e2e-gke-large-correctness:
         job-name: ci-kubernetes-e2e-gke-large-correctness
-        jenkins-timeout: 720
-        timeout: 620
-        frequency: '1 3 * * 7' # Run at 03:01 to avoid start-up clash with gce-large-performance
+        jenkins-timeout: 580
+        timeout: 480
+        frequency: '1 15 * * 7' # Run at 15:01 on sunday
         trigger-job: ''
     - kubernetes-e2e-gke-large-performance:
         job-name: ci-kubernetes-e2e-gke-large-performance
-        jenkins-timeout: 1020
-        timeout: 920
-        frequency: '1 0 * * 6' # Run at 00:01 to avoid start-up clash with gce-large-correctness
+        jenkins-timeout: 700
+        timeout: 600
+        frequency: '1 5 * * 7' # Run at 5:01 on sunday
+        trigger-job: ''
+    - kubernetes-e2e-gke-scale-correctness:
+        job-name: ci-kubernetes-e2e-gke-scale-correctness
+        jenkins-timeout: 1120
+        timeout: 1020
+        frequency: '' #manual (TODO: automate this when possible)
         trigger-job: ''
     - kubernetes-e2e-gke-large-deploy:
         job-name: ci-kubernetes-e2e-gke-large-deploy
@@ -117,12 +123,6 @@
         jenkins-timeout: 300
         timeout: 200
         frequency: '' #manual
-        trigger-job: ''
-    - kubernetes-e2e-gke-scale-correctness:
-        job-name: ci-kubernetes-e2e-gke-scale-correctness
-        jenkins-timeout: 1120
-        timeout: 1020
-        frequency: '' #'1 0 * * 4' # Run at 00:01 on thursday
         trigger-job: ''
 
     # START KUBEMARK
@@ -154,7 +154,7 @@
         job-name: ci-kubernetes-kubemark-high-density-100-gce
         jenkins-timeout: 400
         timeout: 300
-        frequency: 'H 20 * * 6'  # weekly
+        frequency: '@daily'
         trigger-job: ''
     - kubernetes-kubemark-500-gce:
         job-name: ci-kubernetes-kubemark-500-gce

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2430,7 +2430,7 @@
   },
   "ci-kubernetes-e2e-gce-large-correctness": {
     "args": [
-      "--cluster=gce-large-cluster",
+      "--cluster=gce-scale-cluster",
       "--env-file=jobs/env/ci-kubernetes-e2e-gce-large-correctness.env",
       "--extract=ci/latest",
       "--gcp-master-image=gci",
@@ -2489,7 +2489,7 @@
   },
   "ci-kubernetes-e2e-gce-large-performance": {
     "args": [
-      "--cluster=gce-large-cluster",
+      "--cluster=gce-scale-cluster",
       "--env-file=jobs/env/ci-kubernetes-e2e-gce-large-performance.env",
       "--extract=ci/latest",
       "--gcp-master-image=gci",
@@ -6034,7 +6034,7 @@
   },
   "ci-kubernetes-e2e-gke-large-correctness": {
     "args": [
-      "--cluster=gke-large-cluster",
+      "--cluster=gke-scale-cluster",
       "--deployment=gke",
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
@@ -6080,7 +6080,7 @@
   },
   "ci-kubernetes-e2e-gke-large-performance": {
     "args": [
-      "--cluster=gke-large-cluster",
+      "--cluster=gke-scale-cluster",
       "--deployment=gke",
       "--extract=ci/latest",
       "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -2441,7 +2441,7 @@
       "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
-      "--timeout=600m",
+      "--timeout=390m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -2499,7 +2499,7 @@
       "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
-      "--timeout=900m",
+      "--timeout=510m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -2859,7 +2859,7 @@
       "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[DisabledForLargeClusters\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=90m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
-      "--timeout=1000m",
+      "--timeout=570m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -2877,7 +2877,7 @@
       "--mode=docker",
       "--provider=gce",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=50 --node-schedulable-timeout=90m --minStartupPods=8 --gather-resource-usage=master --gather-metrics-at-teardown=master",
-      "--timeout=1300m",
+      "--timeout=1290m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -6047,7 +6047,7 @@
       "--mode=docker",
       "--provider=gke",
       "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m --minStartupPods=8",
-      "--timeout=600m",
+      "--timeout=450m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -6092,7 +6092,7 @@
       "--mode=docker",
       "--provider=gke",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --allowed-not-ready-nodes=20 --node-schedulable-timeout=60m",
-      "--timeout=900m",
+      "--timeout=570m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -6376,7 +6376,7 @@
       "--mode=docker",
       "--provider=gke",
       "--test_args=--ginkgo.skip=\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --allowed-not-ready-nodes=40 --node-schedulable-timeout=90m --minStartupPods=8",
-      "--timeout=1000m",
+      "--timeout=990m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
Turns out our current schedule is less than optimal in terms of job timings. Changing it to fit in more runs, so that we have better signal coming from them.
Should help with spotting regressions easier.

The new schedule is as follows:

| Day | | |
| ------------- |:-------------:| -----:|
| Mon | 5k-node performance @ 00:01 PT | 2k-node performance @ 22:01 PT |
| Tue | 2k-node performance @ 05:01 PT | 5k-node correctness @ 14:01 PT |
| Wed | 5k-node performance @ 00:01 PT | 2k-node performance @ 22:01 PT |
| Thu | 2k-node performance @ 05:01 PT | 5k-node correctness @ 14:01 PT |
| Fri | 5k-node performance @ 00:01 PT | 2k-node performance @ 22:01 PT |
| Sat | 2k-node performance @ 05:01 PT | 5k-node correctness @ 14:01 PT |
| Sun | 'GKE' 2k-node performance @ 05:01 PT | 'GKE' 2k-node correctness @ 15:01 PT |

So:
- we'll have a performance run and a correctness run from each day (alternating b/w 2k and 5k though)
- we keep testing GKE (just like before) but exclusively on sunday
- the timings/timeouts have been set based on historical runs of each job
- we're experimenting with 5k-node correctness job running on weekend given that it's relatively stable now (can be changed to 2k later if it's causing trouble)

Also changed the cluster names for 2k jobs to be same as 5k, so that if one job failed to down the cluster, the following one will do that.

cc @kubernetes/sig-scalability-misc @porridge @krzyzacy @spiffxp 