### PR TITLE
minor dind tweaks

### DIFF
--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -23,7 +23,8 @@ export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
 if [ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]; then
     # If we have opted in to docker in docker, start the docker daemon,
     # and wait a second for it to be fully up.
-    echo "Starting docker..." && service docker start && sleep 1
+    # TODO(bentheelder): there has to be a more reliable solution to this
+    echo "Starting docker..." && service docker start && sleep 5
     # begin cleaning up after any previous runs
     echo "Starting to clean up docker graph."
     # make sure any lingering containers are removed from the data root
@@ -36,8 +37,8 @@ if [ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]; then
     docker volume prune -f || true
     # list what images and volumes remain
     echo "Remaining docker images and volumes are:"
-    docker images --all
-    docker volume ls
+    docker images --all || true
+    docker volume ls || true
     echo "Done setting up docker in docker."
 else
 # If not, make sure `docker` points to the old one compatible with our Jenkins

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20171118-8e58e913
+FROM gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
 LABEL maintainer "Sen Lu <senlu@google.com>"
 
 # install go

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1005,7 +1005,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171120-b24b1023
+      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2546,7 +2546,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171120-b24b1023
+      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
- sleep longer after starting the dind daemon
- make sure all debug / cleanup commands are `foo || true` so we don't ever abort the job over dind things that can be done on the next run or are just for debugging pod logs...

/area images
/area jobs