### PR TITLE
Switch k/kops from SQ to Tide.

### DIFF
--- a/mungegithub/submit-queue/deployment/kops/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kops/configmap.yaml
@@ -2,27 +2,12 @@
 http-cache-dir: /cache/httpcache
 organization: kubernetes
 project: kops
-pr-mungers: check-labels,lgtm-after-commit,submit-queue,needs-rebase
+pr-mungers: check-labels,lgtm-after-commit,needs-rebase
 state: open
 token-file: /etc/secret-volume/token
 period: 2m
 repo-dir: /gitrepos
 github-key-file: /etc/hook-secret-volume/secret
 
-# status contexts options.
-required-contexts: "continuous-integration/travis-ci/pr"
-required-retest-contexts: "pull-kops-e2e-kubernetes-aws"
-protected-branches-extra-contexts: "cla/linuxfoundation"
-
-# submit-queue options.
-protected-branches: "master"
-nonblocking-jobs: ""
-do-not-merge-milestones: ""
-admin-port: 9999
-context-url: https://kops.submit-queue.k8s.io
-
 # munger specific options.
 label-file: /gitrepos/kops/labels.yaml
-
-gate-cla: true
-gate-approved: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -30,6 +30,7 @@ tide:
     - kubernetes/community
     - kubernetes/contrib
     - kubernetes/federation
+    - kubernetes/kops
     - kubernetes/kubernetes-template-project
     - kubernetes/sig-release
     - kubernetes/steering


### PR DESCRIPTION
cc @chrislovecnm This transfers automatic merge handling from the submit-queue instance to Tide.

https://kops.submit-queue.k8s.io
will stop showing data and users will instead be directed to 
https://prow.k8s.io/tide.html

This is the last kubernetes org submit queue instance to switch besides the main kubernetes/kubernetes instance.

/hold
so that I can disable the SQ when this merges.