### PR TITLE
Fix parsing regexp in job ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8382,7 +8382,7 @@
       "--kubernetes-anywhere-kubelet-ci-version=latest-1.8",
       "--kubernetes-anywhere-kubernetes-version=latest-1.8",
       "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\ --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
       "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/56594

/cc @enisoc @luxas 

Job failure info:
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-1-8-on-1-9/204

```
W1129 23:46:52.877] 2017/11/29 23:46:52 util.go:155: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\ --minStartupPods=8 --report-dir=/workspace/_artifacts --disable-log-dump=true
I1129 23:46:53.061] Conformance test: not doing test setup.
I1129 23:47:02.334] Nov 29 23:47:02.334: INFO: Overriding default scale value of zero to 1
I1129 23:47:02.335] Nov 29 23:47:02.334: INFO: Overriding default milliseconds value of zero to 5000
I1129 23:47:02.438] I1129 23:47:02.438653    1374 e2e.go:383] Starting e2e run "98e5095f-d55f-11e7-a43a-0a580a3c0887" on Ginkgo node 1
I1129 23:47:02.444] --- FAIL: TestE2E (0.01s)
I1129 23:47:02.446] panic: regexp: Compile(`\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\`): error parsing regexp: trailing backslash at end of expression: `` [recovered]
I1129 23:47:02.446] 	panic: regexp: Compile(`\[Conformance\]|\[Feature:BootstrapTokens\]|\[Feature:NodeAuthorizer\`): error parsing regexp: trailing backslash at end of expression: ``
```