### PR TITLE
bump testgrid config upload to bazel 0.7

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -4549,7 +4549,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171113-ae73dc58-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171113-ae73dc58-0.7.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
this will fix the config update job, which has been failing since the rules go bump

TODO in follow-up: add more alerting for sig-testing-misc jobs (this job was failing since 11-22 16:47)


/area testgrid
/area jobs