### PR TITLE
Add skip plugin

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -697,15 +697,27 @@ func (c *Client) ListReviews(org, repo string, number int) ([]Review, error) {
 }
 
 // CreateStatus creates or updates the status of a commit.
-func (c *Client) CreateStatus(org, repo, ref string, s Status) error {
-	c.log("CreateStatus", org, repo, ref, s)
+func (c *Client) CreateStatus(org, repo, sha string, s Status) error {
+	c.log("CreateStatus", org, repo, sha, s)
 	_, err := c.request(&request{
 		method:      http.MethodPost,
-		path:        fmt.Sprintf("%s/repos/%s/%s/statuses/%s", c.base, org, repo, ref),
+		path:        fmt.Sprintf("%s/repos/%s/%s/statuses/%s", c.base, org, repo, sha),
 		requestBody: &s,
 		exitCodes:   []int{201},
 	}, nil)
 	return err
+}
+
+// ListStatuses gets commit statuses for a given ref.
+func (c *Client) ListStatuses(org, repo, ref string) ([]Status, error) {
+	c.log("ListStatuses", org, repo, ref)
+	var statuses []Status
+	_, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      fmt.Sprintf("%s/repos/%s/%s/statuses/%s", c.base, org, repo, ref),
+		exitCodes: []int{200},
+	}, &statuses)
+	return statuses, err
 }
 
 // GetRepo returns the repo for the provided owner/name combination.

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -151,9 +151,27 @@ func (f *FakeClient) GetRef(owner, repo, ref string) (string, error) {
 	return "abcde", nil
 }
 
-func (f *FakeClient) CreateStatus(owner, repo, ref string, s github.Status) error {
-	f.CreatedStatuses[ref] = append(f.CreatedStatuses[ref], s)
+func (f *FakeClient) CreateStatus(owner, repo, sha string, s github.Status) error {
+	if f.CreatedStatuses == nil {
+		f.CreatedStatuses = make(map[string][]github.Status)
+	}
+	statuses := f.CreatedStatuses[sha]
+	var updated bool
+	for i := range statuses {
+		if statuses[i].Context == s.Context {
+			statuses[i] = s
+			updated = true
+		}
+	}
+	if !updated {
+		statuses = append(statuses, s)
+	}
+	f.CreatedStatuses[sha] = statuses
 	return nil
+}
+
+func (f *FakeClient) ListStatuses(org, repo, ref string) ([]github.Status, error) {
+	return f.CreatedStatuses[ref], nil
 }
 
 func (f *FakeClient) GetCombinedStatus(owner, repo, ref string) (*github.CombinedStatus, error) {

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//prow/plugins/shrug:go_default_library",
         "//prow/plugins/sigmention:go_default_library",
         "//prow/plugins/size:go_default_library",
+        "//prow/plugins/skip:go_default_library",
         "//prow/plugins/slackevents:go_default_library",
         "//prow/plugins/trigger:go_default_library",
         "//prow/plugins/updateconfig:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -38,6 +38,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/shrug"
 	_ "k8s.io/test-infra/prow/plugins/sigmention"
 	_ "k8s.io/test-infra/prow/plugins/size"
+	_ "k8s.io/test-infra/prow/plugins/skip"
 	_ "k8s.io/test-infra/prow/plugins/slackevents"
 	_ "k8s.io/test-infra/prow/plugins/trigger"
 	_ "k8s.io/test-infra/prow/plugins/updateconfig"

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -68,6 +68,7 @@ filegroup(
         "//prow/plugins/shrug:all-srcs",
         "//prow/plugins/sigmention:all-srcs",
         "//prow/plugins/size:all-srcs",
+        "//prow/plugins/skip:all-srcs",
         "//prow/plugins/slackevents:all-srcs",
         "//prow/plugins/trigger:all-srcs",
         "//prow/plugins/updateconfig:all-srcs",

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -44,7 +44,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	// The Config field is omitted because this plugin is not configurable.
 	return &pluginhelp.PluginHelp{
 			Description: "The label plugin provides commands that add or remove certain types of labels. Labels of the following types can be manipulated: 'area/*', 'priority/*', 'kind/*', and 'sig/*'.",
-			WhoCanUse:   "Members of the repository's organization may use the label commands.",
+			WhoCanUse:   "Anyone can trigger this plugin on a PR.",
 			Usage:       "/[remove-](area|priority|kind|sig) <target>",
 			Examples:    []string{"/kind bug", "/remove-area prow", "/sig testing"},
 		},
@@ -57,7 +57,6 @@ func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent)
 
 type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
-	IsMember(org, user string) (bool, error)
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
 	GetRepoLabels(owner, repo string) ([]github.Label, error)

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"

--- a/prow/plugins/skip/BUILD
+++ b/prow/plugins/skip/BUILD
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["skip.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/skip",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["skip_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/plugins/skip",
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package skip implements the `/skip` command which allows users
+// to clean up commit statuses of non-blocking presubmits on PRs.
+package skip
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "skip"
+
+var (
+	skipRe = regexp.MustCompile(`(?mi)^/skip\s*$`)
+)
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	CreateStatus(org, repo, ref string, s github.Status) error
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
+	ListStatuses(org, repo, ref string) ([]github.Status, error)
+}
+
+func init() {
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	return &pluginhelp.PluginHelp{
+			Description: "The skip plugin allows users to clean up Github stale commit statuses for non-blocking jobs on a PR.",
+			WhoCanUse:   "Anyone can trigger this plugin on a PR.",
+			Usage:       "/skip",
+			Examples:    []string{"/skip"},
+		},
+		nil
+}
+
+func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+	return handle(pc.GitHubClient, pc.Logger, &e, pc.Config.Presubmits[e.Repo.FullName])
+}
+
+func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, presubmits []config.Presubmit) error {
+	if !e.IsPR || e.IssueState != "open" || e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
+	if !skipRe.MatchString(e.Body) {
+		return nil
+	}
+
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	number := e.Number
+
+	pr, err := gc.GetPullRequest(org, repo, number)
+	if err != nil {
+		resp := fmt.Sprintf("Cannot get PR #%d in %s/%s: %v", number, org, repo, err)
+		log.Warn(resp)
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
+	}
+
+	changesFull, err := gc.GetPullRequestChanges(org, repo, number)
+	if err != nil {
+		resp := fmt.Sprintf("Cannot get changes for PR #%d in %s/%s: %v", number, org, repo, err)
+		log.Warn(resp)
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
+	}
+	var changes []string
+	for _, change := range changesFull {
+		changes = append(changes, change.Filename)
+	}
+
+	statuses, err := gc.ListStatuses(org, repo, pr.Head.SHA)
+	if err != nil {
+		resp := fmt.Sprintf("Cannot get commit statuses for PR #%d in %s/%s: %v", number, org, repo, err)
+		log.Warn(resp)
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
+	}
+
+	for _, job := range presubmits {
+		// Ignore blocking jobs.
+		if job.AlwaysRun {
+			continue
+		}
+		// Ignore jobs that need to run against the PR changes.
+		if job.RunIfChanged != "" && job.RunsAgainstChanges(changes) {
+			continue
+		}
+		// Ignore jobs that do not report already.
+		if job.SkipReport {
+			continue
+		}
+		// Ignore jobs that have a green status.
+		if !isNotSuccess(job, statuses) {
+			continue
+		}
+		context := job.Context
+		status := github.Status{
+			State:       github.StatusSuccess,
+			Description: "Skipped",
+			Context:     context,
+		}
+		if err := gc.CreateStatus(org, repo, pr.Head.SHA, status); err != nil {
+			resp := fmt.Sprintf("Cannot update PR status for context %s: %v", context, err)
+			log.Warn(resp)
+			return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
+		}
+	}
+	return nil
+}
+
+func isNotSuccess(job config.Presubmit, statuses []github.Status) bool {
+	for _, status := range statuses {
+		if status.Context == job.Context && status.State != github.StatusSuccess {
+			return true
+		}
+	}
+	return false
+}

--- a/prow/plugins/skip/skip_test.go
+++ b/prow/plugins/skip/skip_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package skip
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+func TestSkipStatus(t *testing.T) {
+	tests := []struct {
+		name string
+
+		presubmits []config.Presubmit
+		sha        string
+		event      *github.GenericCommentEvent
+		prChanges  map[int][]github.PullRequestChange
+		existing   []github.Status
+
+		expected []github.Status
+	}{
+		{
+			name: "Skip some tests",
+
+			presubmits: []config.Presubmit{
+				{
+					AlwaysRun: true,
+					Context:   "unit-tests",
+				},
+				{
+					AlwaysRun: false,
+					Context:   "extended-tests",
+				},
+				{
+					AlwaysRun: false,
+					Context:   "integration-tests",
+				},
+			},
+			sha: "shalala",
+			event: &github.GenericCommentEvent{
+				IsPR:       true,
+				IssueState: "open",
+				Action:     github.GenericCommentActionCreated,
+				Body:       "/skip",
+				Number:     1,
+				Repo:       github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+			},
+			existing: []github.Status{
+				{
+					State:   github.StatusSuccess,
+					Context: "unit-tests",
+				},
+				{
+					State:   github.StatusFailure,
+					Context: "extended-tests",
+				},
+				{
+					State:   github.StatusPending,
+					Context: "integration-tests",
+				},
+			},
+
+			expected: []github.Status{
+				{
+					State:   github.StatusSuccess,
+					Context: "unit-tests",
+				},
+				{
+					State:       github.StatusSuccess,
+					Description: "Skipped",
+					Context:     "extended-tests",
+				},
+				{
+					State:       github.StatusSuccess,
+					Description: "Skipped",
+					Context:     "integration-tests",
+				},
+			},
+		},
+		{
+			name: "Do not skip tests with PR changes that need to run",
+
+			presubmits: []config.Presubmit{
+				{
+					AlwaysRun: true,
+					Context:   "unit-tests",
+				},
+				{
+					AlwaysRun: false,
+					Context:   "extended-tests",
+				},
+				{
+					RunIfChanged: "^(test/integration)",
+					Context:      "integration-tests",
+				},
+			},
+			sha: "shalala",
+			event: &github.GenericCommentEvent{
+				IsPR:       true,
+				IssueState: "open",
+				Action:     github.GenericCommentActionCreated,
+				Body:       "/skip",
+				Number:     1,
+				Repo:       github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+			},
+			existing: []github.Status{
+				{
+					State:   github.StatusSuccess,
+					Context: "unit-tests",
+				},
+				{
+					State:   github.StatusFailure,
+					Context: "extended-tests",
+				},
+				{
+					State:   github.StatusPending,
+					Context: "integration-tests",
+				},
+			},
+			prChanges: map[int][]github.PullRequestChange{
+				1: {
+					{
+						Filename: "test/integration/main.go",
+					},
+					{
+						Filename: "README.md",
+					},
+				},
+			},
+
+			expected: []github.Status{
+				{
+					State:   github.StatusSuccess,
+					Context: "unit-tests",
+				},
+				{
+					State:       github.StatusSuccess,
+					Description: "Skipped",
+					Context:     "extended-tests",
+				},
+				{
+					State:   github.StatusPending,
+					Context: "integration-tests",
+				},
+			},
+		},
+		{
+			name: "Skip tests with PR changes that do not need to run",
+
+			presubmits: []config.Presubmit{
+				{
+					RunIfChanged: "^(test/integration)",
+					Context:      "integration-tests",
+				},
+			},
+			sha: "shalala",
+			event: &github.GenericCommentEvent{
+				IsPR:       true,
+				IssueState: "open",
+				Action:     github.GenericCommentActionCreated,
+				Body:       "/skip",
+				Number:     1,
+				Repo:       github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+			},
+			existing: []github.Status{
+				{
+					State:   github.StatusPending,
+					Context: "integration-tests",
+				},
+			},
+			prChanges: map[int][]github.PullRequestChange{
+				1: {
+					{
+						Filename: "build/core.sh",
+					},
+					{
+						Filename: "README.md",
+					},
+				},
+			},
+
+			expected: []github.Status{
+				{
+					State:       github.StatusSuccess,
+					Description: "Skipped",
+					Context:     "integration-tests",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("running scenario %q", test.name)
+		if err := config.SetRegexes(test.presubmits); err != nil {
+			t.Fatal(err)
+		}
+
+		fghc := &fakegithub.FakeClient{
+			IssueComments: make(map[int][]github.IssueComment),
+			PullRequests: map[int]*github.PullRequest{
+				test.event.Number: {
+					Head: github.PullRequestBranch{
+						SHA: test.sha,
+					},
+				},
+			},
+			PullRequestChanges: test.prChanges,
+			CreatedStatuses: map[string][]github.Status{
+				test.sha: test.existing,
+			},
+		}
+		l := logrus.WithField("plugin", pluginName)
+
+		if err := handle(fghc, l, test.event, test.presubmits); err != nil {
+			t.Errorf("unexpected error: %v.", err)
+			continue
+		}
+
+		// Check that the correct statuses have been updated.
+		created := fghc.CreatedStatuses[test.sha]
+		if len(test.expected) != len(created) {
+			t.Errorf("status mismatch: expected:\n%+v\ngot:\n%+v", test.expected, created)
+			continue
+		}
+	out:
+		for _, got := range created {
+			var found bool
+			for _, exp := range test.expected {
+				if exp.Context == got.Context {
+					found = true
+					if !reflect.DeepEqual(exp, got) {
+						t.Errorf("expected status: %v, got: %v", exp, got)
+						break out
+					}
+				}
+			}
+			if !found {
+				t.Errorf("expected context %q in the results: %v", got.Context, created)
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
Authorize one or more Github teams to overwrite commit statuses.
This is useful in case a commit status is stale or when we want
to fast track a PR that does not affect a failing test.

Tested in https://github.com/openshift/origin/pull/16125#issuecomment-350229495

For more background, see https://github.com/kubernetes/test-infra/issues/4912

/cc cjwagner BenTheElder 

Signed-off-by: Michalis Kargakis <mkargaki@redhat.com>