### PR TITLE
Move kubemark presubmit to prow

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10640,10 +10640,12 @@
     ]
   },
   "pull-kubernetes-kubemark-e2e-gce": {
+    "_comment1": "NOTE: THESE ARE THE JENKINS ARGS / COMMON ARGS (!)",
+    "_comment2": "PLEASE PUT ARGS THAT WILL WORK FOR 1.6 HERE",
+    "_comment3": "Args for 1.7+ should go in prow/config.yaml after the `--` !",
     "args": [
       "--build",
       "--cluster=",
-      "--docker-in-docker",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/pull-kubernetes-kubemark-e2e-gce.env",
       "--extract=local",
@@ -10682,29 +10684,6 @@
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
       "--timeout=80m"
-    ],
-    "scenario": "kubernetes_e2e",
-    "sigOwners": [
-      "sig-scalability"
-    ]
-  },
-  "pull-kubernetes-kubemark-e2e-gce-prow": {
-    "args": [
-      "--build=bazel",
-      "--cluster=",
-      "--env-file=jobs/platform/gce.env",
-      "--env-file=jobs/env/pull-kubernetes-kubemark-e2e-gce.env",
-      "--extract=local",
-      "--gcp-node-image=gci",
-      "--gcp-project=k8s-jkns-pr-kubemark",
-      "--gcp-zone=us-central1-f",
-      "--kubemark",
-      "--kubemark-nodes=5",
-      "--provider=gce",
-      "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce-prow",
-      "--test=false",
-      "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true",
-      "--timeout=45m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -768,8 +768,6 @@ class JobTest(unittest.TestCase):
             'ci-kubernetes-kubemark-high-density-100-gce': 'ci-kubernetes-kubemark-*',
             'ci-kubernetes-kubemark-gce-scale': 'ci-kubernetes-scale-*',
             'pull-kubernetes-kubemark-e2e-gce-big': 'ci-kubernetes-scale-*',
-            'pull-kubernetes-kubemark-e2e-gce': 'pr-kubernetes-kubemark-*',
-            'pull-kubernetes-kubemark-e2e-gce-prow': 'pr-kubernetes-kubemark-*',
             'ci-kubernetes-e2e-gce-large-manual-up': 'ci-kubernetes-scale-*',
             'ci-kubernetes-e2e-gce-large-manual-down': 'ci-kubernetes-scale-*',
             'ci-kubernetes-e2e-gce-large-correctness': 'ci-kubernetes-scale-*',

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1620,28 +1620,25 @@ presubmits:
   - name: pull-kubernetes-kubemark-e2e-gce
     agent: jenkins
     always_run: true
+    max_concurrency: 12
     context: pull-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
-    skip_branches:
-    - release-1.4
-  - name: pull-kubernetes-kubemark-e2e-gce-big
-    agent: jenkins
-    always_run: false
-    context: pull-kubernetes-kubemark-e2e-gce-big
-    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
-    trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
-  - name: pull-kubernetes-kubemark-e2e-gce-prow
+    branches:
+    - release-1.6
+
+  - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
-    always_run: false
-    skip_report: false
-    max_concurrency: 3
-    context: pull-kubernetes-kubemark-e2e-gce-prow
-    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-prow"
-    trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    skip_branches:
+    - release-1.6
+    context: pull-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
         imagePullPolicy: Always
         args:
         - --root=/go/src
@@ -1653,6 +1650,11 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
@@ -1702,6 +1704,12 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
 
+  - name: pull-kubernetes-kubemark-e2e-gce-big
+    agent: jenkins
+    always_run: false
+    context: pull-kubernetes-kubemark-e2e-gce-big
+    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
+    trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
   - name: pull-kubernetes-node-e2e
     agent: kubernetes
     skip_branches:
@@ -3201,28 +3209,25 @@ presubmits:
   - name: pull-security-kubernetes-kubemark-e2e-gce
     agent: jenkins
     always_run: true
+    max_concurrency: 12
     context: pull-security-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
-    skip_branches:
-    - release-1.4
-  - name: pull-security-kubernetes-kubemark-e2e-gce-big
-    agent: jenkins
-    always_run: false
-    context: pull-security-kubernetes-kubemark-e2e-gce-big
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
-    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
-  - name: pull-security-kubernetes-kubemark-e2e-gce-prow
+    branches:
+    - release-1.6
+
+  - name: pull-security-kubernetes-kubemark-e2e-gce
     agent: kubernetes
-    always_run: false
-    skip_report: false
-    max_concurrency: 3
-    context: pull-security-kubernetes-kubemark-e2e-gce-prow
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-prow"
-    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-prow,?(\\s+|$)"
+    always_run: true
+    max_concurrency: 12
+    skip_branches:
+    - release-1.6
+    context: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
         imagePullPolicy: Always
         args:
         - --root=/go/src
@@ -3234,6 +3239,11 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=90"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
@@ -3282,6 +3292,13 @@ presubmits:
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
+
+  - name: pull-security-kubernetes-kubemark-e2e-gce-big
+    agent: jenkins
+    always_run: false
+    context: pull-security-kubernetes-kubemark-e2e-gce-big
+    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
+    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
   - name: pull-security-kubernetes-node-e2e
     agent: kubernetes
     skip_branches:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1637,9 +1637,6 @@ test_groups:
   num_columns_recent: 20
   alert_stale_results_hours: 24
   num_failures_to_alert: 10
-- name: pull-kubernetes-kubemark-e2e-gce-prow
-  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-kubemark-e2e-gce-prow
-  num_columns_recent: 20
 - name: pull-kubernetes-kubemark-e2e-gce-big
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-kubernetes-kubemark-e2e-gce-big
   days_of_results: 1
@@ -4297,8 +4294,6 @@ dashboards:
     test_group_name: pull-kubernetes-unit-prow
   - name: pull-kubernetes-cross-prow
     test_group_name: pull-kubernetes-cross-prow
-  - name: pull-kubernetes-kubemark-e2e-gce-prow
-    test_group_name: pull-kubernetes-kubemark-e2e-gce-prow
 
 - name: sig-ui
   dashboard_tab:


### PR DESCRIPTION
https://k8s-testgrid.appspot.com/sig-testing-canaries#pull-kubernetes-kubemark-e2e-gce-prow is pretty green, it should be safe to flip it to prow now.

/area jobs
/assign @BenTheElder @shyamjvs 