### PR TITLE
Disable pushing metrics to push gateway to stop error spam.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -42,9 +42,6 @@ tide:
     - do-not-merge/hold
     reviewApprovedRequired: true
 
-push_gateway:
-  endpoint: pushgateway
-
 presubmits:
   google/cadvisor:
   - name: pull-cadvisor-e2e


### PR DESCRIPTION
The fix we tried didn't seem to work: https://github.com/kubernetes/test-infra/pull/5767#issuecomment-348648910

We haven't been able to figure out why this error is occurring, but it is making the `plank` and `jenkins-operator` logs pretty difficult to use so we need to disable pushing metrics to the gateway until the problem is resolved.

/assign @Q-Lee 
ref #5764 