### PR TITLE
add docker-in-docker support to the bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -15,7 +15,7 @@
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
 FROM debian:jessie
-LABEL authors="Sen Lu <senlu@google.com>"
+LABEL maintainer="Sen Lu <senlu@google.com>"
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -60,12 +60,55 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.ta
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
-# Install docker
+# Get docker client binary for use with our jenkins nodes, and put it in it's
+# own bin dir. The runner will add this to the path if dind mode is not enabled.
 # Note: 1.11+ changes the tarball format
-RUN curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \
-    | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
+RUN mkdir /docker-no-dind-bin/ && \
+    curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" \
+    | tar -C /docker-no-dind-bin -xvzf- --strip-components=3 usr/local/bin/docker
 
 
+#
+# BEGIN: DOCKER IN DOCKER SETUP
+#
+
+# Install Docker deps, some of these are already installed in the image but
+# that's fine since they won't re-install and we can reuse the code below
+# for another image someday.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    lsb-release
+
+# Add the Docker apt-repository
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
+    | apt-key add - && \
+    add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+    $(lsb_release -cs) stable"
+
+# Install Docker
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce
+
+
+# Move Docker's storage location
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --graph=/docker-graph"' | \
+    tee --append /etc/default/docker
+# NOTE this should be mounted and persisted as a volume ideally (!)
+# We will make a fallback one now just in case
+RUN mkdir /docker-graph
+
+#
+# END: DOCKER IN DOCKER SETUP
+#
+
+
+# note the runner is also responsible for making docker in docker function if
+# env DOCKER_IN_DOCKER_ENABLED is set
 ADD ["runner", \
     "/workspace/"]
 

--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -16,7 +16,22 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
 
+# Check if the job has opted-in to docker-in-docker availability.
+export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+if [ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]; then
+# If we have opted in to docker in docker, start the docker daemon.
+# sometimes there may be errors about cgroups already being mounted,
+# these should not be a problem.
+    echo "Please ignore benign 'cgroup is already mounted' errors here :-)"
+    service docker start
+else
+# If not, make sure `docker` points to the old one compatible with our Jenkins
+    export PATH=/docker-no-dind-bin/:$PATH
+fi
+
+# Clone test-infra and start bootstrap
 git clone https://github.com/kubernetes/test-infra
 ./test-infra/jenkins/bootstrap.py \
     --job=${JOB_NAME} \


### PR DESCRIPTION
Jobs will using the bootstrap image or images based on it now be able to opt in to docker-in-docker support by:

- setting env `DOCKER_IN_DOCKER_ENABLED`
- mounting an `emptyDir` (either temporary space on the host node, or a tmpfs) to `/var/lib/docker` (on some hosts this will be unnecessary, but it really doesn't hurt anyhow) 
- optionally mounting persistent storage to `/docker-graph` to cache the docker image store on the host
- run with `privileged` mode (which our Bazel jobs already do)

This should not break existing workflows as starting the docker service is behind setting the special env. This also means we can check the config for jobs doing this when we want to work on #5436. Also the old docker binary used by jenkins is still installed to it's own directory which we put at the front of `$PATH` if docker-in-docker is not enabled (for instead mounting the socket and using DooD).

Other things:
- enabled `set -x` so that the bootstrap commands are debugged in the logs
- set the idiomatic replacement for the `MAINTAINER` instruction
- this `echo`s a notice that stray cgroup remount errors can be safely ignored since Gubernator will highlight these. I've only seen them on 1-2 runs over many trials and they did not affect anything, but they do make for a lot of highlighted warning text at the beginning of the log if they occur 🤷‍♂️ 

I want to follow up by migrating jobs off of Jenkins to bootstrap based images, but first we will also need to adjust `prow-builds`'s capacity.
I will also kill off the `prow-test-image` in favor of building images on top of bootstrap going forward, I want to reduce the number of image flavors we maintain for test/build and keep them up to date more regularly with uniform $date-$git-sha versioning.