### PR TITLE
Add k/steering to tide with implicit self-approval

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -29,6 +29,7 @@ tide:
     - kubernetes/federation
     - kubernetes/kubernetes-template-project
     - kubernetes/sig-release
+    - kubernetes/steering
     - kubernetes/test-infra
     labels:
     - lgtm

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -19,6 +19,7 @@ approve:
   - kubernetes/community
   - kubernetes/kubectl
   - kubernetes/sig-release
+  - kubernetes/steering
   - kubernetes/test-infra
   implicit_self_approve: true
 - repos:
@@ -139,6 +140,9 @@ plugins:
   - approve
 
   kubernetes/sig-release:
+  - approve
+
+  kubernetes/steering:
   - approve
 
   kubernetes/test-infra:


### PR DESCRIPTION
/hold
depends on kubernetes/steering#15