### PR TITLE
Revert kubeadm version bump on periodic-gce-kubeadm-1.7 to verify if …

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -20797,7 +20797,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171120-fd7d8854
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171027-e53c04a8
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"


### PR DESCRIPTION
…this is the cause of failing tests.

@shyamjvs @mwielgus 