### PR TITLE
Improve plugin-help formatting by allowing text sections to include HTML.

### DIFF
--- a/prow/cmd/deck/static/plugin-help-script.js
+++ b/prow/cmd/deck/static/plugin-help-script.js
@@ -69,12 +69,12 @@ function addSection(div, section, elem) {
 }
 
 function addTextSection(div, section, content) {
-    if (content == "") {
+    if (!content) {
         return;
     }
 
     var p = document.createElement("p");
-    p.appendChild(document.createTextNode(content));
+    p.innerHTML = content
     addSection(div, section, p);
 }
 

--- a/prow/pluginhelp/pluginhelp.go
+++ b/prow/pluginhelp/pluginhelp.go
@@ -22,10 +22,12 @@ package pluginhelp
 // This includes repo specific configuration for every repo that the plugin is enabled for.
 type PluginHelp struct {
 	// Description is a description of what the plugin does and what purpose it achieves.
+	// This field may include HTML.
 	Description string
 	// WhoCanUse is a description of the permissions/role/authorization required to use the plugin.
 	// This is usually specified as a github permissions, but it can also be a github team, an
 	// OWNERS file alias, etc.
+	// This field may include HTML.
 	WhoCanUse string
 	// Usage is a usage string for the plugin. Leave empty if not applicable.
 	Usage string
@@ -33,6 +35,7 @@ type PluginHelp struct {
 	Examples []string
 	// Config is a map from org/repo strings to a string describing the configuration for that repo.
 	// The key "" should map to a string describing configuration that applies to all repos if any.
+	// This configuration strings may include HTML.
 	Config map[string]string
 
 	// Events is a slice containing the events that are handled by the plugin.

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -99,13 +99,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 			return nil, fmt.Errorf("invalid repo in enabledRepos: %q", repo)
 		}
 		opts := optionsForRepo(config, parts[0], parts[1])
-		approveConfig[repo] = fmt.Sprintf("Pull requests %srequire an associated issue.\nPull request authors %simplicitly approve their own PRs.", doNot(opts.IssueRequired), doNot(opts.ImplicitSelfApprove))
+		approveConfig[repo] = fmt.Sprintf("Pull requests %srequire an associated issue.<br>Pull request authors %simplicitly approve their own PRs.", doNot(opts.IssueRequired), doNot(opts.ImplicitSelfApprove))
 	}
 	return &pluginhelp.PluginHelp{
 			Description: `The approve plugin implements a pull request approval process that manages the '` + approvedLabel + `' label and an approval notification comment. Approval is achieved when the set of users that have approved the PR is capable of approving every file changed by the PR. A user is able to approve a file if their username or an alias they belong to is listed in the 'approvers' section of an OWNERS file in the directory of the file or higher in the directory tree.
-
-Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
-For more information see <a href=\"https://github.com/kubernetes/test-infra/blob/master/prow/plugins/approve/approvers/README.md\">here</a>.`,
+<br>
+<br>Per-repo configuration may be used to require that PRs link to an associated issue before approval is granted. It may also be used to specify that the PR authors implicitly approve their own PRs.
+<br>For more information see <a href="https://github.com/kubernetes/test-infra/blob/master/prow/plugins/approve/approvers/README.md">here</a>.`,
 			WhoCanUse: "Users listed as 'approvers' in appropriate OWNERS files.",
 			Usage:     "/(approve|lgtm) [no-issue|cancel]",
 			Examples:  []string{"/approve", "/approve no-issue", "/lgtm", "/lgtm cancel"},

--- a/prow/plugins/blockade/blockade.go
+++ b/prow/plugins/blockade/blockade.go
@@ -72,7 +72,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 			if !stringInSlice(parts[0], blockade.Repos) && !stringInSlice(repo, blockade.Repos) {
 				continue
 			}
-			fmt.Fprintf(&buf, "\nBlock reason: '%s'\n\tBlock regexps: %q\n\tException regexps: %q\n", blockade.Explanation, blockade.BlockRegexps, blockade.ExceptionRegexps)
+			fmt.Fprintf(&buf, "<br>Block reason: '%s'<br>&nbsp&nbsp&nbsp&nbspBlock regexps: %q<br>&nbsp&nbsp&nbsp&nbspException regexps: %q<br>", blockade.Explanation, blockade.BlockRegexps, blockade.ExceptionRegexps)
 		}
 		blockConfig[repo] = buf.String()
 	}

--- a/prow/plugins/docs-no-retest/docs-no-retest.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest.go
@@ -49,7 +49,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	// manually triggered and is not configurable.
 	return &pluginhelp.PluginHelp{
 			Description: `The docs-no-retest plugin applies the '` + labelSkipRetest + `' label to pull requests that only touch documentation type files and thus do not need to be retested against the latest master commit before merging.
-Files extensions '.md', '.png', '.svg', and '.dia' are considered documentation.`,
+<br>Files extensions '.md', '.png', '.svg', and '.dia' are considered documentation.`,
 		},
 		nil
 }

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -641,7 +641,7 @@ func EventsForPlugin(name string) []string {
 		events = append(events, "status")
 	}
 	if _, ok := genericCommentHandlers[name]; ok {
-		events = append(events, "<GenericCommentEvent. Includes: [issue_comment, pull_request_review, pull_request_review_comment, status] and for text modifying actions: [issue, pull_request]>")
+		events = append(events, "GenericCommentEvent (any event for user text)")
 	}
 	return events
 }

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -82,11 +82,11 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
 			Description: `The releasenote plugin implements a release note process that uses a markdown 'releasenote' code block to associate a release note with a pull request. Until the 'releasenote' block in the pull request body is populated the PR will be assigned the '` + releaseNoteLabelNeeded + `' label.
-There are three valid types of release notes that can replace this label:
-	- PRs with a normal release note in the 'releasenote' block are given the label '` + releaseNote + `'.
-	- PRs that have a release note of 'none' in the block are given the label '` + releaseNoteNone + `' to indicate that the PR does not warrant a release note.
-	- PRs that contain 'action required' in their 'releasenote' block are given the label '` + releaseNoteActionRequired + `' to indicate that the PR introduces potentially breaking changes that necessitate user action before upgrading to the release.
-To support old behavior, this plugin also provides a '/release-note-none' command that can be used by organization members to specify that no release note is needed for the PR as an alternative to setting the 'releasenote' block contents to 'none'.`,
+<br>There are three valid types of release notes that can replace this label:
+<br>&nbsp&nbsp&nbsp&nbsp- PRs with a normal release note in the 'releasenote' block are given the label '` + releaseNote + `'.
+<br>&nbsp&nbsp&nbsp&nbsp- PRs that have a release note of 'none' in the block are given the label '` + releaseNoteNone + `' to indicate that the PR does not warrant a release note.
+<br>&nbsp&nbsp&nbsp&nbsp- PRs that contain 'action required' in their 'releasenote' block are given the label '` + releaseNoteActionRequired + `' to indicate that the PR introduces potentially breaking changes that necessitate user action before upgrading to the release.
+<br>To support old behavior, this plugin also provides a '/release-note-none' command that can be used by organization members to specify that no release note is needed for the PR as an alternative to setting the 'releasenote' block contents to 'none'.`,
 			Usage: "In the pull request body text:\n\n```releasenote\n<release note content>\n```",
 		},
 		nil

--- a/prow/plugins/requiresig/requiresig.go
+++ b/prow/plugins/requiresig/requiresig.go
@@ -71,7 +71,13 @@ func helpProvider(config *plugins.Configuration, _ []string) (*pluginhelp.Plugin
 	// Only the 'Description' and 'Config' fields are necessary because this plugin does not react
 	// to any commands.
 	return &pluginhelp.PluginHelp{
-			Description: fmt.Sprintf("When a new issue is opened the require-sig plugin adds the %q label and leaves a comment requesting that a SIG (Special Interest Group) label be added to the issue. SIG labels are labels that have one of the following prefixes: %q.\nOnce a SIG label has been added to an issue, this plugin removes the %q label and deletes the comment it made previously.", needsSigLabel, labelPrefixes, needsSigLabel),
+			Description: fmt.Sprintf(
+				`When a new issue is opened the require-sig plugin adds the %q label and leaves a comment requesting that a SIG (Special Interest Group) label be added to the issue. SIG labels are labels that have one of the following prefixes: %q.
+<br>Once a SIG label has been added to an issue, this plugin removes the %q label and deletes the comment it made previously.`,
+				needsSigLabel,
+				labelPrefixes,
+				needsSigLabel,
+			),
 			Config: map[string]string{
 				"": fmt.Sprintf("The comment the plugin creates includes this link to a list of the existing groups: %s", url),
 			},

--- a/prow/plugins/sigmention/sigmention.go
+++ b/prow/plugins/sigmention/sigmention.go
@@ -62,8 +62,8 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	return &pluginhelp.PluginHelp{
 			Description: `The sigmention plugin responds to SIG (Special Interest Group) Github team mentions like '@kubernetes/sig-testing-bugs'. The plugin responds in two ways:
-	1) The appropriate 'sig/*' and 'kind/*' labels are applied to the issue or pull request. In this case 'sig/testing' and 'kind/bug'.
-	2) If the user who mentioned the Github team is not a member of the organization that owns the repository the bot will create a comment that repeats the mention. This is necessary because non-member mentions do not trigger Github notifications.`,
+<br>&nbsp&nbsp&nbsp&nbsp1) The appropriate 'sig/*' and 'kind/*' labels are applied to the issue or pull request. In this case 'sig/testing' and 'kind/bug'.
+<br>&nbsp&nbsp&nbsp&nbsp2) If the user who mentioned the Github team is not a member of the organization that owns the repository the bot will create a comment that repeats the mention. This is necessary because non-member mentions do not trigger Github notifications.`,
 		},
 		nil
 }

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -40,13 +40,14 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	return &pluginhelp.PluginHelp{
-			Description: `The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated. Generated files identified by the config file '.generated_files' at the repo root are ignored. Labels are applied based on the total number of lines of changes (additions and deletions):
-	size/XS:	0-9
-	size/S:	10-29
-	size/M:	30-99
-	size/L	100-499
-	size/XL:	500-999
-	size/XXL:	1000+`,
+			Description: `The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated. Generated files identified by the config file '.generated_files' at the repo root are ignored. Labels are applied based on the total number of lines of changes (additions and deletions):<ul>
+<li>size/XS:	0-9</li>
+<li>size/S:	10-29</li>
+<li>size/M:	30-99</li>
+<li>size/L	100-499</li>
+<li>size/XL:	500-999</li>
+<li>size/XXL:	1000+</li>
+</ul>`,
 		},
 		nil
 }

--- a/prow/plugins/slackevents/slackevents.go
+++ b/prow/plugins/slackevents/slackevents.go
@@ -61,15 +61,15 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 			return nil, fmt.Errorf("invalid repo in enabledRepos: %q", repo)
 		}
 		if mw := getMergeWarning(config.Slack.MergeWarnings, parts[0], parts[1]); mw != nil {
-			configInfo[repo] = fmt.Sprintf("In this repo merges are considered manual and trigger manual merge warnings if the user who merged is not a member of this whitelist: %s.\nWarnings are sent to the following Slack channels: %s.", strings.Join(mw.WhiteList, ", "), strings.Join(mw.Channels, ", "))
+			configInfo[repo] = fmt.Sprintf("In this repo merges are considered manual and trigger manual merge warnings if the user who merged is not a member of this whitelist: %s.<br>Warnings are sent to the following Slack channels: %s.", strings.Join(mw.WhiteList, ", "), strings.Join(mw.Channels, ", "))
 		} else {
 			configInfo[repo] = "There are no manual merge warnings configured for this repo."
 		}
 	}
 	return &pluginhelp.PluginHelp{
 			Description: `The slackevents plugin reacts to various Github events by commenting in Slack channels.
-	1) The plugin can create comments to alert on manual merges. Manual merges are merges made by a normal user instead of a bot or trusted user.
-	2) The plugin can create comments to reiterate SIG mentions like '@kubernetes/sig-testing-bugs' from Github.`,
+<br>&nbsp&nbsp&nbsp&nbsp1) The plugin can create comments to alert on manual merges. Manual merges are merges made by a normal user instead of a bot or trusted user.
+<br>&nbsp&nbsp&nbsp&nbsp2) The plugin can create comments to reiterate SIG mentions like '@kubernetes/sig-testing-bugs' from Github.`,
 			Config: configInfo,
 		},
 		nil

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -51,11 +51,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		configInfo[repo] = fmt.Sprintf("The trusted Github organization for this repository is %q.", trusted)
 	}
 	return &pluginhelp.PluginHelp{
-			Description: "The trigger plugin starts tests in reaction to commands and pull request events. It is responsible for ensuring that test jobs are only run on trusted PRs. A PR is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR. Trigger starts jobs automatically when a new trusted PR is created or when an untrusted PR becomes trusted, but it can also be used to start jobs manually via the '/test' command. The '/retest' command can be used to rerun jobs that have reported failure.",
-			WhoCanUse:   "Anyone can use the '/test' and '/retest' commands on a trusted PR.\nMembers of the trusted organization for the repo can use the '/ok-to-test' command to mark an untrusted PR as trusted.",
-			Usage:       "/ok-to-test\n/test (<job name>|all)\n/retest",
-			Examples:    []string{"/ok-to-test", "/test all", "/test pull-bazel-test", "/retest"},
-			Config:      configInfo,
+			Description: `The trigger plugin starts tests in reaction to commands and pull request events. It is responsible for ensuring that test jobs are only run on trusted PRs. A PR is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR.
+<br>Trigger starts jobs automatically when a new trusted PR is created or when an untrusted PR becomes trusted, but it can also be used to start jobs manually via the '/test' command.
+<br>The '/retest' command can be used to rerun jobs that have reported failure.`,
+			WhoCanUse: "Anyone can use the '/test' and '/retest' commands on a trusted PR.<br>Members of the trusted organization for the repo can use the '/ok-to-test' command to mark an untrusted PR as trusted.",
+			Usage:     "/ok-to-test\n/test (<job name>|all)\n/retest",
+			Examples:  []string{"/ok-to-test", "/test all", "/test pull-bazel-test", "/retest"},
+			Config:    configInfo,
 		},
 		nil
 }

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -39,7 +39,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 	var configInfo map[string]string
 	if len(enabledRepos) == 1 {
 		msg := fmt.Sprintf(
-			"The main configuration is kept in sync with %s/%s.\nThe plugin configuration is kept in sync with %s/%s.",
+			"The main configuration is kept in sync with '%s/%s'.\nThe plugin configuration is kept in sync with '%s/%s'.",
 			enabledRepos[0],
 			config.ConfigUpdater.ConfigFile,
 			enabledRepos[0],


### PR DESCRIPTION
Letting plugins include HTML in most help fields seems to be the easiest way to support flexible formatting and makes it easy to include links and images.

/cc @rmmh 