### PR TITLE
add https redirect to deck

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -24,7 +24,7 @@ HOOK_VERSION             ?= 0.193
 # SINKER_VERSION is the version of the sinker image
 SINKER_VERSION           ?= 0.26
 # DECK_VERSION is the version of the deck image
-DECK_VERSION             ?= 0.77
+DECK_VERSION             ?= 0.78
 # SPLICE_VERSION is the version of the splice image
 SPLICE_VERSION           ?= 0.34
 # TOT_VERSION is the version of the tot image

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --build-cluster=/etc/cluster/cluster
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
+        - --redirect-http-to=prow.k8s.io
         volumeMounts:
         - mountPath: /etc/cluster
           name: cluster

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.77
+        image: gcr.io/k8s-prow/deck:0.78
         imagePullPolicy: Always
         ports:
           - name: http

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -182,7 +182,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:0.77
+        image: gcr.io/k8s-prow/deck:0.78
         args:
         - --hook-url=http://hook:8888/plugin-help
         ports:


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/pull/6081#issuecomment-354875186

This is the same as before, except now the flag is slightly renamed and takes the target host, I'm also copying (parsing) the request URL before modifying since technically the request object is not supposed to be modified.

/area prow