### PR TITLE
Add a Prow job that runs release script in k8s.io/cluster-registry every 24 hours

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9901,6 +9901,15 @@
       "sig-testing"
     ]
   },
+  "cluster-registry-nightly": {
+    "args": [
+      "./hack/release.sh"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "sig-multicluster"
+    ]
+  },
   "fake-branch": {
     "args": [
       "./fake/fake-branch.sh"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -20143,6 +20143,46 @@ periodics:
       secret:
         secretName: triage-service-account
 
+- cron: "1 5 * * *" # Run at 21:01PST daily (05:01 UTC)
+  agent: kubernetes
+  name: cluster-registry-nightly
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      args:
+      - "--clean"
+      - "--git-cache=/root/.cache/git"
+      - "--job=$(JOB_NAME)"
+      - "--repo=k8s.io/cluster-registry=master"
+      - "--service-account=/etc/service-account/service-account.json"
+      - "--upload=gs://kubernetes-jenkins/logs"
+      env:
+      - name: TEST_TMPDIR
+        value: /root/.cache/bazel
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      # Bazel needs privileged mode in order to sandbox builds.
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: cache-ssd
+        mountPath: /root/.cache
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      resources:
+        requests:
+          memory: "2Gi"
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: cache-ssd
+      hostPath:
+        path: /mnt/disks/ssd0
 - name: issue-creator
   agent: kubernetes
   interval: 24h

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1814,6 +1814,8 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-cluster-registry-bazel
   days_of_results: 1
   num_columns_recent: 20
+- name: cluster-registry-nightly
+  gcs_prefix: kubernetes-jenkins/logs/cluster-registry-nightly
 # k8s-beta (active release branch) jobs
 - name: ci-kubernetes-e2e-gce-cos-k8sbeta-default
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-cos-k8sbeta-default
@@ -3543,6 +3545,11 @@ dashboards:
     test_group_name: periodic-multi-platform-kubeadm-packet-arm64
 
 
+- name: sig-multicluster-cluster-registry
+  dashboard_tab:
+  - name: nightly
+    test_group_name: cluster-registry-nightly
+
 - name: sig-multicluster-federation-gce-old
   dashboard_tab:
   - name: gce-1.7
@@ -4893,6 +4900,7 @@ dashboard_groups:
 
 - name: sig-multicluster
   dashboard_names:
+  - sig-multicluster-cluster-registry
   - sig-multicluster-federation-gce-old
   - sig-multicluster-federation-gce
 


### PR DESCRIPTION
This has to wait for https://github.com/kubernetes/cluster-registry/pull/109, which adds the script that the Prow job calls.