### PR TITLE
Switch kubernetes/kubernetes to use approve plugin.

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -5,7 +5,7 @@ organization: kubernetes
 project: kubernetes
 # Run blunderbuss before approval-handler, so that we can suggest approvers
 # based on assigned reviewer.
-pr-mungers: blunderbuss,approval-handler,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,path-label,stale-green-ci,comment-deleter,close-stale,sig-mention-handler,milestone-maintainer
+pr-mungers: blunderbuss,lgtm-after-commit,cherrypick-auto-approve,label-unapproved-picks,needs-rebase,path-label,stale-green-ci,comment-deleter,close-stale,sig-mention-handler,milestone-maintainer
 state: open
 token-file: /etc/secret-volume/token
 period: 60s
@@ -28,8 +28,6 @@ required-retest-contexts: "\
 
 # munger specific options.
 path-label-config: "/etc/munge-config/path-label.txt"
-approval-requires-issue: true
-implicit-self-approval: true
 number-of-old-test-results: 5
 generated-files-config: .generated_files
 label-file: "/gitrepos/kubernetes/labels.yaml"

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -14,9 +14,13 @@ triggers:
 
 approve:
 - repos:
-  - kubernetes/test-infra
   - kubernetes/kubectl
+  - kubernetes/test-infra
   implicit_self_approve: true
+- repos:
+  - kubernetes/kubernetes
+  implicit_self_approve: true
+  issue_required: true
 
 blockades:
 - repos:
@@ -108,6 +112,7 @@ plugins:
   - approve
 
   kubernetes/kubernetes:
+  - approve
   - trigger
   - release-note
   - docs-no-retest


### PR DESCRIPTION
The approve plugin uses Prow's `repoowners` package which support the `no_parent_owners` OWNERS file option so this PR will enable that functionality on k/k.
This is the last kubernetes repo to switch over from the approval handler munger!
fixes #5197 
/cc @BenTheElder @mml 

I'll deploy this after the weekend.
/hold