### PR TITLE
Revert "Use bazel image for ci kubemark jobs"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9248,7 +9248,6 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-100-gce.env",
       "--extract=ci/latest",
-      "--extract-source",
       "--gcp-project=k8s-jenkins-gci-kubemark",
       "--gcp-zone=us-central1-f",
       "--kubemark",
@@ -9257,7 +9256,7 @@
       "--tag=latest-master",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=260m"
+      "--timeout=240m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9270,7 +9269,6 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-100-gce.env",
       "--extract=ci/latest",
-      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9279,7 +9277,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=260m"
+      "--timeout=240m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9292,7 +9290,6 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest",
-      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9301,7 +9298,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=80m"
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9314,7 +9311,6 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-5-gce.env",
       "--extract=ci/latest-1.9",
-      "--extract-source",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
       "--kubemark",
@@ -9322,7 +9318,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=80m"
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9344,7 +9340,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Empty\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=80m"
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9357,7 +9353,6 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-500-gce.env",
       "--extract=ci/latest",
-      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-blocking-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9366,7 +9361,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=90m"
+      "--timeout=70m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -9379,7 +9374,6 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-gce-scale.env",
       "--extract=ci/latest",
-      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=kubemark-scalability-testing",
       "--gcp-zone=us-east1-b",
@@ -9388,7 +9382,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:Performance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=1100m",
+      "--timeout=1080m",
       "--use-logexporter"
     ],
     "scenario": "kubernetes_e2e",
@@ -9402,7 +9396,6 @@
       "--env-file=jobs/platform/gce.env",
       "--env-file=jobs/env/ci-kubernetes-kubemark-high-density-100-gce.env",
       "--extract=ci/latest",
-      "--extract-source",
       "--gcp-node-image=gci",
       "--gcp-project=k8s-jenkins-kubemark",
       "--gcp-zone=us-central1-f",
@@ -9412,7 +9405,7 @@
       "--provider=gce",
       "--test=false",
       "--test_args=--ginkgo.focus=\\[Feature:HighDensityPerformance\\] --gather-resource-usage=true --gather-metrics-at-teardown=true --output-print-type=json",
-      "--timeout=300m"
+      "--timeout=280m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -20095,10 +20095,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171210-0beb83d94-master
       args:
       - --bare
-      - --timeout=280
+      - --timeout=260
       env:
-      - name: KUBEMARK_BAZEL_BUILD
-        value: "y"
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20114,7 +20114,13 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      # bazel needs privileged mode to sandbox builds
+      - name: docker-graph
+        mountPath: /docker-graph
+      # TODO(bentheelder): sort out container port
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
     volumes:
@@ -20125,6 +20131,9 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-100-gce
   interval: 3h
@@ -20134,10 +20143,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171210-0beb83d94-master
       args:
       - --bare
-      - --timeout=280
+      - --timeout=260
       env:
-      - name: KUBEMARK_BAZEL_BUILD
-        value: "y"
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20153,7 +20162,13 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      # bazel needs privileged mode to sandbox builds
+      - name: docker-graph
+        mountPath: /docker-graph
+      # TODO(bentheelder): sort out container port
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
     volumes:
@@ -20164,6 +20179,9 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-5-gce
   interval: 30m
@@ -20173,10 +20191,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171210-0beb83d94-master
       args:
       - --bare
-      - --timeout=100
+      - --timeout=80
       env:
-      - name: KUBEMARK_BAZEL_BUILD
-        value: "y"
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20192,7 +20210,13 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      # bazel needs privileged mode to sandbox builds
+      - name: docker-graph
+        mountPath: /docker-graph
+      # TODO(bentheelder): sort out container port
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
     volumes:
@@ -20203,6 +20227,9 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-5-gce-last-release
   interval: 30m
@@ -20212,10 +20239,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171210-0beb83d94-master
       args:
       - --bare
-      - --timeout=100
+      - --timeout=80
       env:
-      - name: KUBEMARK_BAZEL_BUILD
-        value: "y"
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20231,7 +20258,13 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      # bazel needs privileged mode to sandbox builds
+      - name: docker-graph
+        mountPath: /docker-graph
+      # TODO(bentheelder): sort out container port
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
     volumes:
@@ -20242,6 +20275,9 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-5-prow-canary
   cron: "0 * * * *"
@@ -20252,7 +20288,7 @@ periodics:
       imagePullPolicy: Always
       args:
       - --bare
-      - --timeout=100
+      - --timeout=80
       env:
       - name: KUBEMARK_BAZEL_BUILD
         value: "y"
@@ -20291,10 +20327,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171210-0beb83d94-master
       args:
       - --bare
-      - --timeout=160
+      - --timeout=140
       env:
-      - name: KUBEMARK_BAZEL_BUILD
-        value: "y"
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20310,7 +20346,13 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      # bazel needs privileged mode to sandbox builds
+      - name: docker-graph
+        mountPath: /docker-graph
+      # TODO(bentheelder): sort out container port
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # docker-in-docker needs privilged mode
       securityContext:
         privileged: true
     volumes:
@@ -20321,6 +20363,9 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-gce-scale
   interval: 12h
@@ -20330,10 +20375,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171210-0beb83d94-master
       args:
       - --bare
-      - --timeout=1120
+      - --timeout=1100
       env:
-      - name: KUBEMARK_BAZEL_BUILD
-        value: "y"
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20349,7 +20394,13 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      # bazel needs privileged mode to sandbox builds
+      - name: docker-graph
+        mountPath: /docker-graph
+      # TODO(bentheelder): sort out container port
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # docker-in-docker needs privilged mode
       securityContext:
         privileged: true
     volumes:
@@ -20360,6 +20411,9 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-kubemark-high-density-100-gce
   interval: 24h
@@ -20369,10 +20423,10 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20171210-0beb83d94-master
       args:
       - --bare
-      - --timeout=320
+      - --timeout=300
       env:
-      - name: KUBEMARK_BAZEL_BUILD
-        value: "y"
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
       - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
@@ -20388,7 +20442,13 @@ periodics:
       - name: ssh
         mountPath: /etc/ssh-key-secret
         readOnly: true
-      # bazel needs privileged mode to sandbox builds
+      - name: docker-graph
+        mountPath: /docker-graph
+      # TODO(bentheelder): sort out container port
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
     volumes:
@@ -20399,6 +20459,9 @@ periodics:
       secret:
         secretName: ssh-key-secret
         defaultMode: 0400
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 
 - name: ci-kubernetes-node-kubelet
   interval: 1h


### PR DESCRIPTION
Reverts kubernetes/test-infra#5888

doesn't look right, revert first and I need to check the diff between the previous image

/shrug
cc @BenTheElder @porridge 