### PR TITLE
Add containerd PR test in kubernetes repo.

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10461,6 +10461,29 @@
       "sig-network"
     ]
   },
+  "pull-kubernetes-e2e-containerd-gce": {
+    "args": [
+      "--build=bazel",
+      "--cluster=",
+      "--env-file=jobs/platform/gce.env",
+      "--env-file=jobs/env/ci-cri-containerd-e2e-gce.env",
+      "--extract=local",
+      "--gcp-master-image=gci",
+      "--gcp-node-image=gci",
+      "--gcp-project=k8s-c8d-pr-e2e",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel=30",
+      "--provider=gce",
+      "--runtime-config=batch/v2alpha1=true,admissionregistration.k8s.io/v1alpha1=true",
+      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce",
+      "--test_args=--ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\] --minStartupPods=8",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
   "pull-kubernetes-e2e-gce": {
     "_comment1": "NOTE: THESE ARE THE JENKINS ARGS / COMMON ARGS (!)",
     "_comment2": "PLEASE PUT ARGS THAT WILL WORK FOR 1.6 HERE",
@@ -10703,6 +10726,23 @@
       "--node-tests=true",
       "--provider=gce",
       "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Slow\\]|\\[Serial\\]\" --flakeAttempts=2",
+      "--timeout=65m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-node"
+    ]
+  },
+  "pull-kubernetes-node-e2e-containerd": {
+    "args": [
+      "--deployment=node",
+      "--gcp-project=k8s-c8d-pr-node-e2e",
+      "--gcp-zone=us-central1-f",
+      "--node-args=--image-config-file=test/e2e_node/image-config.yaml --image-config-dir=$GOPATH/src/github.com/kubernetes-incubator/cri-containerd",
+      "--node-test-args=--container-runtime=remote --container-runtime-endpoint=/var/run/cri-containerd.sock --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/ --container-runtime=remote --container-runtime-endpoint=/var/run/cri-containerd.sock\" --extra-log=\"{\\\"name\\\": \\\"containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"containerd\\\"]}\" --extra-log=\"{\\\"name\\\": \\\"cri-containerd.log\\\", \\\"journalctl\\\": [\\\"-u\\\", \\\"cri-containerd\\\"]}\"",
+      "--node-tests=true",
+      "--provider=gce",
+      "--test_args=--nodes=8 --skip=\"\\[Flaky\\]|\\[Slow\\]|\\[Serial\\]|querying\\s\\/stats\\/summary\" --flakeAttempts=2",
       "--timeout=65m"
     ],
     "scenario": "kubernetes_e2e",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1100,6 +1100,66 @@ presubmits:
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
+  - name: pull-kubernetes-e2e-containerd-gce
+    agent: kubernetes
+    context: pull-kubernetes-e2e-containerd-gce
+    rerun_command: "/test pull-kubernetes-e2e-containerd-gce"
+    trigger: "(?m)^/test pull-kubernetes-e2e-containerd-gce,?(\\s+|$)"
+    always_run: false
+    skip_report: false
+    branches:
+    - master
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --repo=github.com/kubernetes-incubator/cri-containerd
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --timeout=90
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        # Make Bazel use shared cache for its root
+        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
   - name: pull-kubernetes-e2e-gce
     agent: kubernetes
     context: pull-kubernetes-e2e-gce
@@ -1765,6 +1825,61 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+  - name: pull-kubernetes-node-e2e-containerd
+    agent: kubernetes
+    branches:
+    - master
+    always_run: false
+    skip_report: true
+    max_concurrency: 8
+    context: pull-kubernetes-node-e2e-containerd
+    rerun_command: "/test pull-kubernetes-node-e2e-containerd"
+    trigger: "(?m)^/test pull-kubernetes-node-e2e-containerd,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=github.com/kubernetes-incubator/cri-containerd"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
   - name: pull-kubernetes-unit
     agent: jenkins
     always_run: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1106,7 +1106,6 @@ presubmits:
     rerun_command: "/test pull-kubernetes-e2e-containerd-gce"
     trigger: "(?m)^/test pull-kubernetes-e2e-containerd-gce,?(\\s+|$)"
     always_run: false
-    skip_report: false
     branches:
     - master
     spec:
@@ -1830,7 +1829,6 @@ presubmits:
     branches:
     - master
     always_run: false
-    skip_report: true
     max_concurrency: 8
     context: pull-kubernetes-node-e2e-containerd
     rerun_command: "/test pull-kubernetes-node-e2e-containerd"
@@ -2652,6 +2650,65 @@ presubmits:
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
+  - name: pull-security-kubernetes-e2e-containerd-gce
+    agent: kubernetes
+    context: pull-security-kubernetes-e2e-containerd-gce
+    rerun_command: "/test pull-security-kubernetes-e2e-containerd-gce"
+    trigger: "(?m)^/test pull-security-kubernetes-e2e-containerd-gce,?(\\s+|$)"
+    always_run: false
+    branches:
+    - master
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --repo=github.com/kubernetes-incubator/cri-containerd
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --git-cache=/root/.cache/git
+        - --clean
+        - --timeout=90
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        # Make Bazel use shared cache for its root
+        # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - mountPath: /root/.cache
+          name: cache-ssd
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - hostPath:
+          path: /mnt/disks/ssd0
+        name: cache-ssd
   - name: pull-security-kubernetes-e2e-gce
     agent: kubernetes
     context: pull-security-kubernetes-e2e-gce
@@ -3316,6 +3373,60 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
 
+  - name: pull-security-kubernetes-node-e2e-containerd
+    agent: kubernetes
+    branches:
+    - master
+    always_run: false
+    max_concurrency: 8
+    context: pull-security-kubernetes-node-e2e-containerd
+    rerun_command: "/test pull-security-kubernetes-node-e2e-containerd"
+    trigger: "(?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=github.com/kubernetes-incubator/cri-containerd"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
   - name: pull-security-kubernetes-unit
     agent: jenkins
     always_run: true

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1624,6 +1624,14 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kubeadm-gce
   days_of_results: 1
   num_columns_recent: 20
+- name: pull-kubernetes-node-e2e-containerd
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-node-e2e-containerd
+  days_of_results: 1
+  num_columns_recent: 20
+- name: pull-kubernetes-e2e-containerd-gce
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-containerd-gce
+  days_of_results: 1
+  num_columns_recent: 20
 - name: pull-kubernetes-kubemark-e2e-gce
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-kubemark-e2e-gce
   days_of_results: 1
@@ -3752,6 +3760,12 @@ dashboards:
     test_group_name: ci-cri-containerd-e2e-gci-gce
   - name: e2e-ubuntu
     test_group_name: ci-cri-containerd-e2e-ubuntu-gce
+  - name: pull-node-e2e
+    test_group_name: pull-kubernetes-node-e2e-containerd
+    base_options: 'width=10'
+  - name: pull-e2e-gci
+    test_group_name: pull-kubernetes-e2e-containerd-gce
+    base_options: 'width=10'
 
 - name: sig-node-rkt
   dashboard_tab:


### PR DESCRIPTION
These tests only run when triggered:
```
always_run: false
skip_report: false
```

They will be useful to:
1) Validate whether a kubernetes change works with containerd integration.
2) Validate whether a new CRI change works with cri container runtime.

/cc @yujuhong 