### PR TITLE
Update patch managers for 1.9 release

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -69,10 +69,9 @@ slack:
     - kubernetes-dev
     whitelist:
     - k8s-merge-robot
-    - enisoc # 1.6 patch release manager
     - wojtek-t # 1.7 patch release manager
     - jpbetz # 1.8 patch release manager
-    - dashpole # 1.9 branch manager
+    - mbohlool # 1.9 patch release manager
   - repos:
     - kubernetes/test-infra
     channels:


### PR DESCRIPTION
1.9 is released, and @dashpole's responsibilities have been handed over to @mbohlool :)

Also, 1.6 shouldn't need any further patches, so I removed @enisoc.

@dashpole @mbohlool @enisoc: Please raise your hand if you have any objections!