### PR TITLE
Remove deprecated assignees field from OWNERS parsing

### DIFF
--- a/mungegithub/features/repo-updates.go
+++ b/mungegithub/features/repo-updates.go
@@ -44,7 +44,6 @@ const (
 )
 
 type assignmentConfig struct {
-	Assignees []string `json:"assignees" yaml:"assignees"`
 	Approvers []string `json:"approvers" yaml:"approvers"`
 	Reviewers []string `json:"reviewers" yaml:"reviewers"`
 	Labels    []string `json:"labels" yaml:"labels"`
@@ -137,7 +136,6 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 		}
 		c.normalizeUsers()
 		o.approvers[path] = sets.NewString(c.Approvers...)
-		o.approvers[path].Insert(c.Assignees...)
 		o.reviewers[path] = sets.NewString(c.Reviewers...)
 		return nil
 	}
@@ -167,7 +165,6 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 	path = canonicalize(path)
 	c.normalizeUsers()
 	o.approvers[path] = sets.NewString(c.Approvers...)
-	o.approvers[path].Insert(c.Assignees...)
 	o.reviewers[path] = sets.NewString(c.Reviewers...)
 	if len(c.Labels) > 0 {
 		o.labels[path] = sets.NewString(c.Labels...)
@@ -181,7 +178,6 @@ func (o *RepoInfo) walkFunc(path string, info os.FileInfo, err error) error {
 // insensitive operations on the entries
 func (c *assignmentConfig) normalizeUsers() {
 	c.Approvers = caseNormalizeAll(c.Approvers)
-	c.Assignees = caseNormalizeAll(c.Assignees)
 	c.Reviewers = caseNormalizeAll(c.Reviewers)
 }
 

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -48,7 +48,6 @@ type dirOptions struct {
 
 type ownersConfig struct {
 	Options   dirOptions `json:"options,omitempty"`
-	Assignees []string   `json:"assignees,omitempty"`
 	Approvers []string   `json:"approvers,omitempty"`
 	Reviewers []string   `json:"reviewers,omitempty"`
 	Labels    []string   `json:"labels,omitempty"`
@@ -338,8 +337,8 @@ func normLogins(logins []string) sets.String {
 var defaultDirOptions = dirOptions{}
 
 func (o *RepoOwners) applyConfigToPath(path string, config *ownersConfig) {
-	if len(config.Approvers) > 0 || len(config.Assignees) > 0 {
-		o.approvers[path] = o.ExpandAliases(normLogins(config.Approvers).Union(normLogins(config.Assignees)))
+	if len(config.Approvers) > 0 {
+		o.approvers[path] = o.ExpandAliases(normLogins(config.Approvers))
 	}
 	if len(config.Reviewers) > 0 {
 		o.reviewers[path] = o.ExpandAliases(normLogins(config.Reviewers))

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -34,7 +34,7 @@ func getTestClient(enableMdYaml, includeAliases bool) (*Client, func(), error) {
 		"foo":                        []byte("approvers:\n- bob"),
 		"OWNERS":                     []byte("approvers: \n- cjwagner\nreviewers:\n- Alice\n- bob\nlabels:\n - EVERYTHING"),
 		"src/OWNERS":                 []byte("approvers:\n- Best-Approvers"),
-		"src/dir/OWNERS":             []byte("assignees:\n - bob\nreviewers:\n- alice\n- CJWagner\nlabels:\n- src-code"),
+		"src/dir/OWNERS":             []byte("approvers:\n - bob\nreviewers:\n- alice\n- CJWagner\nlabels:\n- src-code"),
 		"src/dir/conformance/OWNERS": []byte("options:\n no_parent_owners: true\napprovers:\n - mml"),
 		"docs/file.md":               []byte("---\napprovers: \n- ALICE\n\nlabels:\n- docs\n---"),
 	}


### PR DESCRIPTION
All repos that used the assignees field have been converted
to use the approvers field instead

Fixes #3851