### PR TITLE
add a cpu request to verify / unit jobs on prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1904,6 +1904,9 @@ presubmits:
         ports:
         - containerPort: 9999
           hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
       volumes:
       - name: service
         secret:
@@ -1954,6 +1957,9 @@ presubmits:
         ports:
         - containerPort: 9999
           hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
       volumes:
       - name: service
         secret:
@@ -3408,6 +3414,9 @@ presubmits:
         ports:
         - containerPort: 9999
           hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
       volumes:
       - name: service
         secret:
@@ -3458,6 +3467,9 @@ presubmits:
         ports:
         - containerPort: 9999
           hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
       volumes:
       - name: service
         secret:


### PR DESCRIPTION
this should help with scheduling these, it seems sometimes they're scheduled on weaker nodes so they take longer than on jenkins.

/area jobs