### PR TITLE
Fix trigger bug that marks branch-sharded jobs as skipped.

### DIFF
--- a/prow/plugins/trigger/ic.go
+++ b/prow/plugins/trigger/ic.go
@@ -116,9 +116,7 @@ func handleIC(c client, trustedOrg string, ic github.IssueCommentEvent) error {
 		if err != nil {
 			return err
 		}
-		for _, job := range retests {
-			requestedJobs[job.Name] = job
-		}
+		requestedJobs = append(requestedJobs, retests...)
 	}
 
 	var comments []github.IssueComment

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -308,15 +308,6 @@ func TestHandleIssueComment(t *testing.T) {
 			},
 		},
 		{
-			name:          "Retest and explicit trigger of same job",
-			Author:        "t",
-			Body:          "/retest\n/test jib",
-			State:         "open",
-			IsPR:          true,
-			ShouldBuild:   true,
-			StartsExactly: "pull-jib",
-		},
-		{
 			name:       "Run if changed job triggered by /ok-to-test",
 			Author:     "t",
 			Body:       "/ok-to-test",
@@ -336,6 +327,32 @@ func TestHandleIssueComment(t *testing.T) {
 			ShouldBuild:   true,
 			StartsExactly: "pull-jab",
 			IssueLabels:   []github.Label{{Name: "needs-ok-to-test"}},
+		},
+		{
+			name:   "/test of branch-sharded job",
+			Author: "t",
+			Body:   "/test jab",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						Name:     "jab",
+						Brancher: config.Brancher{Branches: []string{"master"}},
+						Context:  "pull-jab",
+						Trigger:  `/test jab`,
+					},
+					{
+						Name:     "jab",
+						Brancher: config.Brancher{Branches: []string{"release"}},
+						Context:  "pull-jab",
+						Trigger:  `/test jab`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			ShouldReport:  true,
+			StartsExactly: "pull-jab",
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
I incorrectly assumed that job names are unique while adding RunIfChanged support to comment based job triggers in `ic.go`.

/cc @BenTheElder 