### PR TITLE
Add Stackdriver Logging tests for GKE

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -7074,6 +7074,114 @@
       "sig-scalability"
     ]
   },
+  "ci-kubernetes-e2e-gke-sd-logging-gci-beta": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--extract=ci/k8s-beta",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-instrumentation"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-sd-logging-gci-latest": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--extract=ci/latest",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-instrumentation"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-sd-logging-gci-stable1": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--extract=ci/k8s-stable1",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-instrumentation"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--extract=ci/k8s-beta",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=ubuntu",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-instrumentation"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--extract=ci/latest",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=ubuntu",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-instrumentation"
+    ]
+  },
+  "ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--extract=ci/k8s-stable1",
+      "--gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging",
+      "--gcp-node-image=ubuntu",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=test",
+      "--provider=gke",
+      "--test_args=--ginkgo.focus=\\[Feature:StackdriverLogging\\] --minStartupPods=8",
+      "--timeout=1320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-instrumentation"
+    ]
+  },
   "ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew": {
     "args": [
       "--check-leaked-resources",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -18030,6 +18030,210 @@ periodics:
         defaultMode: 256
         secretName: ssh-key-secret
 
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
+  spec:
+    containers:
+    - args:
+      - --timeout=1400
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
+  spec:
+    containers:
+    - args:
+      - --timeout=1400
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
+  spec:
+    containers:
+    - args:
+      - --timeout=1400
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
+  spec:
+    containers:
+    - args:
+      - --timeout=1400
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
+  spec:
+    containers:
+    - args:
+      - --timeout=1400
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
+- interval: 30m
+  agent: kubernetes
+  name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
+  spec:
+    containers:
+    - args:
+      - --timeout=1400
+      - --bare
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: USER
+        value: prow
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      volumeMounts:
+      - mountPath: /etc/service-account
+        name: service
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+
 - interval: 2h
   agent: kubernetes
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -282,6 +282,18 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-autoscaling
 - name: ci-kubernetes-e2e-gke-stackdriver
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-stackdriver
+- name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-sd-logging-gci-latest
+- name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
+- name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-sd-logging-gci-beta
+- name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
+- name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-sd-logging-gci-stable1
+- name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
 - name: ci-kubernetes-e2e-gci-gke-flaky
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke-flaky
 - name: ci-kubernetes-e2e-gci-gke
@@ -2280,8 +2292,6 @@ dashboards:
   dashboard_tab:
   - name: gci-gke-alpha-features
     test_group_name: ci-kubernetes-e2e-gci-gke-alpha-features
-  - name: gke-stackdriver
-    test_group_name: ci-kubernetes-e2e-gke-stackdriver
   - name: gci-gke-flaky
     test_group_name: ci-kubernetes-e2e-gci-gke-flaky
   - name: gci-gke
@@ -2395,6 +2405,23 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-slow
   - name: gke-ubuntustable1-k8sstable2-updown
     test_group_name: ci-kubernetes-e2e-gke-ubuntustable1-k8sstable2-updown
+
+- name: google-gke-stackdriver
+  dashboard_tab:
+  - name: sd-monitoring
+    test_group_name: ci-kubernetes-e2e-gke-stackdriver
+  - name: sd-logging-gci-latest
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
+  - name: sd-logging-ubuntu-latest
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
+  - name: sd-logging-gci-1.9
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
+  - name: sd-logging-ubuntu-1.9
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
+  - name: sd-logging-gci-1.8
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
+  - name: sd-logging-ubuntu-1.8
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
 
 - name: google-gke-staging
   dashboard_tab:
@@ -3727,6 +3754,30 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gke-stackdriver
     base_options: 'include-filter-by-regex=sig-instrumentation'
     description: 'sig-instrumentation gke stackdriver monitoring e2e tests for master branch'
+  - name: gke-sd-logging-gci-latest
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
+    base_options: 'include-filter-by-regex=sig-instrumentation'
+    description: 'sig-instrumentation gke stackdriver logging e2e tests for master branch with COS'
+  - name: gke-sd-logging-ubuntu-latest
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
+    base_options: 'include-filter-by-regex=sig-instrumentation'
+    description: 'sig-instrumentation gke stackdriver logging e2e tests for master branch with Ubuntu'
+  - name: gke-sd-logging-gci-1.9
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
+    base_options: 'include-filter-by-regex=sig-instrumentation'
+    description: 'sig-instrumentation gke stackdriver logging e2e tests for 1.9 branch with COS'
+  - name: gke-sd-logging-ubuntu-1.9
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
+    base_options: 'include-filter-by-regex=sig-instrumentation'
+    description: 'sig-instrumentation gke stackdriver logging e2e tests for 1.9 branch with Ubuntu'
+  - name: gke-sd-logging-gci-1.8
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
+    base_options: 'include-filter-by-regex=sig-instrumentation'
+    description: 'sig-instrumentation gke stackdriver logging e2e tests for 1.8 branch with COS'
+  - name: gke-sd-logging-ubuntu-1.8
+    test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
+    base_options: 'include-filter-by-regex=sig-instrumentation'
+    description: 'sig-instrumentation gke stackdriver logging e2e tests for 1.9 branch with Ubuntu'
 
 - name: sig-network-gce
   dashboard_tab:


### PR DESCRIPTION
There are 6 new tests:

- For each OS image (COS/Ubuntu)
- For each of the latest branches (master/1.9/1.8)

I also separated Stackdriver tests to the new gke tab