### PR TITLE
Add logging when pod is missing

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -32,7 +32,7 @@ TOT_VERSION              ?= 0.6
 # HOROLOGIUM_VERSION is the version of the horologium image
 HOROLOGIUM_VERSION       ?= 0.20
 # PLANK_VERSION is the version of the plank image
-PLANK_VERSION            ?= 0.63
+PLANK_VERSION            ?= 0.64
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
 JENKINS-OPERATOR_VERSION ?= 0.61
 # TIDE_VERSION is the version of the tide image

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.63
+        image: gcr.io/k8s-prow/plank:0.64
         args:
         - --tot-url=http://tot
         - --build-cluster=/etc/cluster/cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -118,7 +118,7 @@ spec:
     spec:
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:0.63
+        image: gcr.io/k8s-prow/plank:0.64
         args:
         - --dry-run=false
         volumeMounts:

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -328,6 +328,7 @@ func (c *Controller) syncPendingJob(pj kube.ProwJob, pm map[string]kube.Pod, rep
 		} else {
 			pj.Status.BuildID = id
 			pj.Status.PodName = pn
+			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Pod is missing, starting a new pod")
 		}
 	} else {
 		switch pod.Status.Phase {
@@ -335,6 +336,7 @@ func (c *Controller) syncPendingJob(pj kube.ProwJob, pm map[string]kube.Pod, rep
 			c.incrementNumPendingJobs(pj.Spec.Job)
 			// Pod is in Unknown state. This can happen if there is a problem with
 			// the node. Delete the old pod, we'll start a new one next loop.
+			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Pod is in unknown state, deleting & restarting pod")
 			return c.pkc.DeletePod(pj.Metadata.Name)
 
 		case kube.PodSucceeded:


### PR DESCRIPTION
per https://github.com/kubernetes/test-infra/issues/5893#issuecomment-352962161, a prow pod can be restarted without a state transition.

I suspect either the pod is deleted by a controller (sinker misbehaving?) or the pod is in a bad state. Adding some logs to verify which case it is, and we can make appropriate fixes.

/area prow
/assign @cjwagner @BenTheElder 