### PR TITLE
Add k/sig-release to tide with implicit self-approval

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -28,6 +28,7 @@ tide:
     - kubernetes/charts
     - kubernetes/federation
     - kubernetes/kubernetes-template-project
+    - kubernetes/sig-release
     - kubernetes/test-infra
     labels:
     - lgtm

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -17,6 +17,7 @@ approve:
   - kubernetes/charts
   - kubernetes/community
   - kubernetes/kubectl
+  - kubernetes/sig-release
   - kubernetes/test-infra
   implicit_self_approve: true
 - repos:
@@ -134,6 +135,9 @@ plugins:
   - blockade
 
   kubernetes/kubernetes-template-project:
+  - approve
+
+  kubernetes/sig-release:
   - approve
 
   kubernetes/test-infra:


### PR DESCRIPTION
Part of kubernetes/sig-release#44

Won't really be useful until kubernetes/sig-release#47 merges