### PR TITLE
Branch all of the PR jobs that use kubekins-e2e

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1828,21 +1828,13 @@ presubmits:
           path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-kubemark-e2e-gce
-    agent: jenkins
-    always_run: true
-    max_concurrency: 12
-    context: pull-kubernetes-kubemark-e2e-gce
-    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
-    trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
-    branches:
-    - release-1.6
-
-  - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true
     max_concurrency: 12
     skip_branches:
-    - release-1.6
+    - release-1.6  # runs on Jenkins?
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     context: pull-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
@@ -1912,19 +1904,320 @@ presubmits:
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
+  - name: pull-kubernetes-kubemark-e2e-gce
+    agent: kubernetes
+    always_run: true
+    max_concurrency: 12
+    branches:
+    - release-1.8
+    context: pull-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=110"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-kubernetes-kubemark-e2e-gce
+    agent: kubernetes
+    always_run: true
+    max_concurrency: 12
+    branches:
+    - release-1.7
+    context: pull-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=110"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-kubernetes-kubemark-e2e-gce
+    agent: jenkins
+    always_run: true
+    max_concurrency: 12
+    context: pull-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    branches:
+    - release-1.6
 
   - name: pull-kubernetes-kubemark-e2e-gce-big
     agent: kubernetes
     always_run: false
     max_concurrency: 12
     skip_branches:
-    - release-1.6
+    - release-1.6  # not supported
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     context: pull-kubernetes-kubemark-e2e-gce-big
     rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-kubernetes-kubemark-e2e-gce-big
+    agent: kubernetes
+    always_run: false
+    max_concurrency: 12
+    branches:
+    - release-1.8
+    context: pull-kubernetes-kubemark-e2e-gce-big
+    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
+    trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-kubernetes-kubemark-e2e-gce-big
+    agent: kubernetes
+    always_run: false
+    max_concurrency: 12
+    branches:
+    - release-1.7
+    context: pull-kubernetes-kubemark-e2e-gce-big
+    rerun_command: "/test pull-kubernetes-kubemark-e2e-gce-big"
+    trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -3733,21 +4026,13 @@ presubmits:
           path: /mnt/disks/ssd0
 
   - name: pull-security-kubernetes-kubemark-e2e-gce
-    agent: jenkins
-    always_run: true
-    max_concurrency: 12
-    context: pull-security-kubernetes-kubemark-e2e-gce
-    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
-    branches:
-    - release-1.6
-
-  - name: pull-security-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true
     max_concurrency: 12
     skip_branches:
-    - release-1.6
+    - release-1.6  # runs on Jenkins?
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     context: pull-security-kubernetes-kubemark-e2e-gce
     rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
@@ -3817,19 +4102,320 @@ presubmits:
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph
+  - name: pull-security-kubernetes-kubemark-e2e-gce
+    agent: kubernetes
+    always_run: true
+    max_concurrency: 12
+    branches:
+    - release-1.8
+    context: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=110"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-security-kubernetes-kubemark-e2e-gce
+    agent: kubernetes
+    always_run: true
+    max_concurrency: 12
+    branches:
+    - release-1.7
+    context: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=110"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-security-kubernetes-kubemark-e2e-gce
+    agent: jenkins
+    always_run: true
+    max_concurrency: 12
+    context: pull-security-kubernetes-kubemark-e2e-gce
+    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
+    branches:
+    - release-1.6
 
   - name: pull-security-kubernetes-kubemark-e2e-gce-big
     agent: kubernetes
     always_run: false
     max_concurrency: 12
     skip_branches:
-    - release-1.6
+    - release-1.6  # not supported
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     context: pull-security-kubernetes-kubemark-e2e-gce-big
     rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
     trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-security-kubernetes-kubemark-e2e-gce-big
+    agent: kubernetes
+    always_run: false
+    max_concurrency: 12
+    branches:
+    - release-1.8
+    context: pull-security-kubernetes-kubemark-e2e-gce-big
+    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
+    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        # TODO(krzyzacy): Figure out bazel built kubemark image
+        # - name: KUBEMARK_BAZEL_BUILD
+        # value: "y" 
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+      - name: docker-graph
+        hostPath:
+          path: /mnt/disks/ssd0/docker-graph
+  - name: pull-security-kubernetes-kubemark-e2e-gce-big
+    agent: kubernetes
+    always_run: false
+    max_concurrency: 12
+    branches:
+    - release-1.7
+    context: pull-security-kubernetes-kubemark-e2e-gce-big
+    rerun_command: "/test pull-security-kubernetes-kubemark-e2e-gce-big"
+    trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
         args:
         - --root=/go/src
         - "--clean"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1480,8 +1480,9 @@ presubmits:
   - name: pull-kubernetes-e2e-gce-device-plugin-gpu
     agent: kubernetes
     skip_branches:
-    - release-1.6
-    - release-1.7
+    - release-1.6  # not supported
+    - release-1.7  # not supported
+    - release-1.8  # per-release image
     always_run: true
     skip_report: false
     max_concurrency: 12
@@ -1541,12 +1542,76 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  - name: pull-kubernetes-e2e-gce-device-plugin-gpu
+    agent: kubernetes
+    branches:
+    - release-1.8
+    always_run: true
+    skip_report: false
+    max_concurrency: 12
+    context: pull-kubernetes-e2e-gce-device-plugin-gpu
+    rerun_command: "/test pull-kubernetes-e2e-gce-device-plugin-gpu"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
 
   - name: pull-kubernetes-e2e-gke-device-plugin-gpu
     agent: kubernetes
     skip_branches:
-    - release-1.6
-    - release-1.7
+    - release-1.6  # not supported
+    - release-1.7  # not supported
+    - release-1.8  # per-release image
     always_run: false
     skip_report: false
     max_concurrency: 1
@@ -1556,6 +1621,69 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-e2e-gke-device-plugin-gpu
+    agent: kubernetes
+    branches:
+    - release-1.8  # per-release image
+    always_run: false
+    skip_report: false
+    max_concurrency: 1
+    context: pull-kubernetes-e2e-gke-device-plugin-gpu
+    rerun_command: "/test pull-kubernetes-e2e-gke-device-plugin-gpu"
+    trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -3253,11 +3381,13 @@ presubmits:
     always_run: true
     branches:
     - release-1.6
+
   - name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
     agent: kubernetes
     skip_branches:
-    - release-1.6
-    - release-1.7
+    - release-1.6  # not supported
+    - release-1.7  # not supported
+    - release-1.8  # per-release image
     always_run: true
     skip_report: false
     max_concurrency: 12
@@ -3317,12 +3447,76 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    agent: kubernetes
+    branches:
+    - release-1.8
+    always_run: true
+    skip_report: false
+    max_concurrency: 12
+    context: pull-security-kubernetes-e2e-gce-device-plugin-gpu
+    rerun_command: "/test pull-security-kubernetes-e2e-gce-device-plugin-gpu"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
 
   - name: pull-security-kubernetes-e2e-gke-device-plugin-gpu
     agent: kubernetes
     skip_branches:
-    - release-1.6
-    - release-1.7
+    - release-1.6  # not supported
+    - release-1.7  # not supported
+    - release-1.8  # per-release image
     always_run: false
     skip_report: false
     max_concurrency: 1
@@ -3332,6 +3526,69 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=90"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    agent: kubernetes
+    branches:
+    - release-1.8  # per-release image
+    always_run: false
+    skip_report: false
+    max_concurrency: 1
+    context: pull-security-kubernetes-e2e-gke-device-plugin-gpu
+    rerun_command: "/test pull-security-kubernetes-e2e-gke-device-plugin-gpu"
+    trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
         args:
         - --root=/go/src
         - "--clean"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1741,19 +1741,13 @@ presubmits:
     rerun_command: "/test pull-kubernetes-e2e-gke-gci"
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-gci,?(\\s+|$)"
     run_if_changed: '^(cluster/gce|cluster/addons).*$'
-  - name: pull-kubernetes-e2e-kops-aws
-    agent: jenkins
-    branches:
-    - release-1.6
-    max_concurrency: 12
-    always_run: true
-    context: pull-kubernetes-e2e-kops-aws
-    rerun_command: "/test pull-kubernetes-e2e-kops-aws"
-    trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
+
   - name: pull-kubernetes-e2e-kops-aws
     agent: kubernetes
     skip_branches:
-    - release-1.6
+    - release-1.6  # runs on Jenkins?
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     max_concurrency: 12
     always_run: true
     context: pull-kubernetes-e2e-kops-aws
@@ -1826,6 +1820,167 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  - name: pull-kubernetes-e2e-kops-aws
+    agent: kubernetes
+    branches:
+    - release-1.8
+    max_concurrency: 12
+    always_run: true
+    context: pull-kubernetes-e2e-kops-aws
+    rerun_command: "/test pull-kubernetes-e2e-kops-aws"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_AWS_CREDENTIALS_FILE
+          value: /etc/aws-cred/credentials
+        - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-private
+        - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/aws-ssh
+          name: aws-ssh
+          readOnly: true
+        - mountPath: /etc/aws-cred
+          name: aws-cred
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: aws-ssh
+        secret:
+          defaultMode: 256
+          secretName: aws-ssh-key-secret
+      - name: aws-cred
+        secret:
+          defaultMode: 256
+          secretName: aws-cred
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-e2e-kops-aws
+    agent: kubernetes
+    branches:
+    - release-1.7
+    max_concurrency: 12
+    always_run: true
+    context: pull-kubernetes-e2e-kops-aws
+    rerun_command: "/test pull-kubernetes-e2e-kops-aws"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=75"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_AWS_CREDENTIALS_FILE
+          value: /etc/aws-cred/credentials
+        - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-private
+        - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/aws-ssh
+          name: aws-ssh
+          readOnly: true
+        - mountPath: /etc/aws-cred
+          name: aws-cred
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: aws-ssh
+        secret:
+          defaultMode: 256
+          secretName: aws-ssh-key-secret
+      - name: aws-cred
+        secret:
+          defaultMode: 256
+          secretName: aws-cred
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-e2e-kops-aws
+    agent: jenkins
+    branches:
+    - release-1.6
+    max_concurrency: 12
+    always_run: true
+    context: pull-kubernetes-e2e-kops-aws
+    rerun_command: "/test pull-kubernetes-e2e-kops-aws"
+    trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
 
   - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
@@ -3998,19 +4153,13 @@ presubmits:
     rerun_command: "/test pull-security-kubernetes-e2e-gke-gci"
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-gci,?(\\s+|$)"
     run_if_changed: '^(cluster/gce|cluster/addons).*$'
-  - name: pull-security-kubernetes-e2e-kops-aws
-    agent: jenkins
-    branches:
-    - release-1.6
-    max_concurrency: 12
-    always_run: true
-    context: pull-security-kubernetes-e2e-kops-aws
-    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
-    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
+
   - name: pull-security-kubernetes-e2e-kops-aws
     agent: kubernetes
     skip_branches:
-    - release-1.6
+    - release-1.6  # runs on Jenkins?
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     max_concurrency: 12
     always_run: true
     context: pull-security-kubernetes-e2e-kops-aws
@@ -4083,6 +4232,167 @@ presubmits:
       - name: cache-ssd
         hostPath:
           path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-e2e-kops-aws
+    agent: kubernetes
+    branches:
+    - release-1.8
+    max_concurrency: 12
+    always_run: true
+    context: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=75"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_AWS_CREDENTIALS_FILE
+          value: /etc/aws-cred/credentials
+        - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-private
+        - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/aws-ssh
+          name: aws-ssh
+          readOnly: true
+        - mountPath: /etc/aws-cred
+          name: aws-cred
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: aws-ssh
+        secret:
+          defaultMode: 256
+          secretName: aws-ssh-key-secret
+      - name: aws-cred
+        secret:
+          defaultMode: 256
+          secretName: aws-cred
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-e2e-kops-aws
+    agent: kubernetes
+    branches:
+    - release-1.7
+    max_concurrency: 12
+    always_run: true
+    context: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.7
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=75"
+        # the release-1.6 version of this job uses Jenkins, so here we override
+        # some args for jobs on Prow
+        - --
+        - --build=bazel
+        - --mode=local
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_AWS_CREDENTIALS_FILE
+          value: /etc/aws-cred/credentials
+        - name: JENKINS_AWS_SSH_PRIVATE_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-private
+        - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
+          value: /etc/aws-ssh/aws-ssh-public
+        - name: TEST_TMPDIR
+          value: /root/.cache/bazel
+        # Bazel needs privileged mode in order to sandbox builds.
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/aws-ssh
+          name: aws-ssh
+          readOnly: true
+        - mountPath: /etc/aws-cred
+          name: aws-cred
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: aws-ssh
+        secret:
+          defaultMode: 256
+          secretName: aws-ssh-key-secret
+      - name: aws-cred
+        secret:
+          defaultMode: 256
+          secretName: aws-cred
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-e2e-kops-aws
+    agent: jenkins
+    branches:
+    - release-1.6
+    max_concurrency: 12
+    always_run: true
+    context: pull-security-kubernetes-e2e-kops-aws
+    rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
 
   - name: pull-security-kubernetes-kubemark-e2e-gce
     agent: kubernetes

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1741,7 +1741,6 @@ presubmits:
     rerun_command: "/test pull-kubernetes-e2e-gke-gci"
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-gci,?(\\s+|$)"
     run_if_changed: '^(cluster/gce|cluster/addons).*$'
-
   - name: pull-kubernetes-e2e-kops-aws
     agent: kubernetes
     skip_branches:
@@ -1981,7 +1980,6 @@ presubmits:
     context: pull-kubernetes-e2e-kops-aws
     rerun_command: "/test pull-kubernetes-e2e-kops-aws"
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
-
   - name: pull-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true
@@ -4153,7 +4151,6 @@ presubmits:
     rerun_command: "/test pull-security-kubernetes-e2e-gke-gci"
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-gci,?(\\s+|$)"
     run_if_changed: '^(cluster/gce|cluster/addons).*$'
-
   - name: pull-security-kubernetes-e2e-kops-aws
     agent: kubernetes
     skip_branches:
@@ -4393,7 +4390,6 @@ presubmits:
     context: pull-security-kubernetes-e2e-kops-aws
     rerun_command: "/test pull-security-kubernetes-e2e-kops-aws"
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
-
   - name: pull-security-kubernetes-kubemark-e2e-gce
     agent: kubernetes
     always_run: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -2280,8 +2280,9 @@ presubmits:
   - name: pull-kubernetes-node-e2e
     agent: kubernetes
     skip_branches:
-    - release-1.6
-    - release-1.7
+    - release-1.6  # per-release image
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     always_run: true
     max_concurrency: 12
     context: pull-kubernetes-node-e2e
@@ -2290,6 +2291,64 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-kubernetes-node-e2e
+    agent: kubernetes
+    branches:
+    - release-1.8
+    always_run: true
+    max_concurrency: 12
+    context: pull-kubernetes-node-e2e
+    rerun_command: "/test pull-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -4478,8 +4537,9 @@ presubmits:
   - name: pull-security-kubernetes-node-e2e
     agent: kubernetes
     skip_branches:
-    - release-1.6
-    - release-1.7
+    - release-1.6  # per-release image
+    - release-1.7  # per-release image
+    - release-1.8  # per-release image
     always_run: true
     max_concurrency: 12
     context: pull-security-kubernetes-node-e2e
@@ -4488,6 +4548,64 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+        args:
+        - --root=/go/src
+        - "--clean"
+        - "--git-cache=/root/.cache/git"
+        - "--job=$(JOB_NAME)"
+        - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-security-jenkins/pr-logs"
+        - "--timeout=90"
+        - "--" # end bootstrap args, scenario args below
+        - "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml"
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        - name: USER
+          value: prow
+        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-private
+        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+          value: /etc/ssh-key-secret/ssh-public
+        volumeMounts:
+        - mountPath: /etc/service-account
+          name: service
+          readOnly: true
+        - mountPath: /etc/ssh-key-secret
+          name: ssh
+          readOnly: true
+        - name: cache-ssd
+          mountPath: /root/.cache
+        ports:
+        - containerPort: 9999
+          hostPort: 9999
+        resources:
+          requests:
+            memory: "6Gi"
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
+      - name: ssh
+        secret:
+          defaultMode: 256
+          secretName: ssh-key-secret
+      - name: cache-ssd
+        hostPath:
+          path: /mnt/disks/ssd0
+  - name: pull-security-kubernetes-node-e2e
+    agent: kubernetes
+    branches:
+    - release-1.8
+    always_run: true
+    max_concurrency: 12
+    context: pull-security-kubernetes-node-e2e
+    rerun_command: "/test pull-security-kubernetes-node-e2e"
+    trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
         args:
         - --root=/go/src
         - "--clean"


### PR DESCRIPTION
The only reasonable way to review this is per-commit, probably.

I still maintain this is far worse than something like #4918.

This PR is needed because otherwise we can't update bazel (https://github.com/kubernetes/test-infra/pull/5990) without breaking a bunch of release-branch jobs.

/assign @BenTheElder 