### PR TITLE
Revert "add https redirect to deck"

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,7 +24,7 @@ HOOK_VERSION             ?= 0.193
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.26
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.78
+DECK_VERSION             ?= 0.77
 # SPLICE_VERSION is the version of the splice image
 SPLICE_VERSION           ?= 0.34
 # TOT_VERSION is the version of the tot image

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.78
+        image: gcr.io/k8s-prow/deck:0.77
         imagePullPolicy: Always
         ports:
           - name: http
@@ -42,7 +42,6 @@ spec:
         - --build-cluster=/etc/cluster/cluster
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
-        - --redirect-to-https
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.78
+        image: gcr.io/k8s-prow/deck:0.77
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -41,11 +41,10 @@ import (
 )
 
 var (
-	configPath      = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
-	buildCluster    = flag.String("build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
-	tideURL         = flag.String("tide-url", "", "Path to tide. If empty, do not serve tide data.")
-	hookURL         = flag.String("hook-url", "", "Path to hook plugin help endpoint.")
-	redirectToHTTPS = flag.Bool("redirect-to-https", false, "Enable x-forwarded-proto http to https redirect.")
+	configPath   = flag.String("config-path", "/etc/config/config", "Path to config.yaml.")
+	buildCluster = flag.String("build-cluster", "", "Path to file containing a YAML-marshalled kube.Cluster object. If empty, uses the local cluster.")
+	tideURL      = flag.String("tide-url", "", "Path to tide. If empty, do not serve tide data.")
+	hookURL      = flag.String("hook-url", "", "Path to hook plugin help endpoint.")
 	// Feature flag for now, can be removed in the future.
 	enableTracing = flag.Bool("enable-tracing", false, "Enable log tracing in prow.")
 )
@@ -86,20 +85,18 @@ func main() {
 	}
 	ja.Start()
 
-	mux := http.NewServeMux()
-
-	mux.Handle("/", gziphandler.GzipHandler(http.FileServer(http.Dir("/static"))))
-	mux.Handle("/data.js", gziphandler.GzipHandler(handleData(ja)))
-	mux.Handle("/prowjobs.js", gziphandler.GzipHandler(handleProwJobs(ja)))
-	mux.Handle("/log", gziphandler.GzipHandler(handleLog(ja)))
-	mux.Handle("/rerun", gziphandler.GzipHandler(handleRerun(kc)))
-	mux.Handle("/config", gziphandler.GzipHandler(handleConfig(configAgent)))
+	http.Handle("/", gziphandler.GzipHandler(http.FileServer(http.Dir("/static"))))
+	http.Handle("/data.js", gziphandler.GzipHandler(handleData(ja)))
+	http.Handle("/prowjobs.js", gziphandler.GzipHandler(handleProwJobs(ja)))
+	http.Handle("/log", gziphandler.GzipHandler(handleLog(ja)))
+	http.Handle("/rerun", gziphandler.GzipHandler(handleRerun(kc)))
+	http.Handle("/config", gziphandler.GzipHandler(handleConfig(configAgent)))
 	if *enableTracing {
-		mux.Handle("/trace", gziphandler.GzipHandler(handleTrace(ja)))
+		http.Handle("/trace", gziphandler.GzipHandler(handleTrace(ja)))
 	}
 
 	if *hookURL != "" {
-		mux.Handle("/plugin-help.js", gziphandler.GzipHandler(handlePluginHelp(newHelpAgent(*hookURL))))
+		http.Handle("/plugin-help.js", gziphandler.GzipHandler(handlePluginHelp(newHelpAgent(*hookURL))))
 	}
 
 	if *tideURL != "" {
@@ -108,25 +105,10 @@ func main() {
 			path: *tideURL,
 		}
 		ta.start()
-		mux.Handle("/tide.js", gziphandler.GzipHandler(handleTide(configAgent, ta)))
+		http.Handle("/tide.js", gziphandler.GzipHandler(handleTide(configAgent, ta)))
 	}
 
-	// optionally inject http->https redirect handler when behind loadbalancer
-	if *redirectToHTTPS {
-		redirectMux := http.NewServeMux()
-		redirectMux.Handle("/", func(oldMux *http.ServeMux) http.HandlerFunc {
-			return func(w http.ResponseWriter, r *http.Request) {
-				if r.Header.Get("x-forwarded-proto") == "http" {
-					r.URL.Scheme = "https"
-					http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
-				} else {
-					oldMux.ServeHTTP(w, r)
-				}
-			}
-		}(mux))
-		mux = redirectMux
-	}
-	logger.WithError(http.ListenAndServe(":8080", mux)).Fatal("ListenAndServe returned.")
+	logger.WithError(http.ListenAndServe(":8080", nil)).Fatal("ListenAndServe returned.")
 }
 
 func loadToken(file string) (string, error) {


### PR DESCRIPTION
Reverts kubernetes/test-infra#6081

sadly this didn't behave, I don't have logs of this yet because Cole deployed / reverted quickly but apparently `"prow.k8s.io sent an invalid response. ERR_INVALID_REDIRECT"`.