### PR TITLE
cover more test case for ipvs ci job

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8804,12 +8804,12 @@
       "--kubernetes-anywhere-kubernetes-version=ci/latest",
       "--kubernetes-anywhere-proxy-mode=ipvs",
       "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\]|\\[sig-network\\]\\sServices --minStartupPods=8",
       "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [
-      "sig-cluster-lifecycle"
+      "sig-network"
     ]
   },
   "ci-kubernetes-e2e-kubeadm-gce-stable-on-master": {


### PR DESCRIPTION
IPVS ci job should cover test cases in `[sig-network] Services`, which include all cases about kubernetes service, use `ginkgo.focus=[conformance]` can only cover little part of those test cases.