### PR TITLE
make plugin help slightly more discoverable

### DIFF
--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -23,6 +23,7 @@
             <ul class="noBullets">
                 <li>Plugin help for</li>
                 <li><select id="repo" onchange="redraw();"><option>all plugins</option></select></li>
+                <li>(click a plugin below to expand/hide help)</li>
             </ul>
         </div>
         </aside>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -101,6 +101,7 @@ div {
 
 h3.plugin {
     color: blue;
+    cursor: pointer;
 }
 
 div {


### PR DESCRIPTION
- add a hint about expanding plugin help next to the repo selection drop-down
- set `cursor: pointer` for plugin help entries, which hopefully also makes this more obvious

/area prow