### PR TITLE
bootstrap image: don't run cgroupfs_mount when starting docker service

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -91,8 +91,14 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
     $(lsb_release -cs) stable"
 
 # Install Docker
+# TODO(bentheelder): this is a bit of a hack, look into alternatives.
+# Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
+# We're already inside docker though so we can be sure these are already mounted.
+# Trying to remount these makes for a very noisy error block in the beginning of
+# the pod logs, so we just comment out the call to it... :shrug:
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce
+    apt-get install -y --no-install-recommends docker-ce && \
+    sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 
 
 # Move Docker's storage location

--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -22,10 +22,7 @@ set -x
 export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
 if [ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]; then
 # If we have opted in to docker in docker, start the docker daemon.
-# sometimes there may be errors about cgroups already being mounted,
-# these should not be a problem.
     service docker start
-    echo "Please ignore benign 'rmdir: failed ...' / 'cgroup is already mounted' errors here :-)"
 else
 # If not, make sure `docker` points to the old one compatible with our Jenkins
     export PATH=/docker-no-dind-bin/:$PATH


### PR DESCRIPTION
This eliminates all of the annoying errors in the pod logs related to trying to remount cgroups.
You can see what the new script looks like if you expand below:
<details><p>

```shell
$ docker run --rm -it --privileged --entrypoint /bin/bash gcr.io/k8s-testimages/bootstrap
root@8f65407280f7:/workspace# cat /etc/init.d/docker
#!/bin/sh
set -e

### BEGIN INIT INFO
# Provides:           docker
# Required-Start:     $syslog $remote_fs
# Required-Stop:      $syslog $remote_fs
# Should-Start:       cgroupfs-mount cgroup-lite
# Should-Stop:        cgroupfs-mount cgroup-lite
# Default-Start:      2 3 4 5
# Default-Stop:       0 1 6
# Short-Description:  Create lightweight, portable, self-sufficient containers.
# Description:
#  Docker is an open-source project to easily create lightweight, portable,
#  self-sufficient containers from any application. The same container that a
#  developer builds and tests on a laptop can run at scale, in production, on
#  VMs, bare metal, OpenStack clusters, public clouds and more.
### END INIT INFO

export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin

BASE=docker

# modify these in /etc/default/$BASE (/etc/default/docker)
DOCKERD=/usr/bin/dockerd
# This is the pid file managed by docker itself
DOCKER_PIDFILE=/var/run/$BASE.pid
# This is the pid file created/managed by start-stop-daemon
DOCKER_SSD_PIDFILE=/var/run/$BASE-ssd.pid
DOCKER_LOGFILE=/var/log/$BASE.log
DOCKER_OPTS=
DOCKER_DESC="Docker"

# Get lsb functions
. /lib/lsb/init-functions

if [ -f /etc/default/$BASE ]; then
        . /etc/default/$BASE
fi

# Check docker is present
if [ ! -x $DOCKERD ]; then
        log_failure_msg "$DOCKERD not present or not executable"
        exit 1
fi

check_init() {
        # see also init_is_upstart in /lib/lsb/init-functions (which isn't available in Ubuntu 12.04, or we'd use it directly)
        if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; then
                log_failure_msg "$DOCKER_DESC is managed via upstart, try using service $BASE $1"
                exit 1
        fi
}

fail_unless_root() {
        if [ "$(id -u)" != '0' ]; then
                log_failure_msg "$DOCKER_DESC must be run as root"
                exit 1
        fi
}

cgroupfs_mount() {
        # see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
        if grep -v '^#' /etc/fstab | grep -q cgroup \
                || [ ! -e /proc/cgroups ] \
                || [ ! -d /sys/fs/cgroup ]; then
                return
        fi
        if ! mountpoint -q /sys/fs/cgroup; then
                mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
        fi
        (
                cd /sys/fs/cgroup
                for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
                        mkdir -p $sys
                        if ! mountpoint -q $sys; then
                                if ! mount -n -t cgroup -o $sys cgroup $sys; then
                                        rmdir $sys || true
                                fi
                        fi
                done
        )
}

case "$1" in
        start)
                check_init

                fail_unless_root

                #cgroupfs_mount


                touch "$DOCKER_LOGFILE"
                chgrp docker "$DOCKER_LOGFILE"

                ulimit -n 1048576

                # Having non-zero limits causes performance problems due to accounting overhead
                # in the kernel. We recommend using cgroups to do container-local accounting.
                if [ "$BASH" ]; then
                        ulimit -u unlimited
                else
                        ulimit -p unlimited
                fi

                log_begin_msg "Starting $DOCKER_DESC: $BASE"
                start-stop-daemon --start --background \
                        --no-close \
                        --exec "$DOCKERD" \
                        --pidfile "$DOCKER_SSD_PIDFILE" \
                        --make-pidfile \
                        -- \
                                -p "$DOCKER_PIDFILE" \
                                $DOCKER_OPTS \
                                        >> "$DOCKER_LOGFILE" 2>&1
                log_end_msg $?
                ;;

        stop)
                check_init
                fail_unless_root
                if [ -f "$DOCKER_SSD_PIDFILE" ]; then
                        log_begin_msg "Stopping $DOCKER_DESC: $BASE"
                        start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE" --retry 10
                        log_end_msg $?
                else
                        log_warning_msg "Docker already stopped - file $DOCKER_SSD_PIDFILE not found."
                fi
                ;;

        restart)
                check_init
                fail_unless_root
                docker_pid=`cat "$DOCKER_SSD_PIDFILE" 2>/dev/null`
                [ -n "$docker_pid" ] \
                        && ps -p $docker_pid > /dev/null 2>&1 \
                        && $0 stop
                $0 start
                ;;

        force-reload)
                check_init
                fail_unless_root
                $0 restart
                ;;

        status)
                check_init
                status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKERD" "$DOCKER_DESC"
                ;;

        *)
                echo "Usage: service docker {start|stop|restart|status}"
                exit 1
                ;;
esac
```

</p>
</details>  
  


[Test Run With `pull-kubernetes-cross-prow` canary job](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/52755/pull-kubernetes-cross-prow/25/)

/area images