### PR TITLE
Add release 1.9 build

### DIFF
--- a/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
+++ b/jenkins/job-configs/kubernetes-jenkins/bootstrap-ci-commit.yaml
@@ -106,6 +106,14 @@
         job-name: ci-kubernetes-build-1.8
         repo-name: k8s.io/kubernetes
         timeout: 120
+    
+    - kubernetes-build-1.9:
+        branch: release-1.9
+        commit-frequency: 'H/5 * * * *'
+        giturl: 'https://github.com/kubernetes/kubernetes'
+        job-name: ci-kubernetes-build-1.9
+        repo-name: k8s.io/kubernetes
+        timeout: 120
 
     - kubernetes-federation-build-1.7:
         branch: release-1.7

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -265,6 +265,17 @@
       "sig-release"
     ]
   },
+  "ci-kubernetes-build-1.9": {
+    "args": [
+      "--extra-publish-file=k8s-beta",
+      "--hyperkube",
+      "--registry=gcr.io/kubernetes-ci-images"
+    ],
+    "scenario": "kubernetes_build",
+    "sigOwners": [
+      "sig-release"
+    ]
+  },
   "ci-kubernetes-build-debian-unstable": {
     "args": [
       "./debian/jenkins.sh"

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -87,6 +87,8 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
+- name: ci-kubernetes-build-1.9
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.9
 - name: ci-kubernetes-build
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build
 - name: ci-kubernetes-build-1.8
@@ -2570,6 +2572,16 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew
   - name: gke-1-7-1.6-gci-kubectl-skew-serial
     test_group_name: ci-kubernetes-e2e-gke-1-7-1-6-gci-kubectl-skew-serial
+
+- name: sig-release-1.9-all
+  dashboard_tab:
+  - name: build-1.9
+    test_group_name: ci-kubernetes-build-1.9
+
+- name: sig-release-1.9-blocking
+  dashboard_tab:
+  - name: build-1.9
+    test_group_name: ci-kubernetes-build-1.9
 
 - name: sig-release-1.8-all
   dashboard_tab:


### PR DESCRIPTION
we are last-minute bike-shedding the stable tags etc, but we definitely agree we should get the build job up first and then the others (which consume it via the tags).

/area jobs
/hold