### PR TITLE
Cleaning the janitor

### DIFF
--- a/boskos/Makefile
+++ b/boskos/Makefile
@@ -48,7 +48,7 @@ reaper-image:
 
 janitor-image:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o janitor/janitor k8s.io/test-infra/boskos/janitor/
-	docker build -t "gcr.io/k8s-testimages/janitor:$(TAG)" janitor
+	docker build --no-cache -t "gcr.io/k8s-testimages/janitor:$(TAG)" janitor
 	gcloud docker -- push "gcr.io/k8s-testimages/janitor:$(TAG)"
 	rm janitor/janitor
 

--- a/boskos/janitor/Dockerfile
+++ b/boskos/janitor/Dockerfile
@@ -17,6 +17,5 @@ LABEL maintainer="senlu@google.com"
 
 ADD ["janitor", \
      "janitor.py", \
-     "/"]
-RUN ["chmod", "+x", "/janitor.py"]
-ENTRYPOINT ["/janitor"]
+     "/bin/"]
+ENTRYPOINT ["/bin/sh", "-c", "/bin/echo started && /bin/janitor \"$@\"", "--"]

--- a/boskos/janitor/deployment.yaml
+++ b/boskos/janitor/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-testimages/janitor:v20171129-b3934c887
+        image: gcr.io/k8s-testimages/janitor:v20171209-206236aa6
         args:
         - --service-account=/etc/service-account/service-account.json
         - --resource-type=gce-project,gke-project,gci-qa-project,gpu-project

--- a/boskos/janitor/janitor.go
+++ b/boskos/janitor/janitor.go
@@ -72,7 +72,7 @@ type clean func(string) error
 
 // Clean by janitor script
 func janitorClean(proj string) error {
-	cmd := exec.Command("/janitor.py", fmt.Sprintf("--project=%s", proj), "--hour=0")
+	cmd := exec.Command("/bin/janitor.py", fmt.Sprintf("--project=%s", proj), "--hour=0")
 	err := cmd.Run()
 	if err != nil {
 		logrus.WithError(err).Errorf("failed to clean up project %s", proj)


### PR DESCRIPTION
this lets `/bin/sh` be PID1 which should free us from worrying about orphaned processes

xref: https://github.com/kubernetes/test-infra/pull/5884, https://github.com/kubernetes/test-infra/pull/5883