### PR TITLE
actually bump all test-infra bazel jobs to 0.8.0

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -3533,7 +3533,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-test-infra-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.7.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.8.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4548,7 +4548,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.7.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.8.0
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
these slipped through (config updater, and the non-canary presubmit) since the github diff was unusable :-(
/area jobs