### PR TITLE
modify 'hack/e2e.go' command prompt

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -101,7 +101,7 @@ def do_testcmd(name):
         name_escaped = re.escape(name).replace('\\ ', '\\s')
 
         test_args = ('--ginkgo.focus=%s$' % name_escaped)
-        return "go run hack/e2e.go -v -test --test_args='%s'" % test_args
+        return "go run hack/e2e.go -v --test --test_args='%s'" % test_args
 
 
 def do_parse_pod_name(text):

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -72,7 +72,7 @@ class HelperTest(unittest.TestCase):
 
     def test_testcmd_e2e(self):
         self.assertEqual(filters.do_testcmd('[k8s.io] Proxy [k8s.io] works'),
-            "go run hack/e2e.go -v -test --test_args='--ginkgo.focus="
+            "go run hack/e2e.go -v --test --test_args='--ginkgo.focus="
             "Proxy\\s\\[k8s\\.io\\]\\sworks$'")
 
     def test_testcmd_bazel(self):


### PR DESCRIPTION
when some test filed, CI will give a command like this
```
go run hack/e2e.go -v -test --test_args='--ginkgo.focus=\[sig\-network\]\sDNS\sshould\sprovide\sDNS\sfor\sservices\s\s\[Conformance\]$'
```
But this command can't work, lost a `-` before flag `test`