### PR TITLE
Use kubekins-e2e 1.9 image for nodee2e 1.9 tests

### DIFF
--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -991,11 +991,11 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.9
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.9
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-1.9
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.8

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -20377,7 +20377,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.9
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-1.9
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20416,7 +20416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.9
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-1.9
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20455,7 +20455,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20494,7 +20494,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20767,7 +20767,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.9
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-1.9
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20806,7 +20806,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.9
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-1.9
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20845,7 +20845,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20884,7 +20884,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21157,7 +21157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21196,7 +21196,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21391,7 +21391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.9
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-1.9
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21430,7 +21430,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.9
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-1.9
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21469,7 +21469,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21508,7 +21508,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21547,7 +21547,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21586,7 +21586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171220-29cb083c9-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service


### PR DESCRIPTION
Built and pushed the 1.9 image using

```
cd jenkins/e2e-image
K8S=1.9 make push
```

/assign @BenTheElder @krzyzacy 