### PR TITLE
planter: only mount $HOME/.cache/bazel instead of $HOME

### DIFF
--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -24,7 +24,7 @@ IMAGE="${IMAGE_NAME}:${TAG}"
 # run our docker image as the host user with bazel cache and current repo dir
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
 REPO=${REPO:-${PWD}}
-VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --tmpfs /tmp:exec,mode=777"
+VOLUMES="-v ${REPO}:${REPO} -v ${HOME}/.cache/bazel:${HOME}/.cache/bazel --tmpfs /tmp:exec,mode=777"
 GID="$(id -g ${USER})"
 ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
 # the final command to run


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/issues/5736
/area planter