### PR TITLE
explain tide queries

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,7 +24,7 @@ HOOK_VERSION             ?= 0.193
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.26
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.75
+DECK_VERSION             ?= 0.76
 # SPLICE_VERSION is the version of the splice image
 SPLICE_VERSION           ?= 0.34
 # TOT_VERSION is the version of the tot image

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.75
+        image: gcr.io/k8s-prow/deck:0.76
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.75
+        image: gcr.io/k8s-prow/deck:0.76
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:

--- a/prow/cmd/deck/static/index.html
+++ b/prow/cmd/deck/static/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Prow Status</title>
         <link rel="icon" type="image/png" href="favicon.ico">
-        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1">
+        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513816381">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="script.js"></script>

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -3,7 +3,7 @@
     <head>
         <title>Prow Plugin Help</title>
         <link rel="icon" type="image/png" href="favicon.ico">
-        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1">
+        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513816381">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="plugin-help-script.js"></script>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -234,5 +234,60 @@ a:link {
 }
 
 #queries li {
-    padding: .5em;
+    padding: .5em .35em;
+    line-height: 2;
+    color: black;
+}
+
+
+span.label {
+    padding: .11em .35em;
+    border-radius: .2em;
+    border: .1em solid transparent;
+    transition: opacity 0.2s linear;
+    font-weight: bold;
+    margin: 0 .1em;
+    text-align: center;
+    color: white;
+    box-shadow: inset 0 -1px 0 rgba(27,31,35,0.12);
+    background-color: #ededed;
+    color: #333333;
+    white-space: nowrap;
+}
+
+span.label:hover {
+    opacity: 0.85;
+}
+
+.emphasis {
+    font-weight: bold;
+}
+
+
+/* Known GitHub Labels, can be overriden in extensions/style.css */
+/* NOTE: spaces must be stripped from the label name */
+.label.lgtm {
+    background-color: #15dd18;
+    color: #fff;
+}
+.label.approved {
+    background-color: #0ffa16;
+    color: #033304;
+}
+.label.cncf-cla\:yes {
+    background-color: #bfe5bf;
+    color: black;
+}
+.label.needs-ok-to-test {
+    background-color: #b60205;
+    color: white;
+}
+.label.do-not-merge,
+.label.do-not-merge\/hold,
+.label.do-not-merge\/work-in-progress, 
+.label.do-not-merge\/release-note-label-needed, 
+.label.do-not-merge\/cherry-pick-not-approved,
+.label.do-not-merge\/blocked-paths {
+    background-color: #e11d21;
+    color: #fff;
 }

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <title>Tide Status</title>
         <link rel="icon" type="image/png" href="favicon.ico">
-        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1">
+        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513816381">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="tidescript.js"></script>
@@ -21,10 +21,9 @@
         </header>
         <article>
             <div>
-                <h4>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green to merge&nbsp;<span class="success">✓</span></h4>
-                <h4>These GitHub search queries define all other merge requirements:</h4>
+                <h4>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></h4>
+                <h4>Your Pull Request must also match one of these queries (you can click them to check):</h4>
                 <ul id="queries"></ul>
-                <h4>Your Pull Request must show up in one of these queries (you can click them to check).</h4>
             </div>
         </article>
         <article>


### PR DESCRIPTION
also link to deck results for a tide pool instead of GitHub

limitations:
- doesn't support arbitrary new tide query fields
- label colors must be put in CSS
  - this had to be done because GitHub seems to assign the label text colors in their backend so we can't just grab this from the label_sync data
  - this also means it's trivial to override these in `extensions/style.css` for another deployment
- spaces are stripped from labels when assigning a matching CSS class
  - I don't expect to see two variants of a label with and without spaces, and this makes them valid class names

This takes us from:
![screen shot 2017-12-20 at 4 31 21 pm](https://user-images.githubusercontent.com/917931/34235418-7550a420-e5a6-11e7-846e-ef4c0ec65293.png)
To:
![screen shot 2017-12-20 at 4 50 27 pm](https://user-images.githubusercontent.com/917931/34235425-83f0a098-e5a6-11e7-9045-63bbc206d654.png)
