### PR TITLE
make sure the generic canary PRs will trigger the kukbeadm canary job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -810,7 +810,9 @@ presubmits:
       context: pull-kubernetes-e2e-kubeadm-gce-canary
       max_concurrency: 8
       skip_report: false
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
+      # use standard (pull-kubernetes-cross) regex we normally make sure
+      # to trigger on dummy / canary testing PRs
+      run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
       rerun_command: "/test pull-kubernetes-e2e-kubeadm-gce-canary"
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
       spec:
@@ -2587,7 +2589,9 @@ presubmits:
       context: pull-security-kubernetes-e2e-kubeadm-gce-canary
       max_concurrency: 8
       skip_report: false
-      run_if_changed: '^(cmd/kubeadm|build/debs).*$'
+      # use standard (pull-kubernetes-cross) regex we normally make sure
+      # to trigger on dummy / canary testing PRs
+      run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
       rerun_command: "/test pull-security-kubernetes-e2e-kubeadm-gce-canary"
       trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
       spec:


### PR DESCRIPTION
Follow up to #5902, this still won't work because the normal kubeadm job matches on a regex we don't trigger in our typical canary PRs. 

Rather than trying to modify all the canary jobs i'd prefer to just modify the regex for now and leave a comment explaining why.

/area jobs