### PR TITLE
Add help wanted prow plugin

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -17,6 +17,8 @@ Command | Implemented By | Who can run it | Description
 `/reopen` | prow [lifecycle](./prow/plugins/lifecycle) | authors and assignees | reopens a closed issue/PR
 `/lifecycle [state]` | prow [lifecycle](./prow/plugins/lifecycle) | anyone | adds a stale, rotten or frozen state label
 `/remove-lifecycle [state]` | prow [lifecycle](./prow/plugins/lifecycle) | anyone | removes a stale, rotten or frozen state label
+`/help` | prow [help](./prow/plugins/help) | anyone | adds the `help wanted` label
+`/remove-help` | prow [help](./prow/plugins/help) | anyone | removes the `help wanted` label
 `/hold` | prow [hold](./prow/plugins/hold) | anyone | adds the `do-not-merge/hold` label
 `/hold cancel` | prow [hold](./prow/plugins/hold) | anyone | removes the `do-not-merge/hold` label
 `/joke` | prow [yuks](./prow/plugins/yuks) | anyone | tells a bad joke, sometimes

--- a/prow/hook/BUILD
+++ b/prow/hook/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//prow/plugins/docs-no-retest:go_default_library",
         "//prow/plugins/golint:go_default_library",
         "//prow/plugins/heart:go_default_library",
+        "//prow/plugins/help:go_default_library",
         "//prow/plugins/hold:go_default_library",
         "//prow/plugins/label:go_default_library",
         "//prow/plugins/lgtm:go_default_library",

--- a/prow/hook/plugins.go
+++ b/prow/hook/plugins.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/docs-no-retest"
 	_ "k8s.io/test-infra/prow/plugins/golint"
 	_ "k8s.io/test-infra/prow/plugins/heart"
+	_ "k8s.io/test-infra/prow/plugins/help"
 	_ "k8s.io/test-infra/prow/plugins/hold"
 	_ "k8s.io/test-infra/prow/plugins/label"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -146,6 +146,7 @@ plugins:
   - cla
   - golint
   - heart
+  - help
   - hold
   - label
   - lgtm

--- a/prow/plugins/BUILD
+++ b/prow/plugins/BUILD
@@ -57,6 +57,7 @@ filegroup(
         "//prow/plugins/docs-no-retest:all-srcs",
         "//prow/plugins/golint:all-srcs",
         "//prow/plugins/heart:all-srcs",
+        "//prow/plugins/help:all-srcs",
         "//prow/plugins/hold:all-srcs",
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",

--- a/prow/plugins/help/BUILD
+++ b/prow/plugins/help/BUILD
@@ -1,0 +1,48 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["help_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/plugins/help",
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["help.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/help",
+    tags = ["automanaged"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package help
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "help"
+
+var (
+	helpLabel         = "help wanted"
+	helpRe            = regexp.MustCompile(`(?mi)^/help\s*$`)
+	helpRemoveRe      = regexp.MustCompile(`(?mi)^/remove-help\s*$`)
+	helpGuidelinesURL = "https://git.k8s.io/community/contributors/devel/help-wanted.md"
+	helpMsg           = `
+This request has been marked as needing help from a contributor.
+
+Please ensure the request meets the requirements listed [here](` + helpGuidelinesURL + `).
+
+If this request no longer meets these requirements, the label can be removed
+by commenting with the "/remove-help" command.
+`
+)
+
+func init() {
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	// The Config field is omitted because this plugin is not configurable.
+	return &pluginhelp.PluginHelp{
+			Description: "The help plugin provides commands that add or remove the '" + helpLabel + "' label from issues.",
+			WhoCanUse:   "Anyone can trigger this plugin on a PR.",
+			Usage:       "/[remove-]help",
+			Examples:    []string{"/help", "/remove-help"},
+		},
+		nil
+}
+
+type githubClient interface {
+	BotName() (string, error)
+	CreateComment(owner, repo string, number int, comment string) error
+	AddLabel(owner, repo string, number int, label string) error
+	RemoveLabel(owner, repo string, number int, label string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+type commentPruner interface {
+	PruneComments(shouldPrune func(github.IssueComment) bool)
+}
+
+func handleGenericComment(pc plugins.PluginClient, e github.GenericCommentEvent) error {
+	return handle(pc.GitHubClient, pc.Logger, pc.CommentPruner, &e)
+}
+
+func handle(gc githubClient, log *logrus.Entry, cp commentPruner, e *github.GenericCommentEvent) error {
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	commentAuthor := e.User.Login
+
+	// Determine if the issue has the help label
+	labels, err := gc.GetIssueLabels(org, repo, e.Number)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to get issue labels.")
+	}
+	hasHelp := github.HasLabel(helpLabel, labels)
+
+	// If PR has help label and we're asking it to be removed, remove label
+	if hasHelp && helpRemoveRe.MatchString(e.Body) {
+		if err := gc.RemoveLabel(org, repo, e.Number, helpLabel); err != nil {
+			log.WithError(err).Errorf("Github failed to remove the following label: %s", helpLabel)
+		}
+		botName, err := gc.BotName()
+		if err != nil {
+			log.WithError(err).Errorf("Failed to get bot name.")
+		}
+		cp.PruneComments(shouldPrune(log, botName))
+		return nil
+	}
+
+	// If PR does not have the label and we're asking it to be added,
+	// add the label
+	if !hasHelp && helpRe.MatchString(e.Body) {
+		if err := gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.IssueHTMLURL, commentAuthor, helpMsg)); err != nil {
+			log.WithError(err).Errorf("Failed to create comment \"%s\".", helpMsg)
+		}
+		if err := gc.AddLabel(org, repo, e.Number, helpLabel); err != nil {
+			log.WithError(err).Errorf("Github failed to add the following label: %s", helpLabel)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+// shouldPrune finds comments left by this plugin.
+func shouldPrune(log *logrus.Entry, botName string) func(github.IssueComment) bool {
+	return func(comment github.IssueComment) bool {
+		if comment.User.Login != botName {
+			return false
+		}
+		return strings.Contains(comment.Body, helpMsg)
+	}
+}

--- a/prow/plugins/help/help_test.go
+++ b/prow/plugins/help/help_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package help
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+)
+
+type fakePruner struct{}
+
+func (fp *fakePruner) PruneComments(shouldPrune func(github.IssueComment) bool) {}
+
+func formatLabels(labels ...string) []string {
+	r := []string{}
+	for _, l := range labels {
+		r = append(r, fmt.Sprintf("%s/%s#%d:%s", "org", "repo", 1, l))
+	}
+	if len(r) == 0 {
+		return nil
+	}
+	return r
+}
+
+func TestLabel(t *testing.T) {
+	type testCase struct {
+		name                  string
+		body                  string
+		expectedNewLabels     []string
+		expectedRemovedLabels []string
+		issueLabels           []string
+	}
+	testcases := []testCase{
+		{
+			name:                  "Irrelevant comment",
+			body:                  "irrelelvant",
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: []string{},
+			issueLabels:           []string{},
+		},
+		{
+			name:                  "Want helpLabel",
+			body:                  "/help",
+			expectedNewLabels:     formatLabels(helpLabel),
+			expectedRemovedLabels: []string{},
+			issueLabels:           []string{},
+		},
+		{
+			name:                  "Want helpLabel, already have it.",
+			body:                  "/help",
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: []string{},
+			issueLabels:           []string{helpLabel},
+		},
+		{
+			name:                  "Want to remove helpLabel, have it",
+			body:                  "/remove-help",
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: formatLabels(helpLabel),
+			issueLabels:           []string{helpLabel},
+		},
+		{
+			name:                  "Want to remove helpLabel, don't have it",
+			body:                  "/remove-help",
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: []string{},
+			issueLabels:           []string{},
+		},
+	}
+
+	for _, tc := range testcases {
+		sort.Strings(tc.expectedNewLabels)
+		fakeClient := &fakegithub.FakeClient{
+			Issues:         make([]github.Issue, 1),
+			IssueComments:  make(map[int][]github.IssueComment),
+			ExistingLabels: []string{helpLabel},
+			LabelsAdded:    []string{},
+			LabelsRemoved:  []string{},
+		}
+		// Add initial labels
+		for _, label := range tc.issueLabels {
+			fakeClient.AddLabel("org", "repo", 1, label)
+		}
+		e := &github.GenericCommentEvent{
+			Action: github.GenericCommentActionCreated,
+			Body:   tc.body,
+			Number: 1,
+			Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+			User:   github.User{Login: "Alice"},
+		}
+		err := handle(fakeClient, logrus.WithField("plugin", pluginName), &fakePruner{}, e)
+		if err != nil {
+			t.Errorf("For case %s, didn't expect error from label test: %v", tc.name, err)
+			continue
+		}
+
+		// Check that all the correct labels (and only the correct labels) were added.
+		expectLabels := append(formatLabels(tc.issueLabels...), tc.expectedNewLabels...)
+		if expectLabels == nil {
+			expectLabels = []string{}
+		}
+		sort.Strings(expectLabels)
+		sort.Strings(fakeClient.LabelsAdded)
+		if !reflect.DeepEqual(expectLabels, fakeClient.LabelsAdded) {
+			t.Errorf("(%s): Expected the labels %q to be added, but %q were added.", tc.name, expectLabels, fakeClient.LabelsAdded)
+		}
+
+		sort.Strings(tc.expectedRemovedLabels)
+		sort.Strings(fakeClient.LabelsRemoved)
+		if !reflect.DeepEqual(tc.expectedRemovedLabels, fakeClient.LabelsRemoved) {
+			t.Errorf("(%s): Expected the labels %q to be removed, but %q were removed.", tc.name, tc.expectedRemovedLabels, fakeClient.LabelsRemoved)
+		}
+	}
+}


### PR DESCRIPTION
Simplified version of #3952.
Resolves kubernetes/community#860.

This PR implements a new prow plugin that allows the `help wanted` label to be applied to issues.

cc: @kubernetes/sig-contributor-experience-pr-reviews 