### PR TITLE
clarify notice in pod logs about benign dockerd startup errors

### DIFF
--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -24,8 +24,8 @@ if [ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]; then
 # If we have opted in to docker in docker, start the docker daemon.
 # sometimes there may be errors about cgroups already being mounted,
 # these should not be a problem.
-    echo "Please ignore benign 'cgroup is already mounted' errors here :-)"
     service docker start
+    echo "Please ignore benign 'rmdir: failed ...' / 'cgroup is already mounted' errors here :-)"
 else
 # If not, make sure `docker` points to the old one compatible with our Jenkins
     export PATH=/docker-no-dind-bin/:$PATH


### PR DESCRIPTION
also place it immediately *after* the service has started so that it shows in gubernator while running.

none of this will appear in the build logs but they are visible *during* some builds from the pod logs