### PR TITLE
Allow org members to trigger testing in their own org.

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -27,7 +27,7 @@ const botName = "k8s-ci-robot"
 
 type FakeClient struct {
 	Issues              []github.Issue
-	OrgMembers          []string
+	OrgMembers          map[string][]string
 	Collaborators       []string
 	IssueComments       map[int][]github.IssueComment
 	IssueCommentID      int
@@ -67,7 +67,7 @@ func (f *FakeClient) BotName() (string, error) {
 }
 
 func (f *FakeClient) IsMember(org, user string) (bool, error) {
-	for _, m := range f.OrgMembers {
+	for _, m := range f.OrgMembers[org] {
 		if m == user {
 			return true, nil
 		}

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -323,7 +323,7 @@ func TestLabel(t *testing.T) {
 			Issues:         make([]github.Issue, 1),
 			IssueComments:  make(map[int][]github.IssueComment),
 			ExistingLabels: tc.repoLabels,
-			OrgMembers:     []string{orgMember},
+			OrgMembers:     map[string][]string{"org": {orgMember}},
 			LabelsAdded:    []string{},
 			LabelsRemoved:  []string{},
 		}

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -159,7 +159,7 @@ func TestReleaseNoteComment(t *testing.T) {
 	for _, tc := range testcases {
 		fc := &fakegithub.FakeClient{
 			IssueComments: make(map[int][]github.IssueComment),
-			OrgMembers:    []string{"m"},
+			OrgMembers:    map[string][]string{"": {"m"}},
 		}
 		ice := github.IssueCommentEvent{
 			Action: tc.action,

--- a/prow/plugins/sigmention/sigmention_test.go
+++ b/prow/plugins/sigmention/sigmention_test.go
@@ -139,7 +139,7 @@ func TestSigMention(t *testing.T) {
 
 	for _, tc := range testcases {
 		fakeClient := &fakegithub.FakeClient{
-			OrgMembers:     []string{orgMember, bot},
+			OrgMembers:     map[string][]string{"org": {orgMember, bot}},
 			ExistingLabels: tc.repoLabels,
 			IssueComments:  make(map[int][]github.IssueComment),
 		}

--- a/prow/plugins/trigger/ic_test.go
+++ b/prow/plugins/trigger/ic_test.go
@@ -369,7 +369,7 @@ func TestHandleIssueComment(t *testing.T) {
 		g := &fakegithub.FakeClient{
 			CreatedStatuses: map[string][]github.Status{},
 			IssueComments:   map[int][]github.IssueComment{},
-			OrgMembers:      []string{"t"},
+			OrgMembers:      map[string][]string{"org": {"t"}},
 			PullRequests: map[int]*github.PullRequest{
 				0: {
 					Number: 0,
@@ -379,7 +379,8 @@ func TestHandleIssueComment(t *testing.T) {
 					Base: github.PullRequestBranch{
 						Ref: tc.Branch,
 						Repo: github.Repo{
-							Name: "repo",
+							Owner: github.User{Login: "org"},
+							Name:  "repo",
 						},
 					},
 				},
@@ -437,6 +438,7 @@ func TestHandleIssueComment(t *testing.T) {
 		event := github.IssueCommentEvent{
 			Action: github.IssueCommentActionCreated,
 			Repo: github.Repo{
+				Owner:    github.User{Login: "org"},
 				Name:     "repo",
 				FullName: "org/repo",
 			},
@@ -474,8 +476,9 @@ func TestHandleIssueComment(t *testing.T) {
 				t.Errorf("expected a label to be removed")
 				continue
 			}
-			if g.LabelsRemoved[0] != "/repo#0:needs-ok-to-test" {
-				t.Errorf("expected %q to be removed, got %q", "/repo#0:needs-ok-to-test", g.LabelsRemoved[0])
+			expected := "org/repo#0:needs-ok-to-test"
+			if g.LabelsRemoved[0] != expected {
+				t.Errorf("expected %q to be removed, got %q", expected, g.LabelsRemoved[0])
 			}
 		}
 	}

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -115,3 +115,19 @@ func trustedOrgForRepo(config *plugins.Configuration, org, repo string) string {
 	}
 	return org
 }
+
+func isUserTrusted(ghc githubClient, user, trustedOrg, org string) (bool, error) {
+	orgMember, err := ghc.IsMember(trustedOrg, user)
+	if err != nil {
+		return false, err
+	} else if orgMember {
+		return true, nil
+	}
+	if org != trustedOrg {
+		orgMember, err = ghc.IsMember(org, user)
+		if err != nil {
+			return false, err
+		}
+	}
+	return orgMember, nil
+}


### PR DESCRIPTION
fixes #5793 

This could increase API token usage a decent amount if lots of non-members try to trigger testing, but I think it will be fine.

/cc @kargakis 
/area prow
FYI @xiangpengzhao 