### PR TITLE
Increase timeout for ci-kubernetes-e2e-gci-gke-autoscaling job.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -12334,7 +12334,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=320
+      - --timeout=420
       - --bare
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
Increase timeout for ci-kubernetes-e2e-gci-gke-autoscaling job.