### PR TITLE
Trace prow logs in deck

### DIFF
--- a/prow/cmd/deck/BUILD
+++ b/prow/cmd/deck/BUILD
@@ -42,6 +42,7 @@ go_test(
     srcs = [
         "jobs_test.go",
         "main_test.go",
+        "trace_test.go",
     ],
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/deck",
@@ -61,10 +62,12 @@ go_library(
         "main.go",
         "pluginhelp.go",
         "tide.go",
+        "trace.go",
     ],
     importpath = "k8s.io/test-infra/prow/cmd/deck",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/kube/labels:go_default_library",
         "//prow/pjutil:go_default_library",

--- a/prow/cmd/deck/jobs.go
+++ b/prow/cmd/deck/jobs.go
@@ -71,6 +71,7 @@ type listPJClient interface {
 }
 
 type podLogClient interface {
+	ListPods(selector string) ([]kube.Pod, error)
 	GetLog(pod string) ([]byte, error)
 	GetLogStream(pod string, options map[string]string) (io.ReadCloser, error)
 }

--- a/prow/cmd/deck/jobs_test.go
+++ b/prow/cmd/deck/jobs_test.go
@@ -35,6 +35,10 @@ func (f fkc) ListProwJobs(s string) ([]kube.ProwJob, error) {
 
 type fpkc struct{}
 
+func (f fpkc) ListPods(selector string) ([]kube.Pod, error) {
+	return nil, nil
+}
+
 func (f fpkc) GetLog(pod string) ([]byte, error) {
 	if pod == "wowowow" {
 		return []byte("wow"), nil

--- a/prow/cmd/deck/trace.go
+++ b/prow/cmd/deck/trace.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/kube"
+)
+
+type lineData struct {
+	TimeStr   string `json:"time"`
+	time      time.Time
+	PrNum     int    `json:"pr"`
+	Repo      string `json:"repo"`
+	Org       string `json:"org"`
+	EventGUID string `json:"event-GUID"`
+}
+
+type podLine struct {
+	actual      []byte
+	unmarshaled lineData
+}
+
+// linesByTimestamp sorts pod lines by timestamp.
+// Useful when collecting logs across multiple pods.
+type linesByTimestamp []podLine
+
+// linesByTimestamp implements the sort.Interface interface.
+var _ sort.Interface = linesByTimestamp{}
+
+func (l linesByTimestamp) Len() int      { return len(l) }
+func (l linesByTimestamp) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l linesByTimestamp) Less(i, j int) bool {
+	return l[i].unmarshaled.time.Before(l[j].unmarshaled.time)
+}
+
+// linesByTimestamp implements the fmt.Stringer interface.
+var _ fmt.Stringer = linesByTimestamp{}
+
+// Return valid json.
+func (pl linesByTimestamp) String() string {
+	sort.Sort(pl)
+
+	var log string
+	for i, line := range pl {
+		switch i {
+		case len(pl) - 1:
+			log += string(line.actual)
+		default:
+			// buf.ReadBytes('\n') does not remove the newline
+			log += fmt.Sprintf("%s,\n", strings.TrimSuffix(string(line.actual), "\n"))
+		}
+	}
+
+	return fmt.Sprintf("[%s]", log)
+}
+
+func handleTrace(ja *JobAgent) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		prNum, err := validateTraceRequest(r)
+		if err != nil {
+			logrus.Debugf("Invalid request: %v", err)
+			http.Error(w, fmt.Sprintf("Invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		var targets []kube.Pod
+		for _, selector := range ja.c.Config().Deck.TraceTargets {
+			pods, err := ja.pkc.ListPods(selector)
+			if err != nil {
+				logrus.Debugf("Cannot list pods with selector %q: %v", selector, err)
+				http.Error(w, fmt.Sprintf("Cannot list pods with selector %q: %v", selector, err), http.StatusBadGateway)
+				return
+			}
+			for _, pod := range pods {
+				if pod.Status.Phase != kube.PodRunning {
+					logrus.Debugf("Ignoring pod %q: not in %s phase (phase: %s, reason: %s)",
+						pod.Metadata.Name, kube.PodRunning, pod.Status.Phase, pod.Status.Reason)
+					continue
+				}
+				targets = append(targets, pod)
+			}
+		}
+
+		if len(targets) == 0 {
+			logrus.Debug("No targets found.")
+			fmt.Fprint(w, "[]")
+			return
+		}
+
+		pr := r.URL.Query().Get(github.PrLogField)
+		repo := r.URL.Query().Get(github.RepoLogField)
+		org := r.URL.Query().Get(github.OrgLogField)
+		eventGUID := r.URL.Query().Get(github.EventGUID)
+
+		log := make(linesByTimestamp, 0)
+		var buf *bytes.Buffer
+		for _, pod := range targets {
+			// TODO: Cache this and use "since" as a pod/log url parameter to fetch
+			// newer logs.
+			podLog, err := ja.pkc.GetLog(pod.Metadata.Name)
+			if err != nil {
+				logrus.Debugf("cannot get logs from %q: %v", pod.Metadata.Name, err)
+				continue
+			}
+			buf = bytes.NewBuffer(podLog)
+
+			for {
+				line, err := buf.ReadBytes('\n')
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					logrus.Debugf("error while reading log line from %q: %v", pod.Metadata.Name, err)
+					continue
+				}
+
+				var jsonLine lineData
+				if err := json.Unmarshal(line, &jsonLine); err != nil {
+					logrus.Debugf("cannot unmarshal log line from %q (%s): %v", pod.Metadata.Name, string(line), err)
+					continue
+				}
+				if eventGUID != "" && jsonLine.EventGUID != eventGUID {
+					continue
+				}
+				if pr != "" && jsonLine.PrNum != prNum {
+					continue
+				}
+				if repo != "" && jsonLine.Repo != repo {
+					continue
+				}
+				if org != "" && jsonLine.Org != org {
+					continue
+				}
+				jsonLine.time, err = time.Parse(time.RFC3339, jsonLine.TimeStr)
+				if err != nil {
+					logrus.Debugf("could not parse time format: %v", err)
+					// Continue including this in the output at the expense
+					// of not having it sorted.
+				}
+				log = append(log, podLine{actual: line, unmarshaled: jsonLine})
+			}
+		}
+		fmt.Fprint(w, log)
+	}
+}
+
+func validateTraceRequest(r *http.Request) (int, error) {
+	pr := r.URL.Query().Get(github.PrLogField)
+	repo := r.URL.Query().Get(github.RepoLogField)
+	org := r.URL.Query().Get(github.OrgLogField)
+	eventGUID := r.URL.Query().Get(github.EventGUID)
+
+	if (pr == "" || repo == "" || org == "") && eventGUID == "" {
+		return 0, fmt.Errorf("need either %q, %q, and %q or %q to be specified",
+			github.PrLogField, github.RepoLogField, github.OrgLogField, github.EventGUID)
+	}
+	var prNum int
+	if pr != "" {
+		var err error
+		prNum, err = strconv.Atoi(pr)
+		if err != nil {
+			return 0, fmt.Errorf("invalid pr query %q: %v", pr, err)
+		}
+		if prNum < 1 {
+			return 0, fmt.Errorf("invalid pr query %q: needs to be a positive number", pr)
+		}
+	}
+	return prNum, nil
+}

--- a/prow/cmd/deck/trace_test.go
+++ b/prow/cmd/deck/trace_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestLinesByTimestampValidJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		log  linesByTimestamp
+	}{
+		{
+			name: "no line",
+			log:  linesByTimestamp{},
+		},
+		{
+			name: "single line",
+			log: linesByTimestamp{
+				{
+					actual: []byte("{\"component\":\"jenkins-operator\",\"event-GUID\":\"thisisunique\",\"from\":\"triggered\",\"job\":\"origin-ci-ut-origin\",\"level\":\"info\",\"msg\":\"Transitioning states.\",\"name\":\"50ea24ea-d9a9-11e7-8e52-0a58ac101211\",\"org\":\"openshift\",\"pr\":17586,\"repo\":\"origin\",\"time\":\"2017-12-05T10:45:14Z\",\"to\":\"pending\",\"type\":\"presubmit\"}\n"),
+				},
+			},
+		},
+		{
+			name: "multiple lines",
+			log: linesByTimestamp{
+				{
+					actual: []byte("{\"component\":\"jenkins-operator\",\"event-GUID\":\"thisisunique\",\"from\":\"triggered\",\"job\":\"origin-ci-ut-origin\",\"level\":\"info\",\"msg\":\"Transitioning states.\",\"name\":\"50ea24ea-d9a9-11e7-8e52-0a58ac101211\",\"org\":\"openshift\",\"pr\":17586,\"repo\":\"origin\",\"time\":\"2017-12-05T10:45:14Z\",\"to\":\"pending\",\"type\":\"presubmit\"}\n"),
+				},
+				{
+					actual: []byte("{\"author\":\"bob\",\"event-GUID\":\"thisisunique\",\"event-type\":\"issue_comment\",\"job\":\"test_pull_request_origin_extended_conformance_install_update\",\"level\":\"info\",\"msg\":\"Creating a new prowjob.\",\"name\":\"50edc666-d9a9-11e7-8e52-0a58ac101211\",\"org\":\"openshift\",\"plugin\":\"trigger\",\"pr\":17586,\"repo\":\"origin\",\"time\":\"2017-12-05T10:44:48Z\",\"type\":\"presubmit\",\"url\":\"an_url\"}\n"),
+				},
+				{
+					actual: []byte("{\"author\":\"bob\",\"event-GUID\":\"thisisunique\",\"event-type\":\"issue_comment\",\"level\":\"info\",\"msg\":\"Starting test_pull_request_origin_extended_networking_minimal build.\",\"org\":\"openshift\",\"plugin\":\"trigger\",\"pr\":17586,\"repo\":\"origin\",\"time\":\"2017-12-05T10:44:48Z\",\"url\":\"an_url\"}\n"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		jsonLog := test.log.String()
+		if !json.Valid([]byte(jsonLog)) {
+			t.Errorf("%s: got invalid json:\n%v", test.name, jsonLog)
+		}
+	}
+}
+
+func TestValidTraceRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		expectedNum int
+		expectedErr string
+	}{
+		{
+			name:        "valid request - eventGUID",
+			url:         "https://deck/trace?event-GUID=503265b0-d9a9-11e7-9b32-1fd823242322",
+			expectedNum: 0,
+			expectedErr: "",
+		},
+		{
+			name:        "valid request - org/repo#pr",
+			url:         "https://deck/trace?repo=origin&org=openshift&pr=17586",
+			expectedNum: 17586,
+			expectedErr: "",
+		},
+		{
+			name:        "invalid request - pr is not a number",
+			url:         "https://deck/trace?repo=origin&org=openshift&pr=175fd",
+			expectedNum: 0,
+			expectedErr: "invalid pr query \"175fd\": strconv.Atoi: parsing \"175fd\": invalid syntax",
+		},
+		{
+			name:        "invalid request - pr is not a positive number",
+			url:         "https://deck/trace?repo=origin&org=openshift&pr=-17453",
+			expectedNum: 0,
+			expectedErr: "invalid pr query \"-17453\": needs to be a positive number",
+		},
+		{
+			name:        "invalid request - missing org parameter",
+			url:         "https://deck/trace?repo=origin&pr=17453",
+			expectedNum: 0,
+			expectedErr: "need either \"pr\", \"repo\", and \"org\" or \"event-GUID\" to be specified",
+		},
+		{
+			name:        "invalid request - missing repo parameter",
+			url:         "https://deck/trace?org=openshift&pr=17453",
+			expectedNum: 0,
+			expectedErr: "need either \"pr\", \"repo\", and \"org\" or \"event-GUID\" to be specified",
+		},
+		{
+			name:        "invalid request - missing pr parameter",
+			url:         "https://deck/trace?org=openshift&repo=origin",
+			expectedNum: 0,
+			expectedErr: "need either \"pr\", \"repo\", and \"org\" or \"event-GUID\" to be specified",
+		},
+		{
+			name:        "invalid request - missing org and repo parameter",
+			url:         "https://deck/trace?pr=17453",
+			expectedNum: 0,
+			expectedErr: "need either \"pr\", \"repo\", and \"org\" or \"event-GUID\" to be specified",
+		},
+		{
+			name:        "invalid request - missing org and pr parameter",
+			url:         "https://deck/trace?repo=origin",
+			expectedNum: 0,
+			expectedErr: "need either \"pr\", \"repo\", and \"org\" or \"event-GUID\" to be specified",
+		},
+		{
+			name:        "invalid request - missing repo and pr parameter",
+			url:         "https://deck/trace?org=openshift",
+			expectedNum: 0,
+			expectedErr: "need either \"pr\", \"repo\", and \"org\" or \"event-GUID\" to be specified",
+		},
+		{
+			name:        "invalid request - no parameters",
+			url:         "https://deck/trace",
+			expectedNum: 0,
+			expectedErr: "need either \"pr\", \"repo\", and \"org\" or \"event-GUID\" to be specified",
+		},
+	}
+
+	for _, test := range tests {
+		req, err := http.NewRequest(http.MethodGet, test.url, nil)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+			continue
+		}
+		gotNum, gotErr := validateTraceRequest(req)
+		if gotNum != test.expectedNum {
+			t.Errorf("%s: unexpected PR num: %d, expected: %d", test.name, gotNum, test.expectedNum)
+			continue
+		}
+		if gotErr != nil && gotErr.Error() != test.expectedErr {
+			t.Errorf("%s: unexpected error: %q, expected: %q", test.name, gotErr.Error(), test.expectedErr)
+			continue
+		}
+		if test.expectedErr != "" && gotErr == nil {
+			t.Errorf("%s: expected an error (%s) but got none", test.name, test.expectedErr)
+		}
+	}
+}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/robfig/cron.v2"
+	cron "gopkg.in/robfig/cron.v2"
 
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/kube/labels"
@@ -150,8 +150,19 @@ type Sinker struct {
 type Deck struct {
 	// HiddenRepos is a list of orgs and/or repos that should not be displayed by Deck.
 	HiddenRepos []string `json:"hidden_repos,omitempty"`
-	// ExternalAgentLogs is a list of ExternalAgenLog configs.
+	// ExternalAgentLogs ensures external agents can expose
+	// their logs in prow.
 	ExternalAgentLogs []ExternalAgentLog `json:"external_agent_logs,omitempty"`
+	// TraceTargets is a set of label selectors deck uses to
+	// select prow components in order to trace logs.
+	//
+	// Example config:
+	//
+	// trace_targets:
+	// - app=prow
+	//
+	// In the example above, deck will select all pods with the app=prow label.
+	TraceTargets []string `json:"trace_targets,omitempty"`
 }
 
 // ExternalAgentLog ensures an external agent like Jenkins can expose
@@ -306,6 +317,12 @@ func parseConfig(c *Config) error {
 			return fmt.Errorf("error parsing selector %q: %v", c.Deck.ExternalAgentLogs[i].SelectorString, err)
 		}
 		c.Deck.ExternalAgentLogs[i].Selector = s
+	}
+
+	for i := range c.Deck.TraceTargets {
+		if _, err := labels.Parse(c.Deck.TraceTargets[i]); err != nil {
+			return fmt.Errorf("error parsing selector %q: %v", c.Deck.TraceTargets[i], err)
+		}
 	}
 
 	if c.PushGateway.IntervalString == "" {


### PR DESCRIPTION
Add a new opt-in endpoint in deck for tracing logs across
prow. It can be used to trace logs per PR or per event-guid.

@katerinapat @stevekuznetsov fyi