### PR TITLE
Add a test for m5 instances on AWS

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8116,6 +8116,26 @@
       "sig-testing"
     ]
   },
+  "ci-kubernetes-e2e-kops-aws-ena-nvme": {
+    "args": [
+      "--cluster=e2e-kops-aws-ena-nvme.test-cncf-aws.k8s.io",
+      "--deployment=kops",
+      "--env-file=jobs/platform/kops_aws.env",
+      "--extract=ci/latest",
+      "--ginkgo-parallel",
+      "--kops-args=--node-size=m5.large --master-size=m5.large",
+      "--kops-state=s3://k8s-kops-prow/",
+      "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
+      "--kops-zones=us-west-2a",
+      "--provider=aws",
+      "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-aws"
+    ]
+  },
   "ci-kubernetes-e2e-kops-aws-newrunner": {
     "args": [
       "--cluster=e2e-kops-aws-newrunner.test-aws.k8s.io",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -17940,6 +17940,50 @@ periodics:
 
 - interval: 1h
   agent: kubernetes
+  name: ci-kubernetes-e2e-kops-aws-ena-nvme
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_AWS_CREDENTIALS_FILE
+        value: /etc/aws-cred/credentials
+      - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-private
+      - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+        value: /etc/aws-ssh/aws-ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      imagePullPolicy: Always
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/aws-ssh
+        name: aws-ssh
+        readOnly: true
+      - mountPath: /etc/aws-cred
+        name: aws-cred
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: aws-ssh
+      secret:
+        defaultMode: 256
+        secretName: aws-ssh-key-secret
+    - name: aws-cred
+      secret:
+        defaultMode: 256
+        secretName: aws-cred-new
+
+- interval: 1h
+  agent: kubernetes
   name: ci-kubernetes-e2e-kops-aws-newrunner
   spec:
     containers:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1084,6 +1084,8 @@ test_groups:
   - configuration_value: node_os_image
   - configuration_value: Commit
   - configuration_value: infra-commit
+- name: ci-kubernetes-e2e-kops-aws-ena-nvme
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-ena-nvme
 - name: ci-kubernetes-e2e-kops-aws-newrunner
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-newrunner
 - name: ci-kubernetes-e2e-kops-aws-release-1-7
@@ -2026,6 +2028,8 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-kops-aws-updown
   - name: kops-aws-weave
     test_group_name: ci-kubernetes-e2e-kops-aws-weave
+  - name: kops-aws-ena-nvme
+    test_group_name: ci-kubernetes-e2e-kops-aws-ena-nvme
   - name: kops-aws-newrunner
     test_group_name: ci-kubernetes-e2e-kops-aws-newrunner
 


### PR DESCRIPTION
M5 intances have nvme and also need the ENA driver.

NVME support: https://github.com/kubernetes/kubernetes/pull/56607