### PR TITLE
Make Tide's front end faster.

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/ghodss/yaml"
@@ -101,8 +102,9 @@ func main() {
 
 	if *tideURL != "" {
 		ta := &tideAgent{
-			log:  logger.WithField("agent", "tide"),
-			path: *tideURL,
+			log:          logger.WithField("agent", "tide"),
+			path:         *tideURL,
+			updatePeriod: func() time.Duration { return configAgent.Config().Deck.TideUpdatePeriod },
 		}
 		ta.start()
 		http.Handle("/tide.js", gziphandler.GzipHandler(handleTide(configAgent, ta)))

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -211,7 +211,8 @@ func TestTide(t *testing.T) {
 		},
 	})
 	ta := tideAgent{
-		path: s.URL,
+		path:         s.URL,
+		updatePeriod: func() time.Duration { return time.Minute },
 	}
 	if err := ta.update(); err != nil {
 		t.Fatalf("Updating: %v", err)

--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -48,7 +48,7 @@ func (ta *tideAgent) start() {
 		ta.log.WithError(err).Error("Updating pool for the first time.")
 	}
 	go func() {
-		for range time.Tick(time.Minute) {
+		for range time.Tick(time.Second * 10) {
 			if err := ta.update(); err != nil {
 				ta.log.WithError(err).Error("Updating pool.")
 			}

--- a/prow/cmd/deck/tide.go
+++ b/prow/cmd/deck/tide.go
@@ -36,19 +36,23 @@ type tideData struct {
 }
 
 type tideAgent struct {
-	log  *logrus.Entry
-	path string
+	log          *logrus.Entry
+	path         string
+	updatePeriod func() time.Duration
 
 	sync.Mutex
 	pools []tide.Pool
 }
 
 func (ta *tideAgent) start() {
+	startTime := time.Now()
 	if err := ta.update(); err != nil {
 		ta.log.WithError(err).Error("Updating pool for the first time.")
 	}
 	go func() {
-		for range time.Tick(time.Second * 10) {
+		for {
+			time.Sleep(time.Until(startTime.Add(ta.updatePeriod())))
+			startTime = time.Now()
 			if err := ta.update(); err != nil {
 				ta.log.WithError(err).Error("Updating pool.")
 			}

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -97,12 +97,15 @@ func main() {
 
 	c := tide.NewController(ghc, kc, configAgent, gc, logger)
 
+	start := time.Now()
 	sync(c)
 	if *runOnce {
 		return
 	}
 	go func() {
-		for range time.Tick(time.Minute) {
+		for {
+			time.Sleep(time.Until(start.Add(configAgent.Config().Tide.SyncPeriod)))
+			start = time.Now()
 			sync(c)
 		}
 	}()

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -148,6 +148,10 @@ type Sinker struct {
 
 // Deck holds config for deck.
 type Deck struct {
+	// TideUpdatePeriodString compiles into TideUpdatePeriod at load time.
+	TideUpdatePeriodString string `json:"tide_update_period,omitempty"`
+	// TideUpdatePeriod specifies how often Deck will fetch status from Tide. Defaults to 10s.
+	TideUpdatePeriod time.Duration `json:"-"`
 	// HiddenRepos is a list of orgs and/or repos that should not be displayed by Deck.
 	HiddenRepos []string `json:"hidden_repos,omitempty"`
 	// ExternalAgentLogs ensures external agents can expose
@@ -325,6 +329,16 @@ func parseConfig(c *Config) error {
 		}
 	}
 
+	if c.Deck.TideUpdatePeriodString == "" {
+		c.Deck.TideUpdatePeriod = time.Second * 10
+	} else {
+		period, err := time.ParseDuration(c.Deck.TideUpdatePeriodString)
+		if err != nil {
+			return fmt.Errorf("cannot parse duration for deck.tide_update_period: %v", err)
+		}
+		c.Deck.TideUpdatePeriod = period
+	}
+
 	if c.PushGateway.IntervalString == "" {
 		c.PushGateway.Interval = time.Minute
 	} else {
@@ -363,6 +377,16 @@ func parseConfig(c *Config) error {
 			return fmt.Errorf("cannot parse duration for max_pod_age: %v", err)
 		}
 		c.Sinker.MaxPodAge = maxPodAge
+	}
+
+	if c.Tide.SyncPeriodString == "" {
+		c.Tide.SyncPeriod = time.Minute
+	} else {
+		period, err := time.ParseDuration(c.Tide.SyncPeriodString)
+		if err != nil {
+			return fmt.Errorf("cannot parse duration for tide.sync_period: %v", err)
+		}
+		c.Tide.SyncPeriod = period
 	}
 
 	if c.ProwJobNamespace == "" {

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -19,12 +19,17 @@ package config
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"k8s.io/test-infra/prow/github"
 )
 
 // Tide is config for the tide pool.
 type Tide struct {
+	// SyncPeriodString compiles into SyncPeriod at load time.
+	SyncPeriodString string `json:"sync_period,omitempty"`
+	// SyncPeriod specifies how often Tide will sync jobs with Github. Defaults to 1m.
+	SyncPeriod time.Duration `json:"-"`
 	// Queries must not overlap. It must be impossible for any two queries to
 	// ever return the same PR.
 	// TODO: This will only be possible when we allow specifying orgs. At that


### PR DESCRIPTION
Tide's front end has a pretty large update delay. This should reduce it to something more reasonable.
I don't think there is a need for Tide to block requrest while updating the pools it serves so I changed that to remove the downtime from each sync loop.

We may want to generalize the logic for the tide agent and plugin-help agent at some point.

/area prow
/cc @fejta @spxtr 