### PR TITLE
make the boskos janitor reap orphaned processes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -140,6 +140,12 @@
   revision = "454a56f35412459b5e684fd5ec0f9211b94f002a"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/ramr/go-reaper"
+  packages = ["."]
+  revision = "35f6a64e44ff062abfcec2d27cef674212d445c0"
+
+[[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
   revision = "0aa62d5ddceb50dbcb909d790b5345affd3669b6"
@@ -235,6 +241,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d14022b355ab9259b9d1cbd4752a8b38e4500414dee0f51b45089962253dfeaa"
+  inputs-digest = "43bcd9900b0ef26125a5073588a24f6c7a3968d00ded91870bf0bebb4b2617a9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,3 +72,6 @@ ignored = ["github.com/aws/aws-sdk-go*"]
 
 [[constraint]]
   name = "k8s.io/contrib"
+
+[[constraint]]
+  name = "github.com/ramr/go-reaper"

--- a/boskos/janitor/BUILD
+++ b/boskos/janitor/BUILD
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//boskos/client:go_default_library",
         "//boskos/common:go_default_library",
+        "//vendor/github.com/ramr/go-reaper:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
     ],
 )

--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20171129-b3934c887
+        image: gcr.io/k8s-testimages/janitor:v20171208-19d3a763b
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gce-project,gke-project,gci-qa-project,gpu-project

--- a/boskos/janitor/janitor.go
+++ b/boskos/janitor/janitor.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"time"
 
+	reaper "github.com/ramr/go-reaper"
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/boskos/client"
 	"k8s.io/test-infra/boskos/common"
@@ -44,6 +45,8 @@ func main() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 	boskos := client.NewClient("Janitor", "http://boskos")
 	logrus.Info("Initialized boskos client!")
+
+	go reaper.Reap()
 
 	// Activate service account
 	flag.Parse()

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -37,6 +37,7 @@ filegroup(
         "//vendor/github.com/prometheus/common/expfmt:all-srcs",
         "//vendor/github.com/prometheus/common/model:all-srcs",
         "//vendor/github.com/prometheus/procfs:all-srcs",
+        "//vendor/github.com/ramr/go-reaper:all-srcs",
         "//vendor/github.com/satori/go.uuid:all-srcs",
         "//vendor/github.com/shurcooL/githubql:all-srcs",
         "//vendor/github.com/shurcooL/go/ctxhttp:all-srcs",

--- a/vendor/github.com/ramr/go-reaper/.gitattributes
+++ b/vendor/github.com/ramr/go-reaper/.gitattributes
@@ -1,0 +1,1 @@
+*.sh linguist-language=Go

--- a/vendor/github.com/ramr/go-reaper/.gitignore
+++ b/vendor/github.com/ramr/go-reaper/.gitignore
@@ -1,0 +1,25 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+test/testpid1

--- a/vendor/github.com/ramr/go-reaper/BUILD
+++ b/vendor/github.com/ramr/go-reaper/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["reaper.go"],
+    importpath = "github.com/ramr/go-reaper",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/ramr/go-reaper/LICENSE
+++ b/vendor/github.com/ramr/go-reaper/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 ramr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/ramr/go-reaper/Makefile
+++ b/vendor/github.com/ramr/go-reaper/Makefile
@@ -1,0 +1,9 @@
+#!/usr/bin/env make
+
+all:
+
+test:	tests
+
+tests:
+	(cd test; make)
+

--- a/vendor/github.com/ramr/go-reaper/README.md
+++ b/vendor/github.com/ramr/go-reaper/README.md
@@ -1,0 +1,68 @@
+# go-reaper
+Process (grim) reaper library for golang - this is useful for cleaning up
+zombie processes inside docker containers (which do not have an init
+process running as pid 1).
+
+
+tl;dr
+-----
+
+       import reaper "github.com/ramr/go-reaper"
+
+       func main() {
+		//  Start background reaping of orphaned child processes.
+		go reaper.Reap()
+
+		//  Rest of your code ...
+       }
+
+
+
+How and Why
+-----------
+If you run a container without an init process (pid 1) which would
+normally reap zombie processes, you could well end up with a lot of zombie
+processes and eventually exhaust the max process limit on your system.
+
+If you have a golang program that runs as pid 1, then this library allows
+the golang program to setup a background signal handling mechanism to
+handle the death of those orphaned children and not create a load of
+zombies inside the pid namespace your container runs in.
+
+
+Usage:
+------
+For basic usage, see the tl;dr section above. This should be the
+most commonly used route you'd need to take.
+
+But for those that prefer to go down "the road less traveled", you can
+control whether to disable pid 1 checks and/or control the options passed to
+the `wait4` (or `waitpid`) system call by passing configuration to the
+reaper.
+
+
+	import reaper "github.com/ramr/go-reaper"
+
+	func main() {
+		config := reaper.Config{
+			Pid:              0,
+			Options:          0,
+			DisablePid1Check: false,
+		}
+
+		//  Start background reaping of orphaned child processes.
+		go reaper.Start(config)
+
+		//  Rest of your code ...
+	}
+
+
+The `Pid` and `Options` fields in the configuration are the `pid` and
+`options` passed to the linux `wait4` system call.
+
+See the man pages for the `wait4` or `waitpid` system call for details.
+
+       https://linux.die.net/man/2/wait4
+       https://linux.die.net/man/2/waitpid
+
+

--- a/vendor/github.com/ramr/go-reaper/reaper.go
+++ b/vendor/github.com/ramr/go-reaper/reaper.go
@@ -1,0 +1,124 @@
+package reaper
+
+/*  Note:  This is a *nix only implementation.  */
+
+//  Prefer #include style directives.
+import "fmt"
+import "os"
+import "os/signal"
+import "syscall"
+
+type Config struct {
+	Pid              int
+	Options          int
+	DisablePid1Check bool
+}
+
+//  Handle death of child (SIGCHLD) messages. Pushes the signal onto the
+//  notifications channel if there is a waiter.
+func sigChildHandler(notifications chan os.Signal) {
+	var sigs = make(chan os.Signal, 3)
+	signal.Notify(sigs, syscall.SIGCHLD)
+
+	for {
+		var sig = <-sigs
+		select {
+		case notifications <- sig: /*  published it.  */
+		default:
+			/*
+			 *  Notifications channel full - drop it to the
+			 *  floor. This ensures we don't fill up the SIGCHLD
+			 *  queue. The reaper just waits for any child
+			 *  process (pid=-1), so we ain't loosing it!! ;^)
+			 */
+		}
+	}
+
+} /*  End of function  sigChildHandler.  */
+
+//  Be a good parent - clean up behind the children.
+func reapChildren(config Config) {
+	var notifications = make(chan os.Signal, 1)
+
+	go sigChildHandler(notifications)
+
+	pid := config.Pid
+	opts := config.Options
+
+	for {
+		var sig = <-notifications
+		fmt.Printf(" - Received signal %v\n", sig)
+		for {
+			var wstatus syscall.WaitStatus
+
+			/*
+			 *  Reap 'em, so that zombies don't accumulate.
+			 *  Plants vs. Zombies!!
+			 */
+			pid, err := syscall.Wait4(pid, &wstatus, opts, nil)
+			for syscall.EINTR == err {
+				pid, err = syscall.Wait4(pid, &wstatus, opts, nil)
+			}
+
+			if syscall.ECHILD == err {
+				break
+			}
+
+			fmt.Printf(" - Grim reaper cleanup: pid=%d, wstatus=%+v\n",
+				pid, wstatus)
+
+		}
+	}
+
+} /*   End of function  reapChildren.  */
+
+/*
+ *  ======================================================================
+ *  Section: Exported functions
+ *  ======================================================================
+ */
+
+//  Normal entry point for the reaper code. Start reaping children in the
+//  background inside a goroutine.
+func Reap() {
+	/*
+	 *  Only reap processes if we are taking over init's duties aka
+	 *  we are running as pid 1 inside a docker container. The default
+	 *  is to reap all processes.
+	 */
+	Start(Config{
+		Pid:              -1,
+		Options:          0,
+		DisablePid1Check: false,
+	})
+
+} /*  End of [exported] function  Reap.  */
+
+//  Entry point for invoking the reaper code with a specific configuration.
+//  The config allows you to bypass the pid 1 checks, so handle with care.
+//  The child processes are reaped in the background inside a goroutine.
+func Start(config Config) {
+	/*
+	 *  Start the Reaper with configuration options. This allows you to
+	 *  reap processes even if the current pid isn't running as pid 1.
+	 *  So ... use with caution!!
+	 *
+	 *  In most cases, you are better off just using Reap() as that
+	 *  checks if we are running as Pid 1.
+	 */
+	if !config.DisablePid1Check {
+		mypid := os.Getpid()
+		if 1 != mypid {
+			fmt.Printf(" - Grim reaper disabled, pid not 1\n")
+			return
+		}
+	}
+
+	/*
+	 *  Ok, so either pid 1 checks are disabled or we are the grandma
+	 *  of 'em all, either way we get to play the grim reaper.
+	 *  You will be missed, Terry Pratchett!! RIP
+	 */
+	go reapChildren(config)
+
+} /*  End of [exported] function  Start.  */


### PR DESCRIPTION
fixes: https://github.com/kubernetes/test-infra/issues/5877

We think `gcloud` is leaking orphaned python2 processes, but regardless of what leaks them the janitor is a long-lived process running as the entrypoint to a docker container with child and "grand-child" processes at minimum currently, so we should clean up any orphaned child processes.

This PR uses https://github.com/ramr/go-reaper to reap them. 

/area boskos