### PR TITLE
canary bazel 0.8 on test-infra without --batch

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3593,7 +3593,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
         - "--build=//... -//vendor/..."
         - "--install=gubernator/test_requirements.txt"
         - "--test=//... //hack:verify-all -//vendor/..."


### PR DESCRIPTION
- `make -C images/bazelbuild LATEST_BAZEL_VERSION=0.8.0 BAZEL_VERSIONS=0.8.0 push`
- switch test-infra canary job using latest-latest image on test-infra to disable --batch so we can see if we still need this on test-infra.

/area jobs
/area bazel