### PR TITLE
Release 1.9 bazel patchup

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -21111,8 +21111,8 @@ periodics:
         - "--" # end bootstrap args, scenario args below
         - "--test=//... -//build/... -//vendor/..."
         - "--manual-test=//hack:verify-all"
-        - "--test-args=--build_tag_filters=-e2e"
-        - "--test-args=--test_tag_filters=-e2e"
+        - "--test-args=--build_tag_filters=-e2e,-integration"
+        - "--test-args=--test_tag_filters=-e2e,-integration"
         - "--test-args=--flaky_test_attempts=3"
         env:
         - name: TEST_TMPDIR

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -2678,8 +2678,12 @@ dashboards:
   - name: test-go-1.9
     test_group_name: ci-kubernetes-test-go-release-1.9
   - name: bazel-build-1.9
-    test_group_name: periodic-kubernetes-bazel-build-1-9
+    test_group_name: ci-kubernetes-bazel-build-1-9
   - name: bazel-test-1.9
+    test_group_name: ci-kubernetes-bazel-test-1-9
+  - name: periodic-bazel-build-1.9
+    test_group_name: periodic-kubernetes-bazel-build-1-9
+  - name: periodic-bazel-test-1.9
     test_group_name: periodic-kubernetes-bazel-test-1-9
   - name: gce-kubeadm-1.8-on-1.9
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9
@@ -2769,8 +2773,12 @@ dashboards:
   - name: test-go-1.9
     test_group_name: ci-kubernetes-test-go-release-1.9
   - name: bazel-build-1.9
-    test_group_name: periodic-kubernetes-bazel-build-1-9
+    test_group_name: ci-kubernetes-bazel-build-1-9
   - name: bazel-test-1.9
+    test_group_name: ci-kubernetes-bazel-test-1-9
+  - name: periodic-bazel-build-1.9
+    test_group_name: periodic-kubernetes-bazel-build-1-9
+  - name: periodic-bazel-test-1.9
     test_group_name: periodic-kubernetes-bazel-test-1-9
   - name: gce-kubeadm-1.8-on-1.9
     test_group_name: ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9


### PR DESCRIPTION
- follow up to: https://github.com/kubernetes/test-infra/pull/5664/, do the same thing for the periodic job...
- differentiate between periodic and CI bazel jobs in release 1.9 dashboards

TODO(bentheelder): follow up with probably removing one of these from the blocking dash
TODO(someone): possibly generally fix jobs silently being periodic vs CI with some standardized naming

/area jobs