### PR TITLE
Update kops MG config to stop using labels.yaml now that it DNE.

### DIFF
--- a/mungegithub/submit-queue/deployment/kops/configmap.yaml
+++ b/mungegithub/submit-queue/deployment/kops/configmap.yaml
@@ -2,12 +2,10 @@
 http-cache-dir: /cache/httpcache
 organization: kubernetes
 project: kops
-pr-mungers: check-labels,lgtm-after-commit,needs-rebase
+pr-mungers: lgtm-after-commit,needs-rebase
 state: open
 token-file: /etc/secret-volume/token
 period: 2m
 repo-dir: /gitrepos
 github-key-file: /etc/hook-secret-volume/secret
 
-# munger specific options.
-label-file: /gitrepos/kops/labels.yaml


### PR DESCRIPTION
The `labels.yaml` file was removed since the last deployment of the kops SQ so when I tried to deploy #6078 I ran into some issues. This PR just disables the munger as it is no longer needed, its work is done by the label-sync job now.

I have already deployed these changes.
/cc @BenTheElder 