### PR TITLE
Add SELinux flags needed for full volume access

### DIFF
--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -24,7 +24,7 @@ IMAGE="${IMAGE_NAME}:${TAG}"
 # run our docker image as the host user with bazel cache and current repo dir
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)
 REPO=${REPO:-${PWD}}
-VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --tmpfs /tmp:exec,mode=777"
+VOLUMES="-v ${REPO}:${REPO}:Z -v ${HOME}:${HOME}:Z --tmpfs /tmp:exec,mode=777"
 GID="$(id -g ${USER})"
 ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
 # the final command to run


### PR DESCRIPTION
Without `:Z` the SELinux-enabled system won't be able to write to home or any of the mounted volumes. 

@BenTheElder ptal 