### PR TITLE
Skipping broken network-partition tests on GCE upgrades

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3399,8 +3399,8 @@
       "--gcp-zone=us-central1-f",
       "--provider=gce",
       "--skew",
-      "--timeout=900m",
       "--test_args=--ginkgo.skip=\\[sig\\-apps\\]\\sNetwork\\sPartition",
+      "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/k8s-beta --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -3378,7 +3378,7 @@
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[sig\\-apps\\]\\sNetwork\\sPartition",
       "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/k8s-beta --upgrade-image=gci"
     ],
@@ -3400,6 +3400,7 @@
       "--provider=gce",
       "--skew",
       "--timeout=900m",
+      "--test_args=--ginkgo.skip=\\[sig\\-apps\\]\\sNetwork\\sPartition",
       "--upgrade_args=--ginkgo.focus=\\[Feature:ClusterUpgrade\\] --upgrade-target=ci/k8s-beta --upgrade-image=gci"
     ],
     "scenario": "kubernetes_e2e",
@@ -3418,7 +3419,7 @@
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8",
+      "--test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\\[sig\\-apps\\]\\sNetwork\\sPartition",
       "--timeout=900m",
       "--upgrade_args=--ginkgo.focus=\\[Feature:MasterUpgrade\\] --upgrade-target=ci/k8s-beta"
     ],


### PR DESCRIPTION
Fixing the noise in https://github.com/kubernetes/kubernetes/issues/56416 by skipping offending network-partition tests.

cc @kow3ns @enisoc @spiffxp 