### PR TITLE
Remove deprecated flag from tide

### DIFF
--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -43,7 +43,6 @@ var (
 	configPath = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
 	cluster    = flag.String("cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster.")
 
-	_               = flag.String("github-bot-name", "", "Deprecated.")
 	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
 )


### PR DESCRIPTION
Leftover from https://github.com/kubernetes/test-infra/pull/4992

I don't think anybody is using `tide` or depending in this flag atm, that's why I didn't bother adding an announcement.

Signed-off-by: Michalis Kargakis <mkargaki@redhat.com>