### PR TITLE
make sinker much more agressive

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -7,9 +7,9 @@ jenkins_operator:
   report_template: '[Full PR test history](https://k8s-gubernator.appspot.com/pr/{{if eq .Spec.Refs.Org "kubernetes"}}{{if eq .Spec.Refs.Repo "kubernetes"}}{{else}}{{.Spec.Refs.Repo}}/{{end}}{{else}}{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{end}}{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://k8s-gubernator.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://github.com/kubernetes/community/blob/master/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
 
 sinker:
-  resync_period: 1h
+  resync_period: 1m
   max_prowjob_age: 48h
-  max_pod_age: 1h
+  max_pod_age: 30m
 
 deck:
   external_agent_logs:


### PR DESCRIPTION
We're killing active pods because we hit *actual* disk pressure on some of our build cluster nodes (unrelated to the previous spurious disk pressure issues), we can increase the disk sizes but we also should GC pods much more regularly, ~2 hours worth of pods eats a lot of boot disk space that we otherwise don't need.

- Make sinker resync once a minute instead once an hour
- Make sinker kill finished pods 30 minutes old instead of an hour

/area prow