### PR TITLE
Fix handling of GOPATH which is now optional since Go 1.8

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -514,8 +514,7 @@ func dumpFederationLogs(location string) error {
 
 func perfTest() error {
 	// Run perf tests
-	// TODO(fejta): GOPATH may be split by :
-	cmdline := fmt.Sprintf("%s/src/k8s.io/perf-tests/clusterloader/run-e2e.sh", os.Getenv("GOPATH"))
+	cmdline := k8s("perf-tests", "clusterloader", "run-e2e.sh")
 	if err := finishRunning(exec.Command(cmdline)); err != nil {
 		return err
 	}
@@ -524,7 +523,7 @@ func perfTest() error {
 
 func chartsTest() error {
 	// Run helm tests.
-	cmdline := fmt.Sprintf("%s/src/k8s.io/charts/test/helm-test-e2e.sh", os.Getenv("GOPATH"))
+	cmdline := k8s("charts", "test", "helm-test-e2e.sh")
 	return finishRunning(exec.Command(cmdline))
 }
 
@@ -543,7 +542,7 @@ func nodeTest(nodeArgs []string, testArgs, nodeTestArgs, project, zone string) e
 	// prep node args
 	runner := []string{
 		"run",
-		fmt.Sprintf("%s/src/k8s.io/kubernetes/test/e2e_node/runner/remote/run_remote.go", os.Getenv("GOPATH")),
+		k8s("kubernetes", "test", "e2e_node", "runner", "remote", "run_remote.go"),
 		"--cleanup",
 		"--logtostderr",
 		"--vmodule=*=4",

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -207,14 +207,6 @@ func validWorkingDirectory() error {
 	return nil
 }
 
-func validGoEnv() error {
-	gp := os.Getenv("GOPATH")
-	if gp == "" {
-		return fmt.Errorf("GOPATH not set, please check your golang env setting.")
-	}
-	return nil
-}
-
 func writeXML(dump string, start time.Time) {
 	// Note whether timeout occurred
 	c := testCase{
@@ -386,10 +378,6 @@ func complete(o *options) error {
 	}
 	if err := validWorkingDirectory(); err != nil {
 		return fmt.Errorf("called from invalid working directory: %v", err)
-	}
-
-	if err := validGoEnv(); err != nil {
-		return fmt.Errorf("invalid Go Env: %v", err)
 	}
 
 	if o.down {


### PR DESCRIPTION
@fejta 

Much of this code depended on $GOPATH being set and would fail with hard
to debug messages otherwise.

Since Go 1.8 the $GOPATH environment variable is no longer necessary and
will default to ~/go (on Unix and Linux systems.)

Update this code to use the "go/build" package and more specifically the
build.Default context to find the GOPATH. (Tested this with a $GOPATH
set and confirmed it reflects it.)

Furthermore, split paths (in case $GOPATH contains multiple paths
separated by a ":" delimiter) and use the appropriate one in case there
are more than one. In that case, look for ${gopath}/src/k8s.io/${topdir}
and pick the first one that exists. If none of them do, default to using
the first entry in $GOPATH.

Tested: by running `make test-e2e` from the top of Kubernetes repository
with $GOPATH unset in the environment. Confirmed that the
`make -C ${k8spath} quick-release` command spawn by kubetest would use
an absolute path to my ~/go tree.