### PR TITLE
migrate unit and verify to prow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1997,11 +1997,54 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
   - name: pull-kubernetes-unit
-    agent: jenkins
+    agent: kubernetes
     always_run: true
     context: pull-kubernetes-unit
     rerun_command: "/test pull-kubernetes-unit"
     trigger: "(?m)^/test( all| pull-kubernetes-unit),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=60"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        - name: docker-graph
+          mountPath: /docker-graph
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
   - name: pull-kubernetes-unit-prow
     agent: kubernetes
     always_run: false
@@ -2053,11 +2096,48 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
   - name: pull-kubernetes-verify
-    agent: jenkins
+    agent: kubernetes
     always_run: true
     context: pull-kubernetes-verify
     rerun_command: "/test pull-kubernetes-verify"
     trigger: "(?m)^/test( all| pull-kubernetes-verify),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
   - name: pull-kubernetes-verify-prow
     agent: kubernetes
     always_run: false
@@ -3640,11 +3720,54 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
   - name: pull-security-kubernetes-unit
-    agent: jenkins
+    agent: kubernetes
     always_run: true
     context: pull-security-kubernetes-unit
     rerun_command: "/test pull-security-kubernetes-unit"
     trigger: "(?m)^/test( all| pull-security-kubernetes-unit),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+        args:
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=60"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        - name: docker-graph
+          mountPath: /docker-graph
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
   - name: pull-security-kubernetes-unit-prow
     agent: kubernetes
     always_run: false
@@ -3696,11 +3819,48 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
   - name: pull-security-kubernetes-verify
-    agent: jenkins
+    agent: kubernetes
     always_run: true
     context: pull-security-kubernetes-verify
     rerun_command: "/test pull-security-kubernetes-verify"
     trigger: "(?m)^/test( all| pull-security-kubernetes-verify),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+        args:
+        - "--clean"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=75"
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: docker-graph
+          mountPath: /docker-graph
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            cpu: 4
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
   - name: pull-security-kubernetes-verify-prow
     agent: kubernetes
     always_run: false


### PR DESCRIPTION
The canary jobs have been tested pretty extensively and have only been failing on flakes that appear to just be individual integration / verify test failures that can also happen on the Jenkins versions.

These jobs run ~ the same way as the Jenkins ones for now, just using docker in docker in bootstrap instead of the Jenkins VM docker. (they also mount a tmpfs to /tmp to fix some flaky tests using temp dirs)

/area jobs
/hold