### PR TITLE
Fix bug causing jobs to be aborted even if AllowCancellations is false.

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -173,8 +173,10 @@ func (c *Controller) Sync() error {
 	pjs = k8sJobs
 
 	var syncErrs []error
-	if err := c.terminateDupes(pjs, pm); err != nil {
-		syncErrs = append(syncErrs, err)
+	if c.ca.Config().Plank.AllowCancellations {
+		if err := c.terminateDupes(pjs, pm); err != nil {
+			syncErrs = append(syncErrs, err)
+		}
 	}
 
 	pendingCh, nonPendingCh := pjutil.PartitionPending(pjs)
@@ -234,11 +236,9 @@ func (c *Controller) terminateDupes(pjs []kube.ProwJob, pm map[string]kube.Pod) 
 		toCancel := pjs[cancelIndex]
 		// Allow aborting presubmit jobs for commits that have been superseded by
 		// newer commits in Github pull requests.
-		if c.ca.Config().Plank.AllowCancellations {
-			if pod, exists := pm[toCancel.Metadata.Name]; exists {
-				if err := c.pkc.DeletePod(pod.Metadata.Name); err != nil {
-					logrus.Warningf("Cannot cancel pod for prowjob %q: %v", toCancel.Metadata.Name, err)
-				}
+		if pod, exists := pm[toCancel.Metadata.Name]; exists {
+			if err := c.pkc.DeletePod(pod.Metadata.Name); err != nil {
+				logrus.Warningf("Cannot cancel pod for prowjob %q: %v", toCancel.Metadata.Name, err)
 			}
 		}
 		toCancel.Status.CompletionTime = time.Now()


### PR DESCRIPTION
Currently if a job is rerun on a PR and `AllowCancellations` is false, we won't delete the old pod (or jenkins job), but we will still mark the prow job as aborted. I don't think this is the intended behavior.
/cc @kargakis 
@yutongz @sebastienvas 