### PR TITLE
setup release 1.9

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -107,6 +107,14 @@
         repo-name: k8s.io/kubernetes
         timeout: 120
 
+    - kubernetes-build-1.9:
+        branch: release-1.9
+        commit-frequency: 'H/5 * * * *'
+        giturl: 'https://github.com/kubernetes/kubernetes'
+        job-name: ci-kubernetes-build-1.9
+        repo-name: k8s.io/kubernetes
+        timeout: 120
+
     - kubernetes-federation-build-1.7:
         branch: release-1.7
         giturl: 'https://github.com/kubernetes/kubernetes'
@@ -119,6 +127,14 @@
         branch: release-1.8
         giturl: 'https://github.com/kubernetes/kubernetes'
         job-name: ci-kubernetes-federation-build-1.8
+        repo-name: k8s.io/kubernetes
+        commit-frequency: 'H/5 * * * *'
+        timeout: 50
+
+    - kubernetes-federation-build-1.9:
+        branch: release-1.9
+        giturl: 'https://github.com/kubernetes/kubernetes'
+        job-name: ci-kubernetes-federation-build-1.9
         repo-name: k8s.io/kubernetes
         commit-frequency: 'H/5 * * * *'
         timeout: 50

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-repo.yaml
@@ -58,6 +58,12 @@
         job-name: ci-kubernetes-verify-master
         repo-name: k8s.io/kubernetes
         timeout: 80
+    - kubernetes-verify-release-1.9:
+        branch: release-1.9
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-verify-release-1.9
+        repo-name: k8s.io/kubernetes
+        timeout: 80
     - kubernetes-verify-release-1.8:
         branch: release-1.8
         frequency: 'H/5 * * * *'
@@ -66,7 +72,7 @@
         timeout: 80
     - kubernetes-verify-release-1.7:
         branch: release-1.7
-        frequency: 'H/5 * * * *'
+        frequency: 'H H/3 * * *'
         job-name: ci-kubernetes-verify-release-1.7
         repo-name: k8s.io/kubernetes
         timeout: 80
@@ -84,6 +90,12 @@
         job-name: ci-kubernetes-test-go
         repo-name: k8s.io/kubernetes
         timeout: 100
+    - kubernetes-test-go-release-1.9:
+        branch: release-1.9
+        frequency: 'H/5 * * * *'
+        job-name: ci-kubernetes-test-go-release-1.9
+        repo-name: k8s.io/kubernetes
+        timeout: 100
     - kubernetes-test-go-release-1.8:
         branch: release-1.8
         frequency: 'H/5 * * * *'
@@ -92,7 +104,7 @@
         timeout: 100
     - kubernetes-test-go-release-1.7:
         branch: release-1.7
-        frequency: 'H/5 * * * *'
+        frequency: 'H H/3 * * *'
         job-name: ci-kubernetes-test-go-release-1.7
         repo-name: k8s.io/kubernetes
         timeout: 100

--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci.yaml
@@ -137,7 +137,7 @@
         jenkins-timeout: 180
         timeout: 80
         frequency: 'H/5 * * * *' # At least every 30m
-        trigger-job: 'ci-kubernetes-build-1.8'
+        trigger-job: 'ci-kubernetes-build-1.9'
     - kubernetes-kubemark-100-gce:
         job-name: ci-kubernetes-kubemark-100-gce
         jenkins-timeout: 360

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -238,7 +238,7 @@
   },
   "ci-kubernetes-build-1.6": {
     "args": [
-      "--extra-publish-file=k8s-stable3"
+      "--extra-publish-file=k8s-stable4"
     ],
     "scenario": "kubernetes_build",
     "sigOwners": [
@@ -247,7 +247,7 @@
   },
   "ci-kubernetes-build-1.7": {
     "args": [
-      "--extra-publish-file=k8s-stable2"
+      "--extra-publish-file=k8s-stable3"
     ],
     "scenario": "kubernetes_build",
     "sigOwners": [
@@ -255,6 +255,17 @@
     ]
   },
   "ci-kubernetes-build-1.8": {
+    "args": [
+      "--extra-publish-file=k8s-stable2",
+      "--hyperkube",
+      "--registry=gcr.io/kubernetes-ci-images"
+    ],
+    "scenario": "kubernetes_build",
+    "sigOwners": [
+      "sig-release"
+    ]
+  },
+  "ci-kubernetes-build-1.9": {
     "args": [
       "--extra-publish-file=k8s-stable1",
       "--hyperkube",

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -89,6 +89,8 @@ test_groups:
     name_format: '%s [%s]'
 - name: ci-kubernetes-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
+- name: ci-kubernetes-build-1.9
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.9
 - name: ci-kubernetes-build-1.8
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.8
 - name: ci-kubernetes-build-1.6
@@ -388,6 +390,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.6
 - name: ci-kubernetes-verify-release-1.8
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.8
+- name: ci-kubernetes-verify-release-1.9
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-verify-release-1.9
 - name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
 - name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
@@ -2245,6 +2249,8 @@ dashboards:
     test_group_name: ci-kubernetes-build-1.7
   - name: build-1.8
     test_group_name: ci-kubernetes-build-1.8
+  - name: build-1.9
+    test_group_name: ci-kubernetes-build-1.9
   - name: bazel-build
     test_group_name: ci-kubernetes-bazel-build
   - name: bazel-build-1.6
@@ -2570,6 +2576,166 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew
   - name: gke-1-7-1.6-gci-kubectl-skew-serial
     test_group_name: ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew-serial
+
+- name: sig-release-1.9-all
+  dashboard_tab:
+  - name: build-1.9
+    test_group_name: ci-kubernetes-build-1.9
+  - name: verify-1.9
+    test_group_name: ci-kubernetes-verify-release-1.9
+  - name: test-go-1.9
+    test_group_name: ci-kubernetes-test-go-release-1.9
+  - name: bazel-build-1.9
+    test_group_name: periodic-kubernetes-bazel-build-1-9
+  - name: bazel-test-1.9
+    test_group_name: periodic-kubernetes-bazel-test-1-9
+  - name: gce-kubeadm-1.9
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-9
+  - name: gce-kubeadm-1.8-on-1.9
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
+  - name: periodic-gce-kubeadm-1.9
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-9
+  - name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-upgrade-1-8-1-9
+  - name: periodic-kubernetes-e2e-debs-pushed
+    test_group_name: periodic-kubernetes-e2e-debs-pushed
+  - name: gci-gce-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-stable1
+  - name: gci-gce-slow-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-slow-stable1
+  - name: gci-gce-serial-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial-stable1
+  - name: gci-gce-alpha-features-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features-stable1
+  - name: gci-gce-scalability-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-scalability-stable1
+  - name: gci-gce-ingress-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-stable1
+  - name: gci-gce-reboot-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-reboot-stable1
+  - name: gci-gke-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-stable1
+  - name: gci-gke-slow-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow-stable1
+  - name: gci-gke-serial-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-serial-stable1
+  - name: gci-gke-ingress-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-ingress-stable1
+  - name: gci-gke-reboot-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-reboot-stable1
+  - name: gci-gce-soak-1.9
+    test_group_name: ci-kubernetes-soak-gci-gce-stable1
+  - name: kops-aws-1.9
+    test_group_name: ci-kubernetes-e2e-kops-aws-stable1
+  - name: federation-build-1.9
+    test_group_name: ci-kubernetes-federation-build-1.9
+  - name: federation-test-1.9
+    test_group_name: ci-kubernetes-e2e-gce-federation-release-1-9
+  - name: gke-gci-1.7-gci-1.9-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
+  - name: gke-gci-1.7-gci-1.9-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
+  - name: gke-gci-1.7-gci-1.9-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
+  - name: gke-gci-1.8-gci-1.9-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
+  - name: gke-gci-1.8-gci-1.9-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
+  - name: gke-gci-1.8-gci-1.9-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
+  - name: gke-cvm-1-7-gci-1-9-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-gci-1-8-upgrade-master
+  - name: gke-cvm-1-7-gci-1-9-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-gci-1-8-upgrade-cluster
+  - name: gke-cvm-1-7-gci-1-9-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-6-gci-1-8-upgrade-cluster-new
+  - name: gke-cvm-1-8-gci-1-9-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-7-gci-1-8-upgrade-master
+  - name: gke-cvm-1.8-gci-1.9-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-7-gci-1-8-upgrade-cluster
+  - name: gke-cvm-1.8-gci-1.9-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gke-cvm-1-7-gci-1-8-upgrade-cluster-new
+  - name: gce-1.8-1.9-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
+  - name: gce-1.9-1.8-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
+  - name: gke-1.9-1.8-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
+  - name: gke-1.8-1.9-gci-kubectl-skew
+    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
+  - name: gce-1.8-1.9-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
+  - name: gce-1.9-1.8-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
+  - name: gke-1.9-1.8-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
+  - name: gke-1.8-1.9-gci-kubectl-skew-serial
+    test_group_name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
+  - name: gce-1.8-1.9-upgrade-master
+    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-master
+  - name: gce-1.8-1.9-upgrade-cluster
+    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster
+  - name: gce-1.8-1.9-upgrade-cluster-new
+    test_group_name: ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new
+  - name: kubelet-1.9
+    test_group_name: ci-kubernetes-node-kubelet-stable1
+  - name: gce-gpu-1-9
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1
+  - name: gce-device-plugin-gpu-1-9
+    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
+  - name: gke-device-plugin-gpu-1-9
+    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
+
+- name: sig-release-1.9-blocking
+  dashboard_tab:
+  - name: build-1.9
+    test_group_name: ci-kubernetes-build-1.9
+  - name: verify-1.9
+    test_group_name: ci-kubernetes-verify-release-1.9
+  - name: test-go-1.9
+    test_group_name: ci-kubernetes-test-go-release-1.9
+  - name: gce-kubeadm-1.8-on-1.9
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
+  - name: periodic-gce-kubeadm-1.9
+    test_group_name: periodic-kubernetes-e2e-kubeadm-gce-1-9
+  - name: gci-gce-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-stable1
+  - name: gci-gce-slow-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-stable1
+  - name: gci-gce-serial-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-serial-stable1
+  - name: gci-gce-alpha-features-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features-stable1
+  - name: gci-gce-scalability-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-scalability-stable1
+  - name: gci-gce-ingress-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-ingress-stable1
+  - name: gci-gce-reboot-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gce-reboot-stable1
+  - name: gci-gke-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-stable1
+  - name: gci-gke-slow-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow-stable1
+  - name: gci-gke-serial-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-serial-stable1
+  - name: gci-gke-ingress-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-ingress-stable1
+  - name: gci-gke-reboot-1.9
+    test_group_name: ci-kubernetes-e2e-gci-gke-reboot-stable1
+  - name: kops-aws-1.9
+    test_group_name: ci-kubernetes-e2e-kops-aws-stable1
+  - name: federation-build-1.9
+    test_group_name: ci-kubernetes-federation-build-1.9
+  - name: federation-test-1.9
+    test_group_name: ci-kubernetes-e2e-gce-federation-release-1-9
+  - name: kubelet-1.9
+    test_group_name: ci-kubernetes-node-kubelet-stable1
+  - name: gce-gpu-1-9
+    test_group_name: ci-kubernetes-e2e-gce-gpu-stable1
+  - name: gce-device-plugin-gpu-1-9
+    test_group_name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
+  - name: gke-device-plugin-gpu-1-9
+    test_group_name: ci-kubernetes-e2e-gke-device-plugin-gpu-stable1
 
 - name: sig-release-1.8-all
   dashboard_tab:


### PR DESCRIPTION
To setup `release-1.9`:

Testgrid:
- [x] create `sig-release-1.9-all` dashboard
- [x] create `sig-release-1.9-blocking` dashboard
- [ ] add GCS entries for all release-1.9 jobs
- [ ] add 1.9 jobs to any other appropriate dashboards

Jenkins:
- [x] add `ci-kubernetes-build-1.9`, bump stableN for build jobs
- [x] add `kubernetes-test-go-release-1.9`
- [x] add `kubernetes-verify-release-1.9`
- [x] add `kubernetes-build-1.9`
- [x] add `kubernetes-federation-build-1.9`
- [x] update `kubernetes-kubemark-5-gce-last-release` trigger job to `ci-kubernetes-build-1.9`
- [ ] take a second pass to check for any remaining jobs

Prow:
- [x] ensure presubmits will run against `release-1.9` branch the same as existing master
- [ ] add 1.9 versions of any 1.8 specific jobs already on Prow

Other TODO:
- [ ] move jobs to Prow where possible, xref #3778 
  - Need to add more resources to `prow-builds`, also https://github.com/kubernetes/test-infra/pull/5561
- [ ] make sure all jobs in Testgrid exist in Prow/Jenkins


/area jobs