### PR TITLE
rename kubemark-latest cluster name

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9307,7 +9307,7 @@
   },
   "ci-kubernetes-kubemark-5-gce-last-release": {
     "args": [
-      "--cluster=kubemark-5-old",
+      "--cluster=kubemark-latest",
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest-1.9",


### PR DESCRIPTION
similar as https://github.com/kubernetes/test-infra/pull/5795, the problem is:

`ci-kubernetes-kubemark-5-gce` has `--cluster=kubemark-5`
`ci-kubernetes-kubemark-5-gce-last-release` has ``--cluster=kubemark-5-old`

I believe kube-down looks for cluster prefix, and when tearing down `kubemark-5-*`, anything with `kubemark-5-old` will be affected as well.

simply rename the cluster to avoid the issue.

/assign @bentheelder @shyamjvs

