### PR TITLE
update readme to exclude vendor in bazel commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Merge your PR and @k8s-ci-robot will deploy your change automatically.
 ## Building and testing the test-infra
 
 We use [Bazel](https://www.bazel.io/) to build and test the code in this repo.
-The commands `bazel build //...` and `bazel test //...` should be all you need
+The commands `bazel build -- //... -//vendor/...` and `bazel test -- //... -//vendor/...` should be all you need
 for most cases. If you modify Go code, run `./hack/update-bazel.sh` to keep
 `BUILD` files up-to-date.
 


### PR DESCRIPTION
`vendor/` periodically has problematic targets (mostly related to https://github.com/kubernetes/test-infra/issues/5488)