### PR TITLE
Add job for e2e testing with CoreDNS

### DIFF
--- a/images/kubeadm/runner
+++ b/images/kubeadm/runner
@@ -26,7 +26,7 @@ if [ ! -e kubernetes-anywhere ]; then
 
   # Explicitly version this dependency so that upstream commits can't
   # immediately break e2e jobs, and we have control over upgrading/downgrading.
-  git -C kubernetes-anywhere checkout 00ad82ae30d84b15feeafb5e04bf8611da30da2b
+  git -C kubernetes-anywhere checkout d978bfc7c945cfbdf20c4cb8fad69b0622df2d4a
 fi
 
 # This is required until https://github.com/kubernetes/kubernetes-anywhere/issues/332

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8438,6 +8438,27 @@
       "sig-cluster-lifecycle"
     ]
   },
+  "ci-kubernetes-e2e-kubeadm-gce-dns-coredns": {
+    "args": [
+      "--cluster=",
+      "--deployment=kubernetes-anywhere",
+      "--env-file=jobs/platform/gce.env",
+      "--extract=ci/latest",
+      "--gcp-zone=us-central1-f",
+      "--kubeadm=ci",
+      "--kubernetes-anywhere-dump-cluster-logs=true",
+      "--kubernetes-anywhere-kubeadm-feature-gates=CoreDNS=true",
+      "--kubernetes-anywhere-kubelet-ci-version=latest",
+      "--kubernetes-anywhere-kubernetes-version=ci/latest",
+      "--provider=kubernetes-anywhere",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
+      "--timeout=300m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-cluster-lifecycle"
+    ]
+  },
   "ci-kubernetes-e2e-kubeadm-gce-ipvs": {
     "args": [
       "--cluster=",

--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -63,6 +63,8 @@ var (
 		"(kubernetes-anywhere only) Whether to dump cluster logs.")
 	kubernetesAnywhereOSImage = flag.String("kubernetes-anywhere-os-image", "ubuntu-1604-xenial-v20171212",
 		"(kubernetes-anywhere only) The name of the os_image to use for nodes")
+	kubernetesAnywhereKubeadmFeatureGates = flag.String("kubernetes-anywhere-kubeadm-feature-gates", "",
+		"(kubernetes-anywhere only) If specified, that flag will pass on to kubeadm.")
 )
 
 const kubernetesAnywhereConfigTemplate = `
@@ -87,6 +89,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase2.kube_context_name="{{.KubeContext}}"
 .phase2.proxy_mode="{{.KubeproxyMode}}"
 .phase2.kubeadm.master_upgrade.method="{{.UpgradeMethod}}"
+.phase2.kubeadm.feature_gates="{{.KubeadmFeatureGates}}"
 
 .phase3.run_addons=y
 .phase3.kube_proxy=n
@@ -104,20 +107,21 @@ const kubernetesAnywhereMultiClusterConfigTemplate = kubernetesAnywhereConfigTem
 type kubernetesAnywhere struct {
 	path string
 	// These are exported only because their use in the config template requires it.
-	Phase2Provider    string
-	KubeadmVersion    string
-	KubeletVersion    string
-	UpgradeMethod     string
-	KubernetesVersion string
-	NumNodes          int
-	Project           string
-	Cluster           string
-	Zone              string
-	Region            string
-	KubeContext       string
-	CNI               string
-	KubeproxyMode     string
-	OSImage           string
+	Phase2Provider      string
+	KubeadmVersion      string
+	KubeletVersion      string
+	UpgradeMethod       string
+	KubernetesVersion   string
+	NumNodes            int
+	Project             string
+	Cluster             string
+	Zone                string
+	Region              string
+	KubeContext         string
+	CNI                 string
+	KubeproxyMode       string
+	OSImage             string
+	KubeadmFeatureGates string
 }
 
 func initializeKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, error) {
@@ -152,20 +156,21 @@ func initializeKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, er
 	}
 
 	k := &kubernetesAnywhere{
-		path:              *kubernetesAnywherePath,
-		Phase2Provider:    *kubernetesAnywherePhase2Provider,
-		KubeadmVersion:    *kubernetesAnywhereKubeadmVersion,
-		KubeletVersion:    kubeletVersion,
-		UpgradeMethod:     *kubernetesAnywhereUpgradeMethod,
-		KubernetesVersion: *kubernetesAnywhereKubernetesVersion,
-		NumNodes:          *kubernetesAnywhereNumNodes,
-		Project:           project,
-		Cluster:           *kubernetesAnywhereCluster,
-		Zone:              zone,
-		Region:            regexp.MustCompile(`-[^-]+$`).ReplaceAllString(zone, ""),
-		CNI:               *kubernetesAnywhereCNI,
-		KubeproxyMode:     *kubernetesAnywhereProxyMode,
-		OSImage:           *kubernetesAnywhereOSImage,
+		path:                *kubernetesAnywherePath,
+		Phase2Provider:      *kubernetesAnywherePhase2Provider,
+		KubeadmVersion:      *kubernetesAnywhereKubeadmVersion,
+		KubeletVersion:      kubeletVersion,
+		UpgradeMethod:       *kubernetesAnywhereUpgradeMethod,
+		KubernetesVersion:   *kubernetesAnywhereKubernetesVersion,
+		NumNodes:            *kubernetesAnywhereNumNodes,
+		Project:             project,
+		Cluster:             *kubernetesAnywhereCluster,
+		Zone:                zone,
+		Region:              regexp.MustCompile(`-[^-]+$`).ReplaceAllString(zone, ""),
+		CNI:                 *kubernetesAnywhereCNI,
+		KubeproxyMode:       *kubernetesAnywhereProxyMode,
+		OSImage:             *kubernetesAnywhereOSImage,
+		KubeadmFeatureGates: *kubernetesAnywhereKubeadmFeatureGates,
 	}
 
 	return k, nil
@@ -251,6 +256,10 @@ func (k *kubernetesAnywhere) writeConfig(configTemplate string) error {
 func (k *kubernetesAnywhere) Up() error {
 	cmd := exec.Command("make", "-C", k.path, "WAIT_FOR_KUBECONFIG=y", "deploy")
 	if err := finishRunning(cmd); err != nil {
+		return err
+	}
+
+	if err := k.TestSetup(); err != nil {
 		return err
 	}
 

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5628,7 +5628,49 @@ periodics:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
-
+  - name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
+    agent: kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171108-e53c04a8
+        args:
+        - "--repo=k8s.io/kubernetes=master"
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--timeout=320"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        env:
+        - name: USER
+          value: prow
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: ssh
+          mountPath: /etc/ssh-key-secret
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          secretName: ssh-key-secret
+          defaultMode: 0400
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
 - interval: 1h
   agent: kubernetes
   name: ci-kubernetes-charts-gce

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -973,6 +973,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-cni-calico
 - name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-cni-flannel
+- name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-dns-coredns
 - name: ci-kubernetes-e2e-kubeadm-gce-stable-on-master
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-stable-on-master
 - name: ci-kubernetes-e2e-kubeadm-gce-upgrade-stable-master
@@ -3559,6 +3561,9 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-cni-calico
   - name: kubeadm-gce-cni-flannel
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
+  - name: kubeadm-gce-dns-coredns
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
+
 
 - name: sig-cluster-lifecycle-multi-platform
   dashboard_tab:
@@ -3728,6 +3733,10 @@ dashboards:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: kubeadm-gce-cni-flannel
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-cni-flannel
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: kubeadm-gce-dns-coredns
+    test_group_name: ci-kubernetes-e2e-kubeadm-gce-dns-coredns
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
 


### PR DESCRIPTION
## What this PR does / why we need it:

add a new prow Job for running all e2e integration tests on a cluster initialized with CoreDNS as the default DNS server.

the job named kubeadm-gce-coredns will be visible in the TestGrid, in the panel of sig-cluster-lifecycle-all, next to kubeadm-gce 

## Which issue this PR fixes 
Adds part of e2e integration requires for CoreDNS that is an ALPHA feature added to kubeadm 
See: kubernetes/kubeadm#446
it has a counter part needed in the project "kubernetes-anywhere". See https://github.com/kubernetes/kubernetes-anywhere/pull/486

## Special notes for your reviewer:
