### PR TITLE
Temporarily disable local PV statefulset e2e test

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4135,7 +4135,7 @@
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:(Audit|LocalPersistentVolumes|FlexVolume|PodPreset)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6 --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:(Audit|LocalPersistentVolumes|FlexVolume|PodPreset)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6|StatefulSet --minStartupPods=8",
       "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",
@@ -4604,7 +4604,7 @@
       "--gke-create-command=container clusters create --quiet --enable-kubernetes-alpha",
       "--gke-environment=test",
       "--provider=gke",
-      "--test_args=--ginkgo.focus=\\[Feature:(DynamicKubeletConfig|LocalPersistentVolumes)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6 --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:(DynamicKubeletConfig|LocalPersistentVolumes)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6|StatefulSet --minStartupPods=8",
       "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
Fixes kubernetes/kubernetes#56412.

Temporarily disable this test to allow 1.9 beta cut to proceed.  This is a new test introduced in 1.9 for a new alpha feature, however, it is exposing a bug that was introduced in 1.8 for a different alpha feature.  The plan is to fix the underlying issue and re-enable this test before 1.9 releases.