### PR TITLE
Adding the approve plugin to the charts repo

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -14,6 +14,7 @@ triggers:
 
 approve:
 - repos:
+  - kubernetes/charts
   - kubernetes/community
   - kubernetes/kubectl
   - kubernetes/test-infra
@@ -84,6 +85,7 @@ plugins:
   - trigger
 
   kubernetes/charts:
+  - approve
   - trigger
 
   kubernetes/cluster-registry:


### PR DESCRIPTION
On the charts repo we would like to start having the automation merge PRs and use OWNERS files for different areas. This is the first step in heading there within the test-infra repo.

See kubernetes/charts#3006 for the issue over there. This has been a topic of discussion in the [charts meeting](https://docs.google.com/document/d/1h6UTTuNRbFI81higrN3JUV2XxyzqqVjZET4Xz4WTR-8/edit) for some time.