### PR TITLE
Enable build scenario to run from federation directory

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -36,9 +36,10 @@ def main(args):
 
     This is a python port of the kubernetes/hack/jenkins/build.sh script.
     """
-    if os.path.split(os.getcwd())[-1] != 'kubernetes':
+    if os.path.split(os.getcwd())[-1] != 'kubernetes' and \
+        os.path.split(os.getcwd())[-1] != 'federation':
         print >>sys.stderr, (
-            'Scenario should only run from a kubernetes directory!')
+            'Scenario should only run from either kubernetes or federation directory!')
         sys.exit(1)
     env = {
         # Skip gcloud update checking; do we still need this?


### PR DESCRIPTION
We are seeing below error when federation build job is run on k/f repo.

```
W1115 10:09:23.344] Scenario should only run from a kubernetes directory!
```
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-federation-build/7/build-log.txt

So this PR is update the build scenario to allow running from federation repo.

/assign @krzyzacy 
/cc @kubernetes/sig-multicluster-pr-reviews 