### PR TITLE
bootstrap: log "node" name (Jenkins agent or Prow pod) in build log

### DIFF
--- a/jenkins/bootstrap.py
+++ b/jenkins/bootstrap.py
@@ -908,6 +908,7 @@ def bootstrap(args):
     gsutil = GSUtil(call)
 
     logging.info('Bootstrap %s...', job)
+    logging.info('Builder: %s', node())
     if IMAGE_NAME_ENV in os.environ:
         logging.info('Image: %s', os.environ[IMAGE_NAME_ENV])
     build = build_name(started)


### PR DESCRIPTION
Sometimes we crash so hard we don't create `started.json`. This gives us a failsafe to find the pod name for a job.

/assign @BenTheElder 