### PR TITLE
fix a few more deck/tide frontend things

### DIFF
--- a/prow/cmd/deck/static/index.html
+++ b/prow/cmd/deck/static/index.html
@@ -5,7 +5,7 @@
         <link rel="icon" type="image/png" href="favicon.ico">
         <link rel="stylesheet" type="text/css" href="style.css">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
-        <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="script.js"></script>
         <script type="text/javascript" src="data.js?var=allBuilds"></script>
         <script type="text/javascript" src="extensions/script.js"></script>

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -5,7 +5,7 @@
         <link rel="icon" type="image/png" href="favicon.ico">
         <link rel="stylesheet" type="text/css" href="style.css">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
-        <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="plugin-help-script.js"></script>
         <script type="text/javascript" src="plugin-help.js?var=allHelp"></script>
         <script type="text/javascript" src="extensions/script.js"></script>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -5,6 +5,8 @@ body {
     color: #444;
     padding: 0;
     margin: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 header {
@@ -19,9 +21,10 @@ header a {
 }
 
 header a.logo {
-    height: 3em;
+    height: 2.5em;
     padding: 0;
     margin: 0;
+    margin-top: .2em;
 }
 
 a.current {

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -6,7 +6,7 @@
         <link rel="icon" type="image/png" href="favicon.ico">
         <link rel="stylesheet" type="text/css" href="style.css">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
-        <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="tidescript.js"></script>
         <script type="text/javascript" src="tide.js?var=tideData"></script>
         <script type="text/javascript" src="extensions/script.js"></script>


### PR DESCRIPTION
/area prow

After bumping deck I noticed some of the text was quite blurry on my workstation and the header has an unwanted scrollbar.

- load the bold font
- enable font smoothing in webkit / moz browsers
- fix the logo height / offset

Before:
![image](https://user-images.githubusercontent.com/917931/34180882-194a935c-e4c5-11e7-9404-8810a1071706.png)
After:
![image](https://user-images.githubusercontent.com/917931/34180907-287e10ec-e4c5-11e7-8318-9070a1829113.png)
