### PR TITLE
Make it possible to manually trigger RunIfChanged jobs that do not need to run.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -20,7 +20,7 @@ ALPINE_VERSION           ?= 0.1
 # GIT_VERSION is the version of the alpine+git image
 GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
-HOOK_VERSION             ?= 0.184
+HOOK_VERSION             ?= 0.185
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.24
 # DECK_VERSION is the version of the deck image

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.184
+        image: gcr.io/k8s-prow/hook:0.185
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:0.184
+        image: gcr.io/k8s-prow/hook:0.185
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -214,7 +214,7 @@ func TestHandleIssueComment(t *testing.T) {
 			},
 		},
 		{
-			name:   "Retest of run_if_changed job that hasn't run",
+			name:   "Retest of run_if_changed job that hasn't run. Changes require job",
 			Author: "t",
 			Body:   "/retest",
 			State:  "open",
@@ -234,7 +234,7 @@ func TestHandleIssueComment(t *testing.T) {
 			StartsExactly: "pull-jab",
 		},
 		{
-			name:   "Retest of run_if_changed job that failed",
+			name:   "Retest of run_if_changed job that failed. Changes require job",
 			Author: "t",
 			Body:   "/retest",
 			State:  "open",
@@ -272,7 +272,7 @@ func TestHandleIssueComment(t *testing.T) {
 			StartsExactly: "pull-jub",
 		},
 		{
-			name:   "Retest should 'skip' run_if_changed job that doesn't need to run on the changes",
+			name:   "Retest of run_if_changed job that failed. Changes do not require the job",
 			Author: "t",
 			Body:   "/retest",
 			State:  "open",
@@ -287,25 +287,7 @@ func TestHandleIssueComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldReport: true,
-		},
-		{
-			name:   "Retest should not build/report run_if_changed SkipReport job that doesn't need to run on the changes",
-			Author: "t",
-			Body:   "/retest",
-			State:  "open",
-			IsPR:   true,
-			Presubmits: map[string][]config.Presubmit{
-				"org/repo": {
-					{
-						Name:         "jib",
-						RunIfChanged: "CHANGED2",
-						SkipReport:   true,
-						Context:      "pull-jib",
-						Trigger:      `/test all`,
-					},
-				},
-			},
+			ShouldBuild: true,
 		},
 		{
 			name:       "Run if changed job triggered by /ok-to-test",
@@ -351,8 +333,32 @@ func TestHandleIssueComment(t *testing.T) {
 				},
 			},
 			ShouldBuild:   true,
-			ShouldReport:  true,
 			StartsExactly: "pull-jab",
+		},
+		{
+			name:   "branch-sharded job. no shard matches base branch",
+			Author: "t",
+			Branch: "branch",
+			Body:   "/test jab",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						Name:     "jab",
+						Brancher: config.Brancher{Branches: []string{"master"}},
+						Context:  "pull-jab",
+						Trigger:  `/test jab`,
+					},
+					{
+						Name:     "jab",
+						Brancher: config.Brancher{Branches: []string{"release"}},
+						Context:  "pull-jab",
+						Trigger:  `/test jab`,
+					},
+				},
+			},
+			ShouldReport: true,
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
fixes #5833
discussion ref #5655 
/cc @BenTheElder @stevekuznetsov 

Also fixes #5069 
The first bullet in that issue should already be fixed by previous PRs. The second bullet should be fixed by this PR:
> In kubernetes/kubernetes#54051 I observed that upon /test pull-kubernetes-bazel-test, pull-kubernetes-bazel-test jumped down to green with "skipped" for ~30s (ish?) before it went to "job triggered"

It looks like the problem was probably branch-sharded jobs. Versions of the job that don't apply to the branch would mark the context as "Skipped" before `plank` could create/report the prowjob for the version that is actually supposed to run.