### PR TITLE
Pin ETCD versions to avoid ETCD downgrade issues

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -680,6 +680,7 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env=ETCD_VERSION=3.0.17",
       "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/k8s-stable1",
@@ -701,6 +702,7 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
+      "--env=ETCD_VERSION=3.0.17",
       "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/k8s-stable1",

--- a/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
@@ -3,3 +3,8 @@
 
 STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 
+# TODO: This is pinned to the 1.8 version of etcd. 1.9 was changed to
+# 3.1.x. ETCD doesn't downgrade minor versions. So for downgrades, we
+# pin this to the lower version. The long term fix is to change
+# downgrade/upgrade to not upgrade/downgrade etcd.
+ETCD_VERSION=3.0.17


### PR DESCRIPTION
This is a temporary work around to avoid changing ETCD versions. The
long term fix should be to avoid changing ETCD versions in the upgrade
logic.

ref: https://github.com/kubernetes/kubernetes/issues/56244

cc @enisoc @krzyzacy 