### PR TITLE
Enable docker-in-docker for federation ci job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4790,19 +4790,28 @@ periodics:
       - --timeout=920
       - --bare
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
+      # docker-in-docker needs privilged mode
+      securityContext:
+        privileged: true
       image: gcr.io/k8s-testimages/kubekins-e2e:v20171120-5e89f3c1-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
+      - name: var-lib-docker
+        mountPath: /var/lib/docker
     volumes:
     - name: service
       secret:
         secretName: service-account
+    - name: var-lib-docker
+      emptyDir: {}
 - interval: 30m
   agent: kubernetes
   name: ci-federation-e2e-gce-serial
@@ -4812,19 +4821,28 @@ periodics:
       - --timeout=920
       - --bare
       env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
+      # docker-in-docker needs privilged mode
+      securityContext:
+        privileged: true
       image: gcr.io/k8s-testimages/kubekins-e2e:v20171120-5e89f3c1-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
+      - name: var-lib-docker
+        mountPath: /var/lib/docker
     volumes:
     - name: service
       secret:
         secretName: service-account
+    - name: var-lib-docker
+      emptyDir: {}
 
 - name: ci-kubernetes-bazel-build
   interval: 30m

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4794,26 +4794,15 @@ periodics:
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e:v20171120-5e89f3c1-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
     volumes:
     - name: service
       secret:
         secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
 - interval: 30m
   agent: kubernetes
   name: ci-federation-e2e-gce-serial
@@ -4827,26 +4816,15 @@ periodics:
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
-      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-private
-      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-        value: /etc/ssh-key-secret/ssh-public
       image: gcr.io/k8s-testimages/kubekins-e2e:v20171120-5e89f3c1-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
-      - mountPath: /etc/ssh-key-secret
-        name: ssh
-        readOnly: true
     volumes:
     - name: service
       secret:
         secretName: service-account
-    - name: ssh
-      secret:
-        defaultMode: 256
-        secretName: ssh-key-secret
 
 - name: ci-kubernetes-bazel-build
   interval: 30m


### PR DESCRIPTION
Federation CI job needs docker daemon to push the fcp image to gcr registry. So set the `DOCKER_IN_DOCKER_ENABLED` env var in-order that prow job has container image running docker daemon.

Here is the failure that's happening because docker daemon not available in federation ci job (prow job)
```
W1120 10:50:10.614] 2017/11/20 10:50:10 util.go:155: Running: ../federation/deploy/cluster/federation-up.sh
W1120 10:50:19.507] Cannot connect to the Docker daemon. Is the docker daemon running on this host?
W1120 10:50:19.572] 2017/11/20 10:50:19 util.go:157: Step '../federation/deploy/cluster/federation-up.sh' finished in 9.099477368s
```
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-federation-e2e-gce/1108

/assign @BenTheElder 
/cc @krzyzacy @marun @irfanurrehman @kubernetes/sig-multicluster-bugs 