### PR TITLE
Add a kubernetes-anywhere-os-image flag

### DIFF
--- a/kubetest/anywhere.go
+++ b/kubetest/anywhere.go
@@ -61,6 +61,8 @@ var (
 		"(kubernetes-anywhere only) The name of the CNI plugin used for the cluster's SDN.")
 	kubernetesAnywhereDumpClusterLogs = flag.Bool("kubernetes-anywhere-dump-cluster-logs", false,
 		"(kubernetes-anywhere only) Whether to dump cluster logs.")
+	kubernetesAnywhereOSImage = flag.String("kubernetes-anywhere-os-image", "ubuntu-1604-xenial-v20171212",
+		"(kubernetes-anywhere only) The name of the os_image to use for nodes")
 )
 
 const kubernetesAnywhereConfigTemplate = `
@@ -69,7 +71,7 @@ const kubernetesAnywhereConfigTemplate = `
 .phase1.ssh_user=""
 .phase1.cloud_provider="gce"
 
-.phase1.gce.os_image="ubuntu-1604-xenial-v20171212"
+.phase1.gce.os_image="{{.OSImage}}"
 .phase1.gce.instance_type="n1-standard-1"
 .phase1.gce.project="{{.Project}}"
 .phase1.gce.region="{{.Region}}"
@@ -115,6 +117,7 @@ type kubernetesAnywhere struct {
 	KubeContext       string
 	CNI               string
 	KubeproxyMode     string
+	OSImage           string
 }
 
 func initializeKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, error) {
@@ -162,6 +165,7 @@ func initializeKubernetesAnywhere(project, zone string) (*kubernetesAnywhere, er
 		Region:            regexp.MustCompile(`-[^-]+$`).ReplaceAllString(zone, ""),
 		CNI:               *kubernetesAnywhereCNI,
 		KubeproxyMode:     *kubernetesAnywhereProxyMode,
+		OSImage:           *kubernetesAnywhereOSImage,
 	}
 
 	return k, nil

--- a/kubetest/anywhere_test.go
+++ b/kubetest/anywhere_test.go
@@ -35,6 +35,7 @@ func TestNewKubernetesAnywhere(t *testing.T) {
 		cni               string
 		expectConfigLines []string
 		kubeproxyMode     string
+		osImage           string
 	}{
 		{
 			name:   "kubeadm defaults",
@@ -153,6 +154,25 @@ func TestNewKubernetesAnywhere(t *testing.T) {
 				".phase3.cni=\"weave\"",
 			},
 		},
+		{
+			name:   "kubeadm with default os_image",
+			phase2: "kubeadm",
+
+			expectConfigLines: []string{
+				".phase1.gce.os_image=\"ubuntu-1604-xenial-v20171212\"",
+				".phase2.provider=\"kubeadm\"",
+			},
+		},
+		{
+			name:    "kubeadm with specific os_image",
+			phase2:  "kubeadm",
+			osImage: "my-awesome-os-image",
+
+			expectConfigLines: []string{
+				".phase1.gce.os_image=\"my-awesome-os-image\"",
+				".phase2.provider=\"kubeadm\"",
+			},
+		},
 	}
 
 	mockGSFiles := map[string]string{
@@ -189,6 +209,9 @@ func TestNewKubernetesAnywhere(t *testing.T) {
 		*kubernetesAnywhereUpgradeMethod = tc.kubeadmUpgrade
 		*kubernetesAnywhereCNI = tc.cni
 		*kubernetesAnywhereProxyMode = tc.kubeproxyMode
+		if tc.osImage != "" {
+			*kubernetesAnywhereOSImage = tc.osImage
+		}
 
 		_, err = newKubernetesAnywhere("fake-project", "fake-zone")
 		if err != nil {


### PR DESCRIPTION
Followup to #5986, next time we have questions about whether the problem is with kubernetes-anwyhere's os-image, it'd be nice not to have to rebuild the kubekins-e2e or e2e-kubeadm images to find out