### PR TITLE
Use real name and email in cherrypicker

### DIFF
--- a/experiment/cherrypicker/main.go
+++ b/experiment/cherrypicker/main.go
@@ -83,6 +83,10 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting bot name.")
 	}
+	email, err := githubClient.Email()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting bot e-mail.")
+	}
 	// The bot needs to be able to push to its own Github fork and potentially pull
 	// from private repos.
 	gitClient.SetCredentials(botName, oauthSecret)
@@ -92,7 +96,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error listing bot repositories.")
 	}
 
-	server := NewServer(botName, webhookSecret, gitClient, githubClient, repos)
+	server := NewServer(botName, email, webhookSecret, gitClient, githubClient, repos)
 
 	http.Handle("/", server)
 	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))

--- a/experiment/cherrypicker/server.go
+++ b/experiment/cherrypicker/server.go
@@ -55,6 +55,7 @@ type githubClient interface {
 type Server struct {
 	hmacSecret []byte
 	botName    string
+	email      string
 
 	gc *git.Client
 	// Used for unit testing
@@ -69,10 +70,11 @@ type Server struct {
 	repos    []github.Repo
 }
 
-func NewServer(name string, hmac []byte, gc *git.Client, ghc *github.Client, repos []github.Repo) *Server {
+func NewServer(name, email string, hmac []byte, gc *git.Client, ghc *github.Client, repos []github.Repo) *Server {
 	return &Server{
 		hmacSecret: hmac,
 		botName:    name,
+		email:      email,
 
 		gc:  gc,
 		ghc: ghc,
@@ -289,10 +291,14 @@ func (s *Server) handle(l *logrus.Entry, comment github.IssueComment, org, repo,
 		return err
 	}
 
-	if err := r.Config("user.name", "cherrypicker"); err != nil {
+	if err := r.Config("user.name", s.botName); err != nil {
 		return err
 	}
-	if err := r.Config("user.email", "cherrypicker@localhost"); err != nil {
+	email := s.email
+	if email == "" {
+		email = fmt.Sprintf("%s@localhost", s.botName)
+	}
+	if err := r.Config("user.email", email); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
/cc stevekuznetsov 

We will need to make the bot email public in its profile for this to work.