### PR TITLE
Update rules_go to 0.8.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,8 +12,8 @@ check_version("0.8.0")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "f80dec7889568c36eb191d3d1534d2db4574d430",
     remote = "https://github.com/bazelbuild/rules_go.git",
+    tag = "0.8.1",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/boskos/BUILD
+++ b/boskos/BUILD
@@ -12,7 +12,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos",
     pure = "on",
-    race = "off",
 )
 
 go_test(

--- a/boskos/janitor/BUILD
+++ b/boskos/janitor/BUILD
@@ -12,7 +12,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/janitor",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/boskos/metrics/BUILD
+++ b/boskos/metrics/BUILD
@@ -13,7 +13,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/metrics",
     pure = "on",
-    race = "off",
     tags = ["automanaged"],
 )
 

--- a/boskos/reaper/BUILD
+++ b/boskos/reaper/BUILD
@@ -11,7 +11,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/boskos/reaper",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/gcsweb/cmd/gcsweb/BUILD
+++ b/gcsweb/cmd/gcsweb/BUILD
@@ -11,7 +11,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -41,7 +41,7 @@ rm -f ${TESTINFRA_ROOT}/vendor/k8s.io/apimachinery/pkg/util/sets/BUILD
 # The gazelle commit should match the rules_go commit in the WORKSPACE file.
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-  f80dec7889568c36eb191d3d1534d2db4574d430 \
+  0.8.1 \
   "${TMP_GOPATH}"
 
 touch "${TESTINFRA_ROOT}/vendor/BUILD"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -28,7 +28,7 @@ TMP_GOPATH=$(mktemp -d)
 # The gazelle commit should match the rules_go commit in the WORKSPACE file.
 "${TESTINFRA_ROOT}/hack/go_install_from_commit.sh" \
   github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle \
-  f80dec7889568c36eb191d3d1534d2db4574d430 \
+  0.8.1 \
   "${TMP_GOPATH}"
 
 touch "${TESTINFRA_ROOT}/vendor/BUILD"

--- a/kubetest/BUILD
+++ b/kubetest/BUILD
@@ -12,7 +12,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/kubetest",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/label_sync/BUILD
+++ b/label_sync/BUILD
@@ -39,7 +39,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/label_sync",
     pure = "on",
-    race = "off",
     tags = ["automanaged"],
 )
 

--- a/logexporter/cmd/BUILD
+++ b/logexporter/cmd/BUILD
@@ -11,7 +11,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/logexporter/cmd",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/mungegithub/BUILD
+++ b/mungegithub/BUILD
@@ -11,7 +11,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/mungegithub",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/prow/cmd/deck/BUILD
+++ b/prow/cmd/deck/BUILD
@@ -26,7 +26,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/deck",
     pure = "on",
-    race = "off",
 )
 
 go_binary(
@@ -34,7 +33,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/deck",
     pure = "on",
-    race = "off",
 )
 
 go_test(

--- a/prow/cmd/hook/BUILD
+++ b/prow/cmd/hook/BUILD
@@ -17,7 +17,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/hook",
     pure = "on",
-    race = "off",
 )
 
 go_binary(
@@ -28,7 +27,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/hook",
     pure = "on",
-    race = "off",
 )
 
 go_test(

--- a/prow/cmd/horologium/BUILD
+++ b/prow/cmd/horologium/BUILD
@@ -14,7 +14,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/horologium",
     pure = "on",
-    race = "off",
 )
 
 go_binary(
@@ -22,7 +21,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/horologium",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/prow/cmd/jenkins-operator/BUILD
+++ b/prow/cmd/jenkins-operator/BUILD
@@ -15,7 +15,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/jenkins-operator",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/prow/cmd/plank/BUILD
+++ b/prow/cmd/plank/BUILD
@@ -13,7 +13,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/plank",
     pure = "on",
-    race = "off",
 )
 
 go_binary(
@@ -21,7 +20,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/plank",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/prow/cmd/sinker/BUILD
+++ b/prow/cmd/sinker/BUILD
@@ -14,7 +14,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/sinker",
     pure = "on",
-    race = "off",
 )
 
 go_binary(
@@ -22,7 +21,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/sinker",
     pure = "on",
-    race = "off",
 )
 
 go_test(

--- a/prow/cmd/splice/BUILD
+++ b/prow/cmd/splice/BUILD
@@ -14,7 +14,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/splice",
     pure = "on",
-    race = "off",
 )
 
 go_binary(
@@ -22,7 +21,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/splice",
     pure = "on",
-    race = "off",
 )
 
 go_test(

--- a/prow/cmd/tide/BUILD
+++ b/prow/cmd/tide/BUILD
@@ -11,7 +11,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tide",
     pure = "on",
-    race = "off",
     visibility = ["//visibility:public"],
 )
 
@@ -35,7 +34,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tide",
     pure = "on",
-    race = "off",
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/tot/BUILD
+++ b/prow/cmd/tot/BUILD
@@ -14,7 +14,6 @@ go_image(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tot",
     pure = "on",
-    race = "off",
 )
 
 go_binary(
@@ -22,7 +21,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/prow/cmd/tot",
     pure = "on",
-    race = "off",
 )
 
 go_test(

--- a/velodrome/fetcher/BUILD
+++ b/velodrome/fetcher/BUILD
@@ -12,7 +12,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/fetcher",
     pure = "on",
-    race = "off",
 )
 
 go_test(

--- a/velodrome/token-counter/BUILD
+++ b/velodrome/token-counter/BUILD
@@ -11,7 +11,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/token-counter",
     pure = "on",
-    race = "off",
 )
 
 go_library(

--- a/velodrome/transform/BUILD
+++ b/velodrome/transform/BUILD
@@ -12,7 +12,6 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/velodrome/transform",
     pure = "on",
-    race = "off",
 )
 
 go_test(


### PR DESCRIPTION
Mostly what's relevant to us is bugfixes and performance improvements around pure and race modes.

For example, we no longer need to explicitly say `race = "off"` with `pure = "on"`, and the go toolchain tools are now never built in race mode (which should make `bazel test` faster).