### PR TITLE
Fix cri-containerd log collection.

### DIFF
--- a/jobs/env/ci-cri-containerd-e2e-gce.env
+++ b/jobs/env/ci-cri-containerd-e2e-gce.env
@@ -11,7 +11,7 @@ TEST_ETCD_VERSION=2.2.1
 # ENABLE_POD_SECURITY_POLICY=true
 
 # Envs for cri-containerd.
-LOG_DUMP_SYSTEMD_SERVICES=containerd,cri-containerd,cri-containerd-installation
+LOG_DUMP_SYSTEMD_SERVICES=containerd cri-containerd cri-containerd-installation
 KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/kubernetes-incubator/cri-containerd/test/e2e/master.yaml,cri-containerd-configure-sh=/workspace/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
 KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/kubernetes-incubator/cri-containerd/test/e2e/node.yaml,cri-containerd-configure-sh=/workspace/github.com/kubernetes-incubator/cri-containerd/test/configure.sh
 KUBE_CONTAINER_RUNTIME=remote


### PR DESCRIPTION
In the flag, it's separated by comma. But in env it should be space.

Or else we'll get something like this http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce/245/artifacts/bootstrap-e2e-minion-group-172d/.