### PR TITLE
Use go1.9.2 and bazel 0.8.1 in kubekins-e2e for k8s 1.9+

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
 LABEL maintainer "beacham@google.com"
 
 RUN apt-get update && apt-get install -y \

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -53,7 +53,7 @@ RUN INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"; \
 
 # add env we can debug with the image name:tag
 ARG IMAGE
-ENV IMAGE=${IMAGE}}
+ENV IMAGE=${IMAGE}
 
 ADD ["e2e-runner.sh", \
     "kops-e2e-runner.sh", \

--- a/jenkins/e2e-image/Makefile
+++ b/jenkins/e2e-image/Makefile
@@ -17,8 +17,8 @@ TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 K8S ?= master
 
-GO ?= 1.9.1
-BAZEL ?= 0.6.1
+GO ?= 1.9.2
+BAZEL ?= 0.8.1
 CFSSL ?= R1.2
 
 ifeq ($(K8S), 1.8)

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -551,7 +551,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -653,7 +653,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -753,7 +753,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -851,7 +851,7 @@ presubmits:
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -2331,7 +2331,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -2433,7 +2433,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -2533,7 +2533,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -2630,7 +2630,7 @@ presubmits:
       trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -4473,7 +4473,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4597,7 +4597,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4640,7 +4640,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4764,7 +4764,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4807,7 +4807,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -4936,7 +4936,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -5383,7 +5383,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5426,7 +5426,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5460,7 +5460,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5503,7 +5503,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5546,7 +5546,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -5589,7 +5589,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -18711,7 +18711,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
       args:
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--clean"
@@ -21507,7 +21507,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -21632,7 +21632,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -21677,7 +21677,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -21800,7 +21800,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -21845,7 +21845,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -21975,7 +21975,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=release-1.9"
         - "--clean"
@@ -22018,7 +22018,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171215-0c6357162
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171218-b4eb6b44d
         args:
         - "--repo=k8s.io/kubernetes=release-1.9"
         - "--clean"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -416,7 +416,7 @@ presubmits:
       trigger: "(?m)^/test( all| pull-cri-containerd-node-e2e),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
           args:
           - --root=/go/src
           - "--clean"
@@ -1235,7 +1235,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1304,7 +1304,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1372,7 +1372,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1440,7 +1440,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1490,7 +1490,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1555,7 +1555,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1633,7 +1633,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1720,7 +1720,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1796,7 +1796,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1868,7 +1868,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1926,7 +1926,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -1984,7 +1984,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -2043,7 +2043,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-node-e2e-containerd,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3012,7 +3012,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -3081,7 +3081,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -3149,7 +3149,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -3217,7 +3217,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -3266,7 +3266,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3331,7 +3331,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3409,7 +3409,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3496,7 +3496,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3572,7 +3572,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3644,7 +3644,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3702,7 +3702,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -3760,7 +3760,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -3819,7 +3819,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
         args:
         - --root=/go/src
         - "--clean"
@@ -5151,7 +5151,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5185,7 +5185,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5207,7 +5207,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --root=/go/src
       - "--clean"
@@ -5274,7 +5274,7 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5316,7 +5316,7 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5647,7 +5647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5681,7 +5681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5715,7 +5715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5749,7 +5749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5783,7 +5783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5817,7 +5817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5851,7 +5851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5885,7 +5885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5919,7 +5919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5953,7 +5953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -5987,7 +5987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6021,7 +6021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6055,7 +6055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6089,7 +6089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6123,7 +6123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6157,7 +6157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6191,7 +6191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6225,7 +6225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6259,7 +6259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6293,7 +6293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6327,7 +6327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6361,7 +6361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6432,7 +6432,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6468,7 +6468,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6504,7 +6504,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6540,7 +6540,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6576,7 +6576,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6612,7 +6612,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6648,7 +6648,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6684,7 +6684,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6720,7 +6720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6756,7 +6756,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6792,7 +6792,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6828,7 +6828,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6864,7 +6864,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6900,7 +6900,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6936,7 +6936,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6972,7 +6972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7008,7 +7008,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7044,7 +7044,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7080,7 +7080,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7116,7 +7116,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7152,7 +7152,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7188,7 +7188,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7224,7 +7224,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7260,7 +7260,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7296,7 +7296,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7332,7 +7332,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7368,7 +7368,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7404,7 +7404,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7440,7 +7440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7476,7 +7476,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7512,7 +7512,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7548,7 +7548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7584,7 +7584,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7620,7 +7620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7656,7 +7656,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7692,7 +7692,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7728,7 +7728,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7764,7 +7764,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7800,7 +7800,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7836,7 +7836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7872,7 +7872,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7908,7 +7908,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7944,7 +7944,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7980,7 +7980,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8016,7 +8016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8052,7 +8052,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8088,7 +8088,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8124,7 +8124,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8160,7 +8160,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8196,7 +8196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8232,7 +8232,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8268,7 +8268,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8304,7 +8304,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8340,7 +8340,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8376,7 +8376,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8412,7 +8412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8448,7 +8448,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8484,7 +8484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8520,7 +8520,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8556,7 +8556,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8592,7 +8592,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8628,7 +8628,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8664,7 +8664,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8700,7 +8700,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8734,7 +8734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8768,7 +8768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8802,7 +8802,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8836,7 +8836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8870,7 +8870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8904,7 +8904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8938,7 +8938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8972,7 +8972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9006,7 +9006,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9040,7 +9040,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9074,7 +9074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9108,7 +9108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9142,7 +9142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9176,7 +9176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9210,7 +9210,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9244,7 +9244,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9278,7 +9278,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9312,7 +9312,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9346,7 +9346,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9380,7 +9380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9414,7 +9414,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9448,7 +9448,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9482,7 +9482,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9516,7 +9516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9550,7 +9550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9584,7 +9584,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9618,7 +9618,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9652,7 +9652,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9686,7 +9686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9720,7 +9720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9754,7 +9754,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9788,7 +9788,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9896,7 +9896,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9934,7 +9934,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9968,7 +9968,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10002,7 +10002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10036,7 +10036,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10070,7 +10070,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10104,7 +10104,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10138,7 +10138,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10172,7 +10172,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10206,7 +10206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10240,7 +10240,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10274,7 +10274,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10308,7 +10308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10342,7 +10342,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10376,7 +10376,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10410,7 +10410,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10444,7 +10444,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10513,7 +10513,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10551,7 +10551,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10589,7 +10589,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10623,7 +10623,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10657,7 +10657,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10691,7 +10691,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10725,7 +10725,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10759,7 +10759,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10793,7 +10793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10827,7 +10827,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10861,7 +10861,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10895,7 +10895,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10929,7 +10929,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10963,7 +10963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10997,7 +10997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11031,7 +11031,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11065,7 +11065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11099,7 +11099,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11133,7 +11133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11167,7 +11167,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11201,7 +11201,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11235,7 +11235,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11271,7 +11271,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11307,7 +11307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11343,7 +11343,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11379,7 +11379,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11415,7 +11415,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11451,7 +11451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11487,7 +11487,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11523,7 +11523,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11559,7 +11559,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11595,7 +11595,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11631,7 +11631,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11667,7 +11667,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11703,7 +11703,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11739,7 +11739,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11775,7 +11775,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11811,7 +11811,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11847,7 +11847,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11883,7 +11883,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11917,7 +11917,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11951,7 +11951,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11985,7 +11985,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12019,7 +12019,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12053,7 +12053,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12087,7 +12087,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12121,7 +12121,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12155,7 +12155,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12189,7 +12189,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12223,7 +12223,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12257,7 +12257,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12291,7 +12291,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12325,7 +12325,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12359,7 +12359,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12393,7 +12393,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12427,7 +12427,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12496,7 +12496,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12530,7 +12530,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12564,7 +12564,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12598,7 +12598,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12632,7 +12632,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12666,7 +12666,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12700,7 +12700,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12734,7 +12734,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12768,7 +12768,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12802,7 +12802,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12836,7 +12836,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12870,7 +12870,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12904,7 +12904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12938,7 +12938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12972,7 +12972,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13006,7 +13006,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13040,7 +13040,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13074,7 +13074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13108,7 +13108,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13142,7 +13142,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13176,7 +13176,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13210,7 +13210,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13244,7 +13244,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13278,7 +13278,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13312,7 +13312,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13346,7 +13346,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13380,7 +13380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13414,7 +13414,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13448,7 +13448,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13482,7 +13482,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13516,7 +13516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13550,7 +13550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13584,7 +13584,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13618,7 +13618,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13652,7 +13652,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13686,7 +13686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13757,7 +13757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13793,7 +13793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13829,7 +13829,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13865,7 +13865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13901,7 +13901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13937,7 +13937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13973,7 +13973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14009,7 +14009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14045,7 +14045,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14081,7 +14081,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14117,7 +14117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14153,7 +14153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14189,7 +14189,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14225,7 +14225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14261,7 +14261,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14297,7 +14297,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14333,7 +14333,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14369,7 +14369,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14405,7 +14405,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14441,7 +14441,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14477,7 +14477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14513,7 +14513,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14549,7 +14549,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14585,7 +14585,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14621,7 +14621,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14657,7 +14657,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14693,7 +14693,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14729,7 +14729,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14765,7 +14765,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14801,7 +14801,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14835,7 +14835,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14869,7 +14869,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14903,7 +14903,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14937,7 +14937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14971,7 +14971,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15005,7 +15005,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15039,7 +15039,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15073,7 +15073,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15107,7 +15107,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15141,7 +15141,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15175,7 +15175,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15209,7 +15209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15243,7 +15243,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15277,7 +15277,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15311,7 +15311,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15345,7 +15345,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15379,7 +15379,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15413,7 +15413,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15447,7 +15447,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15482,7 +15482,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15516,7 +15516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15550,7 +15550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15584,7 +15584,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15618,7 +15618,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15652,7 +15652,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15686,7 +15686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15720,7 +15720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15754,7 +15754,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15788,7 +15788,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15822,7 +15822,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15856,7 +15856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15890,7 +15890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15924,7 +15924,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15958,7 +15958,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15992,7 +15992,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16026,7 +16026,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16060,7 +16060,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16133,7 +16133,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16206,7 +16206,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16240,7 +16240,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16274,7 +16274,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16308,7 +16308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16342,7 +16342,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16376,7 +16376,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16410,7 +16410,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16444,7 +16444,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16478,7 +16478,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16516,7 +16516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16550,7 +16550,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16584,7 +16584,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16618,7 +16618,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16652,7 +16652,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16686,7 +16686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16720,7 +16720,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16754,7 +16754,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16788,7 +16788,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16822,7 +16822,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16856,7 +16856,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16890,7 +16890,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16924,7 +16924,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16958,7 +16958,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16992,7 +16992,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17026,7 +17026,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17060,7 +17060,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17094,7 +17094,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17128,7 +17128,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17164,7 +17164,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17200,7 +17200,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17236,7 +17236,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17272,7 +17272,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17308,7 +17308,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17344,7 +17344,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17380,7 +17380,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17416,7 +17416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17452,7 +17452,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17488,7 +17488,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17524,7 +17524,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17560,7 +17560,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17597,7 +17597,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17633,7 +17633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17669,7 +17669,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17705,7 +17705,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17741,7 +17741,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17777,7 +17777,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17813,7 +17813,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17849,7 +17849,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17885,7 +17885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17921,7 +17921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17957,7 +17957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17993,7 +17993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18029,7 +18029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18065,7 +18065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18101,7 +18101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18135,7 +18135,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18171,7 +18171,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18214,7 +18214,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18433,7 +18433,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18476,7 +18476,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18519,7 +18519,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18562,7 +18562,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18605,7 +18605,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18648,7 +18648,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18689,7 +18689,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18846,7 +18846,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18885,7 +18885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18924,7 +18924,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18963,7 +18963,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19002,7 +19002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19041,7 +19041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19080,7 +19080,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19119,7 +19119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19158,7 +19158,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19197,7 +19197,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19236,7 +19236,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19275,7 +19275,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19314,7 +19314,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19353,7 +19353,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19392,7 +19392,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19431,7 +19431,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19470,7 +19470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19509,7 +19509,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19548,7 +19548,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19587,7 +19587,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19626,7 +19626,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19665,7 +19665,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19704,7 +19704,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19743,7 +19743,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19782,7 +19782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19821,7 +19821,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19860,7 +19860,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19899,7 +19899,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19938,7 +19938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19977,7 +19977,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20016,7 +20016,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20055,7 +20055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20077,7 +20077,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --bare
       - --timeout=260
@@ -20125,7 +20125,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --bare
       - --timeout=260
@@ -20173,7 +20173,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --bare
       - --timeout=80
@@ -20221,7 +20221,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --bare
       - --timeout=80
@@ -20309,7 +20309,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --bare
       - --timeout=140
@@ -20357,7 +20357,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --bare
       - --timeout=1100
@@ -20405,7 +20405,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --bare
       - --timeout=300
@@ -20453,7 +20453,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -20490,7 +20490,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -20527,7 +20527,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --repo=k8s.io/kubernetes=release-1.9
       - --timeout=90
@@ -20564,7 +20564,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -20601,7 +20601,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -20638,7 +20638,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -20675,7 +20675,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -20712,7 +20712,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -20749,7 +20749,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
       args:
       - --repo=k8s.io/kubernetes=release-1.8
       - --timeout=90
@@ -20786,7 +20786,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -20823,7 +20823,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -20873,7 +20873,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20908,7 +20908,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20943,7 +20943,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20978,7 +20978,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21013,7 +21013,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21048,7 +21048,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21083,7 +21083,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21118,7 +21118,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21141,7 +21141,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -21177,7 +21177,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171215-2b220188a-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171215-2b220188a-master'
+DEFAULT_KUBEKINS_TAG = 'v20171218-a18c352b4-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
Forgot to include this in #5961.

/hold