### PR TITLE
Migrate keep-open labels to lifecycle/frozen, never auto-remove lifecycle/frozen labels

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -34,8 +34,6 @@ labels:
     name: do-not-merge/release-note-label-needed
   - color: e11d21
     name: do-not-merge/work-in-progress
-  - color: fbca04
-    name: keep-open
   - color: e11d21
     name: kind/bug
   - color: c7def8
@@ -46,6 +44,9 @@ labels:
     name: lgtm
   - color: d3e2f0
     name: lifecycle/frozen
+    previously:
+    - color: fbca04
+      name: keep-open
   - color: "604460"
     name: lifecycle/rotten
   - color: "795548"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -22238,40 +22238,14 @@ periodics:
       - |-
         --comment=Issues go stale after 30d of inactivity.
         Mark the issue as fresh with `/remove-lifecycle stale`.
-        Freeze the issue for 90d with `/lifecycle frozen`.
         Stale issues rot after an additional 30d of inactivity and eventually close.
+
+        Prevent issues from auto-closing with an `/lifecycle frozen` comment.
 
         If this issue is safe to close now please do so with `/close`.
 
         Send feedback to sig-testing, kubernetes/test-infra and/or `@fejta`.
         /lifecycle stale
-      - --template
-      - --ceiling=10
-      - --confirm
-      volumeMounts:
-      - name: token
-        mountPath: /etc/token
-    volumes:
-    - name: token
-      secret:
-        secretName: fejta-bot-token
-
-- name: periodic-test-infra-unfreeze
-  interval: 24h
-  agent: kubernetes
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
-      args:
-      - --query=org:kubernetes label:lifecycle/frozen
-      - --updated=2160h
-      - --token=/etc/token/bot-github-token
-      - |-
-        --comment=Issues unfreeze after 90d of inactivity.
-        Refreeze for another 90 days with `/lifecycle frozen`.
-
-        Send feedback to sig-testing, kubernetes/test-infra and/or `@fejta`.
-        /remove-lifecycle frozen
       - --template
       - --ceiling=10
       - --confirm

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1047,8 +1047,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-1-8
 - name: periodic-kubernetes-bazel-build-1-9
   gcs_prefix: kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-1-9
-- name: periodic-test-infra-unfreeze
-  gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-unfreeze
 - name: periodic-test-infra-stale
   gcs_prefix: kubernetes-jenkins/logs/periodic-test-infra-stale
 - name: periodic-test-infra-rotten
@@ -4289,9 +4287,6 @@ dashboards:
     test_group_name: periodic-test-infra-retester
     code_search_url_template:
       url: https://github.com/kubernetes/test-infra/compare/<start-custom-0>...<end-custom-0>
-  - name: unfreeze
-    description: Removes lifecycle/frozen from issues after 30d of inactivity
-    test_group_name: periodic-test-infra-unfreeze
   - name: stale
     description: Adds lifecycle/stale to issues after 30d of inactivity
     test_group_name: periodic-test-infra-stale


### PR DESCRIPTION
/assign @mattfarina @cjwagner @stevekuznetsov 

Delete the periodic unfreeze job.
Update the stale comment to note that `/lifecycle frozen` permanently prevents issues from getting auto-closed.

ref #5507