### PR TITLE
Update label sync to v20171219-22a3ef0f6

### DIFF
--- a/label_sync/BUILD
+++ b/label_sync/BUILD
@@ -35,7 +35,6 @@ docker_push(
 # bazel-bin/.../label_sync.binary is the binary
 go_image(
     name = "label_sync-image",
-    base = "@distroless-base//image",
     embed = [":go_default_library"],
     importpath = "k8s.io/test-infra/label_sync",
     pure = "on",

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-testimages/label_sync:v20171215-9c0f9501e
+              image: gcr.io/k8s-testimages/label_sync:v20171219-22a3ef0f6
               args:
               - --config=/etc/config/labels.yaml
               - --dry-run=false

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,12 +26,13 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-testimages/label_sync:v20171215-9c0f9501e
+        image: gcr.io/k8s-testimages/label_sync:latest
         args:
         - --config=/etc/config/labels.yaml
         - --dry-run=false
         - --orgs=kubernetes
         - --token=/etc/github/oauth
+        - --only=kubernetes/contrib
         volumeMounts:
         - name: oauth
           mountPath: /etc/github

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-testimages/label_sync:latest
+        image: gcr.io/k8s-testimages/label_sync:v20171219-22a3ef0f6
         args:
         - --config=/etc/config/labels.yaml
         - --dry-run=false


### PR DESCRIPTION
`v20171215-9c0f9501e` fails with the following:
```
  Warning  Failed                 43s   kubelet, gke-prow-default-pool-116f5d3e-rdf6  Error: failed to start container "label-sync": Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"/app/label_sync/label_sync-image.binary\": stat /app/label_sync/label_sync-image.binary: no such file or directory"
```

It does not appear as though `go_image()` produces valid images.

Pushing a new image now that we bumped rules_docker

/assign @cblecker 
/cc @ixdy @mattmoor 