### PR TITLE
Enable tide for the charts repo

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -27,6 +27,7 @@ tide:
   - repos:
     - kubernetes/test-infra
     - kubernetes/federation
+    - kubernetes/charts
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
This closes kubernetes/charts#3006