### PR TITLE
Emit a log line when dispatching events

### DIFF
--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -228,7 +228,9 @@ func (s *Server) demuxExternal(l *logrus.Entry, externalPlugins []plugins.Extern
 	for _, p := range externalPlugins {
 		go func(p plugins.ExternalPlugin) {
 			if err := s.dispatch(p.Endpoint, payload, h); err != nil {
-				l.WithError(err).Errorf("Error dispatching event to external plugin %q.", p.Name)
+				l.WithError(err).WithField("external-plugin", p.Name).Error("Error dispatching event to external plugin.")
+			} else {
+				l.WithField("external-plugin", p.Name).Info("Dispatched event to external plugin")
 			}
 		}(p)
 	}


### PR DESCRIPTION
When an event is successfully dispatched to an external pluign we should
log this to allow for event tracing.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @cjwagner 
/assign @kargakis 