### PR TITLE
Make tide's config smarter.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,23 +20,23 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.182
+HOOK_VERSION             ?= 0.183
 # SINKER_VERSION is the version of the sinker image
-SINKER_VERSION           ?= 0.23
+SINKER_VERSION           ?= 0.24
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.66
+DECK_VERSION             ?= 0.67
 # SPLICE_VERSION is the version of the splice image
-SPLICE_VERSION           ?= 0.32
+SPLICE_VERSION           ?= 0.33
 # TOT_VERSION is the version of the tot image
-TOT_VERSION              ?= 0.5
+TOT_VERSION              ?= 0.6
 # HOROLOGIUM_VERSION is the version of the horologium image
-HOROLOGIUM_VERSION       ?= 0.18
+HOROLOGIUM_VERSION       ?= 0.19
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= 0.60
+PLANK_VERSION            ?= 0.61
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
-JENKINS-OPERATOR_VERSION ?= 0.58
+JENKINS-OPERATOR_VERSION ?= 0.59
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.13
+TIDE_VERSION             ?= 0.14
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/README.md
+++ b/prow/README.md
@@ -36,6 +36,8 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 30, 2017* If you use tide, you'll need to switch your query format
+ and bump all prow component versions to reflect the changes in #5754.
  - *November 14, 2017* `horologium:0.17` fixes cron job not being scheduled.
  - *November 10, 2017* If you want to use cron feature in prow, you need to bump to:
  `hook:0.181`, `sinker:0.23`, `deck:0.62`, `splice:0.32`, `horologium:0.15`

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.66
+        image: gcr.io/k8s-prow/deck:0.67
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.182
+        image: gcr.io/k8s-prow/hook:0.183
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.18
+        image: gcr.io/k8s-prow/horologium:0.19
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/jenkins_deployment.yaml
+++ b/prow/cluster/jenkins_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: jenkins-operator
-        image: gcr.io/k8s-prow/jenkins-operator:0.58
+        image: gcr.io/k8s-prow/jenkins-operator:0.59
         ports:
         - name: logs
           containerPort: 8080

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.60
+        image: gcr.io/k8s-prow/plank:0.61
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
-        image: gcr.io/k8s-prow/sinker:0.23
+        image: gcr.io/k8s-prow/sinker:0.24
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/splice_deployment.yaml
+++ b/prow/cluster/splice_deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: splice
-        image: gcr.io/k8s-prow/splice:0.32
+        image: gcr.io/k8s-prow/splice:0.33
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.182
+        image: gcr.io/k8s-prow/hook:0.183
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.60
+        image: gcr.io/k8s-prow/plank:0.61
         args:
         - --dry-run=false
         volumeMounts:
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.23
+        image: gcr.io/k8s-prow/sinker:0.24
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.66
+        image: gcr.io/k8s-prow/deck:0.67
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:
@@ -225,7 +225,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:0.18
+        image: gcr.io/k8s-prow/horologium:0.19
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.13
+        image: gcr.io/k8s-prow/tide:0.14
         args:
         - --dry-run=false
         ports:

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -57,7 +57,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:0.5
+        image: gcr.io/k8s-prow/tot:0.6
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -22,8 +22,23 @@ log_level: info
 
 tide:
   queries:
-  - "type:pr state:open repo:kubernetes/test-infra repo:kubernetes/federation label:lgtm label:approved -label:needs-ok-to-test -label:do-not-merge/work-in-progress -label:do-not-merge/hold label:\"cncf-cla: yes\""
-  - "type:pr state:open repo:kubernetes/kubectl review:approved -label:do-not-merge/work-in-progress -label:do-not-merge/hold"
+  - repos:
+    - kubernetes/test-infra
+    - kubernetes/federation
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - needs-ok-to-test
+    - do-not-merge/work-in-progress
+    - do-not-merge/hold
+  - repos:
+    - kubernetes/kubectl
+    missingLabels:
+    - do-not-merge/work-in-progress
+    - do-not-merge/hold
+    reviewApprovedRequired: true
 
 push_gateway:
   endpoint: pushgateway

--- a/prow/config/BUILD
+++ b/prow/config/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "config_test.go",
         "jobs_test.go",
+        "tide_test.go",
     ],
     data = [
         "//jobs",
@@ -32,6 +33,7 @@ go_library(
         "agent.go",
         "config.go",
         "jobs.go",
+        "tide.go",
     ],
     importpath = "k8s.io/test-infra/prow/config",
     deps = [

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -86,13 +86,6 @@ type PushGateway struct {
 	Interval time.Duration `json:"-"`
 }
 
-// Tide is config for the tide pool.
-type Tide struct {
-	// These must be valid GitHub search queries. They should not overlap,
-	// which is to say two queries should never return the same PR.
-	Queries []string `json:"queries,omitempty"`
-}
-
 // Controller holds configuration applicable to all agent-specific
 // prow controllers.
 type Controller struct {

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Tide is config for the tide pool.
+type Tide struct {
+	// Queries must not overlap. It must be impossible for any two queries to
+	// ever return the same PR.
+	// TODO: This will only be possible when we allow specifying orgs. At that
+	//       point, verify the above condition.
+	Queries []TideQuery `json:"queries,omitempty"`
+}
+
+// TideQuery is turned into a GitHub search query. See the docs for details:
+// https://help.github.com/articles/searching-issues-and-pull-requests/
+type TideQuery struct {
+	Repos []string `json:"repos,omitempty"`
+
+	Labels        []string `json:"labels,omitempty"`
+	MissingLabels []string `json:"missingLabels,omitempty"`
+
+	ReviewApprovedRequired bool `json:"reviewApprovedRequired,omitempty"`
+}
+
+func (tq *TideQuery) Query() string {
+	toks := []string{"is:pr", "state:open"}
+	for _, r := range tq.Repos {
+		toks = append(toks, fmt.Sprintf("repo:\"%s\"", r))
+	}
+	for _, l := range tq.Labels {
+		toks = append(toks, fmt.Sprintf("label:\"%s\"", l))
+	}
+	for _, l := range tq.MissingLabels {
+		toks = append(toks, fmt.Sprintf("-label:\"%s\"", l))
+	}
+	if tq.ReviewApprovedRequired {
+		toks = append(toks, "review:approved")
+	}
+	return strings.Join(toks, " ")
+}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTideQuery(t *testing.T) {
+	tq := &TideQuery{
+		Repos:                  []string{"k/k", "k/t-i"},
+		Labels:                 []string{"lgtm", "approved"},
+		MissingLabels:          []string{"foo"},
+		ReviewApprovedRequired: true,
+	}
+	q := " " + tq.Query() + " "
+	checkTok := func(tok string) {
+		if !strings.Contains(q, " "+tok+" ") {
+			t.Errorf("Expected query to contain \"%s\", got \"%s\"", tok, q)
+		}
+	}
+	checkTok("is:pr")
+	checkTok("state:open")
+	checkTok("repo:\"k/k\"")
+	checkTok("repo:\"k/t-i\"")
+	checkTok("label:\"lgtm\"")
+	checkTok("label:\"approved\"")
+	checkTok("-label:\"foo\"")
+	checkTok("review:approved")
+}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -109,7 +109,7 @@ func (c *Controller) Sync() error {
 	c.logger.Info("Building tide pool.")
 	var pool []PullRequest
 	for _, q := range c.ca.Config().Tide.Queries {
-		prs, err := c.search(ctx, q)
+		prs, err := c.search(ctx, q.Query())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
See #4913. This is needed to add a status context for PRs in/out of the tide pool.

The only tricky thing here is that I'm making a breaking change to the config. This means that we need to bump everything that uses it. With rules_k8s stuff this would be pretty much trivial, but we're not there yet. Once this merges, all the components' configs will stop updating until they're bumped. There won't be any real downtime though :)

cc @stevekuznetsov 

/area prow