### PR TITLE
log image name:tag when running bootstrap jobs

### DIFF
--- a/images/bazelbuild/Dockerfile
+++ b/images/bazelbuild/Dockerfile
@@ -14,7 +14,12 @@
 
 # Includes git, gcloud, and bazel.
 FROM ubuntu:16.04
-LABEL maintainer="spxtr@google.com"
+# TODO(bentheelder): consider replacing all maintainers with a test-infra-maintainers alias of some sort
+LABEL maintainer="bentheelder@google.com"
+
+# add env we can debug with the image name:tag
+ARG IMAGE
+ENV IMAGE=${IMAGE}
 
 ARG BAZEL_VERSION
 

--- a/images/bazelbuild/Makefile
+++ b/images/bazelbuild/Makefile
@@ -22,7 +22,7 @@ BAZEL_VERSIONS=0.5.2 0.5.4 0.6.1 0.7.0 $(LATEST_BAZEL_VERSION)
 all: build
 
 do_build = \
-	docker build --pull --build-arg BAZEL_VERSION=$(VERSION) -t $(IMG):$(TAG)-$(VERSION) .;\
+	docker build --pull --build-arg BAZEL_VERSION=$(VERSION) --build-arg IMAGE=$(IMG):$(TAG)-$(VERSION) -t $(IMG):$(TAG)-$(VERSION) .;\
 	docker tag $(IMG):$(TAG)-$(VERSION) $(IMG):latest-$(VERSION);\
 	echo Built $(IMG):$(TAG)-$(VERSION) and tagged with latest-$(VERSION);\
 	[ "$(VERSION)" == "$(LATEST_BAZEL_VERSION)" ] &&\

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -22,6 +22,10 @@ RUN mkdir -p /workspace
 ENV WORKSPACE=/workspace \
     TERM=xterm
 
+# add env we can debug with the image name:tag
+ARG IMAGE
+ENV IMAGE=${IMAGE}
+
 # common util tools
 # https://github.com/GoogleCloudPlatform/gsutil/issues/446 for python-openssl
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/images/bootstrap/Makefile
+++ b/images/bootstrap/Makefile
@@ -18,7 +18,7 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 all: build
 
 build:
-	docker build --no-cache -t $(IMG):$(TAG) .
+	docker build --build-arg IMAGE=$(IMG):$(TAG) -t $(IMG):$(TAG) .
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):$(TAG) and tagged with latest
 

--- a/images/gcloud/Dockerfile
+++ b/images/gcloud/Dockerfile
@@ -16,6 +16,10 @@
 FROM golang:1.9
 LABEL maintainer="senlu@google.com"
 
+# add env we can debug with the image name:tag
+ARG IMAGE
+ENV IMAGE=${IMAGE}
+
 RUN apt-get update && apt-get install -y \
     python \
     rsync \

--- a/images/gcloud/Makefile
+++ b/images/gcloud/Makefile
@@ -15,7 +15,7 @@
 VERSION = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 image:
-	docker build -t "gcr.io/k8s-testimages/gcloud-in-go:$(VERSION)" .
+	docker build --build-arg IMAGE="gcr.io/k8s-testimages/gcloud-in-go:$(VERSION)" -t "gcr.io/k8s-testimages/gcloud-in-go:$(VERSION)" .
 
 push: image
 	gcloud docker -- push "gcr.io/k8s-testimages/gcloud-in-go:$(VERSION)"

--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -653,6 +653,7 @@ NODE_ENV = 'NODE_NAME'
 SERVICE_ACCOUNT_ENV = 'GOOGLE_APPLICATION_CREDENTIALS'
 WORKSPACE_ENV = 'WORKSPACE'
 GCS_ARTIFACTS_ENV = 'GCS_ARTIFACTS_DIR'
+IMAGE_NAME_ENV = 'IMAGE'
 
 
 def build_name(started):
@@ -907,6 +908,8 @@ def bootstrap(args):
     gsutil = GSUtil(call)
 
     logging.info('Bootstrap %s...', job)
+    if IMAGE_NAME_ENV in os.environ:
+        logging.info('Image: %s', os.environ[IMAGE_NAME_ENV])
     build = build_name(started)
 
     if upload:

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -49,6 +49,10 @@ RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
     wget -q "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}" && \
     chmod +x "${INSTALLER}" && "./${INSTALLER}" && rm "${INSTALLER}"
 
+# add env we can debug with the image name:tag
+ARG IMAGE
+ENV IMAGE=${IMAGE}}
+
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \
     "kubetest", \

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -46,7 +46,7 @@ kubetest:
 
 build: kubetest
 	@echo Building with go:$(GO) and bazel:$(BAZEL)
-	docker build --build-arg GO_VERSION=$(GO) --build-arg BAZEL_VERSION=$(BAZEL) --build-arg CFSSL_VERSION=$(CFSSL) -t $(IMG):$(TAG)-$(K8S) .
+	docker build --build-arg GO_VERSION=$(GO) --build-arg BAZEL_VERSION=$(BAZEL) --build-arg CFSSL_VERSION=$(CFSSL) --build-arg IMAGE=$(IMG):$(TAG)-$(K8S) -t $(IMG):$(TAG)-$(K8S) .
 	docker tag $(IMG):$(TAG)-$(K8S) $(IMG):latest-$(K8S)
 	rm kubetest
 	@echo Built $(IMG):$(TAG)-$(K8S) and tagged with latest-$(K8S)


### PR DESCRIPTION
this should supersede https://github.com/kubernetes/test-infra/pull/5241

- add an `$IMAGE` build arg / env to every image we run with bootstrap and update the makefiles to supply the arg
- make bootstrap check for this env and log it early on when it exists

This will allow us to determine which version of an image a job ran with from the build logs.

/area images
/area bootstrap