### PR TITLE
Create images for bazel 0.8.1 and use everywhere except kubernetes/kubernetes <= 1.8

### DIFF
--- a/images/bazelbuild/Makefile
+++ b/images/bazelbuild/Makefile
@@ -16,7 +16,7 @@ IMG = gcr.io/k8s-testimages/bazelbuild
 TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # TODO(bentheelder): retire some of these as they become unnecessary
-LATEST_BAZEL_VERSION=0.8.0
+LATEST_BAZEL_VERSION=0.8.1
 BAZEL_VERSIONS=0.5.2 0.5.4 0.6.1 0.7.0 $(LATEST_BAZEL_VERSION)
 
 all: build

--- a/planter/Makefile
+++ b/planter/Makefile
@@ -14,7 +14,7 @@
 
 # note: sync this with planter.sh!
 # this should be bazel version - planter sub version
-BAZEL_VERSION = 0.7.0
+BAZEL_VERSION = 0.8.1
 IMAGE_NAME = gcr.io/k8s-testimages/planter
 TAG = $(BAZEL_VERSION)
 

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -19,7 +19,7 @@
 set -o errexit
 set -o nounset
 IMAGE_NAME="gcr.io/k8s-testimages/planter"
-TAG="${TAG:-0.7.0}"
+TAG="${TAG:-0.8.1}"
 IMAGE="${IMAGE_NAME}:${TAG}"
 # run our docker image as the host user with bazel cache and current repo dir
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || true)

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -209,7 +209,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-federation-bazel-test),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -310,7 +310,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-cluster-registry-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -351,7 +351,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-cluster-registry-verify-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -496,7 +496,7 @@ presubmits:
     - release-1.8 # different target set
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -901,7 +901,7 @@ presubmits:
     - release-1.8 # different set of targets
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2276,7 +2276,7 @@ presubmits:
     - release-1.8 # different target set
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2679,7 +2679,7 @@ presubmits:
     - release-1.8 # different set of targets
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4309,7 +4309,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4350,7 +4350,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -4849,7 +4849,7 @@ postsubmits:
     - release-1.9
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4890,7 +4890,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -5338,7 +5338,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21295,7 +21295,7 @@ periodics:
   name: cluster-registry-nightly
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21922,7 +21922,7 @@ periodics:
   - master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21963,7 +21963,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -810,7 +810,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
         env:
@@ -1059,7 +1058,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
         - "--test=//... -//build/... -//vendor/..."
         - "--manual-test=//hack:verify-all"
         - "--test-args=--build_tag_filters=-e2e"
@@ -2589,7 +2587,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-security-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
         - "--build=//... -//vendor/..."
         - "--release=//build/release-tars"
         env:
@@ -2836,7 +2833,6 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-security-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
         - "--test=//... -//build/... -//vendor/..."
         - "--manual-test=//hack:verify-all"
         - "--test-args=--build_tag_filters=-e2e"
@@ -4989,7 +4985,6 @@ postsubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--" # end bootstrap args, scenario args below
-        - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
         - "--build=//... -//vendor/..."
         - "--install=gubernator/test_requirements.txt"
         - "--test=//... //hack:verify-all -//vendor/..."
@@ -21240,7 +21235,6 @@ periodics:
       - "--service-account=/etc/service-account/service-account.json"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--" # end bootstrap args, scenario args below
-      - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/3956
       - "--build=//... -//vendor/..."
       - "--install=gubernator/test_requirements.txt"
       - "--test=//... //hack:verify-all -//vendor/..."

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -209,7 +209,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-federation-bazel-test),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -310,7 +310,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-cluster-registry-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -351,7 +351,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-cluster-registry-verify-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -496,7 +496,7 @@ presubmits:
     - release-1.8 # different target set
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -599,7 +599,7 @@ presubmits:
     - release-1.8
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -700,7 +700,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -901,7 +901,7 @@ presubmits:
     - release-1.8 # different set of targets
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -951,7 +951,7 @@ presubmits:
     - release-1.8
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -999,7 +999,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2276,7 +2276,7 @@ presubmits:
     - release-1.8 # different target set
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2379,7 +2379,7 @@ presubmits:
     - release-1.8
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2480,7 +2480,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2679,7 +2679,7 @@ presubmits:
     - release-1.8 # different set of targets
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2729,7 +2729,7 @@ presubmits:
     - release-1.8
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2777,7 +2777,7 @@ presubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4050,7 +4050,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-test-infra-bazel),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.8.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4309,7 +4309,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4350,7 +4350,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -4395,7 +4395,7 @@ postsubmits:
     - release-1.6
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4433,7 +4433,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -4515,7 +4515,7 @@ postsubmits:
     - release-1.7
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4555,7 +4555,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -4682,7 +4682,7 @@ postsubmits:
     - release-1.8
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4722,7 +4722,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -4849,7 +4849,7 @@ postsubmits:
     - release-1.9
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -4890,7 +4890,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+        - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
           args:
           - "--clean"
           - "--git-cache=/root/.cache/git"
@@ -4980,7 +4980,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.8.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -5060,7 +5060,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.8.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -5338,7 +5338,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21231,7 +21231,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.8.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.8.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21295,7 +21295,7 @@ periodics:
   name: cluster-registry-nightly
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21463,7 +21463,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21501,7 +21501,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.5.2  # https://github.com/kubernetes/kubernetes/issues/51571
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -21584,7 +21584,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21624,7 +21624,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -21752,7 +21752,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21792,7 +21792,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -21922,7 +21922,7 @@ periodics:
   - master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+    - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
       args:
       - "--clean"
       - "--git-cache=/root/.cache/git"
@@ -21963,7 +21963,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20171128-a188d25f-0.6.1
+      - image: gcr.io/k8s-testimages/bazelbuild:v20171214-ae38d82a-0.6.1
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
After some canary testing on `kubernetes/kubernetes`, we can use 0.8.1 there, too.

/assign @BenTheElder 