### PR TITLE
Need to use the test version of env vars to pin etcd

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -680,8 +680,8 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--env=ETCD_VERSION=3.0.17",
       "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env=TEST_ETCD_VERSION=3.0.17",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/k8s-stable1",
       "--extract=ci/k8s-beta",
@@ -702,8 +702,8 @@
     "args": [
       "--check-leaked-resources",
       "--check-version-skew=false",
-      "--env=ETCD_VERSION=3.0.17",
       "--env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf",
+      "--env=TEST_ETCD_VERSION=3.0.17",
       "--env-file=jobs/platform/gce.env",
       "--extract=ci/k8s-stable1",
       "--extract=ci/k8s-beta",

--- a/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
+++ b/jobs/env/ci-kubernetes-e2e-gce-new-master-upgrade-cluster.env
@@ -7,4 +7,4 @@ STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
 # 3.1.x. ETCD doesn't downgrade minor versions. So for downgrades, we
 # pin this to the lower version. The long term fix is to change
 # downgrade/upgrade to not upgrade/downgrade etcd.
-ETCD_VERSION=3.0.17
+TEST_ETCD_VERSION=3.0.17


### PR DESCRIPTION
In kuberenetes/cluster/gce/config-test.sh, ETCD_VERSION is overwritten by what ever is in TEST_ETCD_VERSION.

ref https://github.com/kubernetes/kubernetes/issues/56244 and https://github.com/kubernetes/kubernetes/issues/56879

cc @enisoc @BenTheElder 