### PR TITLE
Ingress-GCE e2e testing setup

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10603,6 +10603,21 @@
       "sig-instrumentation"
     ]
   },
+  "pull-ingress-gce-e2e": {
+    "args": [
+      "--buildIngressGCE",
+      "--cluster=",
+      "--extract=ci/latest",
+      "--gcp-zone=us-central1-f",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
+      "--timeout=60m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "pull-kops-e2e-kubernetes-aws": {
     "args": [
       "--aws",
@@ -10870,15 +10885,6 @@
     "scenario": "kubernetes_e2e",
     "sigOwners": [
       "sig-testing"
-    ]
-  },
-  "pull-kubernetes-ingress-gce-test": {
-    "args": [
-      "true"
-    ],
-    "scenario": "execute",
-    "sigOwners": [
-      "sig-network"
     ]
   },
   "pull-kubernetes-kubemark-e2e-gce": {

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -136,13 +136,13 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
   kubernetes/ingress-gce:
-  - name: pull-kubernetes-ingress-gce-test
+  - name: pull-ingress-gce-e2e
     agent: kubernetes
-    context: pull-kubernetes-ingress-gce-test
+    context: pull-ingress-gce-e2e
     branches:
     - master
-    rerun_command: "/test pull-kubernetes-ingress-gce-test"
-    trigger: "(?m)^/test( all| pull-kubernetes-ingress-gce-test),?(\\s+|$)"
+    rerun_command: "/test pull-ingress-gce-e2e"
+    trigger: "(?m)^/test( all| pull-ingress-gce-e2e),?(\\s+|$)"
     always_run: true
     spec:
       containers:
@@ -2054,7 +2054,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -2129,7 +2129,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -2204,7 +2204,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -2286,7 +2286,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -2356,7 +2356,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -2426,7 +2426,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -4464,7 +4464,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -4539,7 +4539,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -4614,7 +4614,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -4696,7 +4696,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -4766,7 +4766,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -4836,7 +4836,7 @@ presubmits:
         env:
         # TODO(krzyzacy): Figure out bazel built kubemark image
         # - name: KUBEMARK_BAZEL_BUILD
-        # value: "y" 
+        # value: "y"
         - name: DOCKER_IN_DOCKER_ENABLED
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
Getting k/ingress-gce ready for presubmit e2e testing. The final goal is to run the ingress e2e tests specified in k/k every time a PR is opened in k/ingress-gce 

Changes:

1. Remove previously committed boilerplate from jobs/config.json and replaced with proper initial configuration.
2. Modified kubetest to allow for specifying whether it should build ingress-gce
3. Corresponding changes in prow/config.yaml to bring everything together.