### PR TITLE
Turndown SQ, turnup prow blunderbuss and tide for k/contrib

### DIFF
--- a/mungegithub/submit-queue/deployment/contrib/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/contrib/configmap.yaml
@@ -4,7 +4,7 @@ organization: kubernetes
 project: contrib
 # Make sure approval-handler and blunderbuss run before submit-queue.
 # Otherwise it's going to take an extra-cycle to detect the label change.
-pr-mungers: blunderbuss,lgtm-after-commit,submit-queue,needs-rebase
+pr-mungers: lgtm-after-commit,needs-rebase
 state: open
 token-file: /etc/secret-volume/token
 period: 2m

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -28,6 +28,7 @@ tide:
     - kubernetes/charts
     - kubernetes/cluster-registry
     - kubernetes/community
+    - kubernetes/contrib
     - kubernetes/federation
     - kubernetes/kubernetes-template-project
     - kubernetes/sig-release

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -111,6 +111,7 @@ plugins:
 
   kubernetes/contrib:
   - approve
+  - blunderbuss
 
   kubernetes/dns:
   - trigger


### PR DESCRIPTION
This is like #6019 but now for kubernetes/contrib instead of kubernetes/community

/hold
need @cjwagner or someone with mungegithub super powers to be able to bounce it once this is merged
need someone with admin rights to kubernetes/contrib to run `migratestatus` once submit-queue is turned down