### PR TITLE
Fix ci-kubemark images

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -19706,7 +19706,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
       imagePullPolicy: Always
       args:
       - --bare
@@ -19755,7 +19755,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
       imagePullPolicy: Always
       args:
       - --bare
@@ -19804,7 +19804,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
       imagePullPolicy: Always
       args:
       - --bare
@@ -19853,7 +19853,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
       imagePullPolicy: Always
       args:
       - --bare
@@ -19954,7 +19954,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171108-8b5aad9f-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171201-f8fa79b46-master
       imagePullPolicy: Always
       args:
       - --bare


### PR DESCRIPTION
whoops - patch up https://github.com/kubernetes/test-infra/pull/5747 for the outdated image tags

(the old one does not have dind yet)

/assign @BenTheElder @shyamjvs 