### PR TITLE
`requiresig` plugin for Prow.

### DIFF
--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//prow/plugins/milestonestatus:go_default_library",
         "//prow/plugins/releasenote:go_default_library",
         "//prow/plugins/reopen:go_default_library",
+        "//prow/plugins/requiresig:go_default_library",
         "//prow/plugins/shrug:go_default_library",
         "//prow/plugins/sigmention:go_default_library",
         "//prow/plugins/size:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -34,6 +34,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/milestonestatus"
 	_ "k8s.io/test-infra/prow/plugins/releasenote"
 	_ "k8s.io/test-infra/prow/plugins/reopen"
+	_ "k8s.io/test-infra/prow/plugins/requiresig"
 	_ "k8s.io/test-infra/prow/plugins/shrug"
 	_ "k8s.io/test-infra/prow/plugins/sigmention"
 	_ "k8s.io/test-infra/prow/plugins/size"

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -64,6 +64,7 @@ filegroup(
         "//prow/plugins/milestonestatus:all-srcs",
         "//prow/plugins/releasenote:all-srcs",
         "//prow/plugins/reopen:all-srcs",
+        "//prow/plugins/requiresig:all-srcs",
         "//prow/plugins/shrug:all-srcs",
         "//prow/plugins/sigmention:all-srcs",
         "//prow/plugins/size:all-srcs",

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -163,6 +163,7 @@ type Configuration struct {
 	Blockades       []Blockade      `json:"blockades,omitempty"`
 	Approve         []Approve       `json:"approve,omitempty"`
 	Blunderbuss     Blunderbuss     `json:"blunderbuss,omitempty"`
+	RequireSIG      RequireSIG      `json:"requiresig,omitempty"`
 }
 
 // ExternalPlugin holds configuration for registering an external
@@ -212,6 +213,12 @@ func (pa *PluginAgent) MDYAMLEnabled(org, repo string) bool {
 	}
 	return false
 
+}
+
+// RequireSIG specifies configuration for the require-sig plugin.
+type RequireSIG struct {
+	// GroupListURL is the URL where a list of the available SIGs can be found.
+	GroupListURL string `json:"group_list_url,omitempty"`
 }
 
 /*

--- a/prow/plugins/requiresig/BUILD
+++ b/prow/plugins/requiresig/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["requiresig.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/requiresig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["requiresig_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/plugins/requiresig",
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/plugins/requiresig/requiresig.go
+++ b/prow/plugins/requiresig/requiresig.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requiresig
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	labelPrefixes = []string{"sig/", "committee/", "wg/"}
+)
+
+const (
+	pluginName    = "require-sig"
+	needsSigLabel = "needs-sig"
+
+	needsSIGMessage = "There are no sig labels on this issue. Please add a sig label."
+	needsSIGDetails = `A sig label can be added by either:
+
+1. mentioning a sig: ` + "`@kubernetes/sig-<group-name>-<group-suffix>`" + `
+    e.g., ` + "`@kubernetes/sig-contributor-experience-<group-suffix>`" + ` to notify the contributor experience sig, OR
+
+2. specifying the label manually: ` + "`/sig <group-name>`" + `
+    e.g., ` + "`/sig scalability`" + ` to apply the ` + "`sig/scalability`" + ` label
+
+Note: Method 1 will trigger an email to the group. See the [group list](https://github.com/kubernetes/community/blob/master/sig-list.md).
+The ` + "`<group-suffix>`" + ` in method 1 has to be replaced with one of these: _**bugs, feature-requests, pr-reviews, test-failures, proposals**_`
+)
+
+type githubClient interface {
+	BotName() (string, error)
+	AddLabel(org, repo string, number int, label string) error
+	RemoveLabel(org, repo string, number int, label string) error
+	CreateComment(org, repo string, number int, content string) error
+}
+
+type commentPruner interface {
+	PruneComments(shouldPrune func(github.IssueComment) bool)
+}
+
+func init() {
+	plugins.RegisterIssueHandler(pluginName, handleIssue, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, _ []string) (*pluginhelp.PluginHelp, error) {
+	// Only the 'Description' and 'Config' fields are necessary because this plugin does not react
+	// to any commands.
+	return &pluginhelp.PluginHelp{
+			Description: fmt.Sprintf("When a new issue is opened the require-sig plugin adds the %q label and leaves a comment requesting that a SIG (Special Interest Group) label be added to the issue. SIG labels are labels that have one of the following prefixes: %q.\nOnce a SIG label has been added to an issue, this plugin removes the %q label and deletes the comment it made previously.", needsSigLabel, labelPrefixes, needsSigLabel),
+			Config: map[string]string{
+				"": fmt.Sprintf("The comment the plugin creates includes this link to a list of the existing groups: %s", config.RequireSIG.GroupListURL),
+			},
+		},
+		nil
+}
+
+func handleIssue(pc plugins.PluginClient, ie github.IssueEvent) error {
+	return handle(pc.Logger, pc.GitHubClient, pc.CommentPruner, &ie)
+}
+
+func isSigLabel(label string) bool {
+	for i := range labelPrefixes {
+		if strings.HasPrefix(label, labelPrefixes[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSigLabel(labels []github.Label) bool {
+	for i := range labels {
+		if isSigLabel(labels[i].Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// handle is the workhorse notifying issue owner to add a sig label if there is none
+// The algorithm:
+// (1) return if this is not an opened, labelled, or unlabelled event or if the issue is closed.
+// (2) find if the issue has a sig label
+// (3) find if the issue has a needs-sig label
+// (4) if the issue has both the sig and needs-sig labels, remove the needs-sig label and delete the comment.
+// (5) if the issue has none of the labels, add the needs-sig label and comment
+// (6) if the issue has only the sig label, do nothing
+// (7) if the issue has only the needs-sig label, do nothing
+func handle(log *logrus.Entry, ghc githubClient, cp commentPruner, ie *github.IssueEvent) error {
+	if ie.Issue.IsPullRequest() || ie.Issue.State == "closed" ||
+		(ie.Action != github.IssueActionOpened && ie.Action != github.IssueActionLabeled && ie.Action != github.IssueActionUnlabeled) {
+		return nil
+	}
+
+	org := ie.Repo.Owner.Login
+	repo := ie.Repo.Name
+	number := ie.Issue.Number
+
+	hasSigLabel := hasSigLabel(ie.Issue.Labels)
+	hasNeedsSigLabel := github.HasLabel(needsSigLabel, ie.Issue.Labels)
+
+	if hasSigLabel && hasNeedsSigLabel {
+		if err := ghc.RemoveLabel(org, repo, number, needsSigLabel); err != nil {
+			log.WithError(err).Errorf("Failed to remove %s label.", needsSigLabel)
+		}
+		botName, err := ghc.BotName()
+		if err != nil {
+			return fmt.Errorf("error getting bot name: %v", err)
+		}
+		cp.PruneComments(shouldPrune(log, botName))
+	} else if !hasSigLabel && !hasNeedsSigLabel {
+		if err := ghc.AddLabel(org, repo, number, needsSigLabel); err != nil {
+			log.WithError(err).Errorf("Failed to add %s label.", needsSigLabel)
+		}
+		msg := plugins.FormatResponse(ie.Issue.User.Login, needsSIGMessage, needsSIGDetails)
+		if err := ghc.CreateComment(org, repo, number, msg); err != nil {
+			log.WithError(err).Error("Failed to create comment.")
+		}
+	}
+	return nil
+}
+
+// shouldPrune finds comments left by this plugin.
+func shouldPrune(log *logrus.Entry, botName string) func(github.IssueComment) bool {
+	return func(comment github.IssueComment) bool {
+		if comment.User.Login != botName {
+			return false
+		}
+		return strings.Contains(comment.Body, needsSIGMessage)
+	}
+}


### PR DESCRIPTION
This replace the `sig-mention` munger, but there is already a `sig-mention` plugin that reiterates sig mentions from non-members so I named this plugin `requiresig` since it is the component that actually enforces the requirement that issues have a sig label.
ref #3331 