### PR TITLE
Only delete prow pod when prowjob is marked as complete

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -22,7 +22,7 @@ GIT_VERSION              ?= 0.1
 # HOOK_VERSION is the version of the hook image
 HOOK_VERSION             ?= 0.193
 # SINKER_VERSION is the version of the sinker image
-SINKER_VERSION           ?= 0.25
+SINKER_VERSION           ?= 0.26
 # DECK_VERSION is the version of the deck image
 DECK_VERSION             ?= 0.74
 # SPLICE_VERSION is the version of the splice image

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       - name: sinker
         args:
         - --build-cluster=/etc/cluster/cluster
-        image: gcr.io/k8s-prow/sinker:0.25
+        image: gcr.io/k8s-prow/sinker:0.26
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:0.25
+        image: gcr.io/k8s-prow/sinker:0.26
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -143,6 +143,18 @@ func TestClean(t *testing.T) {
 		},
 		{
 			Metadata: kube.ObjectMeta{
+				Name: "old-just-complete",
+				Labels: map[string]string{
+					kube.CreatedByProw: "true",
+				},
+			},
+			Status: kube.PodStatus{
+				Phase:     kube.PodSucceeded,
+				StartTime: time.Now().Add(-maxPodAge).Add(-time.Second),
+			},
+		},
+		{
+			Metadata: kube.ObjectMeta{
 				Name: "new-failed",
 				Labels: map[string]string{
 					kube.CreatedByProw: "true",
@@ -192,6 +204,32 @@ func TestClean(t *testing.T) {
 		"old-succeeded",
 	}
 	prowJobs := []kube.ProwJob{
+		{
+			Metadata: kube.ObjectMeta{
+				Name: "old-failed",
+			},
+			Status: kube.ProwJobStatus{
+				StartTime:      time.Now().Add(-maxProwJobAge).Add(-time.Second),
+				CompletionTime: time.Now().Add(-time.Second),
+			},
+		},
+		{
+			Metadata: kube.ObjectMeta{
+				Name: "old-succeeded",
+			},
+			Status: kube.ProwJobStatus{
+				StartTime:      time.Now().Add(-maxProwJobAge).Add(-time.Second),
+				CompletionTime: time.Now().Add(-time.Second),
+			},
+		},
+		{
+			Metadata: kube.ObjectMeta{
+				Name: "old-just-complete",
+			},
+			Status: kube.ProwJobStatus{
+				StartTime: time.Now().Add(-maxProwJobAge).Add(-time.Second),
+			},
+		},
 		{
 			Metadata: kube.ObjectMeta{
 				Name: "old-complete",
@@ -258,6 +296,8 @@ func TestClean(t *testing.T) {
 		},
 	}
 	deletedProwJobs := []string{
+		"old-failed",
+		"old-succeeded",
 		"old-complete",
 		"older-periodic",
 		"oldest-periodic",


### PR DESCRIPTION
I think this will resolve https://github.com/kubernetes/test-infra/issues/5893

It did not occur so often because sinker was running once per 30min, until we let it sync every minute fairy recently @BenTheElder 

alternatively we can introduce things like `finishedAt` from upstream types, but that will be more messy. This should be enough for now since prow pods and prowjobs are sharing the same name

/area prow
/assign @BenTheElder @cjwagner @spxtr 

cc @porridge 