### PR TITLE
prow: add StorageMedium to emptyDir

### DIFF
--- a/prow/kube/types.go
+++ b/prow/kube/types.go
@@ -100,6 +100,7 @@ type SecretSource struct {
 }
 
 type EmptyDirVolumeSource struct {
+	Medium string `json:"medium,omitempty"`
 	// NOTE: fields ommitted here as Prow does not currently use them
 }
 


### PR DESCRIPTION
I want to try using medium: Memory on prow for cross
TODO: bump all the things