### PR TITLE
fix empty continuation line warning in docker image

### DIFF
--- a/planter/Dockerfile
+++ b/planter/Dockerfile
@@ -23,6 +23,8 @@ ARG BAZEL_VERSION
 WORKDIR "/workspace"
 RUN mkdir -p "/workspace"
 
+# TODO(bentheelder): we should probably have these pip deps in bazel,
+# remove these from the container if kettle is fixed.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
@@ -35,8 +37,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     zlib1g-dev \
     && apt-get clean && \
-    # TODO(bentheelder): we should probably have these as bazel dependencies,
-    # remove these from the container if kettle is fixed.
     pip install pylint pyyaml
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
this fixes:
```
[WARNING]: Empty continuation line found in:
    RUN apt-get update && apt-get install -y --no-install-recommends     build-essential     ca-certificates     git     python     python-pip     rpm     unzip     wget     zip     zlib1g-dev     && apt-get clean &&     pip install pylint pyyaml
[WARNING]: Empty continuation lines will become errors in a future release.
```

/area planter