### PR TITLE
Updating make targets for multicluster ingress job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10684,9 +10684,11 @@
       "make",
       "--",
       "-j",
-      "2",
+      "4",
       "test",
-      "coveralls"
+      "coveralls",
+      "vet",
+      "fmt"
     ],
     "scenario": "execute",
     "sigOwners": [


### PR DESCRIPTION
Updating the config to run `make vet` and `make fmt` as well.
Also updating `-j 2` to 4 so that all 4 jobs can run in parallel.

cc @G-Harmon @krzyzacy @BenTheElder 