### PR TITLE
[1.9] Disable freeze mode on milestone munger.

### DIFF
--- a/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/misc-mungers/deployment/kubernetes/configmap.yaml
@@ -34,5 +34,5 @@ label-file: "/gitrepos/kubernetes/labels.yaml"
 alias-file: "/gitrepos/kubernetes/OWNERS_ALIASES"
 use-reviewers: true
 # milestone-maintainer
-milestone-modes: v1.8=dev,v1.9=freeze
+milestone-modes: v1.8=dev,v1.9=dev,v1.10=dev
 milestone-freeze-date: "TBD"


### PR DESCRIPTION
This is the other half of lifting code freeze, now that we're done using the milestone to track release-blockers.

/assign @cjwagner 

Feel free to push this at your leisure.

Closes https://github.com/kubernetes/sig-release/issues/41.