### PR TITLE
Add a new job for Spark on GKE CI testing

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -11200,5 +11200,24 @@
     "sigOwners": [
       "sig-testing"
     ]
+  },
+  "spark-k8s-periodic": {
+    "args": [
+      "--check-leaked-resources",
+      "--deployment=gke",
+      "--extract=gke",
+      "--gcp-node-image=gci",
+      "--gcp-zone=us-central1-f",
+      "--gke-environment=prod",
+      "--provider=gke",
+      "--test=false",
+      "--test-cmd=../e2e/e2e-prow.sh",
+      "--test-cmd-name=spark-integration",
+      "--timeout=120m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-big-data"
+    ]
   }
 }

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -24108,6 +24108,46 @@ periodics:
       secret:
         secretName: fejta-bot-token
 
+- interval: 1h
+  agent: kubernetes
+  name: spark-k8s-periodic
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-1.8
+      args:
+      - "--clean"
+      - "--job=$(JOB_NAME)"
+      - "--repo=github.com/apache-spark-on-k8s/spark-integration=cloud-testing-scripts"
+      - "--upload=gs://kubernetes-jenkins/logs/"
+      - "--timeout=150"
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - name: docker-graph
+        mountPath: /docker-graph
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+      resources:
+        requests:
+          cpu: 4
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
+
 - interval: 8h
   agent: kubernetes
   name: tf-k8s-periodic
@@ -24127,3 +24167,4 @@ periodics:
     - name: service
       secret:
         secretName: service-account
+

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1632,6 +1632,8 @@ test_groups:
   num_columns_recent: 30
 - name: tf-k8s-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/tensorflow_k8s/tf-k8s-postsubmit
+- name: spark-k8s-periodic
+  gcs_prefix: kubernetes-jenkins/logs/spark-k8s-periodic
 # kube-proxy daemonset migration jobs
 - name: ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-latest-downgrade-kube-proxy-ds
@@ -3532,6 +3534,10 @@ dashboards:
   - name: tf-k8s-presubmit
     description: Presubmit tests of TfJob CRD running on stable GKE.
     test_group_name: tf-k8s-presubmit
+  - name: spark-k8s-periodic
+    description: Periodic builds and testing of Apache Spark at head running on stable GKE.
+    test_group_name: spark-k8s-periodic
+
 
 - name: sig-autoscaling
   dashboard_tab:


### PR DESCRIPTION
Adding a new job for testing the Kubernetes scheduler backend in Apache Spark.

cc/ @cjwagner @kimoonkim @liyinan926 @krzyzacy 