### PR TITLE
Add back ssh-keys to federation ci jobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4796,6 +4796,10 @@ periodics:
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
       # docker-in-docker needs privilged mode
       securityContext:
         privileged: true
@@ -4804,12 +4808,19 @@ periodics:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
       - name: var-lib-docker
         mountPath: /var/lib/docker
     volumes:
     - name: service
       secret:
         secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
     - name: var-lib-docker
       emptyDir: {}
 - interval: 30m
@@ -4827,6 +4838,10 @@ periodics:
         value: /etc/service-account/service-account.json
       - name: USER
         value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
       # docker-in-docker needs privilged mode
       securityContext:
         privileged: true
@@ -4835,12 +4850,19 @@ periodics:
       - mountPath: /etc/service-account
         name: service
         readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
       - name: var-lib-docker
         mountPath: /var/lib/docker
     volumes:
     - name: service
       secret:
         secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
     - name: var-lib-docker
       emptyDir: {}
 


### PR DESCRIPTION
The name of the env variables `JENKINS_GCE_SSH_PRIVATE_KEY_FILE` mislead me to believe they were unnecessary for prow jobs. But indeed they are being used as is evident form the failure logs.
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-federation-e2e-gce-serial/1131/build-log.txt

/assign @BenTheElder 
/cc @krzyzacy 

