### PR TITLE
Change k/k SQ loop period from 10m to 1m.

### DIFF
--- a/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kubernetes/configmap.yaml
@@ -5,7 +5,7 @@ project: kubernetes
 pr-mungers: submit-queue
 state: open
 token-file: /etc/secret-volume/token
-period: 10m
+period: 1m
 github-key-file: /etc/hook-secret-volume/secret
 
 # status context options.


### PR DESCRIPTION
Now that there aren't 10 million PRs in the queue this should be safe to reduce. It was originally set to 20s, but 1m should be sufficiently fast.
/cc @rmmh 