### PR TITLE
Change cluster name for canary kubemark job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9332,7 +9332,7 @@
   },
   "ci-kubernetes-kubemark-5-prow-canary": {
     "args": [
-      "--cluster=kubemark-5-prow-canary",
+      "--cluster=prow-kubemark-canary",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest",


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/pull/5758#issuecomment-349071379

I suspect it's either some gcp or kubernetes thing - change cluster name and see if situation improves.

/area jobs
/assign @BenTheElder 
cc @shyamjvs 