### PR TITLE
Switch kops newrunner jobs to use alpha channel

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8124,7 +8124,7 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
-      "--kops-args=--node-size=m5.large --master-size=m5.large",
+      "--kops-args=--node-size=m5.large --master-size=m5.large --channel=alpha",
       "--kops-state=s3://k8s-kops-prow/",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
       "--kops-zones=us-west-2a",


### PR DESCRIPTION
The alpha channel contains the 'development' configuration - in
particular the AMIs / Google Cloud Image to use for each k8s version.

We want to be using the alpha channel for tests that aren't tied to a
release branch - both so that we test the upcoming images, but also
because the images for upcoming kubernetes versions won't necessarily be
in the stable channel.