### PR TITLE
Fix flag for pull-ingress-gce-e2e in config.json

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10836,7 +10836,7 @@
   },
   "pull-ingress-gce-e2e": {
     "args": [
-      "--buildIngressGCE",
+      "--build-ingressgce",
       "--cluster=",
       "--extract=ci/latest",
       "--gcp-zone=us-central1-f",


### PR DESCRIPTION
Fix flag for pull-ingress-gce-e2e in config.json. It was incorrectly --buildIngressGCE when it should have been --build-ingressgce.