### PR TITLE
Prevent Deck's '/rerun' path from exposing info about hidden repo jobs.

### DIFF
--- a/prow/cmd/deck/BUILD
+++ b/prow/cmd/deck/BUILD
@@ -74,7 +74,6 @@ go_library(
         "//vendor/github.com/NYTimes/gziphandler:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -66,6 +66,8 @@ func main() {
 	if err != nil {
 		logger.WithError(err).Fatal("Error getting client.")
 	}
+	kc.SetHiddenReposProvider(func() []string { return configAgent.Config().Deck.HiddenRepos })
+
 	var pkc *kube.Client
 	if *buildCluster == "" {
 		pkc = kc.Namespace(configAgent.Config().PodNamespace)

--- a/prow/kube/BUILD
+++ b/prow/kube/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/kube/client_test.go
+++ b/prow/kube/client_test.go
@@ -58,6 +58,62 @@ func TestNamespace(t *testing.T) {
 	}
 }
 
+func TestSetHiddenReposProviderGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		switch r.URL.Path {
+		case "/apis/prow.k8s.io/v1/namespaces/ns/prowjobs/pja":
+			fmt.Fprint(w, `{"spec": {"job": "a", "refs": {"org": "org", "repo": "repo"}}}`)
+		case "/apis/prow.k8s.io/v1/namespaces/ns/prowjobs/pjb":
+			fmt.Fprint(w, `{"spec": {"job": "b", "refs": {"org": "hidden-org", "repo": "repo"}}}`)
+		default:
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	c.SetHiddenReposProvider(func() []string { return []string{"hidden-org"} })
+	pj, err := c.GetProwJob("pja")
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if got, expected := pj.Spec.Job, "a"; got != expected {
+		t.Errorf("Expected returned prowjob to be job %q, but got %q.", expected, got)
+	}
+
+	pj, err = c.GetProwJob("pjb")
+	if err == nil {
+		t.Fatal("Expected error getting hidden prowjob, but did not receive an error.")
+	}
+}
+
+func TestSetHiddenReposProviderList(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/apis/prow.k8s.io/v1/namespaces/ns/prowjobs" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"items": [{"spec": {"job": "a", "refs": {"org": "org", "repo": "hidden-repo"}}}, {"spec": {"job": "b", "refs": {"org": "org", "repo": "repo"}}}]}`)
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	c.SetHiddenReposProvider(func() []string { return []string{"org/hidden-repo"} })
+	pjs, err := c.ListProwJobs(EmptySelector)
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	}
+	if len(pjs) != 1 {
+		t.Fatalf("Expected one prowjobs, but got %v.", pjs)
+	}
+	if got, expected := pjs[0].Spec.Job, "b"; got != expected {
+		t.Errorf("Expected returned prowjob to be job %q, but got %q.", expected, got)
+	}
+}
+
 func TestListPods(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {


### PR DESCRIPTION
fixes #5910 
/cc @BenTheElder 