### PR TITLE
Add ability for tide to use squash and rebase merge methods

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -43,6 +43,8 @@ tide:
     - do-not-merge/work-in-progress
     - do-not-merge/hold
     reviewApprovedRequired: true
+  merge_method:
+    kubernetes/charts: squash
 
 presubmits:
   google/cadvisor:

--- a/prow/config/BUILD
+++ b/prow/config/BUILD
@@ -22,6 +22,7 @@ go_test(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/config",
     deps = [
+        "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
     ],
@@ -37,6 +38,7 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/config",
     deps = [
+        "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/kube/labels:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
 )
 
@@ -115,6 +116,16 @@ func checkRetest(t *testing.T, repo string, presubmits []Presubmit) {
 func TestRetestMatchJobsName(t *testing.T) {
 	for repo, presubmits := range c.Presubmits {
 		checkRetest(t, repo, presubmits)
+	}
+}
+
+func TestTideMergeMethod(t *testing.T) {
+	for name, method := range c.Tide.MergeType {
+		if method != github.MergeMerge &&
+			method != github.MergeRebase &&
+			method != github.MergeSquash {
+			t.Errorf("Merge type %q for %s is not a valid type", method, name)
+		}
 	}
 }
 

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -19,6 +19,8 @@ package config
 import (
 	"fmt"
 	"strings"
+
+	"k8s.io/test-infra/prow/github"
 )
 
 // Tide is config for the tide pool.
@@ -28,6 +30,27 @@ type Tide struct {
 	// TODO: This will only be possible when we allow specifying orgs. At that
 	//       point, verify the above condition.
 	Queries []TideQuery `json:"queries,omitempty"`
+
+	// A key/value pair of an org/repo as the key and merge method to override
+	// the default method of merge. Valid options are squash, rebase, and merge.
+	MergeType map[string]github.PullRequestMergeType `json:"merge_method,omitempty"`
+}
+
+// MergeMethod returns the merge method to use for a repo. The default of merge is
+// returned when not overridden.
+func (t *Tide) MergeMethod(org, repo string) github.PullRequestMergeType {
+	name := org + "/" + repo
+
+	v, ok := t.MergeType[name]
+	if !ok {
+		if ov, found := t.MergeType[org]; found {
+			return ov
+		}
+
+		return github.MergeMerge
+	}
+
+	return v
 }
 
 // TideQuery is turned into a GitHub search query. See the docs for details:

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -55,6 +55,18 @@ const (
 	stateCannotBeChangedMessagePrefix = "state cannot be changed."
 )
 
+// PullRequestMergeType enumerates the types of merges the GitHub API can
+// perform
+// https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
+type PullRequestMergeType string
+
+// Possible types of merges for the GitHub merge API
+const (
+	MergeMerge  PullRequestMergeType = "merge"
+	MergeRebase PullRequestMergeType = "rebase"
+	MergeSquash PullRequestMergeType = "squash"
+)
+
 // ClientError represents https://developer.github.com/v3/#client-errors
 type ClientError struct {
 	Message string `json:"message"`

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -348,7 +348,8 @@ func (c *Controller) pickBatch(sp subpool) ([]PullRequest, error) {
 func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 	for _, pr := range prs {
 		if err := c.ghc.Merge(sp.org, sp.repo, int(pr.Number), github.MergeDetails{
-			SHA: string(pr.HeadRef.Target.OID),
+			SHA:         string(pr.HeadRef.Target.OID),
+			MergeMethod: string(c.ca.Config().Tide.MergeMethod(sp.org, sp.repo)),
 		}); err != nil {
 			if _, ok := err.(github.ModifiedHeadError); ok {
 				// This is a possible source of incorrect behavior. If someone


### PR DESCRIPTION
The GitHub API default to a merge but can also use rebase and
squash methods. This change adds configuration to prow to optionally
use a method other than merge. See the GitHub API for more
details. https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button