### PR TITLE
Add deck mode to tide and plank.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,7 +24,7 @@ HOOK_VERSION             ?= 0.181
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.23
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.64
+DECK_VERSION             ?= 0.65
 # SPLICE_VERSION is the version of the splice image
 SPLICE_VERSION           ?= 0.32
 # TOT_VERSION is the version of the tot image

--- a/prow/README.md
+++ b/prow/README.md
@@ -106,15 +106,7 @@ Test with:
 bazel test --features=race //prow/...
 ```
 
-You can run `cmd/hook` in a local mode for testing, and hit it with arbitrary
-fake webhooks. To do this, run in one shell:
-```
-./bazel-bin/prow/cmd/hook/hook --local --config-path prow/config.yaml --plugin-config prow/plugins.yaml
-```
-This will listen on `localhost:8888` for webhooks. Send one with:
-```
-./bazel-bin/prow/cmd/phony/phony --event issue_comment --payload prow/cmd/phony/examples/test_comment.json
-```
+**TODO**(spxtr): Unify and document how to run prow components locally.
 
 ## How to run a given job on prow
 

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.64
+        image: gcr.io/k8s-prow/deck:0.65
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.64
+        image: gcr.io/k8s-prow/deck:0.65
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -115,10 +115,12 @@ func handleProwJobs(ja *JobAgent) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache")
 		jobs := ja.ProwJobs()
-		jd, err := json.Marshal(jobs)
+		jd, err := json.Marshal(struct {
+			Items []kube.ProwJob `json:"items"`
+		}{jobs})
 		if err != nil {
 			logrus.WithError(err).Error("Error marshaling jobs.")
-			jd = []byte("[]")
+			jd = []byte("{}")
 		}
 		// If we have a "var" query, then write out "var value = {...};".
 		// Otherwise, just write out the JSON.

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -39,12 +39,14 @@ var (
 	totURL = flag.String("tot-url", "", "Tot URL")
 
 	configPath   = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
+	cluster      = flag.String("cluster", "", "Path to kube.Cluster YAML file. If empty, uses the local cluster.")
 	buildCluster = flag.String("build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
 	selector     = flag.String("label-selector", kube.EmptySelector, "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
 
 	githubEndpoint  = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
 	githubTokenFile = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token.")
 	dryRun          = flag.Bool("dry-run", true, "Whether or not to make mutating API calls to GitHub.")
+	deckURL         = flag.String("deck-url", "", "Deck URL for read-only access to the cluster.")
 )
 
 func main() {
@@ -61,20 +63,6 @@ func main() {
 		logger.WithError(err).Fatal("Error starting config agent.")
 	}
 
-	kc, err := kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)
-	if err != nil {
-		logger.WithError(err).Fatal("Error getting kube client.")
-	}
-	var pkc *kube.Client
-	if *buildCluster == "" {
-		pkc = kc.Namespace(configAgent.Config().PodNamespace)
-	} else {
-		pkc, err = kube.NewClientFromFile(*buildCluster, configAgent.Config().PodNamespace)
-		if err != nil {
-			logger.WithError(err).Fatal("Error getting kube client to build cluster.")
-		}
-	}
-
 	oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
 	if err != nil {
 		logger.WithError(err).Fatalf("Could not read oauth secret file.")
@@ -88,10 +76,35 @@ func main() {
 	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
 
 	var ghc *github.Client
+	var kc, pkc *kube.Client
 	if *dryRun {
 		ghc = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+		kc = kube.NewFakeClient(*deckURL)
+		pkc = kc
 	} else {
 		ghc = github.NewClient(oauthSecret, *githubEndpoint)
+		if *cluster == "" {
+			kc, err = kube.NewClientInCluster(configAgent.Config().ProwJobNamespace)
+			if err != nil {
+				logger.WithError(err).Fatal("Error getting kube client.")
+			}
+		} else {
+			kc, err = kube.NewClientFromFile(*cluster, configAgent.Config().ProwJobNamespace)
+			if err != nil {
+				logger.WithError(err).Fatal("Error getting kube client.")
+			}
+		}
+		if *buildCluster == "" {
+			pkc, err = kube.NewClientInCluster(configAgent.Config().PodNamespace)
+			if err != nil {
+				logger.WithError(err).Fatal("Error getting kube client.")
+			}
+		} else {
+			pkc, err = kube.NewClientFromFile(*buildCluster, configAgent.Config().PodNamespace)
+			if err != nil {
+				logger.WithError(err).Fatal("Error getting kube client to build cluster.")
+			}
+		}
 	}
 
 	c, err := plank.NewController(kc, pkc, ghc, configAgent, *totURL, *selector)


### PR DESCRIPTION
This lets one run these programs locally, but using the production data that is served up by deck.

If this pattern is useful for other controllers then it's pretty easy to add it to them. I need it in order to make sure that tide will work properly for k/k.

/area prow