### PR TITLE
Event guid in prowjobs

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -21,6 +21,9 @@ import (
 	"time"
 )
 
+// EventGUID is sent by Github in a header of every webhook request.
+const EventGUID = "event-GUID"
+
 // These are possible State entries for a Status.
 const (
 	StatusPending = "pending"

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -106,6 +106,9 @@ type PullRequestEvent struct {
 	Repo        Repo                   `json:"repository"`
 	Label       Label                  `json:"label"`
 	Sender      User                   `json:"sender"`
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }
 
 // PullRequest contains information about a PullRequest.
@@ -197,6 +200,9 @@ type IssueEvent struct {
 	Action IssueEventAction `json:"action"`
 	Issue  Issue            `json:"issue"`
 	Repo   Repo             `json:"repository"`
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }
 
 // ListedIssueEvent represents an issue event from the events API (not from a webhook payload).
@@ -224,6 +230,9 @@ type IssueCommentEvent struct {
 	Issue   Issue                   `json:"issue"`
 	Comment IssueComment            `json:"comment"`
 	Repo    Repo                    `json:"repository"`
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }
 
 type Issue struct {
@@ -287,6 +296,9 @@ type StatusEvent struct {
 	Context     string `json:"context,omitempty"`
 	Sender      User   `json:"sender,omitempty"`
 	Repo        Repo   `json:"repository,omitempty"`
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }
 
 // IssuesSearchResult represents the result of an issues search.
@@ -306,6 +318,9 @@ type PushEvent struct {
 	// Sender contains more information that Pusher about the user.
 	Sender User `json:"sender"`
 	Repo   Repo `json:"repository"`
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }
 
 func (pe PushEvent) Branch() string {
@@ -338,6 +353,9 @@ type ReviewEvent struct {
 	PullRequest PullRequest       `json:"pull_request"`
 	Repo        Repo              `json:"repository"`
 	Review      Review            `json:"review"`
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }
 
 // Review describes a Pull Request review.
@@ -367,6 +385,9 @@ type ReviewCommentEvent struct {
 	PullRequest PullRequest              `json:"pull_request"`
 	Repo        Repo                     `json:"repository"`
 	Comment     ReviewComment            `json:"comment"`
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }
 
 // ReviewComment describes a Pull Request review.

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -114,8 +114,8 @@ func ValidateWebhook(w http.ResponseWriter, r *http.Request, hmacSecret []byte) 
 func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.Header) error {
 	l := logrus.WithFields(
 		logrus.Fields{
-			"event-type": eventType,
-			"event-GUID": eventGUID,
+			"event-type":     eventType,
+			github.EventGUID: eventGUID,
 		},
 	)
 	// We don't want to fail the webhook due to a metrics error.

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -131,6 +131,7 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		if err := json.Unmarshal(payload, &i); err != nil {
 			return err
 		}
+		i.GUID = eventGUID
 		srcRepo = i.Repo.FullName
 		go s.handleIssueEvent(l, i)
 	case "issue_comment":
@@ -138,6 +139,7 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		if err := json.Unmarshal(payload, &ic); err != nil {
 			return err
 		}
+		ic.GUID = eventGUID
 		srcRepo = ic.Repo.FullName
 		go s.handleIssueCommentEvent(l, ic)
 	case "pull_request":
@@ -145,6 +147,7 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		if err := json.Unmarshal(payload, &pr); err != nil {
 			return err
 		}
+		pr.GUID = eventGUID
 		srcRepo = pr.Repo.FullName
 		go s.handlePullRequestEvent(l, pr)
 	case "pull_request_review":
@@ -152,6 +155,7 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		if err := json.Unmarshal(payload, &re); err != nil {
 			return err
 		}
+		re.GUID = eventGUID
 		srcRepo = re.Repo.FullName
 		go s.handleReviewEvent(l, re)
 	case "pull_request_review_comment":
@@ -159,6 +163,7 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		if err := json.Unmarshal(payload, &rce); err != nil {
 			return err
 		}
+		rce.GUID = eventGUID
 		srcRepo = rce.Repo.FullName
 		go s.handleReviewCommentEvent(l, rce)
 	case "push":
@@ -166,6 +171,7 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		if err := json.Unmarshal(payload, &pe); err != nil {
 			return err
 		}
+		pe.GUID = eventGUID
 		srcRepo = pe.Repo.FullName
 		go s.handlePushEvent(l, pe)
 	case "status":
@@ -173,6 +179,7 @@ func (s *Server) demuxEvent(eventType, eventGUID string, payload []byte, h http.
 		if err := json.Unmarshal(payload, &se); err != nil {
 			return err
 		}
+		se.GUID = eventGUID
 		srcRepo = se.Repo.FullName
 		go s.handleStatusEvent(l, se)
 	}

--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -185,7 +185,12 @@ func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 				},
 			},
 		}
-		if _, err := c.KubeClient.CreateProwJob(pjutil.NewProwJob(pjutil.PresubmitSpec(job, kr), job.Labels)); err != nil {
+		labels := make(map[string]string)
+		for k, v := range job.Labels {
+			labels[k] = v
+		}
+		labels[github.EventGUID] = ic.GUID
+		if _, err := c.KubeClient.CreateProwJob(pjutil.NewProwJob(pjutil.PresubmitSpec(job, kr), labels)); err != nil {
 			errors = append(errors, err)
 		}
 	}

--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -33,7 +33,12 @@ func handlePE(c client, pe github.PushEvent) error {
 			BaseRef: pe.Branch(),
 			BaseSHA: pe.After,
 		}
-		if _, err := c.KubeClient.CreateProwJob(pjutil.NewProwJob(pjutil.PostsubmitSpec(j, kr), j.Labels)); err != nil {
+		labels := make(map[string]string)
+		for k, v := range j.Labels {
+			labels[k] = v
+		}
+		labels[github.EventGUID] = pe.GUID
+		if _, err := c.KubeClient.CreateProwJob(pjutil.NewProwJob(pjutil.PostsubmitSpec(j, kr), labels)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This should help in carrying the main information about a github event (guid) that resulted in the creation of a prowjob across contexts (plank, jenkins-operator, elsewhere).