### PR TITLE
Add needs-rebase external prow plugin.

### DIFF
--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -30,6 +30,7 @@ filegroup(
         "//experiment/cherrypicker:all-srcs",
         "//experiment/commenter:all-srcs",
         "//experiment/manual-trigger:all-srcs",
+        "//experiment/needs-rebase:all-srcs",
         "//experiment/refresh:all-srcs",
     ],
     tags = ["automanaged"],

--- a/experiment/needs-rebase/BUILD
+++ b/experiment/needs-rebase/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/experiment/needs-rebase",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//experiment/needs-rebase/plugin:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/hook:go_default_library",
+        "//prow/pluginhelp/externalplugins:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "needs-rebase",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/experiment/needs-rebase",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//experiment/needs-rebase/plugin:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/needs-rebase/main.go
+++ b/experiment/needs-rebase/main.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/experiment/needs-rebase/plugin"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/hook"
+	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+var (
+	port              = flag.Int("port", 8888, "Port to listen on.")
+	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	pluginConfig      = flag.String("plugin-config", "/etc/plugins/plugins", "Path to plugin config file.")
+	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+	updatePeriod      = flag.Duration("update-period", time.Hour*24, "Period duration for periodic scans of all PRs.")
+)
+
+func main() {
+	flag.Parse()
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	// TODO: Use global option from the prow config.
+	logrus.SetLevel(logrus.WarnLevel)
+	log := logrus.StandardLogger().WithField("plugin", "needs-rebase")
+
+	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
+	// We'll get SIGTERM first and then SIGKILL after our graceful termination
+	// deadline.
+	signal.Ignore(syscall.SIGTERM)
+
+	webhookSecretRaw, err := ioutil.ReadFile(*webhookSecretFile)
+	if err != nil {
+		log.WithError(err).Fatal("Could not read webhook secret file.")
+	}
+	webhookSecret := bytes.TrimSpace(webhookSecretRaw)
+
+	oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
+	if err != nil {
+		log.WithError(err).Fatal("Could not read oauth secret file.")
+	}
+	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
+
+	_, err = url.Parse(*githubEndpoint)
+	if err != nil {
+		log.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
+	}
+
+	pa := &plugins.PluginAgent{}
+	if err := pa.Start(*pluginConfig); err != nil {
+		log.WithError(err).Fatalf("Error loading plugin config from %q.", *pluginConfig)
+	}
+
+	githubClient := github.NewClient(oauthSecret, *githubEndpoint)
+	if *dryRun {
+		githubClient = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+	}
+	githubClient.Throttle(360, 360)
+
+	server := &Server{
+		hmacSecret: webhookSecret,
+
+		ghc: githubClient,
+		log: log,
+	}
+
+	go periodicUpdate(log, pa, githubClient, *updatePeriod)
+
+	http.Handle("/", server)
+	externalplugins.ServeExternalPluginHelp(http.DefaultServeMux, log, plugin.HelpProvider)
+	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
+}
+
+// Server implements http.Handler. It validates incoming GitHub webhooks and
+// then dispatches them to the appropriate plugins.
+type Server struct {
+	hmacSecret []byte
+
+	ghc *github.Client
+	log *logrus.Entry
+}
+
+// ServeHTTP validates an incoming webhook and puts it into the event channel.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// TODO: Move webhook handling logic out of hook binary so that we don't have to import all
+	// plugins just to validate the webhook.
+	eventType, eventGUID, payload, ok := hook.ValidateWebhook(w, r, s.hmacSecret)
+	if !ok {
+		return
+	}
+	fmt.Fprint(w, "Event received. Have a nice day.")
+
+	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
+		logrus.WithError(err).Error("Error parsing event.")
+	}
+}
+
+func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
+	l := s.log.WithFields(
+		logrus.Fields{
+			"event-type":     eventType,
+			github.EventGUID: eventGUID,
+		},
+	)
+	switch eventType {
+	case "pull_request":
+		var pre github.PullRequestEvent
+		if err := json.Unmarshal(payload, &pre); err != nil {
+			return err
+		}
+		go func() {
+			if err := plugin.HandleEvent(l, s.ghc, &pre); err != nil {
+				l.Info("Error handling event.")
+			}
+		}()
+	default:
+		s.log.Debugf("received an event of type %q but didn't ask for it", eventType)
+	}
+	return nil
+}
+
+func periodicUpdate(log *logrus.Entry, pa *plugins.PluginAgent, ghc *github.Client, period time.Duration) {
+	update := func() {
+		if err := plugin.HandleAll(log, ghc, pa.Config()); err != nil {
+			log.WithError(err).Error("Error during periodic update of all PRs.")
+		}
+	}
+
+	update()
+	for range time.Tick(period) {
+		update()
+	}
+}

--- a/experiment/needs-rebase/plugin/BUILD
+++ b/experiment/needs-rebase/plugin/BUILD
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["plugin.go"],
+    importpath = "k8s.io/test-infra/experiment/needs-rebase/plugin",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/shurcooL/githubql:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["plugin_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/experiment/needs-rebase/plugin",
+    deps = [
+        "//prow/github:go_default_library",
+        "//prow/plugins:go_default_library",
+        "//vendor/github.com/shurcooL/githubql:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/needs-rebase/plugin/plugin.go
+++ b/experiment/needs-rebase/plugin/plugin.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shurcooL/githubql"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const (
+	pluginName         = "needs-rebase"
+	needsRebaseLabel   = "needs-rebase"
+	needsRebaseMessage = "PR needs rebase."
+)
+
+var sleep = time.Sleep
+
+type githubClient interface {
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	CreateComment(org, repo string, number int, comment string) error
+	BotName() (string, error)
+	AddLabel(org, repo string, number int, label string) error
+	RemoveLabel(org, repo string, number int, label string) error
+	IsMergeable(org, repo string, number int, sha string) (bool, error)
+	DeleteStaleComments(org, repo string, number int, comments []github.IssueComment, isStale func(github.IssueComment) bool) error
+	Query(context.Context, interface{}, map[string]interface{}) error
+}
+
+type commentPruner interface {
+	PruneComments(shouldPrune func(github.IssueComment) bool)
+}
+
+// func init() {
+// 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequestEvent, helpProvider)
+// }
+
+// func handlePullRequestEvent(pc plugins.PluginClient, pre github.PullRequestEvent) error {
+// 	return handleEvent(pc.Logger, pc.GitHubClient, pc.CommentPruner, &pre)
+// }
+
+func HelpProvider(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
+	return &pluginhelp.PluginHelp{
+			Description: `The needs-rebase plugin manages the '` + needsRebaseLabel + `' label by removing it from Pull Requests that are mergeable and adding it to those which are not.
+The plugin reacts to commit changes on PRs in addition to periodically scanning all open PRs for any changes to mergeability that could have resulted from changes in other PRs.`,
+		},
+		nil
+}
+
+func HandleEvent(log *logrus.Entry, ghc githubClient, pre *github.PullRequestEvent) error {
+	if pre.Action != github.PullRequestActionOpened && pre.Action != github.PullRequestActionSynchronize && pre.Action != github.PullRequestActionReopened {
+		return nil
+	}
+
+	// Before checking mergeability wait a few seconds to give github a chance to calculate it.
+	// This initial delay prevents us from always wasting the first API token.
+	sleep(time.Second * 5)
+
+	org := pre.Repo.Owner.Login
+	repo := pre.Repo.Name
+	number := pre.Number
+	sha := pre.PullRequest.Head.SHA
+
+	mergeable, err := ghc.IsMergeable(org, repo, number, sha)
+	if err != nil {
+		return err
+	}
+	labels, err := ghc.GetIssueLabels(org, repo, number)
+	if err != nil {
+		return err
+	}
+	hasLabel := github.HasLabel(needsRebaseLabel, labels)
+
+	return takeAction(log, ghc, org, repo, number, pre.PullRequest.User.Login, hasLabel, mergeable)
+}
+
+func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuration) error {
+	orgs, repos := config.EnabledReposForPlugin(pluginName)
+	var buf bytes.Buffer
+	fmt.Fprint(&buf, "is:pr is:open")
+	for _, org := range orgs {
+		fmt.Fprintf(&buf, " org:\"%s\"", org)
+	}
+	for _, repo := range repos {
+		fmt.Fprintf(&buf, " repo:\"%s\"", repo)
+	}
+	prs, err := search(context.Background(), log, ghc, buf.String())
+	if err != nil {
+		return err
+	}
+
+	for _, pr := range prs {
+		// Skip PRs that are calculating mergeability. They will be updated by event or next loop.
+		if pr.Mergeable == githubql.MergeableStateUnknown {
+			continue
+		}
+		org := string(pr.Repository.Owner.Login)
+		repo := string(pr.Repository.Name)
+		num := int(pr.Number)
+		l := log.WithFields(logrus.Fields{
+			"org":  org,
+			"repo": repo,
+			"pr":   num,
+		})
+		hasLabel := false
+		for _, node := range pr.Labels.Nodes {
+			if node.Label.Name == needsRebaseLabel {
+				hasLabel = true
+				break
+			}
+		}
+		err := takeAction(
+			l,
+			ghc,
+			org,
+			repo,
+			num,
+			string(pr.Author.Login),
+			hasLabel,
+			pr.Mergeable == githubql.MergeableStateMergeable,
+		)
+		if err != nil {
+			l.WithError(err).Error("Error handling PR.")
+		}
+	}
+	return nil
+}
+
+func takeAction(log *logrus.Entry, ghc githubClient, org, repo string, num int, author string, hasLabel, mergeable bool) error {
+	if !mergeable && !hasLabel {
+		if err := ghc.AddLabel(org, repo, num, needsRebaseLabel); err != nil {
+			log.WithError(err).Errorf("Failed to add %q label.", needsRebaseLabel)
+		}
+		msg := plugins.FormatSimpleResponse(author, needsRebaseMessage)
+		return ghc.CreateComment(org, repo, num, msg)
+	} else if mergeable && hasLabel {
+		// remove label and prune comment
+		if err := ghc.RemoveLabel(org, repo, num, needsRebaseLabel); err != nil {
+			log.WithError(err).Errorf("Failed to remove %q label.", needsRebaseLabel)
+		}
+		botName, err := ghc.BotName()
+		if err != nil {
+			return err
+		}
+		return ghc.DeleteStaleComments(org, repo, num, nil, shouldPrune(botName))
+	}
+	return nil
+}
+
+func shouldPrune(botName string) func(github.IssueComment) bool {
+	return func(ic github.IssueComment) bool {
+		return github.NormLogin(botName) == github.NormLogin(ic.User.Login) &&
+			strings.Contains(ic.Body, needsRebaseMessage)
+	}
+}
+
+func search(ctx context.Context, log *logrus.Entry, ghc githubClient, q string) ([]pullRequest, error) {
+	var ret []pullRequest
+	vars := map[string]interface{}{
+		"query":        githubql.String(q),
+		"searchCursor": (*githubql.String)(nil),
+	}
+	var totalCost int
+	var remaining int
+	for {
+		sq := searchQuery{}
+		if err := ghc.Query(ctx, &sq, vars); err != nil {
+			return nil, err
+		}
+		totalCost += int(sq.RateLimit.Cost)
+		remaining = int(sq.RateLimit.Remaining)
+		for _, n := range sq.Search.Nodes {
+			ret = append(ret, n.PullRequest)
+		}
+		if !sq.Search.PageInfo.HasNextPage {
+			break
+		}
+		vars["searchCursor"] = githubql.NewString(sq.Search.PageInfo.EndCursor)
+	}
+	log.Infof("Search for query \"%s\" cost %d point(s). %d remaining.", q, totalCost, remaining)
+	return ret, nil
+}
+
+// TODO(spxtr): Add useful information for frontend stuff such as links.
+type pullRequest struct {
+	Number githubql.Int
+	Author struct {
+		Login githubql.String
+	}
+	Repository struct {
+		Name  githubql.String
+		Owner struct {
+			Login githubql.String
+		}
+	}
+	Labels struct {
+		Nodes []struct {
+			Label struct {
+				Name githubql.String
+			}
+		}
+	} `graphql:"labels(first:100)"`
+	Mergeable githubql.MergeableState
+}
+
+type searchQuery struct {
+	RateLimit struct {
+		Cost      githubql.Int
+		Remaining githubql.Int
+	}
+	Search struct {
+		PageInfo struct {
+			HasNextPage githubql.Boolean
+			EndCursor   githubql.String
+		}
+		Nodes []struct {
+			PullRequest pullRequest `graphql:"... on PullRequest"`
+		}
+	} `graphql:"search(type: ISSUE, first: 100, after: $searchCursor, query: $query)"`
+}

--- a/experiment/needs-rebase/plugin/plugin_test.go
+++ b/experiment/needs-rebase/plugin/plugin_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/shurcooL/githubql"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+func testKey(org, repo string, num int) string {
+	return fmt.Sprintf("%s/%s#%d", org, repo, num)
+}
+
+type fghc struct {
+	allPRs []struct {
+		PullRequest pullRequest `graphql:"... on PullRequest"`
+	}
+
+	initialLabels []github.Label
+	mergeable     bool
+
+	// The following are maps are keyed using 'testKey'
+	commentCreated, commentDeleted map[string]bool
+	labelsAdded, labelsRemoved     map[string][]string
+}
+
+func newFakeClient(prs []pullRequest, initialLabels []string, mergeable bool) *fghc {
+	f := &fghc{
+		mergeable:      mergeable,
+		commentCreated: make(map[string]bool),
+		commentDeleted: make(map[string]bool),
+		labelsAdded:    make(map[string][]string),
+		labelsRemoved:  make(map[string][]string),
+	}
+	for _, pr := range prs {
+		s := struct {
+			PullRequest pullRequest `graphql:"... on PullRequest"`
+		}{pr}
+		f.allPRs = append(f.allPRs, s)
+	}
+	for _, label := range initialLabels {
+		f.initialLabels = append(f.initialLabels, github.Label{Name: label})
+	}
+	return f
+}
+
+func (f *fghc) GetIssueLabels(org, repo string, number int) ([]github.Label, error) {
+	return f.initialLabels, nil
+}
+
+func (f *fghc) CreateComment(org, repo string, number int, comment string) error {
+	f.commentCreated[testKey(org, repo, number)] = true
+	return nil
+}
+
+func (f *fghc) BotName() (string, error) {
+	return "k8s-ci-robot", nil
+}
+
+func (f *fghc) AddLabel(org, repo string, number int, label string) error {
+	key := testKey(org, repo, number)
+	f.labelsAdded[key] = append(f.labelsAdded[key], label)
+	return nil
+}
+
+func (f *fghc) RemoveLabel(org, repo string, number int, label string) error {
+	key := testKey(org, repo, number)
+	f.labelsRemoved[key] = append(f.labelsRemoved[key], label)
+	return nil
+}
+
+func (f *fghc) IsMergeable(org, repo string, number int, sha string) (bool, error) {
+	return f.mergeable, nil
+}
+
+func (f *fghc) DeleteStaleComments(org, repo string, number int, comments []github.IssueComment, isStale func(github.IssueComment) bool) error {
+	f.commentDeleted[testKey(org, repo, number)] = true
+	return nil
+}
+
+func (f *fghc) Query(_ context.Context, q interface{}, _ map[string]interface{}) error {
+	query, ok := q.(*searchQuery)
+	if !ok {
+		return errors.New("invalid query format")
+	}
+	query.Search.Nodes = f.allPRs
+	return nil
+}
+
+func (f *fghc) compareExpected(t *testing.T, org, repo string, num int, expectedAdded []string, expectedRemoved []string, expectComment bool, expectDeletion bool) {
+	key := testKey(org, repo, num)
+	sort.Strings(expectedAdded)
+	sort.Strings(expectedRemoved)
+	sort.Strings(f.labelsAdded[key])
+	sort.Strings(f.labelsRemoved[key])
+	if !reflect.DeepEqual(expectedAdded, f.labelsAdded[key]) {
+		t.Errorf("Expected the following labels to be added to %s: %q, but got %q.", key, expectedAdded, f.labelsAdded[key])
+	}
+	if !reflect.DeepEqual(expectedRemoved, f.labelsRemoved[key]) {
+		t.Errorf("Expected the following labels to be removed from %s: %q, but got %q.", key, expectedRemoved, f.labelsRemoved[key])
+	}
+	if expectComment && !f.commentCreated[key] {
+		t.Errorf("Expected a comment to be created on %s, but none was.", key)
+	} else if !expectComment && f.commentCreated[key] {
+		t.Errorf("Unexpected comment on %s.", key)
+	}
+	if expectDeletion && !f.commentDeleted[key] {
+		t.Errorf("Expected a comment to be deleted from %s, but none was.", key)
+	} else if !expectDeletion && f.commentDeleted[key] {
+		t.Errorf("Unexpected comment deletion on %s.", key)
+	}
+}
+
+func TestHandleEvent(t *testing.T) {
+	oldSleep := sleep
+	sleep = func(time.Duration) { return }
+	defer func() { sleep = oldSleep }()
+
+	testCases := []struct {
+		name string
+
+		mergeable bool
+		labels    []string
+
+		expectedAdded   []string
+		expectedRemoved []string
+		expectComment   bool
+		expectDeletion  bool
+	}{
+		{
+			name:      "mergeable no-op",
+			mergeable: true,
+			labels:    []string{"lgtm", "needs-sig"},
+		},
+		{
+			name:      "unmergeable no-op",
+			mergeable: false,
+			labels:    []string{"lgtm", "needs-sig", "needs-rebase"},
+		},
+		{
+			name:      "mergeable -> unmergeable",
+			mergeable: false,
+			labels:    []string{"lgtm", "needs-sig"},
+
+			expectedAdded: []string{"needs-rebase"},
+			expectComment: true,
+		},
+		{
+			name:      "unmergeable -> mergeable",
+			mergeable: true,
+			labels:    []string{"lgtm", "needs-sig", "needs-rebase"},
+
+			expectedRemoved: []string{"needs-rebase"},
+			expectDeletion:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		fake := newFakeClient(nil, tc.labels, tc.mergeable)
+		pre := &github.PullRequestEvent{
+			Action: github.PullRequestActionSynchronize,
+			Repo: github.Repo{
+				Name:  "repo",
+				Owner: github.User{Login: "org"},
+			},
+			Number: 5,
+		}
+		t.Logf("Running test scenario: %q", tc.name)
+		if err := HandleEvent(logrus.WithField("plugin", pluginName), fake, pre); err != nil {
+			t.Fatalf("Unexpected error handling event: %v.", err)
+		}
+		fake.compareExpected(t, "org", "repo", 5, tc.expectedAdded, tc.expectedRemoved, tc.expectComment, tc.expectDeletion)
+	}
+}
+
+func TestHandleAll(t *testing.T) {
+	testPRs := []struct {
+		labels    []string
+		mergeable bool
+
+		expectedAdded, expectedRemoved []string
+		expectComment, expectDeletion  bool
+	}{
+		{
+			mergeable: true,
+			labels:    []string{"lgtm", "needs-sig"},
+		},
+		{
+			mergeable: false,
+			labels:    []string{"lgtm", "needs-sig", "needs-rebase"},
+		},
+		{
+			mergeable: false,
+			labels:    []string{"lgtm", "needs-sig"},
+
+			expectedAdded: []string{"needs-rebase"},
+			expectComment: true,
+		},
+		{
+			mergeable: true,
+			labels:    []string{"lgtm", "needs-sig", "needs-rebase"},
+
+			expectedRemoved: []string{"needs-rebase"},
+			expectDeletion:  true,
+		},
+	}
+
+	prs := []pullRequest{}
+	for i, testPR := range testPRs {
+		pr := pullRequest{
+			Number: githubql.Int(i),
+		}
+		if testPR.mergeable {
+			pr.Mergeable = githubql.MergeableStateMergeable
+		} else {
+			pr.Mergeable = githubql.MergeableStateConflicting
+		}
+		for _, label := range testPR.labels {
+			s := struct {
+				Label struct {
+					Name githubql.String
+				}
+			}{
+				Label: struct {
+					Name githubql.String
+				}{
+					Name: githubql.String(label),
+				},
+			}
+			pr.Labels.Nodes = append(pr.Labels.Nodes, s)
+		}
+		prs = append(prs, pr)
+	}
+	fake := newFakeClient(prs, nil, false)
+	config := &plugins.Configuration{
+		Plugins: map[string][]string{"/": {"lgtm", pluginName}},
+	}
+
+	if err := HandleAll(logrus.WithField("plugin", pluginName), fake, config); err != nil {
+		t.Fatalf("Unexpected error handling all prs: %v.", err)
+	}
+	for i, pr := range testPRs {
+		fake.compareExpected(t, "", "", i, pr.expectedAdded, pr.expectedRemoved, pr.expectComment, pr.expectDeletion)
+	}
+}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1360,4 +1361,32 @@ func (c *Client) ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent,
 		return nil, err
 	}
 	return events, nil
+}
+
+// IsMergeable determines if a PR can be merged.
+// Mergeability is calculated by a background job on github and is not immediately available when
+// new commits are added so the PR must be polled until the background job completes.
+func (c *Client) IsMergeable(org, repo string, number int, sha string) (bool, error) {
+	backoff := time.Second * 3
+	maxTries := 3
+	for try := 0; try < maxTries; try++ {
+		pr, err := c.GetPullRequest(org, repo, number)
+		if err != nil {
+			return false, err
+		}
+		if pr.Head.SHA != sha {
+			return false, fmt.Errorf("pull request head changed while checking mergeability (%s -> %s)", sha, pr.Head.SHA)
+		}
+		if pr.Merged {
+			return false, errors.New("pull request was merged while checking mergeability")
+		}
+		if pr.Mergable != nil {
+			return *pr.Mergable, nil
+		}
+		if try+1 < maxTries {
+			c.time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+	return false, fmt.Errorf("reached maximum number of retries (%d) checking mergeability", maxTries)
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -146,6 +146,12 @@ type PullRequest struct {
 	// If Merged is false, MergeSHA is a commit SHA that github created to test if
 	// the PR can be merged automatically.
 	MergeSHA *string `json:"merge_commit_sha"`
+	// ref https://developer.github.com/v3/pulls/#response-1
+	// The value of the mergeable attribute can be true, false, or null. If the value
+	// is null, this means that the mergeability hasn't been computed yet, and a
+	// background job was started to compute it. When the job is complete, the response
+	// will include a non-null value for the mergeable attribute.
+	Mergable *bool `json:"mergeable,omitempty"`
 }
 
 // PullRequestBranch contains information about a particular branch in a PR.

--- a/prow/pluginhelp/hook/hook_test.go
+++ b/prow/pluginhelp/hook/hook_test.go
@@ -71,7 +71,9 @@ func TestGeneratePluginHelp(t *testing.T) {
 		http.Error(w, "404 Not Found", http.StatusNotFound)
 	}))
 	defer noHelpSever.Close()
-	helpfulServer := httptest.NewServer(externalplugins.ServeExternalPluginHelp(
+	mux := http.NewServeMux()
+	externalplugins.ServeExternalPluginHelp(
+		mux,
 		logrus.WithField("plugin", "helpful-external"),
 		func(enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 			if got, expected := enabledRepos, []string{"org1/repo1"}; !reflect.DeepEqual(got, expected) {
@@ -79,7 +81,8 @@ func TestGeneratePluginHelp(t *testing.T) {
 			}
 			return &helpfulExternalHelp, nil
 		},
-	))
+	)
+	helpfulServer := httptest.NewServer(mux)
 	defer helpfulServer.Close()
 
 	config := &plugins.Configuration{

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -645,3 +645,23 @@ func EventsForPlugin(name string) []string {
 	}
 	return events
 }
+
+func (c *Configuration) EnabledReposForPlugin(plugin string) (orgs, repos []string) {
+	for repo, plugins := range c.Plugins {
+		found := false
+		for _, candidate := range plugins {
+			if candidate == plugin {
+				found = true
+				break
+			}
+		}
+		if found {
+			if strings.Contains(repo, "/") {
+				repos = append(repos, repo)
+			} else {
+				orgs = append(orgs, repo)
+			}
+		}
+	}
+	return
+}

--- a/prow/plugins/respond.go
+++ b/prow/plugins/respond.go
@@ -41,6 +41,19 @@ func FormatResponse(to, message, reason string) string {
 	return fmt.Sprintf(format, to, message, reason, AboutThisBotWithoutCommands)
 }
 
+// FormatSimpleReponse formats a response that does not warrant additional explanation in the
+// details section.
+func FormatSimpleResponse(to, message string) string {
+	format := `@%s: %s
+
+<details>
+
+%s
+</details>`
+
+	return fmt.Sprintf(format, to, message, AboutThisBotWithoutCommands)
+}
+
 // FormatICResponse nicely formats a response to an issue comment.
 func FormatICResponse(ic github.IssueComment, s string) string {
 	return FormatResponseRaw(ic.Body, ic.HTMLURL, ic.User.Login, s)


### PR DESCRIPTION
/cc @kargakis 
fixes #6022 

We should definitely generalize webhook handling logic soon so that external plugins can share a library with the hook binary instead of copying and pasting code from hook.