### PR TITLE
don't set TMPDIR on prow verify scenario

### DIFF
--- a/scenarios/kubernetes_verify.py
+++ b/scenarios/kubernetes_verify.py
@@ -131,8 +131,7 @@ def main(branch, script, force, on_prow):
             '-e', 'KUBE_FORCE_VERIFY_CHECKS=%s' % force,
             '-e', 'KUBE_VERIFY_GIT_BRANCH=%s' % branch,
             '-e', 'REPO_DIR=%s' % k8s,  # hack/lib/swagger.sh depends on this
-            '-e', 'TMPDIR=/tmp',  # https://golang.org/src/os/file_unix.go
-            '--tmpfs', '/tmp:exec,mode=777',
+            '--tmpfs', '/tmp:exec,mode=1777',
             'gcr.io/k8s-testimages/kubekins-test:%s' % tag,
             'bash', '-c', 'cd kubernetes && %s' % script,
         ])


### PR DESCRIPTION
Sen found a hackdir script in k/k that uses {$TMPDIR:-/tmp/}, also we verified that everywhere was already using `/tmp` anyhow (which is reasonable...) so let's just not set this.

also explicitly set the sticky bit on temp

/area scenarios
/shrug