### PR TITLE
ensure that timestamps do not contain magical substring

### DIFF
--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -78,6 +78,11 @@ class MakeJsonTest(unittest.TestCase):
                      {'name': 't2', 'time': 2.0}])
 
     def test_main(self):
+        # these tests look for dissallowed substrings in the json, so we guarantee
+        # a fixed timestamp that will not produce them :shrug:
+        # https://github.com/kubernetes/test-infra/issues/4825
+        time.time = lambda: 1512507930.230854
+
         now = time.time()
         last_month = now - (60 * 60 * 24 * 30)
         junits = ['<testsuite><testcase name="t1" time="3.0"></testcase></testsuite>']


### PR DESCRIPTION
every case in https://github.com/kubernetes/test-infra/issues/4825 has contained "456" in a timestamp, so just banish that substring from the (testing value) timestamps, since sometime time.time() does actually contain 456...

/area kettle
/shrug