### PR TITLE
make tide explanation bulleted, and link to branch in pool

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,7 +24,7 @@ HOOK_VERSION             ?= 0.193
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.26
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.76
+DECK_VERSION             ?= 0.77
 # SPLICE_VERSION is the version of the splice image
 SPLICE_VERSION           ?= 0.34
 # TOT_VERSION is the version of the tot image

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.76
+        image: gcr.io/k8s-prow/deck:0.77
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.76
+        image: gcr.io/k8s-prow/deck:0.77
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:

--- a/prow/cmd/deck/static/index.html
+++ b/prow/cmd/deck/static/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Prow Status</title>
         <link rel="icon" type="image/png" href="favicon.ico">
-        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513816381">
+        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513905648">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="script.js"></script>

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -3,7 +3,7 @@
     <head>
         <title>Prow Plugin Help</title>
         <link rel="icon" type="image/png" href="favicon.ico">
-        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513816381">
+        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513905648">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
         <script type="text/javascript" src="plugin-help-script.js"></script>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -233,10 +233,12 @@ a:link {
     display: none;
 }
 
+
 #queries li {
     padding: .5em .35em;
-    line-height: 2;
+    line-height: 1.75;
     color: black;
+    list-style-type: disc;
 }
 
 
@@ -290,4 +292,8 @@ span.label:hover {
 .label.do-not-merge\/blocked-paths {
     background-color: #e11d21;
     color: #fff;
+}
+.label.needs-rebase {
+    background-color: #BDBDBD;
+    color: #333333;
 }

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -4,10 +4,10 @@
         <meta charset="UTF-8">
         <title>Tide Status</title>
         <link rel="icon" type="image/png" href="favicon.ico">
-        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513816381">
+        <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513905648">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
-        <script type="text/javascript" src="tidescript.js"></script>
+        <script type="text/javascript" src="tidescript.js?reload-me-please=1513905648"></script>
         <script type="text/javascript" src="tide.js?var=tideData"></script>
         <script type="text/javascript" src="extensions/script.js"></script>
     </head>
@@ -22,7 +22,7 @@
         <article>
             <div>
                 <h4>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></h4>
-                <h4>Your Pull Request must also match one of these queries (you can click them to check):</h4>
+                <h4>Your Pull Request must also match one of these GitHub search queries (you can click them to check):</h4>
                 <ul id="queries"></ul>
             </div>
         </article>

--- a/prow/cmd/deck/static/tidescript.js
+++ b/prow/cmd/deck/static/tidescript.js
@@ -47,7 +47,7 @@ function redrawQueries() {
         // GitHub query search link
         var a = createLink(
             "https://github.com/search?utf8=" + encodeURIComponent("\u2713") + "&q=" + encodeURIComponent(query),
-            "Query Search Link"
+            "GitHub Search Link"
         );
         li.appendChild(a);
 
@@ -55,27 +55,34 @@ function redrawQueries() {
         // all queries should implicitly mean this
         var explanationPrefix = " - Meaning: Is an open Pull Request in one of the following repos: ";
         li.appendChild(document.createTextNode(explanationPrefix));
+        var ul = document.createElement("ul");
+        var innerLi = document.createElement("li");
+        ul.appendChild(innerLi);
+        li.appendChild(ul);
         // add the list of repos
         var repos = tideQuery["repos"];
         for (var j = 0; j < repos.length; j++) {
-            var a = createLink("https://github.com/" + repos[j], repos[j]);
-            li.appendChild(a);
+            innerLi.appendChild(createLink("https://github.com/" + repos[j], repos[j]));
             if (j+1 < repos.length) {
-                li.appendChild(document.createTextNode(", "));
+                innerLi.appendChild(document.createTextNode(", "));
             }
         }
         // required labels
         var hasLabels = tideQuery.hasOwnProperty("labels") && tideQuery["labels"].length > 0;
         if (hasLabels) {
             var labels = tideQuery["labels"];
-            li.appendChild(document.createTextNode("; "));
             li.appendChild(createSpan(["emphasis"], "", "with"));
             li.appendChild(document.createTextNode(" the following labels: "));
+            li.appendChild(document.createElement("br"));
+            var ul = document.createElement("ul");
+            var innerLi = document.createElement("li");
+            ul.appendChild(innerLi);
+            li.appendChild(ul);
             for (var j = 0; j < labels.length; j++) {
                 var label = labels[j];
-                li.appendChild(createSpan(["label", normalizeLabelToClass(label)], "", label));
+                innerLi.appendChild(createSpan(["label", normalizeLabelToClass(label)], "", label));
                 if (j+1 < labels.length) {
-                    li.appendChild(document.createTextNode(", "));
+                    innerLi.appendChild(document.createTextNode(" "));
                 }
             }
         }
@@ -84,17 +91,21 @@ function redrawQueries() {
         if (hasMissingLabels) {
             var missingLabels = tideQuery["missingLabels"];
             if (hasLabels) {
-                li.appendChild(document.createTextNode("; and "));
+                li.appendChild(createSpan(["emphasis"], "", "and without"));
             } else {
-                li.appendChild(document.createTextNode("; "));
+                li.appendChild(createSpan(["emphasis"], "", "without"));
             }
-            li.appendChild(createSpan(["emphasis"], "", "without"));
             li.appendChild(document.createTextNode(" the following labels: "));
+            li.appendChild(document.createElement("br"));
+            var ul = document.createElement("ul");
+            var innerLi = document.createElement("li");
+            ul.appendChild(innerLi);
+            li.appendChild(ul);
             for (var j = 0; j < missingLabels.length; j++) {
                 var label = missingLabels[j];
-                li.appendChild(createSpan(["label", normalizeLabelToClass(label)], "", label));
+                innerLi.appendChild(createSpan(["label", normalizeLabelToClass(label)], "", label));
                 if (j+1 < missingLabels.length) {
-                    li.appendChild(document.createTextNode(", "));
+                    innerLi.appendChild(document.createTextNode(" "));
                 }
             }
         }
@@ -102,14 +113,12 @@ function redrawQueries() {
         // GitHub native review required
         var reviewApprovedRequired = tideQuery.hasOwnProperty("reviewApprovedRequired") && tideQuery["reviewApprovedRequired"];
         if (reviewApprovedRequired) {
-            li.appendChild(document.createTextNode("; and must be approved "));
+            li.appendChild(document.createTextNode("and must be "));
             li.appendChild(createLink(
                 "https://help.github.com/articles/about-pull-request-reviews/",
                 "approved by GitHub review"
             ));
         }
-
-        li.appendChild(document.createTextNode("."));
 
         // actually add the entry
         queries.appendChild(li);
@@ -129,9 +138,14 @@ function redrawPools() {
         var pool = tideData.Pools[i];
         var r = document.createElement("tr");
 
-        var repoName = pool.Org + "/" + pool.Repo + " " + pool.Branch;
+        
         var deckLink = "/?repo="+pool.Org+"%2F"+pool.Repo;
-        r.appendChild(createLinkCell(repoName, deckLink, ""));
+        var repoLink = "https://github.com/" + pool.Org + "/" + pool.Repo + "/tree/" + pool.Branch;
+        var linksTD = document.createElement("td");
+        linksTD.appendChild(createLink(deckLink, pool.Org + "/" + pool.Repo));
+        linksTD.appendChild(document.createTextNode(" "));
+        linksTD.appendChild(createLink(repoLink, pool.Branch));
+        r.appendChild(linksTD);
         r.appendChild(createActionCell(pool));
         r.appendChild(createPRCell(pool, pool.BatchPending));
         r.appendChild(createPRCell(pool, pool.SuccessPRs));


### PR DESCRIPTION
As discussed on slack, long queries don't work well with the new UX, so this cleans that up a bit
![image](https://user-images.githubusercontent.com/917931/34281696-46ec3bf6-e675-11e7-8625-60be4617fba6.png)


This also makes the branch section of the pool entries link to the branch on GitHub branch

EDIT: and now fixes a bug with "approved approved" for approval required queries.

This also renames "Query Search Link" to "GitHub Search Link" and clarifies that these are GitHub queries in the text above, which hopefully makes their use more obvious.