### PR TITLE
Use cncf aws account for a few aws jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8145,11 +8145,12 @@
   },
   "ci-kubernetes-e2e-kops-aws-newrunner": {
     "args": [
-      "--cluster=e2e-kops-aws-newrunner.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-newrunner.test-cncf-aws.k8s.io",
       "--deployment=kops",
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
+      "--kops-state=s3://k8s-kops-prow/",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
@@ -8163,11 +8164,12 @@
   "ci-kubernetes-e2e-kops-aws-release-1-6": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws-release-16.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-release-16.test-cncf-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-release-1-6.env",
       "--extract=ci/latest-1.6",
       "--ginkgo-parallel",
+      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8180,11 +8182,12 @@
   "ci-kubernetes-e2e-kops-aws-release-1-7": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws-release-17.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-release-17.test-cncf-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--ginkgo-parallel",
+      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8197,10 +8200,11 @@
   "ci-kubernetes-e2e-kops-aws-sig-cli": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws-sig-cli.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-sig-cli.test-cncf-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
+      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\\[sig-cli\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8213,12 +8217,13 @@
   "ci-kubernetes-e2e-kops-aws-stable1": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws-stable1.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io",
       "--env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-stable1.txt",
       "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-1.8-ci-green.txt",
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/k8s-stable1",
       "--ginkgo-parallel",
+      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8251,11 +8256,12 @@
   "ci-kubernetes-e2e-kops-aws-weave": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws-weave.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-weave.test-cncf-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--networking=weave",
+      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort"
     ],

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -17612,7 +17612,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 24h
   agent: kubernetes
@@ -17655,7 +17655,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 6h
   agent: kubernetes
@@ -17698,7 +17698,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 2h
   agent: kubernetes
@@ -17741,7 +17741,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 2h
   agent: kubernetes
@@ -17784,7 +17784,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 1h
   agent: kubernetes
@@ -17870,7 +17870,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 30m
   agent: kubernetes


### PR DESCRIPTION
http://k8s-testgrid.appspot.com/sig-testing-canaries#kops-aws-cncf-canary is green-ish

except kops-master, kops-1.9 and pr-kops since the world is still in code freeze.
also except kops-updown which seems is using another different account

/area jobs

/assign @BenTheElder @justinsb 
cc @zmerlynn @fejta 