### PR TITLE
Add metrics in prow controllers

### DIFF
--- a/prow/cmd/plank/BUILD
+++ b/prow/cmd/plank/BUILD
@@ -23,7 +23,9 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/kube/labels:go_default_library",
+        "//prow/metrics:go_default_library",
         "//prow/plank:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -201,6 +201,13 @@ func (c *Controller) Sync() error {
 	return fmt.Errorf("errors syncing: %v, errors reporting: %v", syncErrs, reportErrs)
 }
 
+// SyncMetrics records metrics for the cached prowjobs.
+func (c *Controller) SyncMetrics() {
+	c.pjLock.RLock()
+	defer c.pjLock.RUnlock()
+	kube.GatherProwJobMetrics(c.pjs)
+}
+
 // getJenkinsJobs returns all the Jenkins jobs for all active
 // prowjobs from the provided list. It handles deduplication.
 func getJenkinsJobs(pjs []kube.ProwJob) []string {

--- a/prow/kube/BUILD
+++ b/prow/kube/BUILD
@@ -20,12 +20,14 @@ go_library(
     name = "go_default_library",
     srcs = [
         "client.go",
+        "metrics.go",
         "prowjob.go",
         "types.go",
     ],
     importpath = "k8s.io/test-infra/prow/kube",
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/prow/kube/metrics.go
+++ b/prow/kube/metrics.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	prowJobs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "prowjobs",
+		Help: "Number of prowjobs in the system",
+	}, []string{
+		// name of the job
+		"job",
+		// type of the prowjob: presubmit, postsubmit, periodic, batch
+		"type",
+		// state of the prowjob: triggered, pending, success, failure, aborted, error
+		"state",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(prowJobs)
+}
+
+// GatherProwJobMetrics gathers prometheus metrics for prowjobs.
+func GatherProwJobMetrics(pjs []ProwJob) {
+	// map of job to job type to state to count
+	metricMap := make(map[string]map[string]map[string]float64)
+
+	for _, pj := range pjs {
+		if metricMap[pj.Spec.Job] == nil {
+			metricMap[pj.Spec.Job] = make(map[string]map[string]float64)
+		}
+		if metricMap[pj.Spec.Job][string(pj.Spec.Type)] == nil {
+			metricMap[pj.Spec.Job][string(pj.Spec.Type)] = make(map[string]float64)
+		}
+		metricMap[pj.Spec.Job][string(pj.Spec.Type)][string(pj.Status.State)]++
+	}
+
+	for job, jobMap := range metricMap {
+		for jobType, typeMap := range jobMap {
+			for state, count := range typeMap {
+				prowJobs.WithLabelValues(job, jobType, state).Set(count)
+			}
+		}
+	}
+}

--- a/prow/kube/metrics.go
+++ b/prow/kube/metrics.go
@@ -53,6 +53,10 @@ func GatherProwJobMetrics(pjs []ProwJob) {
 		metricMap[pj.Spec.Job][string(pj.Spec.Type)][string(pj.Status.State)]++
 	}
 
+	// This may be racing with the prometheus server but we need to remove
+	// stale metrics like triggered or pending jobs that are now complete.
+	prowJobs.Reset()
+
 	for job, jobMap := range metricMap {
 		for jobType, typeMap := range jobMap {
 			for state, count := range typeMap {

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -219,6 +219,13 @@ func (c *Controller) Sync() error {
 	return fmt.Errorf("errors syncing: %v, errors reporting: %v", syncErrs, reportErrs)
 }
 
+// SyncMetrics records metrics for the cached prowjobs.
+func (c *Controller) SyncMetrics() {
+	c.pjLock.RLock()
+	defer c.pjLock.RUnlock()
+	kube.GatherProwJobMetrics(c.pjs)
+}
+
 // terminateDupes aborts presubmits that have a newer version. It modifies pjs
 // in-place when it aborts.
 // TODO: Dry this out - need to ensure we can abstract children cancellation first.


### PR DESCRIPTION
@krzyzacy @cjwagner @stevekuznetsov ptal, this is modeled after how we gather metrics in k8s and origin controllers. My only worry was that this would make switching to reflectors harder but I don't think that's true anymore.