### PR TITLE
Lengthen timeouts for kubelet-serial suite

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -9758,7 +9758,7 @@
       "--node-tests=true",
       "--provider=gce",
       "--test_args=--nodes=1 --focus=\"\\[Serial\\]\" --skip=\"\\[Flaky\\]|\\[Benchmark\\]\"",
-      "--timeout=180m"
+      "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -10694,11 +10694,11 @@
       "--gcp-project=k8s-jkns-ci-node-e2e",
       "--gcp-zone=us-central1-f",
       "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml",
-      "--node-test-args=--feature-gates=DynamicKubeletConfig=true,LocalStorageCapacityIsolation=true,PodPriority=true --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-test-args= --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
       "--node-tests=true",
       "--provider=gce",
       "--test_args=--nodes=1 --focus=\"\\[Flaky\\]\"",
-      "--timeout=120m"
+      "--timeout=60m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
@@ -10728,7 +10728,7 @@
       "--gcp-project=k8s-jkns-ci-node-e2e",
       "--gcp-zone=us-west1-b",
       "--node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml",
-      "--node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
+      "--node-test-args=--feature-gates=DynamicKubeletConfig=true,PodPriority=true,LocalStorageCapacityIsolation=true --kubelet-flags=\"--cgroups-per-qos=true --cgroup-root=/\"",
       "--node-tests=true",
       "--provider=gce",
       "--test_args=--nodes=1 --focus=\"\\[Serial\\]\" --skip=\"\\[Flaky\\]|\\[Benchmark\\]\"",


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/57467 moves some tests from the flaky suite to the serial suite.  To ensure the suite does not hit timeouts, increase the timeout for the serial suite.
This should wait until https://github.com/kubernetes/kubernetes/pull/57467 merges.