### PR TITLE
Fix bugs related to RunIfChanged presubmit option.

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -147,41 +147,63 @@ func (ps Presubmit) RunsAgainstChanges(changes []string) bool {
 	return false
 }
 
-func matching(j Presubmit, body string, testAll bool) (out []Presubmit) {
-	if j.re.MatchString(body) || (testAll && j.AlwaysRun) {
-		out = append(out, j)
-	}
+type ChangedFilesProvider func() ([]string, error)
 
-	for _, child := range j.RunAfterSuccess {
-		out = append(out, matching(child, body, testAll)...)
-	}
-
-	return
-}
-
-func (c *Config) MatchingPresubmits(fullRepoName, body string, testAll *regexp.Regexp) []Presubmit {
-	var result []Presubmit
-	ott := testAll.MatchString(body)
-	if jobs, ok := c.Presubmits[fullRepoName]; ok {
-		for _, job := range jobs {
-			result = append(result, matching(job, body, ott)...)
+func matching(result map[string]Presubmit, j Presubmit, body string, testAll bool, changes ChangedFilesProvider) error {
+	if (testAll && j.AlwaysRun) || j.re.MatchString(body) {
+		result[j.Name] = j
+	} else if testAll && j.RunIfChanged != "" {
+		files, err := changes()
+		if err != nil {
+			return err
+		}
+		if j.RunsAgainstChanges(files) {
+			result[j.Name] = j
 		}
 	}
-	return result
+	for _, child := range j.RunAfterSuccess {
+		if err := matching(result, child, body, testAll, changes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Config) MatchingPresubmits(fullRepoName, body string, testAll bool, changes ChangedFilesProvider) (map[string]Presubmit, error) {
+	result := make(map[string]Presubmit)
+	if jobs, ok := c.Presubmits[fullRepoName]; ok {
+		for _, job := range jobs {
+			if err := matching(result, job, body, testAll, changes); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return result, nil
 }
 
 // RetestPresubmits returns all presubmits that should be run given a /retest command.
 // This is the set of all presubmits intersected with ((alwaysRun + runContexts) - skipContexts)
-func (c *Config) RetestPresubmits(fullRepoName string, skipContexts, runContexts map[string]bool) []Presubmit {
+func (c *Config) RetestPresubmits(fullRepoName string, skipContexts, runContexts map[string]bool, changes ChangedFilesProvider) ([]Presubmit, error) {
 	var result []Presubmit
 	if jobs, ok := c.Presubmits[fullRepoName]; ok {
 		for _, job := range jobs {
-			if (job.AlwaysRun || runContexts[job.Context]) && !skipContexts[job.Context] {
+			if skipContexts[job.Context] {
+				continue
+			}
+			if job.AlwaysRun || runContexts[job.Context] {
 				result = append(result, job)
+			} else if job.RunIfChanged != "" {
+				files, err := changes()
+				if err != nil {
+					return nil, err
+				}
+				if job.RunsAgainstChanges(files) {
+					result = append(result, job)
+				}
 			}
 		}
 	}
-	return result
+	return result, nil
 }
 
 // GetPresubmit returns the presubmit job for the provided repo and job name.
@@ -207,6 +229,15 @@ func (c *Config) SetPresubmits(jobs map[string][]Presubmit) error {
 				return err
 			}
 			nj[k][i].re = re
+			if v[i].RunIfChanged == "" {
+				continue
+			}
+			re, err = regexp.Compile(v[i].RunIfChanged)
+			if err != nil {
+				return err
+			}
+			nj[k][i].reChanges = re
+
 		}
 	}
 	c.Presubmits = nj

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -26,7 +26,11 @@ import (
 	"testing"
 )
 
-var podRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+var (
+	podRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+	noChangesProvider = func() ([]string, error) { return nil, nil }
+)
 
 const (
 	testThis   = "/test all"
@@ -265,7 +269,7 @@ func TestCommentBodyMatches(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		actualJobs := c.MatchingPresubmits(tc.repo, tc.body, regexp.MustCompile(`/ok-to-test`))
+		actualJobs, _ := c.MatchingPresubmits(tc.repo, tc.body, regexp.MustCompile(`/ok-to-test`).MatchString(tc.body), noChangesProvider)
 		match := true
 		if len(actualJobs) != len(tc.expectedJobs) {
 			match = false
@@ -351,7 +355,7 @@ func TestRetestPresubmits(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		actualContexts := c.RetestPresubmits("org/repo", tc.skipContexts, tc.runContexts)
+		actualContexts, _ := c.RetestPresubmits("org/repo", tc.skipContexts, tc.runContexts, noChangesProvider)
 		match := true
 		if len(actualContexts) != len(tc.expectedContexts) {
 			match = false

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -36,6 +36,7 @@ type FakeClient struct {
 	PullRequestComments map[int][]github.ReviewComment
 	Reviews             map[int][]github.Review
 	CombinedStatuses    map[string]*github.CombinedStatus
+	CreatedStatuses     map[string][]github.Status
 	IssueEvents         map[int][]github.ListedIssueEvent
 
 	//All Labels That Exist In The Repo
@@ -151,6 +152,7 @@ func (f *FakeClient) GetRef(owner, repo, ref string) (string, error) {
 }
 
 func (f *FakeClient) CreateStatus(owner, repo, ref string, s github.Status) error {
+	f.CreatedStatuses[ref] = append(f.CreatedStatuses[ref], s)
 	return nil
 }
 


### PR DESCRIPTION
Specifically, RunIfChanged was not considered at all by issue comment
triggers. This PR refactors the IC triggers to consider the
RunIfChanged field.
Also fixes SkipReport handling and adds deduplication in the event of
multiple commands in the same comment triggering the same job.
/cc @BenTheElder 
/area prow
/kind bug
ref #5584 