### PR TITLE
Make kubetest support extract latest gke version

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -5115,7 +5115,7 @@
       "--check-leaked-resources",
       "--cluster=",
       "--deployment=gke",
-      "--extract=ci/gke-staging-latest",
+      "--extract=gke-latest",
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-b",
       "--ginkgo-parallel",


### PR DESCRIPTION
okay, for prod/staging/test environment, we still gonna get `defaultClusterVersion`, but for latest gke, we'll get the first value from `validMasterVersions` - this should match the current behavior of extracting from gs://kubernetes-release-gke/release/gke-staging-latest.txt, and we can get rid of the file pointer.

/area kubetest
/assign @mindprince @foxish 