### PR TITLE
handle separate git dir "symlink" properly

### DIFF
--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -80,7 +80,7 @@ def get_git_cache(k8s):
     if not os.path.isfile(git):
         return None
     with open(git) as git_file:
-        return git_file.read()
+        return git_file.read().replace("gitdir: ", "")
 
 
 def main(branch, script, force, on_prow):


### PR DESCRIPTION
It's not documented anywhere that I can see, but the way `--separate-git-dir=$FOO` works is creating a `.git` file containing `gitdir: $FOO`

/shrug
/area scenarios