### PR TITLE
Configure testgrid links for cri-o

### DIFF
--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -4834,9 +4834,17 @@ dashboards:
   dashboard_tab:
   - name: crio-e2e-fedora
     test_group_name: test_pull_request_crio_e2e_fedora
+    open_test_template:
+        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<test-id>.txt
+    results_url_template:
+        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: 'width=10'
   - name: crio-e2e-rhel
     test_group_name: test_pull_request_crio_e2e_rhel
+    open_test_template:
+        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>/<test-id>.txt
+    results_url_template:
+        url: https://gcsweb-ci.svc.ci.openshift.org/gcs/<gcs_prefix>
     base_options: 'width=10'
 
 #


### PR DESCRIPTION
This commit is a follow-up on pr#5630

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@stevekuznetsov PTAL, I'm not quite sure about the `<test-id>.txt`, just that I saw google-gce-compute-image-tools use it, so I did the same.