### PR TITLE
Add pre-submit job for kubernetes-anywhere repo

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10374,6 +10374,26 @@
       "sig-instrumentation"
     ]
   },
+  "pull-k8s-anywhere-e2e-gce": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--kubeadm=stable",
+      "--kubernetes-anywhere-dump-cluster-logs=true",
+      "--kubernetes-anywhere-kubernetes-version=latest",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\] --minStartupPods=8",
+      "--timeout=55m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
   "pull-kops-e2e-kubernetes-aws": {
     "args": [
       "--aws",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -456,6 +456,56 @@ presubmits:
       - name: service
         secret:
           secretName: service-account
+  kubernetes/kubernetes-anywhere:
+  - name: pull-k8s-anywhere-e2e-gce
+    agent: kubernetes
+    always_run: true
+    context: pull-k8s-anywhere-e2e-gce
+    rerun_command: "/test pull-k8s-anywhere-e2e-gce"
+    trigger: "(?m)^/test( all| pull-k8s-anywhere-e2e-gce),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171108-e53c04a8
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--git-cache=/root/.cache/git"
+        - "--timeout=75"
+        - "--clean"
+        env:
+        - name: USER
+          value: prow
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: SKIP_RELEASE_VALIDATION # See: https://github.com/kubernetes/kubernetes/pull/50391
+          value: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: ssh
+          mountPath: /etc/ssh-key-secret
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          secretName: ssh-key-secret
+          defaultMode: 0400
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
   kubernetes/kubernetes:
   - name: pull-kubernetes-bazel-build
     agent: kubernetes

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -118,6 +118,10 @@ plugins:
   - docs-no-retest
   - blockade
 
+  kubernetes/kubernetes-anywhere:
+  - trigger
+  - approve
+
   kubernetes/test-infra:
   - trigger
   - config-updater

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1707,6 +1707,10 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-federation-verify
   days_of_results: 1
   num_columns_recent: 20
+- name: pull-k8s-anywhere-e2e-gce
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-k8s-anywhere-e2e-gce
+  days_of_results: 1
+  num_columns_recent: 20
 # release-1.8
 - name: ci-kubernetes-e2e-gce-cos-k8sstable1-default
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sstable1-default
@@ -4894,6 +4898,12 @@ dashboards:
     alert_options:
       alert_mail_to_addresses: 'istio-oncall@googlegroups.com'
 
+- name: presubmits-k8s-anywhere
+  dashboard_tab:
+  - name: e2e-gce
+    test_group_name: pull-k8s-anywhere-e2e-gce
+    base_options: 'width=10'
+
 #
 # Start dashboard groups
 #
@@ -4931,6 +4941,7 @@ dashboard_groups:
   - presubmits-kubernetes-blocking
   - presubmits-kubernetes-nonblocking
   - presubmits-test-infra
+  - presubmits-k8s-anywhere
 
 - name: sig-cli
   dashboard_names:

--- a/testgrid/jenkins_verify/jenkins_validate.go
+++ b/testgrid/jenkins_verify/jenkins_validate.go
@@ -79,6 +79,7 @@ func main() {
 	for _, job := range prowConfig.AllPresubmits([]string{
 		"jlewi/mlkube.io",
 		"kubernetes/kubernetes",
+		"kubernetes/kubernetes-anywhere",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",
 		"kubernetes/federation",


### PR DESCRIPTION
supersedes https://github.com/kubernetes/test-infra/pull/5269

Adding the pre-submit job for `k/kubernetes-anywhere` repo which tests every pr for the repo against stable kubeadm and kubernetes version. This will give signals to the approvers in `k/kubernetes-anywhere` repo before the code is merged.

/assign @krzyzacy 
/cc @cmluciano @pipejakob @kubernetes/sig-cluster-lifecycle-pr-reviews