### PR TITLE
Configure prow to run tests for google/kubeflow

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -23467,7 +23467,7 @@ periodics:
         secretName: fejta-bot-token
 - name: kubeflow-periodic
   interval: 8h
-  agent: kubernetes  
+  agent: kubernetes
   spec:
     containers:
     - image: gcr.io/mlkube-testing/kubeflow-testing:latest

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -65,6 +65,30 @@ presubmits:
     context: pull-cadvisor-e2e
     rerun_command: "/test pull-cadvisor-e2e"
     trigger: "(?m)^/test( all| pull-cadvisor-e2e),?(\\s+|$)"
+  google/kubeflow:
+  - name: kubeflow-presubmit
+    context: kubeflow-presubmit
+    agent: kubernetes
+    always_run: true         # Run for every PR, or only when requested.
+    rerun_command: "/test kubeflow-presubmit"
+    trigger: "(?m)^/test( all| kubeflow-presubmit),?(\\s+|$)"
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/mlkube-testing/kubeflow-testing:latest
+        imagePullPolicy: Always
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
   kubernetes/charts:
   - name: pull-charts-e2e
     agent: jenkins
@@ -5635,6 +5659,26 @@ presubmits:
           secretName: service-account
 
 postsubmits:
+  google/kubeflow:
+  - name: kubeflow-postsubmit
+    agent: kubernetes
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/mlkube-testing/kubeflow-testing:latest
+        imagePullPolicy: Always
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+      volumes:
+      - name: service
+        secret:
+          secretName: service-account
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build
     agent: kubernetes
@@ -23421,6 +23465,24 @@ periodics:
     - name: token
       secret:
         secretName: fejta-bot-token
+- name: kubeflow-periodic
+  interval: 8h
+  agent: kubernetes  
+  spec:
+    containers:
+    - image: gcr.io/mlkube-testing/kubeflow-testing:latest
+      imagePullPolicy: Always
+      env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
 
 - interval: 1h
   agent: kubernetes

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -8,6 +8,7 @@ triggers:
   - kubernetes-incubator
   - kubernetes-security
   - google/cadvisor
+  - google/kubeflow
   - tensorflow/k8s
   - GoogleCloudPlatform/k8s-multicluster-ingress
   trusted_org: kubernetes
@@ -91,6 +92,11 @@ config_updater:
 
 plugins:
   google/cadvisor:
+  - trigger
+
+  google/kubeflow:  
+  - lgtm
+  - size
   - trigger
 
   kubernetes/charts:
@@ -187,7 +193,7 @@ plugins:
   kubernetes-security/kubernetes:
   - trigger
 
-  tensorflow/k8s:
+  tensorflow/k8s:  
   - trigger
 
   spxtr/envoy:

--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -193,7 +193,7 @@ plugins:
   kubernetes-security/kubernetes:
   - trigger
 
-  tensorflow/k8s:  
+  tensorflow/k8s:
   - trigger
 
   spxtr/envoy:

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -1637,6 +1637,13 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster-parallel
 - name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
+- name: kubeflow-periodic
+  gcs_prefix: kubernetes-jenkins/logs/kubeflow-periodic
+- name: kubeflow-presubmit
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/kubeflow-presubmit
+  num_columns_recent: 30
+- name: kubeflow-postsubmit
+  gcs_prefix: kubernetes-jenkins/logs/google_kubeflow/kubeflow-postsubmit
 - name: tf-k8s-periodic
   gcs_prefix: kubernetes-jenkins/logs/tf-k8s-periodic
 - name: tf-k8s-presubmit
@@ -3550,6 +3557,15 @@ dashboards:
 
 - name: sig-big-data
   dashboard_tab:
+  - name: kubeflow-periodic
+    description: Periodic testing of Kubeflow.
+    test_group_name: kubeflow-periodic
+  - name: kubeflow-postsubmit
+    description: Postsubmit tests for Kubeflow.
+    test_group_name: kubeflow-postsubmit
+  - name: kubeflow-presubmit
+    description: Presubmit tests for Kubeflow.
+    test_group_name: kubeflow-presubmit
   - name: tf-k8s-periodic
     description: Periodic builds and testing of TfJob CRD at head running on stable GKE.
     test_group_name: tf-k8s-periodic

--- a/testgrid/jenkins_verify/jenkins_validate.go
+++ b/testgrid/jenkins_verify/jenkins_validate.go
@@ -77,7 +77,7 @@ func main() {
 
 	// Also check k/k presubmit, prow postsubmit and periodic jobs
 	for _, job := range prowConfig.AllPresubmits([]string{
-		"jlewi/mlkube.io",
+		"google/kubeflow",
 		"kubernetes/kubernetes",
 		"kubernetes/test-infra",
 		"kubernetes/cluster-registry",


### PR DESCRIPTION
* Fixes #6097 

* google/kubeflow is an OSS project to make Kubernetes the best platform for ML.

* Define prow jobs for pre and post submit tests as well as a periodic job.

* Setup plugins for the google/kubeflow repository

* Define test dashboards.

* Part of google/kubeflow#38

/cc @BenTheElder @krzyzacy 