### PR TITLE
set an env in the e2e image that kubetest can check to know when it i…

### DIFF
--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -18,6 +18,8 @@
 FROM gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
 LABEL maintainer "Sen Lu <senlu@google.com>"
 
+ENV KUBETEST_IN_DOCKER="true"
+
 # install cfssl to prevent https://github.com/kubernetes/kubernetes/issues/55589
 # The invocation at the end is to prevent download failures downloads as in the bug.
 # TODO(porridge): bump CFSSL_VERSION to one where cfssljson supports the -version flag and test it as well.

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -302,6 +302,11 @@ func main() {
 		log.Fatalf("Flags validation failed. err: %v", err)
 	}
 
+	// do things when we know we are running in the CI (see the kubetest image)
+	if os.Getenv("KUBETEST_IN_DOCKER") == "true" {
+		o.flushMemAfterBuild = true
+	}
+
 	err := complete(o)
 
 	if boskos.HasResource() {


### PR DESCRIPTION
…s in CI

and enable flushing memory after build when it is detected

/area kubetest
/area images

replaces: https://github.com/kubernetes/test-infra/pull/5813