### PR TITLE
Disable advanced audit logs in large clusters env.

### DIFF
--- a/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-large-correctness.env
@@ -20,5 +20,7 @@ CONTROLLER_MANAGER_TEST_ARGS=--concurrent-service-syncs=5
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+# Turn off advanced audit until we implement streaming of audit logs.
+ENABLE_APISERVER_ADVANCED_AUDIT=false
 
 ### test-env

--- a/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-scale-correctness.env
@@ -24,5 +24,7 @@ APISERVER_TEST_ARGS=--max-requests-inflight=1500 --max-mutating-requests-infligh
 TEST_CLUSTER_RESYNC_PERIOD=--min-resync-period=12h
 # Increase apiserver's delete collection parallelism
 TEST_CLUSTER_DELETE_COLLECTION_WORKERS=--delete-collection-workers=16
+# Turn off advanced audit until we implement streaming of audit logs.
+ENABLE_APISERVER_ADVANCED_AUDIT=false
 
 ### test-env


### PR DESCRIPTION
Due to problems with large clusters, advanced audit logs test currently
disabled for them.