### PR TITLE
Scrub the deck

### DIFF
--- a/prow/cmd/deck/static/index.html
+++ b/prow/cmd/deck/static/index.html
@@ -13,7 +13,7 @@
     <body>
         <header>
             <ul>
-                <li><a href="/"><h1>Prow Status</h1></a></li>
+                <li><a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"></img></a><a href="/" class="current"><h1>Prow Status</h1></a></li>
                 <li><a href="/plugin-help.html"><h1>Plugin Help</h1></a></li>
                 <li><a href="/tide.html"><h1>Tide Status</h1></a></li>
             </ul>

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -12,7 +12,11 @@
     </head>
     <body>
         <header>
-            <a href="/"><h1>Prow Plugin Help</h1></a>
+            <ul>
+                <li><a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"></img></a><a href="/"><h1>Prow Status</h1></a></li>
+                <li><a href="/plugin-help.html" class="current"><h1>Plugin Help</h1></a></li>
+                <li><a href="/tide.html"><h1>Tide Status</h1></a></li>
+            </ul>
         </header>
         <aside>
         <div>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -16,7 +16,7 @@ header {
 }
 
 header a {
-    color: inherit;
+    color: inherit !important;
 }
 
 header ul {

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -10,30 +10,60 @@ body {
 header {
     background-color: #3f51b5;
     color: white;
-    padding: 2px;
-    padding-left: 20px;
-    box-shadow: 0px 0px 10px #666;
+    padding: .1em;
+    box-shadow: 0px 0px .5em #666;
 }
 
 header a {
     color: inherit !important;
 }
 
+header a.logo {
+    height: 3em;
+    padding: 0;
+    margin: 0;
+}
+
+a.current {
+    text-decoration: underline !important;
+}
+
+img.logo {
+    height: inherit;
+}
+
 header ul {
     list-style-type: none;
     overflow: auto;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 header ul li {
-    float: right;
+    display: inline;
     list-style-type: none;
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-left: .5em;
+    padding-right: .5em;
+    list-style: none;
+    display: inline-block;
 }
 
 header ul li:first-child {
-    float: left;
+    margin: 0;
+    padding-left: .25em;
+    padding-right: .25em;
+    display: flex;
 }
+
+header ul li:first-child a:first-child {
+   padding-right: .5em;
+}
+
 
 h1 {
     font-weight: normal;
@@ -155,7 +185,7 @@ th {
 }
 
 .success {
-    color: #22dd22;
+    color: #28a745;
 }
 
 .failure {
@@ -197,4 +227,8 @@ a:link {
 
 #plugin-shrug {
     display: none;
+}
+
+#queries li {
+    padding: .5em;
 }

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>Tide Status</title>
         <link rel="icon" type="image/png" href="favicon.ico">
         <link rel="stylesheet" type="text/css" href="style.css">
@@ -12,12 +13,18 @@
     </head>
     <body>
         <header>
-            <a href="/"><h1>Tide Status</h1></a>
+            <ul>
+                <li><a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"></img></a><a href="/"><h1>Prow Status</h1></a></li>
+                <li><a href="/plugin-help.html"><h1>Plugin Help</h1></a></li>
+                <li><a href="/tide.html" class="current"><h1>Tide Status</h1></a></li>
+            </ul>
         </header>
         <article>
             <div>
-                <h4>Github search queries that define all merge requirements:</h4>
+                <h4>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green to merge&nbsp;<span class="success">✓</span></h4>
+                <h4>These GitHub search queries define all other merge requirements:</h4>
                 <ul id="queries"></ul>
+                <h4>Your Pull Request must show up in one of these queries (you can click them to check).</h4>
             </div>
         </article>
         <article>


### PR DESCRIPTION
- make success check mark match GitHub color
- make links always be the color we applied
- make the header match across dashboards and highlight the current page's link
- add kubernetes logo / test-infra link in default deployment (TBD: making this easy to swap)
- use flex for the header instead of half-working ul/li/:first-child setup
- clarify merge requirements in tide
- improve some spacing / migrating things towards EM which is more friendly than px for DPI tweaks etc..

TODO:
- I'd like to display the labels matching how they look on github
- probably other things