### PR TITLE
Extend the TestGrid with (containerized) node e2e over RHEL on AWS

### DIFF
--- a/buckets.yaml
+++ b/buckets.yaml
@@ -34,3 +34,6 @@ gs://gce-daisy-test/logs/:
 gs://origin-federated-results/pr-logs/directory/:
   contact: "lsm5"
   prefix: "cri-o"
+gs://kubernetes-github-redhat/logs/:
+  contact: "ingvagabund"
+  prefix: "redhat:"

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1890,6 +1890,11 @@ test_groups:
 - name: ci-kubernetes-e2e-gci-gce-scalability-beta
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-beta
   num_failures_to_alert: 1
+# RHEL node e2e tests on AWS (contact: aos-pod@redhat.com)
+- name: ci-kubernetes-conformance-node-e2e-containerized-rhel
+  gcs_prefix: kubernetes-github-redhat/logs/ci-kubernetes-conformance-node-e2e-containerized-rhel
+- name: ci-kubernetes-conformance-node-e2e-rhel
+  gcs_prefix: kubernetes-github-redhat/logs/ci-kubernetes-conformance-node-e2e-rhel
 
 # CRI-O
 - name: test_pull_request_crio_e2e_fedora
@@ -3961,6 +3966,10 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet-stable2
   - name: kubelet-1.6
     test_group_name: ci-kubernetes-node-kubelet-stable3
+  - name: kubelet-conformance-aws-e2e-rhel
+    test_group_name: ci-kubernetes-conformance-node-e2e-rhel
+  - name: kubelet-containerized-conformance-aws-e2e-rhel
+    test_group_name: ci-kubernetes-conformance-node-e2e-containerized-rhel
 
 - name: sig-node-ppc64le
   dashboard_tab:

--- a/testgrid/config/config_test.go
+++ b/testgrid/config/config_test.go
@@ -37,6 +37,7 @@ var (
 		"google",
 		"kopeio",
 		"tectonic",
+		"redhat",
 	}
 	orgs = []string{
 		"presubmits",


### PR DESCRIPTION
The PR allows the TestGrid to consume logs from:
- running node e2e tests on RHEL on AWS
- running node e2e tests over containerized Kubelet on RHEL on AWS

Weakly depends on https://github.com/kubernetes/kubernetes/pull/56250

Based on https://github.com/kubernetes/test-infra/blob/master/docs/contributing-test-results.md.