### PR TITLE
Test PVC Protection in ci-kubernetes-e2e-gci-gce-alpha-features

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -4099,7 +4099,7 @@
       "--gcp-node-image=gci",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:(Audit|LocalPersistentVolumes|FlexVolume|PodPreset|MountPropagation)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6 --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Feature:(Audit|LocalPersistentVolumes|FlexVolume|PodPreset|MountPropagation|PVCProtection)\\]|Networking --ginkgo.skip=Networking-Performance|IPv6 --minStartupPods=8",
       "--timeout=180m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
PVC Protection alpha feature was merged into K8s 1.9 in PRs:
- https://github.com/kubernetes/kubernetes/pull/55824
- https://github.com/kubernetes/kubernetes/pull/55873

PVC Protection E2E tests are in PR: https://github.com/kubernetes/kubernetes/pull/56931

Adding the PVC Protection tests into the list of Alpha feature tests that are run.