### PR TITLE
fix prow link coloring

### DIFF
--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -16,7 +16,7 @@ header {
 }
 
 header a {
-    color: inherit;
+    color: inherit !important;
 }
 
 header ul {


### PR DESCRIPTION
without `!important` the text is blue when you have not visited the page before (AFAICT), which leads to some bad looking first visits to eg the plugin-help page.

/area prow