### PR TITLE
wait for the docker socket to be ready

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -64,6 +64,7 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.ta
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
+# TODO(bentheelder): remove this once we are no longer using Jenkins
 # Get docker client binary for use with our jenkins nodes, and put it in it's
 # own bin dir. The runner will add this to the path if dind mode is not enabled.
 # Note: 1.11+ changes the tarball format

--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -16,31 +16,48 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -x
 
 # Check if the job has opted-in to docker-in-docker availability.
 export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
-if [ "$DOCKER_IN_DOCKER_ENABLED" == "true" ]; then
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Docker in Docker enabled, initializing..."
+    printf '=%.0s' {1..80}; echo
     # If we have opted in to docker in docker, start the docker daemon,
-    # and wait a second for it to be fully up.
-    # TODO(bentheelder): there has to be a more reliable solution to this
-    echo "Starting docker..." && service docker start && sleep 5
+    service docker start
+    # the service can be started but the docker socket not ready, wait for ready
+    WAIT_N=0
+    MAX_WAIT=5
+    while true; do
+        # docker ps -q should only work if the daemon is ready
+        docker ps -q > /dev/null 2>&1 && break
+        if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+            WAIT_N=$((WAIT_N+1))
+            echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
+            sleep ${WAIT_N}
+        else
+            echo "Reached maximum attempts, not waiting any longer..."
+            break
+        fi
+    done
     # begin cleaning up after any previous runs
     echo "Starting to clean up docker graph."
     # make sure any lingering containers are removed from the data root
-    docker stop $(docker ps -aq) || true
-    docker rm $(docker ps -aq) || true
+    docker ps -aq | xargs -r docker stop || true
+    docker ps -aq | xargs -r docker rm || true
     # cleanup kube-build images from kubernetes' dockerized builds
-    docker rmi -f $(docker images -q kube-build) || true
+    docker images -q kube-build | xargs -r docker rmi -f || true
     # then cleanup images and volumes not associated with tagged images
-    docker rmi -f $(docker images --filter dangling=true -qa) || true
+    docker images --filter dangling=true -qa | xargs -r docker rmi -f || true
+    echo "NOTE: The total reclaimed space below is ONLY for volumes."
     docker volume prune -f || true
     # list what images and volumes remain
     echo "Remaining docker images and volumes are:"
     docker images --all || true
     docker volume ls || true
+    printf '=%.0s' {1..80}; echo
     echo "Done setting up docker in docker."
 else
+# TODO(bentheelder): remove this once we are no longer using Jenkins
 # If not, make sure `docker` points to the old one compatible with our Jenkins
     export PATH=/docker-no-dind-bin/:$PATH
 fi

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+FROM gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
 LABEL maintainer "Sen Lu <senlu@google.com>"
 
 ENV KUBETEST_IN_DOCKER="true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1074,7 +1074,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2065,7 +2065,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-unit),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -2158,7 +2158,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-verify),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -2856,7 +2856,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -3846,7 +3846,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-unit),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -3939,7 +3939,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-verify),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171127-a1522ede
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"


### PR DESCRIPTION
This should be cleaner than the existing solution in terms of how it behaves at runtime, however it's more slightly hacky bash.

This also:
-  cleans up the log output a bit, which was a bit redundant and had noisy docker error output when there were no images to clean up
- adds a TODO to remove the aging alternate docker client binary we only use on Jenkins

/area images