### PR TITLE
Perform three-way merges when applying

### DIFF
--- a/experiment/cherrypicker/server.go
+++ b/experiment/cherrypicker/server.go
@@ -303,7 +303,7 @@ func (s *Server) handle(l *logrus.Entry, comment github.IssueComment, org, repo,
 	}
 
 	// Apply the patch.
-	if err := r.Apply(localPath); err != nil {
+	if err := r.Am(localPath); err != nil {
 		resp := fmt.Sprintf("#%d failed to apply on top of branch %q: %v", num, targetBranch, err)
 		s.log.WithFields(l.Data).Info(resp)
 		return s.ghc.CreateComment(org, repo, num, plugins.FormatICResponse(comment, resp))

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -252,11 +252,12 @@ func (r *Repo) Merge(commitlike string) (bool, error) {
 	return false, nil
 }
 
-// Apply tries to apply the patch in the given path into the current branch.
-// It returns an error if the patch cannot be applied.
-func (r *Repo) Apply(path string) error {
+// Am tries to apply the patch in the given path into the current branch
+// by performing a three-way merge (similar to git cherry-pick). It returns
+// an error if the patch cannot be applied.
+func (r *Repo) Am(path string) error {
 	r.logger.Infof("Applying %s.", path)
-	co := r.gitCommand("am", path)
+	co := r.gitCommand("am", "--3way", path)
 	b, err := co.CombinedOutput()
 	if err == nil {
 		return nil


### PR DESCRIPTION
There are cases where `am` will fail because it's stricter than `cherry-pick`. 

/cc stevekuznetsov 

@php-coder thanks for bringing this up!