### PR TITLE
serve tide queries

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -171,8 +171,9 @@ func handleTide(ca *config.Agent, ta *tideAgent) http.HandlerFunc {
 		ta.Lock()
 		defer ta.Unlock()
 		payload := tideData{
-			Queries: queries,
-			Pools:   ta.pools,
+			Queries:     queries,
+			TideQueries: queryConfigs,
+			Pools:       ta.pools,
 		}
 		pd, err := json.Marshal(payload)
 		if err != nil {

--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -25,12 +25,14 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/tide"
 )
 
 type tideData struct {
-	Queries []string
-	Pools   []tide.Pool
+	Queries     []string
+	TideQueries []config.TideQuery
+	Pools       []tide.Pool
 }
 
 type tideAgent struct {


### PR DESCRIPTION
This will be used to let the front-end explain tide queries while linking to the raw queries.

I'm eventually headed towards something like:
![image](https://user-images.githubusercontent.com/917931/34187219-28b6d6be-e4e5-11e7-9198-a3ed354df94d.png)

This should get all the data we need except the label colors to the front-end, and then I will replicate this.
/area prow