### PR TITLE
Disables SELinux for Planter container

### DIFF
--- a/planter/README.md
+++ b/planter/README.md
@@ -1,14 +1,14 @@
 # Planter
 
 Planter is a container + wrapper script for your bazel builds.
-It will run a docker container as the current user that can run bazel builds
-in your `$PWD`. It has been tested on macOS and Linux against 
+It will run a Docker container as the current user that can run bazel builds
+in your `$PWD`. It has been tested on macOS and Linux against
 `kubernetes/test-infra` and `kubernetes/kubernetes`.
 
 To build kubernetes set up your `$GOPATH/src` to contain:
 ```
-$GOPATH/src/k8s.io/kubernetes/ ... <kubernetes/kubernetes checkout>
-$GOPATH/src/k8s.io/test-infra/ ... <kubernetes/test-infra checkout>
+$GOPATH/src/k8s.io/kubernetes/   # ... <kubernetes/kubernetes checkout>
+$GOPATH/src/k8s.io/test-infra/   # ... <kubernetes/test-infra checkout>
 ```
 Then from `$GOPATH/src/k8s.io/kubernetes/` run:
  `./../planter/planter.sh make bazel-build`.
@@ -19,12 +19,19 @@ Then from `$GOPATH/src/k8s.io/kubernetes/` run:
 
 Planter repects the following environment variables:
 
- - `TAG`: the planter image tag, this will default to the current stable version
- used to build kubernetes, but you may override it with EG `TAG=0.6.1`
+ - `TAG`: The Planter image tag. This will default to the current stable
+   version used to build Kubernetes, but you may override it with EG
+   `TAG=0.6.1`.
    - These should now match bazel release versions eg `0.8.0rc2`
- - `DRY_RUN`: if set planter will only echo the docker command that would have been run
+ - `DRY_RUN`: If set, Planter will only echo the Docker command that would have
+   been run.
+ - `HOME`: Your home directory. This will be mounted in to the container.
+ - `PWD`: Will be set to the working directory in the image.
+ - `USER`: Used to run the image as the current user.
 
- - `HOME`: your home directory, this will be mounted in to the container
- - `PWD`: will be set to the working directory in the image
- - `USER`: used to run the image as the current user
+## SELinux
 
+Currently, SELinux is disabled for the container that runs the bazel
+environment, which allows for the rest of the host system to leave SELinux
+enabled. Automatic relabeling is not done to avoid inadvertantly causing issues
+with the host system.

--- a/planter/planter.sh
+++ b/planter/planter.sh
@@ -56,8 +56,8 @@ VOLUMES="-v ${REPO}:${REPO} -v ${HOME}:${HOME} --mount type=tmpfs,destination=${
 # Part of this is handled in planter/entrypoint.sh
 GID="$(id -g ${USER})"
 ENV="-e USER=${USER} -e GID=${GID} -e UID=${UID} -e HOME=${HOME}"
-# construct the final docker command
-CMD="docker pull ${IMAGE} && docker run --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}"
+# construct the final docker command, with SELinux disabled for this container
+CMD="docker pull ${IMAGE} && docker run --security-opt label:disable --rm ${VOLUMES} --user ${UID} -w ${PWD} ${ENV} ${DOCKER_EXTRA:-} ${IMAGE} ${@}"
 if [ -n "${DRY_RUN+set}" ]; then
     echo "${CMD}"
 else


### PR DESCRIPTION
As Planter uses a bind mount on the /home/lmadsen directory, on systems that use
SELinux, the bind mount requires SELinux to be disabled so that files can
be accessed. We're unable to use the :z or :Z options, as this causes a
relabling of the entire /home/lmadsen directory contents, which has the implication
of locking admins from sshing back into the machine.

By creating the Planter container as a Super Privileged Container we
avoid administrators from having to disable SELinux system wide.

Relates to #5607