### PR TITLE
[WIP] Move /ok-to-test to be handled in GenericCommentEvent

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -487,4 +487,7 @@ type GenericCommentEvent struct {
 	IssueState   string
 	IssueBody    string
 	IssueHTMLURL string
+
+	// GUID is included in the header of the request received by Github.
+	GUID string
 }


### PR DESCRIPTION
Fixes #3827.

I think this will work, but it does muddy things with labels a bit. When you pull down a PR as an "Issue" then you get things like the labels applied. That's not the case for a PR object however.