### PR TITLE
Rename metrics duration json field

### DIFF
--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -179,7 +179,7 @@ func gather(c *jenkins.Controller, logger *logrus.Entry) {
 		case <-tick:
 			start := time.Now()
 			c.SyncMetrics()
-			logger.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Debug("Metrics synced")
+			logger.WithField("metrics-duration", fmt.Sprintf("%v", time.Since(start))).Debug("Metrics synced")
 		case <-sig:
 			logger.Debug("Jenkins operator gatherer is shutting down...")
 			return

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -164,7 +164,7 @@ func gather(c *plank.Controller, logger *logrus.Entry) {
 		case <-tick:
 			start := time.Now()
 			c.SyncMetrics()
-			logger.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Debug("Metrics synced")
+			logger.WithField("metrics-duration", fmt.Sprintf("%v", time.Since(start))).Debug("Metrics synced")
 		case <-sig:
 			logger.Debug("Plank gatherer is shutting down...")
 			return


### PR DESCRIPTION
Needed so we can differentiate between this and the
duration for the normal sync loop.

/cc stevekuznetsov 

Signed-off-by: Michalis Kargakis <mkargaki@redhat.com>