### PR TITLE
assign some more codeowners reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,10 @@
 bootstrap/** @bentheelder
 boskos/** @krzyzacy
 gubernator/** @rmmh
-jenkins/bootstrap* @bentheelder @krzyzacy
+images/** @bentheelder @krzyzacy
+images/bazelbuild/** @bentheelder @ixdy
+images/pull-test-infra-gubernator/** @rmmh
+jenkins/** @bentheelder @krzyzacy
 jobs/** @bentheelder @krzyzacy
 kettle/** @rmmh
 kubetest/** @krzyzacy
@@ -10,5 +13,6 @@ mungegithub/** @cjwagner
 planter/** @bentheelder
 prow/** @cjwagner @kargakis
 prow/config.yaml @bentheelder @krzyzacy
+scenarios/** @bentheelder @krzyzacy
 testgrid/** @krzyzacy @michelle192837
 triage/** @rmmh


### PR DESCRIPTION
- `images/**` bentheelder and krzyzacy 
- `images/bazelbuild/**` bentheelder and ixdy
- `images/pull-test-infra-gubernator/**` rmmh
- `jenkins/**` bentheelder and krzyzacy
- `scenarios/**` bentheelder and krzyzacy

These people are already reviewing / owning these directories, let's automate that a bit more.