### PR TITLE
Refactor label sync for deleting, migrating labels

### DIFF
--- a/label_sync/BUILD
+++ b/label_sync/BUILD
@@ -25,7 +25,6 @@ go_test(
     importpath = "k8s.io/test-infra/label_sync",
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//prow/github:go_default_library"],
 )
 
 go_library(

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1,10 +1,167 @@
 # Standard labels set (common for all kubernetes repos)
 ---
 labels:
+  # Keys for each item: color, name, deleteAfter, previously
+  #   deleteAfter: 2006-01-02T15:04:05Z07:00 (rfc3339)
+  #   previously: list of previous labels (color name deleteAfter, previously)
   - color: 0ffa16
     name: approved
   - color: fef2c0
     name: approved-for-milestone
+  - color: fef2c0
+    name: cherrypick-approved
+  - color: fef2c0
+    name: cherrypick-candidate
+  - color: bfe5bf
+    name: 'cla: human-approved'
+  - color: e11d21
+    name: 'cla: no'
+  - color: bfe5bf
+    name: 'cla: yes'
+  - color: e11d21
+    name: 'cncf-cla: no'
+  - color: bfe5bf
+    name: 'cncf-cla: yes'
+  - color: e11d21
+    name: do-not-merge
+  - color: e11d21
+    name: do-not-merge/blocked-paths
+  - color: e11d21
+    name: do-not-merge/cherry-pick-not-approved
+  - color: e11d21
+    name: do-not-merge/hold
+  - color: e11d21
+    name: do-not-merge/release-note-label-needed
+  - color: e11d21
+    name: do-not-merge/work-in-progress
+  - color: fbca04
+    name: keep-open
+  - color: e11d21
+    name: kind/bug
+  - color: c7def8
+    name: kind/documentation
+  - color: c7def8
+    name: kind/feature
+  - color: 15dd18
+    name: lgtm
+  - color: b60205
+    name: needs-ok-to-test
+  - color: BDBDBD
+    name: needs-rebase
+  - color: ededed
+    name: needs-sig
+  - color: fbca04
+    name: ok-to-merge
+  - color: fef2c0
+    name: priority/awaiting-more-evidence
+  - color: fbca04
+    name: priority/backlog
+  - color: e11d21
+    name: priority/critical-urgent
+  - color: e11d21
+    name: priority/failing-test
+  - color: eb6420
+    name: priority/important-longterm
+  - color: eb6420
+    name: priority/important-soon
+  - color: ffaa00
+    name: queue/blocks-others
+  - color: ffaa00
+    name: queue/critical-fix
+  - color: ffaa00
+    name: queue/fix
+  - color: ffaa00
+    name: queue/multiple-rebases
+  - color: c2e0c6
+    name: release-note
+  - color: c2e0c6
+    name: release-note-action-required
+  - color: db5a64
+    name: release-note-label-needed
+  - color: c2e0c6
+    name: release-note-none
+  - color: d93f0b
+    name: requires-release-czar-attention
+  - color: eb6420
+    name: retest-not-required
+  - color: fbca04
+    name: retest-not-required-docs-only
+  - color: d2b48c
+    name: sig/api-machinery
+  - color: d2b48c
+    name: sig/apps
+  - color: d2b48c
+    name: sig/architecture
+  - color: d2b48c
+    name: sig/auth
+  - color: d2b48c
+    name: sig/autoscaling
+  - color: d2b48c
+    name: sig/aws
+  - color: d2b48c
+    name: sig/azure
+  - color: d2b48c
+    name: sig/big-data
+  - color: d2b48c
+    name: sig/cli
+  - color: d2b48c
+    name: sig/cluster-lifecycle
+  - color: d2b48c
+    name: sig/cluster-ops
+  - color: d2b48c
+    name: sig/contributor-experience
+  - color: d2b48c
+    name: sig/docs
+  - color: d2b48c
+    name: sig/federation
+  - color: d2b48c
+    name: sig/gcp
+  - color: d2b48c
+    name: sig/instrumentation
+  - color: d2b48c
+    name: sig/network
+  - color: d2b48c
+    name: sig/node
+  - color: d2b48c
+    name: sig/onprem
+  - color: d2b48c
+    name: sig/openstack
+  - color: d2b48c
+    name: sig/release
+  - color: d2b48c
+    name: sig/rktnetes
+  - color: d2b48c
+    name: sig/scalability
+  - color: d2b48c
+    name: sig/scheduling
+  - color: d2b48c
+    name: sig/service-catalog
+  - color: d2b48c
+    name: sig/storage
+  - color: d2b48c
+    name: sig/testing
+  - color: d2b48c
+    name: sig/ui
+  - color: d2b48c
+    name: sig/windows
+  - color: ee9900
+    name: size/L
+  - color: eebb00
+    name: size/M
+  - color: 77bb00
+    name: size/S
+  - color: ee5500
+    name: size/XL
+  - color: "009900"
+    name: size/XS
+  - color: ee0000
+    name: size/XXL
+  - color: fef2c0
+    name: status/in-progress
+  - color: fef2c0
+    name: status/in-review
+
+unknown:
 #  - color: 0052cc
 #    name: area/admin
 #  - color: 0052cc
@@ -145,54 +302,20 @@ labels:
 #    name: area/workload-api/replicaset
 #  - color: d93f0b
 #    name: beta-blocker
-  - color: fef2c0
-    name: cherrypick-approved
-  - color: fef2c0
-    name: cherrypick-candidate
-  - color: bfe5bf
-    name: 'cla: human-approved'
-  - color: e11d21
-    name: 'cla: no'
-  - color: bfe5bf
-    name: 'cla: yes'
-  - color: e11d21
-    name: 'cncf-cla: no'
-  - color: bfe5bf
-    name: 'cncf-cla: yes'
-  - color: e11d21
-    name: do-not-merge
-  - color: e11d21
-    name: do-not-merge/blocked-paths
-  - color: e11d21
-    name: do-not-merge/cherry-pick-not-approved
-  - color: e11d21
-    name: do-not-merge/hold
-  - color: e11d21
-    name: do-not-merge/release-note-label-needed
-  - color: e11d21
-    name: do-not-merge/work-in-progress
 #  - color: fbca04
 #    name: flake-has-meta
 #  - color: 006b75
 #    name: for-new-contributors
 #  - color: 006b75
 #    name: help-wanted
-  - color: fbca04
-    name: keep-open
 #  - color: c7def8
 #    name: kind/api-change
-  - color: e11d21
-    name: kind/bug
 #  - color: c7def8
 #    name: kind/cleanup
 #  - color: c7def8
 #    name: kind/design
-  - color: c7def8
-    name: kind/documentation
 #  - color: c7def8
 #    name: kind/enhancement
-  - color: c7def8
-    name: kind/feature
 #  - color: f7c6c7
 #    name: kind/flake
 #  - color: c7def8
@@ -211,32 +334,10 @@ labels:
 #    name: kind/technical-debt
 #  - color: fbca04
 #    name: kind/upgrade-test-failure
-  - color: 15dd18
-    name: lgtm
 #  - color: ededed
 #    name: needs-ok-to-merge
-  - color: b60205
-    name: needs-ok-to-test
-  - color: BDBDBD
-    name: needs-rebase
-  - color: ededed
-    name: needs-sig
 #  - color: 0e8a16
 #    name: non-release-blocker
-  - color: fbca04
-    name: ok-to-merge
-  - color: fef2c0
-    name: priority/awaiting-more-evidence
-  - color: fbca04
-    name: priority/backlog
-  - color: e11d21
-    name: priority/critical-urgent
-  - color: e11d21
-    name: priority/failing-test
-  - color: eb6420
-    name: priority/important-longterm
-  - color: eb6420
-    name: priority/important-soon
 #  - color: ff0000
 #    name: priority/P0
 #  - color: ededed
@@ -245,106 +346,10 @@ labels:
 #    name: priority/P2
 #  - color: ededed
 #    name: priority/P3
-  - color: ffaa00
-    name: queue/blocks-others
-  - color: ffaa00
-    name: queue/critical-fix
-  - color: ffaa00
-    name: queue/fix
-  - color: ffaa00
-    name: queue/multiple-rebases
 #  - color: d93f0b
 #    name: release-blocker
-  - color: c2e0c6
-    name: release-note
-  - color: c2e0c6
-    name: release-note-action-required
-  - color: db5a64
-    name: release-note-label-needed
-  - color: c2e0c6
-    name: release-note-none
-  - color: d93f0b
-    name: requires-release-czar-attention
-  - color: eb6420
-    name: retest-not-required
-  - color: fbca04
-    name: retest-not-required-docs-only
-  - color: d2b48c
-    name: sig/api-machinery
-  - color: d2b48c
-    name: sig/apps
-  - color: d2b48c
-    name: sig/architecture
-  - color: d2b48c
-    name: sig/auth
-  - color: d2b48c
-    name: sig/autoscaling
-  - color: d2b48c
-    name: sig/aws
-  - color: d2b48c
-    name: sig/azure
-  - color: d2b48c
-    name: sig/big-data
-  - color: d2b48c
-    name: sig/cli
-  - color: d2b48c
-    name: sig/cluster-lifecycle
-  - color: d2b48c
-    name: sig/cluster-ops
-  - color: d2b48c
-    name: sig/contributor-experience
-  - color: d2b48c
-    name: sig/docs
-  - color: d2b48c
-    name: sig/federation
-  - color: d2b48c
-    name: sig/gcp
-  - color: d2b48c
-    name: sig/instrumentation
-  - color: d2b48c
-    name: sig/network
-  - color: d2b48c
-    name: sig/node
-  - color: d2b48c
-    name: sig/onprem
-  - color: d2b48c
-    name: sig/openstack
-  - color: d2b48c
-    name: sig/release
-  - color: d2b48c
-    name: sig/rktnetes
-  - color: d2b48c
-    name: sig/scalability
-  - color: d2b48c
-    name: sig/scheduling
-  - color: d2b48c
-    name: sig/service-catalog
-  - color: d2b48c
-    name: sig/storage
-  - color: d2b48c
-    name: sig/testing
-  - color: d2b48c
-    name: sig/ui
-  - color: d2b48c
-    name: sig/windows
-  - color: ee9900
-    name: size/L
-  - color: eebb00
-    name: size/M
-  - color: 77bb00
-    name: size/S
-  - color: ee5500
-    name: size/XL
-  - color: "009900"
-    name: size/XS
-  - color: ee0000
-    name: size/XXL
 #  - color: "795548"
 #    name: stale
-  - color: fef2c0
-    name: status/in-progress
-  - color: fef2c0
-    name: status/in-review
 #  - color: ededed
 #    name: team/api (deprecated - do not use)
 #  - color: ededed

--- a/label_sync/labels_example.yaml
+++ b/label_sync/labels_example.yaml
@@ -5,4 +5,9 @@ labels:
     name: lgtm
   - color: red
     name: priority/P0
+    previously:
+    - color: blue
+      name: P0
+  - name: dead-label
+    deleteAfter: 2017-01-01T13:00:00Z
 ...

--- a/label_sync/repos.yaml
+++ b/label_sync/repos.yaml
@@ -1,6 +1,0 @@
-org: kubernetes
-repos:
-- full_name: kubernetes/test-infra
-  name: test-infra
-- full_name: kubernetes/community
-  name: community

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -620,14 +620,26 @@ func (c *Client) AddRepoLabel(org, repo, label, color string) error {
 	return err
 }
 
-// Updates org/repo label to label/color
-func (c *Client) UpdateRepoLabel(org, repo, label, color string) error {
-	c.log("UpdateRepoLabel", org, repo, label, color)
+// Updates org/repo label to new name and color
+func (c *Client) UpdateRepoLabel(org, repo, label, name, color string) error {
+	c.log("UpdateRepoLabel", org, repo, label, name, color)
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("%s/repos/%s/%s/labels/%s", c.base, org, repo, label),
-		requestBody: Label{Name: label, Color: color},
+		requestBody: Label{Name: name, Color: color},
 		exitCodes:   []int{200},
+	}, nil)
+	return err
+}
+
+// Delete label in org/repo
+func (c *Client) DeleteRepoLabel(org, repo, label string) error {
+	c.log("DeleteRepoLabel", org, repo, label)
+	_, err := c.request(&request{
+		method:      http.MethodDelete,
+		path:        fmt.Sprintf("%s/repos/%s/%s/labels/%s", c.base, org, repo, label),
+		requestBody: Label{Name: label},
+		exitCodes:   []int{204},
 	}, nil)
 	return err
 }


### PR DESCRIPTION
Create an unused label section in the labels.yaml

Refactor label_sync/main.go:
* `Label` includes a `Previously` tree field to track previous versions of the label
* `Label` includes a `DeleteAfter` time to delete retired labels
* Replace `--org` with a comma-separated list of `--orgs`
* Remove the `--dump*` and `--local` flags
* Add a comma-separated list of repos to `--skip` (blacklist)
* Add a comma-separated list of repos to `--only` process, instead of all of them (whitelist)
* Replace a bunch of `structs` which just held a single type with that type
* Remove named return parameters and naked returns.
* Fix prow client to rename labels correctly
* Changes to sync behavior:
  * Fix support for correcting the case of an issue name
  * Add support for migrating an issue to the current name (previous name exists, current doesn't)
  * Add support for migrating all issues to the current name (previous and current names exist)
  * Add support for deleting a label (DeleteAfter is set and is in the past)

/assign @lukaszgryglicki @cjwagner 


https://docs.google.com/document/d/19APxy9WQ28FAuSAGUS0gFGX_-1BdZfDvudxDZwKTJv4/edit

