### PR TITLE
Add new test job for the CPU Manager feature.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9685,6 +9685,23 @@
       "sig-node"
     ]
   },
+  "ci-kubernetes-node-kubelet-serial-cpu-manager": {
+    "args": [
+      "--deployment=node",
+      "--gcp-project=k8s-jkns-ci-node-e2e",
+      "--gcp-zone=us-west1-b",
+      "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml",
+      "--node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=1 --focus=\"\\[Feature:CPUManager\\]\"",
+      "--timeout=180m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "ci-kubernetes-node-kubelet-stable1": {
     "args": [
       "--deployment=node",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -784,6 +784,7 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-e2e-gce': 'ci-kubernetes-e2e-gce-*',
             'ci-kubernetes-e2e-gce-canary': 'ci-kubernetes-e2e-gce-*',
             'ci-kubernetes-node-kubelet-serial': 'ci-kubernetes-node-kubelet-*',
+            'ci-kubernetes-node-kubelet-serial-cpu-manager': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-flaky': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-conformance': 'ci-kubernetes-node-kubelet-*',
             'ci-kubernetes-node-kubelet-benchmark': 'ci-kubernetes-node-kubelet-*',

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -1,0 +1,15 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    project: ubuntu-os-gke-cloud
+    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    machine: n1-standard-4
+  cos-stable1:
+    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    machine: n1-standard-4

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -20045,6 +20045,43 @@ periodics:
         secretName: ssh-key-secret
         defaultMode: 0400
 
+- name: ci-kubernetes-node-kubelet-serial-cpu-manager
+  interval: 4h
+  agent: kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --timeout=240
+      - --root=/go/src
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      - name: USER
+        value: prow
+      - name: GOPATH
+        value: /go
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: ssh
+        mountPath: /etc/ssh-key-secret
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        secretName: ssh-key-secret
+        defaultMode: 0400
+
 - name: ci-kubernetes-node-kubelet-stable1
   interval: 1h
   agent: kubernetes

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -74,6 +74,13 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-serial-cpu-manager
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-cpu-manager
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
 - name: ci-cri-containerd-build
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-build
 - name: ci-cri-containerd-e2e-gci-gce
@@ -3281,6 +3288,10 @@ dashboards:
   - name: kubelet-serial-gce-e2e
     test_group_name: ci-kubernetes-node-kubelet-serial
     base_options: 'include-filter-by-regex=GPU'
+  - name: kubelet-serial-gce-e2e-cpu-manager
+    test_group_name: ci-kubernetes-node-kubelet-serial-cpu-manager
+    alert_options:
+      alert_mail_to_addresses: 'balaji.warft@gmail.com, connor.p.d@gmail.com'
 
 - name: sig-api-machinery
   dashboard_tab:


### PR DESCRIPTION
- Adds ubuntu and cos images with 4-core machine type.
- Adds a periodic job for running cpu manager serial e2e node tests.

CC @ConnorDoyle @yguo0905 @yujuhong @vishh 
x-ref: https://github.com/kubernetes/kubernetes/pull/56096