### PR TITLE
allow cross-prow to be triggered against branches other than master

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1009,8 +1009,6 @@ presubmits:
     rerun_command: "/test pull-kubernetes-cross-prow"
     trigger: "(?m)^/test pull-kubernetes-cross-prow,?(\\s+|$)"
     always_run: false
-    branches:
-    - master
     spec:
       containers:
       # TODO(bentheelder): when we migrate off of jenkins clean up this image
@@ -2507,8 +2505,6 @@ presubmits:
     rerun_command: "/test pull-security-kubernetes-cross-prow"
     trigger: "(?m)^/test pull-security-kubernetes-cross-prow,?(\\s+|$)"
     always_run: false
-    branches:
-    - master
     spec:
       containers:
       # TODO(bentheelder): when we migrate off of jenkins clean up this image


### PR DESCRIPTION
/area jobs

I'm running two against master right now, so far so good after adding the new nodes. We need to check this against 1.8/1.7 to be sure before switching over to prow by default though.