### PR TITLE
clean up after kubernetes docker builds

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -102,7 +102,7 @@ RUN apt-get update && \
 
 
 # Move Docker's storage location
-RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --graph=/docker-graph"' | \
+RUN echo 'DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"' | \
     tee --append /etc/default/docker
 # NOTE this should be mounted and persisted as a volume ideally (!)
 # We will make a fallback one now just in case

--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -21,8 +21,24 @@ set -x
 # Check if the job has opted-in to docker-in-docker availability.
 export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
 if [ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]; then
-# If we have opted in to docker in docker, start the docker daemon.
-    service docker start
+    # If we have opted in to docker in docker, start the docker daemon,
+    # and wait a second for it to be fully up.
+    echo "Starting docker..." && service docker start && sleep 1
+    # begin cleaning up after any previous runs
+    echo "Starting to clean up docker graph."
+    # make sure any lingering containers are removed from the data root
+    docker stop $(docker ps -aq) || true
+    docker rm $(docker ps -aq) || true
+    # cleanup kube-build images from kubernetes' dockerized builds
+    docker rmi -f $(docker images -q kube-build) || true
+    # then cleanup images and volumes not associated with tagged images
+    docker rmi -f $(docker images --filter dangling=true -qa) || true
+    docker volume prune -f || true
+    # list what images and volumes remain
+    echo "Remaining docker images and volumes are:"
+    docker images --all
+    docker volume ls
+    echo "Done setting up docker in docker."
 else
 # If not, make sure `docker` points to the old one compatible with our Jenkins
     export PATH=/docker-no-dind-bin/:$PATH
@@ -35,3 +51,4 @@ git clone https://github.com/kubernetes/test-infra
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
     --upload='gs://kubernetes-jenkins/logs' \
     "$@"
+

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1005,7 +1005,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171118-8e58e913
+      - image: gcr.io/k8s-testimages/bootstrap:v20171120-b24b1023
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2546,7 +2546,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171118-8e58e913
+      - image: gcr.io/k8s-testimages/bootstrap:v20171120-b24b1023
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
- replace `--graph` flag with `--data-root` replacement (`--graph` [has just been deprecated](https://docs.docker.com/engine/deprecated/)), which more explicitly just remaps where `/var/lib/docker` is.
- after the docker service is booted find and remote all lingering `kube-build` images left behind by `make release`
- then find and remove all dangling images
- then prune the volume store (deleting all leftover volumes)
- list the remaining images and volumes in the pod logs for debugging (they won't show up in the uploaded build logs, but we can watch a job and make sure they include all the images we want to preserve and do not contain the ones we want to GC)

This is necessary because the dockerd docs are quite clear now that you can only actually remaps*all* persistent docker storage and (IE /var/lib/docker) and the kubernetes builds generate a lot of junk, so we must clean everything.

We *could* just remove the entire directory or always mount a tmpfs/emptyDir but then we wouldn't be caching the ~2GB cross build images and friends, and we definitely don't want every cross job downloading a couple GB of docker images.

/area images