### PR TITLE
Improve janitor logging

### DIFF
--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20171116-33413a400
+        image: gcr.io/k8s-testimages/janitor:v20171129-b3934c887
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gce-project,gke-project,gci-qa-project,gpu-project

--- a/boskos/janitor/janitor.go
+++ b/boskos/janitor/janitor.go
@@ -73,9 +73,11 @@ type clean func(string) error
 // Clean by janitor script
 func janitorClean(proj string) error {
 	cmd := exec.Command("/janitor.py", fmt.Sprintf("--project=%s", proj), "--hour=0")
-	b, err := cmd.CombinedOutput()
+	err := cmd.Run()
 	if err != nil {
-		logrus.Infof("janitor.py has some issue: %s", string(b))
+		logrus.WithError(err).Errorf("failed to clean up project %s", proj)
+	} else {
+		logrus.Infof("successfully cleaned up project %s", proj)
 	}
 	return err
 }


### PR DESCRIPTION
The detail of script output is noisy && unreadable, let's just log if the cleaning is successful or not.

/area boskos
/kind bikeshed
/assign @BenTheElder 