### PR TITLE
Move over rest of the kops jobs to new aws account

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8499,7 +8499,7 @@
   "ci-kubernetes-e2e-kops-aws": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws.test-cncf-aws.k8s.io",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws.env",
       "--extract=ci/latest",
@@ -8516,7 +8516,7 @@
   "ci-kubernetes-e2e-kops-aws-beta": {
     "args": [
       "--aws",
-      "--cluster=e2e-kops-aws-stable1.test-aws.k8s.io",
+      "--cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io",
       "--env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-beta.txt",
       "--env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-1.9-ci-green.txt",
       "--env-file=jobs/platform/kops_aws.env",
@@ -8534,7 +8534,7 @@
   "ci-kubernetes-e2e-kops-aws-canary": {
     "args": [
       "--aws",
-      "--aws-cluster-domain=test-aws.k8s.io",
+      "--aws-cluster-domain=test-cncf-aws.k8s.io",
       "--cluster=e2e-kops-aws-canary",
       "--env-file=jobs/platform/kops_aws.env",
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-canary.env",
@@ -8558,7 +8558,6 @@
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-canary.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
-      "--kops-state=s3://k8s-kops-prow/",
       "--kops-zones=us-west-2c",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
@@ -8577,7 +8576,6 @@
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--node-size=m5.large --master-size=m5.large --channel=alpha",
-      "--kops-state=s3://k8s-kops-prow/",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
       "--kops-zones=us-west-2a",
       "--provider=aws",
@@ -8596,7 +8594,6 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
-      "--kops-state=s3://k8s-kops-prow/",
       "--kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
@@ -8615,7 +8612,6 @@
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-release-1-6.env",
       "--extract=ci/latest-1.6",
       "--ginkgo-parallel",
-      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8633,7 +8629,6 @@
       "--env-file=jobs/env/ci-kubernetes-e2e-kops-aws-release-1-7.env",
       "--extract=ci/latest-1.7",
       "--ginkgo-parallel",
-      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8650,7 +8645,6 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/latest",
       "--ginkgo-parallel",
-      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\\[sig-cli\\] --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8669,7 +8663,6 @@
       "--env-file=jobs/platform/kops_aws.env",
       "--extract=ci/k8s-stable1",
       "--ginkgo-parallel",
-      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort",
       "--timeout=120m"
@@ -8707,7 +8700,6 @@
       "--extract=ci/latest",
       "--ginkgo-parallel",
       "--kops-args=--networking=weave",
-      "--kops-state=s3://k8s-kops-prow/",
       "--provider=aws",
       "--test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[HPA\\]|Dashboard|Services.*functioning.*NodePort"
     ],
@@ -11194,7 +11186,7 @@
     "_comment3": "Args for 1.7+ should go in prow/config.yaml after the `--` !",
     "args": [
       "--aws",
-      "--aws-cluster-domain=test-aws.k8s.io",
+      "--aws-cluster-domain=test-cncf-aws.k8s.io",
       "--build",
       "--check-leaked-resources=false",
       "--cluster=",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1940,7 +1940,7 @@ presubmits:
       - name: aws-cred
         secret:
           defaultMode: 256
-          secretName: aws-cred
+          secretName: aws-cred-new
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -4535,7 +4535,7 @@ presubmits:
       - name: aws-cred
         secret:
           defaultMode: 256
-          secretName: aws-cred
+          secretName: aws-cred-new
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
@@ -20855,7 +20855,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 1h
   agent: kubernetes
@@ -20898,7 +20898,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 1h
   agent: kubernetes
@@ -20942,7 +20942,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 1h
   agent: kubernetes
@@ -21289,7 +21289,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 24h
   agent: kubernetes
@@ -24198,7 +24198,7 @@ periodics:
     - name: aws-cred
       secret:
         defaultMode: 256
-        secretName: aws-cred
+        secretName: aws-cred-new
 
 - interval: 24h
   agent: kubernetes

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -817,7 +817,7 @@ def create_parser():
     parser.add_argument(
         '--kops-nodes', default=4, type=int, help='Number of nodes to start')
     parser.add_argument(
-        '--kops-state', default='s3://k8s-kops-jenkins/',
+        '--kops-state', default='s3://k8s-kops-prow/',
         help='Name of the aws state storage')
     parser.add_argument(
         '--kops-state-gce', default='gs://k8s-kops-gce/',

--- a/scenarios/kubernetes_e2e_test.py
+++ b/scenarios/kubernetes_e2e_test.py
@@ -492,7 +492,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         self.assertIn('kops-e2e-runner.sh', lastcall)
         self.assertIn('--kops-cluster=foo.test-aws.k8s.io', lastcall)
         self.assertIn('--kops-zones', lastcall)
-        self.assertIn('--kops-state=s3://k8s-kops-jenkins/', lastcall)
+        self.assertIn('--kops-state=s3://k8s-kops-prow/', lastcall)
         self.assertIn('--kops-nodes=4', lastcall)
         self.assertIn('--kops-ssh-key', lastcall)
 
@@ -525,7 +525,7 @@ class ScenarioTest(unittest.TestCase):  # pylint: disable=too-many-public-method
         self.assertIn('--deployment=kops', lastcall)
         self.assertIn('--kops-cluster=foo.example.com', lastcall)
         self.assertIn('--kops-zones', lastcall)
-        self.assertIn('--kops-state=s3://k8s-kops-jenkins/', lastcall)
+        self.assertIn('--kops-state=s3://k8s-kops-prow/', lastcall)
         self.assertIn('--kops-nodes=4', lastcall)
         self.assertIn('--kops-ssh-key', lastcall)
         self.assertIn('kubetest', lastcall)


### PR DESCRIPTION
/hold
open up the PR first for rest of the kops job cc @fejta 
seems https://k8s-testgrid.appspot.com/google-aws#kops-aws-1.8 is still flaking on up, I'll probably need to pin jobs to specific zones @justinsb 

Also I'm not sure about https://github.com/kubernetes/test-infra/issues/5805, will probably try to hunt down someone who owns the bucket.

xref https://github.com/kubernetes/test-infra/issues/5086



