### PR TITLE
Fix extract gke option value for kubetest & bump kubetest

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
 LABEL maintainer "beacham@google.com"
 
 RUN apt-get update && apt-get install -y \

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -373,10 +373,10 @@ func (e extractStrategy) Extract(project, zone string, extractSrc bool) error {
 		if zone == "" {
 			return fmt.Errorf("--gcp-zone unset")
 		}
-		if e.option == "gke" {
+		if e.value == "gke" {
 			log.Print("*** --extract=gke is deprecated, migrate to --extract=gke-default ***")
 		}
-		if strings.HasSuffix(e.option, "-latest") {
+		if e.option == "latest" {
 			// get latest supported master version
 			res, err := output(exec.Command("gcloud", "container", "get-server-config", fmt.Sprintf("--project=%v", project), fmt.Sprintf("--zone=%v", zone), "--format=value(validMasterVersions)"))
 			if err != nil {
@@ -386,7 +386,7 @@ func (e extractStrategy) Extract(project, zone string, extractSrc bool) error {
 			if len(versions) == 0 {
 				return fmt.Errorf("invalid gke master version string: %s", string(res))
 			}
-			return setReleaseFromGcs("kubernetes-release/release", versions[0], extractSrc)
+			return getKube("https://storage.googleapis.com/kubernetes-release-gke/release", "v"+versions[0], extractSrc)
 		}
 
 		// get default cluster version for default extract strategy

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -518,7 +518,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -620,7 +620,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -720,7 +720,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2111,7 +2111,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2213,7 +2213,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2313,7 +2313,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -4071,7 +4071,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4195,7 +4195,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4238,7 +4238,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4362,7 +4362,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4405,7 +4405,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4534,7 +4534,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4978,7 +4978,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5021,7 +5021,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5055,7 +5055,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5098,7 +5098,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5141,7 +5141,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5184,7 +5184,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -18340,7 +18340,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
       args:
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--clean"
@@ -20812,7 +20812,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -20937,7 +20937,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -20982,7 +20982,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -21105,7 +21105,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -21150,7 +21150,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -21280,7 +21280,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=release-1.9"
         - "--clean"
@@ -21323,7 +21323,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171201-6540ed059
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171204-13a5e5dc5
         args:
         - "--repo=k8s.io/kubernetes=release-1.9"
         - "--clean"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -383,7 +383,7 @@ presubmits:
       trigger: "(?m)^/test( all| pull-cri-containerd-node-e2e),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
           args:
           - --root=/go/src
           - "--clean"
@@ -1153,7 +1153,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1222,7 +1222,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1290,7 +1290,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1358,7 +1358,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1408,7 +1408,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1473,7 +1473,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1551,7 +1551,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1638,7 +1638,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         imagePullPolicy: Always
         args:
         - --root=/go/src
@@ -1722,7 +1722,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1780,7 +1780,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -1838,7 +1838,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -1897,7 +1897,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-node-e2e-containerd,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2743,7 +2743,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2812,7 +2812,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2880,7 +2880,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2948,7 +2948,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -2997,7 +2997,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3062,7 +3062,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3140,7 +3140,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3227,7 +3227,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         imagePullPolicy: Always
         args:
         - --root=/go/src
@@ -3311,7 +3311,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3369,7 +3369,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -3427,7 +3427,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -3486,7 +3486,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
         args:
         - --root=/go/src
         - "--clean"
@@ -4749,7 +4749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4783,7 +4783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4805,7 +4805,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --root=/go/src
       - "--clean"
@@ -4872,7 +4872,7 @@ periodics:
       # docker-in-docker needs privilged mode
       securityContext:
         privileged: true
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -4914,7 +4914,7 @@ periodics:
       # docker-in-docker needs privilged mode
       securityContext:
         privileged: true
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5242,7 +5242,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5276,7 +5276,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5310,7 +5310,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5344,7 +5344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5378,7 +5378,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5412,7 +5412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5446,7 +5446,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5480,7 +5480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5514,7 +5514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5548,7 +5548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5582,7 +5582,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5616,7 +5616,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5650,7 +5650,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5684,7 +5684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5718,7 +5718,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5752,7 +5752,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5786,7 +5786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5820,7 +5820,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5854,7 +5854,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5888,7 +5888,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5922,7 +5922,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5956,7 +5956,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6027,7 +6027,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6063,7 +6063,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6099,7 +6099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6135,7 +6135,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6171,7 +6171,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6207,7 +6207,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6243,7 +6243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6279,7 +6279,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6315,7 +6315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6351,7 +6351,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6387,7 +6387,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6423,7 +6423,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6459,7 +6459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6495,7 +6495,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6531,7 +6531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6567,7 +6567,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6603,7 +6603,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6639,7 +6639,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6675,7 +6675,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6711,7 +6711,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6747,7 +6747,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6783,7 +6783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6819,7 +6819,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6855,7 +6855,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6891,7 +6891,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6927,7 +6927,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6963,7 +6963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6999,7 +6999,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7035,7 +7035,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7071,7 +7071,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7107,7 +7107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7143,7 +7143,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7179,7 +7179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7215,7 +7215,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7251,7 +7251,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7287,7 +7287,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7323,7 +7323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7359,7 +7359,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7395,7 +7395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7431,7 +7431,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7467,7 +7467,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7503,7 +7503,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7539,7 +7539,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7575,7 +7575,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7611,7 +7611,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7647,7 +7647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7683,7 +7683,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7719,7 +7719,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7755,7 +7755,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7791,7 +7791,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7827,7 +7827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7863,7 +7863,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7899,7 +7899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7935,7 +7935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7971,7 +7971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8007,7 +8007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8043,7 +8043,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8079,7 +8079,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8115,7 +8115,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8151,7 +8151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8187,7 +8187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8223,7 +8223,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8259,7 +8259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8295,7 +8295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8329,7 +8329,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8363,7 +8363,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8397,7 +8397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8431,7 +8431,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8465,7 +8465,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8499,7 +8499,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8533,7 +8533,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8567,7 +8567,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8601,7 +8601,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8635,7 +8635,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8669,7 +8669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8703,7 +8703,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8737,7 +8737,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8771,7 +8771,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8805,7 +8805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8839,7 +8839,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8873,7 +8873,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8907,7 +8907,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8941,7 +8941,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8975,7 +8975,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9009,7 +9009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9043,7 +9043,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9077,7 +9077,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9111,7 +9111,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9145,7 +9145,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9179,7 +9179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9213,7 +9213,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9247,7 +9247,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9281,7 +9281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9315,7 +9315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9349,7 +9349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9383,7 +9383,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9417,7 +9417,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9525,7 +9525,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9563,7 +9563,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9597,7 +9597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9631,7 +9631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9665,7 +9665,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9699,7 +9699,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9733,7 +9733,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9767,7 +9767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9801,7 +9801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9835,7 +9835,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9869,7 +9869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9903,7 +9903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9937,7 +9937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9971,7 +9971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10005,7 +10005,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10039,7 +10039,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10073,7 +10073,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10142,7 +10142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10180,7 +10180,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10218,7 +10218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10252,7 +10252,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10286,7 +10286,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10320,7 +10320,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10354,7 +10354,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10388,7 +10388,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10422,7 +10422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10456,7 +10456,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10490,7 +10490,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10524,7 +10524,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10558,7 +10558,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10592,7 +10592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10626,7 +10626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10660,7 +10660,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10694,7 +10694,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10728,7 +10728,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10762,7 +10762,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10796,7 +10796,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10830,7 +10830,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10864,7 +10864,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10900,7 +10900,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10936,7 +10936,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10972,7 +10972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11008,7 +11008,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11044,7 +11044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11080,7 +11080,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11116,7 +11116,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11152,7 +11152,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11188,7 +11188,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11224,7 +11224,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11260,7 +11260,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11296,7 +11296,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11332,7 +11332,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11368,7 +11368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11404,7 +11404,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11440,7 +11440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11476,7 +11476,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11512,7 +11512,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11546,7 +11546,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11580,7 +11580,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11614,7 +11614,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11648,7 +11648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11682,7 +11682,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11716,7 +11716,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11750,7 +11750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11784,7 +11784,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11818,7 +11818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11852,7 +11852,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11886,7 +11886,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11920,7 +11920,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11954,7 +11954,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11988,7 +11988,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12022,7 +12022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12056,7 +12056,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12125,7 +12125,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12159,7 +12159,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12193,7 +12193,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12227,7 +12227,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12261,7 +12261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12295,7 +12295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12329,7 +12329,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12363,7 +12363,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12397,7 +12397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12431,7 +12431,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12465,7 +12465,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12499,7 +12499,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12533,7 +12533,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12567,7 +12567,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12601,7 +12601,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12635,7 +12635,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12669,7 +12669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12703,7 +12703,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12737,7 +12737,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12771,7 +12771,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12805,7 +12805,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12839,7 +12839,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12873,7 +12873,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12907,7 +12907,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12941,7 +12941,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12975,7 +12975,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13009,7 +13009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13043,7 +13043,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13077,7 +13077,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13111,7 +13111,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13145,7 +13145,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13179,7 +13179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13213,7 +13213,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13247,7 +13247,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13281,7 +13281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13315,7 +13315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13386,7 +13386,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13422,7 +13422,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13458,7 +13458,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13494,7 +13494,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13530,7 +13530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13566,7 +13566,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13602,7 +13602,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13638,7 +13638,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13674,7 +13674,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13710,7 +13710,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13746,7 +13746,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13782,7 +13782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13818,7 +13818,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13854,7 +13854,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13890,7 +13890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13926,7 +13926,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13962,7 +13962,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13998,7 +13998,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14034,7 +14034,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14070,7 +14070,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14106,7 +14106,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14142,7 +14142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14178,7 +14178,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14214,7 +14214,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14250,7 +14250,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14286,7 +14286,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14322,7 +14322,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14358,7 +14358,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14394,7 +14394,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14430,7 +14430,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14464,7 +14464,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14498,7 +14498,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14532,7 +14532,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14566,7 +14566,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14600,7 +14600,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14634,7 +14634,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14668,7 +14668,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14702,7 +14702,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14736,7 +14736,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14770,7 +14770,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14804,7 +14804,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14838,7 +14838,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14872,7 +14872,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14906,7 +14906,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14940,7 +14940,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14974,7 +14974,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15008,7 +15008,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15042,7 +15042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15076,7 +15076,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15111,7 +15111,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15145,7 +15145,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15179,7 +15179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15213,7 +15213,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15247,7 +15247,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15281,7 +15281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15315,7 +15315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15349,7 +15349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15383,7 +15383,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15417,7 +15417,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15451,7 +15451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15485,7 +15485,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15519,7 +15519,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15553,7 +15553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15587,7 +15587,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15621,7 +15621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15655,7 +15655,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15689,7 +15689,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15762,7 +15762,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15835,7 +15835,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15869,7 +15869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15903,7 +15903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15937,7 +15937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15971,7 +15971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16005,7 +16005,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16039,7 +16039,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16073,7 +16073,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16107,7 +16107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16145,7 +16145,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16179,7 +16179,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16213,7 +16213,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16247,7 +16247,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16281,7 +16281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16315,7 +16315,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16349,7 +16349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16383,7 +16383,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16417,7 +16417,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16451,7 +16451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16485,7 +16485,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16519,7 +16519,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16553,7 +16553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16587,7 +16587,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16621,7 +16621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16655,7 +16655,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16689,7 +16689,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16723,7 +16723,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16757,7 +16757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16793,7 +16793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16829,7 +16829,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16865,7 +16865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16901,7 +16901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16937,7 +16937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16973,7 +16973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17009,7 +17009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17045,7 +17045,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17081,7 +17081,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17117,7 +17117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17153,7 +17153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17189,7 +17189,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17226,7 +17226,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17262,7 +17262,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17298,7 +17298,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17334,7 +17334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17370,7 +17370,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17406,7 +17406,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17442,7 +17442,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17478,7 +17478,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17514,7 +17514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17550,7 +17550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17586,7 +17586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17622,7 +17622,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17658,7 +17658,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17694,7 +17694,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17730,7 +17730,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17764,7 +17764,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17800,7 +17800,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17843,7 +17843,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18062,7 +18062,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18105,7 +18105,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18148,7 +18148,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18191,7 +18191,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18234,7 +18234,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18277,7 +18277,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18318,7 +18318,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18475,7 +18475,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18514,7 +18514,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18553,7 +18553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18592,7 +18592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18631,7 +18631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18670,7 +18670,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18709,7 +18709,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18748,7 +18748,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18787,7 +18787,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18826,7 +18826,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18865,7 +18865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18904,7 +18904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18943,7 +18943,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18982,7 +18982,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19021,7 +19021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19060,7 +19060,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19099,7 +19099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19138,7 +19138,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19177,7 +19177,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19216,7 +19216,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19255,7 +19255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19294,7 +19294,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19333,7 +19333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19372,7 +19372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19411,7 +19411,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19450,7 +19450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19489,7 +19489,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19528,7 +19528,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19567,7 +19567,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19606,7 +19606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19645,7 +19645,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19684,7 +19684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19758,7 +19758,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -19795,7 +19795,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -19832,7 +19832,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --repo=k8s.io/kubernetes=release-1.9
       - --timeout=90
@@ -19869,7 +19869,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -19906,7 +19906,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -19943,7 +19943,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -19980,7 +19980,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -20017,7 +20017,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -20054,7 +20054,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.8
       args:
       - --repo=k8s.io/kubernetes=release-1.8
       - --timeout=90
@@ -20091,7 +20091,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -20128,7 +20128,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -20178,7 +20178,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20213,7 +20213,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20248,7 +20248,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20283,7 +20283,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20318,7 +20318,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20353,7 +20353,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20388,7 +20388,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20423,7 +20423,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20446,7 +20446,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -20482,7 +20482,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171201-f8fa79b46-master'
+DEFAULT_KUBEKINS_TAG = 'v20171204-8e1bbdcba-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
e.option is the first match from `^gke-?(default|latest)?$`, and e.value is the full name of the string.

/area kubetest
/hold