### PR TITLE
Use bazel image for ci kubemark jobs

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9248,6 +9248,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-100-gce.env",
       "--extract=ci/latest",
+      "--extract-source",
       "--gcp-project=k8s-jenkins-gci-kubemark",
       "--gcp-zone=us-central1-f",
       "--kubemark",
@@ -9256,7 +9257,7 @@
       "--tag=latest-master",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=240m"
+      "--timeout=260m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9269,6 +9270,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-100-gce.env",
       "--extract=ci/latest",
+      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9277,7 +9279,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=240m"
+      "--timeout=260m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9290,6 +9292,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest",
+      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9298,7 +9301,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=60m"
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9311,6 +9314,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest-1.9",
+      "--extract-source",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
       "--kubemark",
@@ -9318,7 +9322,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=60m"
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9340,7 +9344,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=60m"
+      "--timeout=80m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9353,6 +9357,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-500-gce.env",
       "--extract=ci/latest",
+      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-blocking-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9361,7 +9366,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=70m"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9374,6 +9379,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-gce-scale.env",
       "--extract=ci/latest",
+      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=kubemark-scalability-testing",
       "--gcp-zone=us-east1-a",
@@ -9382,7 +9388,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=1080m",
+      "--timeout=1100m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -9396,6 +9402,7 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-high-density-100-gce.env",
       "--extract=ci/latest",
+      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9405,7 +9412,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:HighDensityPerformance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=280m"
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -20095,10 +20095,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --bare
-      - --timeout=260
+      - --timeout=280
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: true
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20114,13 +20114,7 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      - name: docker-graph
-        mountPath: /docker-graph
-      # TODO(bentheelder): sort out container port
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
-      # docker-in-docker needs privileged mode
+      # bazel needs privileged mode to sandbox builds
       securityContext:
         privileged: true
     volumes:
@@ -20131,9 +20125,6 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-100-gce
   interval: 3h
@@ -20143,10 +20134,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --bare
-      - --timeout=260
+      - --timeout=280
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: true
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20162,13 +20153,7 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      - name: docker-graph
-        mountPath: /docker-graph
-      # TODO(bentheelder): sort out container port
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
-      # docker-in-docker needs privileged mode
+      # bazel needs privileged mode to sandbox builds
       securityContext:
         privileged: true
     volumes:
@@ -20179,9 +20164,6 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-5-gce
   interval: 30m
@@ -20191,10 +20173,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --bare
-      - --timeout=80
+      - --timeout=100
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: true
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20210,13 +20192,7 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      - name: docker-graph
-        mountPath: /docker-graph
-      # TODO(bentheelder): sort out container port
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
-      # docker-in-docker needs privileged mode
+      # bazel needs privileged mode to sandbox builds
       securityContext:
         privileged: true
     volumes:
@@ -20227,9 +20203,6 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-5-gce-last-release
   interval: 30m
@@ -20239,10 +20212,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --bare
-      - --timeout=80
+      - --timeout=100
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: true
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20258,13 +20231,7 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      - name: docker-graph
-        mountPath: /docker-graph
-      # TODO(bentheelder): sort out container port
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
-      # docker-in-docker needs privileged mode
+      # bazel needs privileged mode to sandbox builds
       securityContext:
         privileged: true
     volumes:
@@ -20275,9 +20242,6 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-5-prow-canary
   cron: "0 * * * *"
@@ -20288,7 +20252,7 @@ periodics:
       imagePullPolicy: Always
       args:
       - --bare
-      - --timeout=80
+      - --timeout=100
       env:
       - name: KUBEMARK_BAZEL_BUILD
         value: "y"
@@ -20327,10 +20291,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --bare
-      - --timeout=140
+      - --timeout=160
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: true
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20346,13 +20310,7 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      - name: docker-graph
-        mountPath: /docker-graph
-      # TODO(bentheelder): sort out container port
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
-      # docker-in-docker needs privilged mode
+      # bazel needs privileged mode to sandbox builds
       securityContext:
         privileged: true
     volumes:
@@ -20363,9 +20321,6 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-gce-scale
   interval: 12h
@@ -20375,10 +20330,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --bare
-      - --timeout=1100
+      - --timeout=1120
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: true
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20394,13 +20349,7 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      - name: docker-graph
-        mountPath: /docker-graph
-      # TODO(bentheelder): sort out container port
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
-      # docker-in-docker needs privilged mode
+      # bazel needs privileged mode to sandbox builds
       securityContext:
         privileged: true
     volumes:
@@ -20411,9 +20360,6 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-high-density-100-gce
   interval: 24h
@@ -20423,10 +20369,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171204-8e1bbdcba-master
       args:
       - --bare
-      - --timeout=300
+      - --timeout=320
       env:
-      - name: DOCKER_IN_DOCKER_ENABLED
-        value: true
+      - name: KUBEMARK_BAZEL_BUILD
+        value: "y"
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20442,13 +20388,7 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      - name: docker-graph
-        mountPath: /docker-graph
-      # TODO(bentheelder): sort out container port
-      ports:
-      - containerPort: 9999
-        hostPort: 9999
-      # docker-in-docker needs privileged mode
+      # bazel needs privileged mode to sandbox builds
       securityContext:
         privileged: true
     volumes:
@@ -20459,9 +20399,6 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
-    - name: docker-graph
-      hostPath:
-        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-node-kubelet
   interval: 1h


### PR DESCRIPTION
https://k8s-testgrid.appspot.com/sig-testing-canaries#kubemark-canary-prow uses bazel built kubemark image and is a sea of green now, switch off rest of the ci-kubemark jobs to use bazel image.

Side effect is seems the overall time would increase between 5-20min, which should be fine with ci jobs. I increased timeout for all ci kubemark jobs for 20min to compensate this offset. This should free up more prow nodes for us.

(also keep an eye after this is merged, should be fine after enough canary runs)

/area jobs
/assign @BenTheElder 
cc @shyamjvs @porridge 