### PR TITLE
Use tide for kubernetes/community

### DIFF
--- a/mungegithub/submit-queue/deployment/community/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/community/configmap.yaml
@@ -6,7 +6,7 @@ project: community
 # Otherwise it's going to take an extra-cycle to detect the label change.
 # Run blunderbuss before approval-handler, so that we can suggest approvers
 # based on assigned reviewer.
-pr-mungers: comment-deleter,lgtm-after-commit,needs-rebase,owner-label,sig-mention-handler,submit-queue
+pr-mungers: comment-deleter,lgtm-after-commit,needs-rebase,owner-label,sig-mention-handler
 state: open
 token-file: /etc/secret-volume/token
 period: 5m

--- a/mungegithub/submit-queue/deployment/community/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/community/configmap.yaml
@@ -6,7 +6,7 @@ project: community
 # Otherwise it's going to take an extra-cycle to detect the label change.
 # Run blunderbuss before approval-handler, so that we can suggest approvers
 # based on assigned reviewer.
-pr-mungers: blunderbuss,comment-deleter,lgtm-after-commit,needs-rebase,owner-label,sig-mention-handler,submit-queue
+pr-mungers: comment-deleter,lgtm-after-commit,needs-rebase,owner-label,sig-mention-handler,submit-queue
 state: open
 token-file: /etc/secret-volume/token
 period: 5m

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -36,15 +36,18 @@ tide:
     - approved
     - "cncf-cla: yes"
     missingLabels:
-    - needs-ok-to-test
-    - do-not-merge/work-in-progress
-    - do-not-merge/hold
+    - do-not-merge
     - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-ok-to-test
   - repos:
     - kubernetes/kubectl
     missingLabels:
-    - do-not-merge/work-in-progress
     - do-not-merge/hold
+    - do-not-merge/work-in-progress
     reviewApprovedRequired: true
   merge_method:
     kubernetes/charts: squash

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -26,6 +26,7 @@ tide:
   queries:
   - repos:
     - kubernetes/charts
+    - kubernetes/community
     - kubernetes/federation
     - kubernetes/kubernetes-template-project
     - kubernetes/sig-release
@@ -38,6 +39,7 @@ tide:
     - needs-ok-to-test
     - do-not-merge/work-in-progress
     - do-not-merge/hold
+    - do-not-merge/blocked-paths
   - repos:
     - kubernetes/kubectl
     missingLabels:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -102,6 +102,7 @@ plugins:
 
   kubernetes/community:
   - approve
+  - blunderbuss
   - blockade
   - trigger
 


### PR DESCRIPTION
Strawman PR:
- could we start using tide for k/community as-is?
- what other mungers do we need to migrate over to prow before we could decommission k/community's mungegithub?