### PR TITLE
bump test images

### DIFF
--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -56,7 +56,7 @@ PROW_CONFIG_TEMPLATE = """
           value: /etc/ssh-key-secret/ssh-private
         - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
           value: /etc/ssh-key-secret/ssh-public
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service

--- a/images/kubeadm/Dockerfile
+++ b/images/kubeadm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+FROM gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
 LABEL maintainer "beacham@google.com"
 
 # add env we can debug with the image name:tag

--- a/jenkins/e2e-image/Dockerfile
+++ b/jenkins/e2e-image/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
+FROM gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
 LABEL maintainer "Sen Lu <senlu@google.com>"
 
 ENV KUBETEST_IN_DOCKER="true"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -158,7 +158,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -517,7 +517,7 @@ presubmits:
       trigger: "(?m)^/test( all| pull-cri-containerd-node-e2e),?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
           args:
           - --root=/go/src
           - "--clean"
@@ -1336,7 +1336,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1405,7 +1405,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1473,7 +1473,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1541,7 +1541,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -1592,7 +1592,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1655,7 +1655,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -1721,7 +1721,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1784,7 +1784,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -1855,7 +1855,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -1931,7 +1931,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -2007,7 +2007,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -2094,7 +2094,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2169,7 +2169,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -2244,7 +2244,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -2331,7 +2331,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2401,7 +2401,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -2471,7 +2471,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -2544,7 +2544,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -2602,7 +2602,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -2660,7 +2660,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -2718,7 +2718,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -2777,7 +2777,7 @@ presubmits:
     trigger: "(?m)^/test pull-kubernetes-node-e2e-containerd,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -3746,7 +3746,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -3815,7 +3815,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -3883,7 +3883,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -3951,7 +3951,7 @@ presubmits:
         # https://docs.bazel.build/versions/master/output_directories.html#documentation-of-the-current-bazel-output-directory-layout
         - name: TEST_TMPDIR
           value: /root/.cache/bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         volumeMounts:
         - mountPath: /etc/service-account
           name: service
@@ -4002,7 +4002,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -4065,7 +4065,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-gce-device-plugin-gpu),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -4131,7 +4131,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -4194,7 +4194,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-e2e-gke-device-plugin-gpu,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -4265,7 +4265,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -4341,7 +4341,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -4417,7 +4417,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-e2e-kops-aws),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -4504,7 +4504,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -4579,7 +4579,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -4654,7 +4654,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-kubemark-e2e-gce),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -4741,7 +4741,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -4811,7 +4811,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -4881,7 +4881,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-kubemark-e2e-gce-big,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -4954,7 +4954,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -5012,7 +5012,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
         args:
         - --root=/go/src
         - "--clean"
@@ -5070,7 +5070,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
         args:
         - --root=/go/src
         - "--clean"
@@ -5128,7 +5128,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-node-e2e),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
         args:
         - --root=/go/src
         - "--clean"
@@ -5187,7 +5187,7 @@ presubmits:
     trigger: "(?m)^/test pull-security-kubernetes-node-e2e-containerd,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
         args:
         - --root=/go/src
         - "--clean"
@@ -6519,7 +6519,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6553,7 +6553,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6575,7 +6575,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --root=/go/src
       - "--clean"
@@ -6642,7 +6642,7 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -6684,7 +6684,7 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7100,7 +7100,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7134,7 +7134,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7168,7 +7168,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7202,7 +7202,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7236,7 +7236,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7270,7 +7270,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7304,7 +7304,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7338,7 +7338,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7372,7 +7372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7406,7 +7406,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7440,7 +7440,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7474,7 +7474,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7508,7 +7508,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7542,7 +7542,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7576,7 +7576,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7610,7 +7610,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7644,7 +7644,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7678,7 +7678,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7712,7 +7712,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7746,7 +7746,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7780,7 +7780,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7814,7 +7814,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7885,7 +7885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7921,7 +7921,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7957,7 +7957,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -7993,7 +7993,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8029,7 +8029,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8065,7 +8065,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8101,7 +8101,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8137,7 +8137,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8173,7 +8173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8209,7 +8209,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8245,7 +8245,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8281,7 +8281,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8317,7 +8317,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8353,7 +8353,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8389,7 +8389,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8425,7 +8425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8461,7 +8461,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8497,7 +8497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8533,7 +8533,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8569,7 +8569,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8605,7 +8605,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8641,7 +8641,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8677,7 +8677,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8713,7 +8713,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8749,7 +8749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8785,7 +8785,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8821,7 +8821,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8857,7 +8857,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8893,7 +8893,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8929,7 +8929,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -8965,7 +8965,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9001,7 +9001,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9037,7 +9037,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9073,7 +9073,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9109,7 +9109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9145,7 +9145,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9181,7 +9181,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9217,7 +9217,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9253,7 +9253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9289,7 +9289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9325,7 +9325,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9361,7 +9361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9397,7 +9397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9433,7 +9433,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9469,7 +9469,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9505,7 +9505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9541,7 +9541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9577,7 +9577,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9613,7 +9613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9649,7 +9649,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9685,7 +9685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9721,7 +9721,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9757,7 +9757,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9793,7 +9793,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9829,7 +9829,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9865,7 +9865,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9901,7 +9901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9937,7 +9937,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -9973,7 +9973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10009,7 +10009,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10045,7 +10045,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10081,7 +10081,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10117,7 +10117,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10153,7 +10153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10187,7 +10187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10221,7 +10221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10255,7 +10255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10289,7 +10289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10323,7 +10323,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10357,7 +10357,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10391,7 +10391,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10425,7 +10425,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10459,7 +10459,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10493,7 +10493,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10527,7 +10527,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10561,7 +10561,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10595,7 +10595,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10629,7 +10629,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10663,7 +10663,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10697,7 +10697,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10731,7 +10731,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10765,7 +10765,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10799,7 +10799,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10833,7 +10833,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10867,7 +10867,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10901,7 +10901,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10935,7 +10935,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -10969,7 +10969,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11003,7 +11003,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11037,7 +11037,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11071,7 +11071,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11105,7 +11105,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11139,7 +11139,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11173,7 +11173,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11207,7 +11207,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11241,7 +11241,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11349,7 +11349,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11387,7 +11387,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11421,7 +11421,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11455,7 +11455,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11489,7 +11489,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11523,7 +11523,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11557,7 +11557,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11591,7 +11591,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11625,7 +11625,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11659,7 +11659,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11693,7 +11693,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11727,7 +11727,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11761,7 +11761,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11795,7 +11795,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11829,7 +11829,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11863,7 +11863,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11897,7 +11897,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -11966,7 +11966,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12004,7 +12004,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12042,7 +12042,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12076,7 +12076,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12110,7 +12110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12144,7 +12144,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12178,7 +12178,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12212,7 +12212,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12246,7 +12246,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12280,7 +12280,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12314,7 +12314,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12348,7 +12348,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12382,7 +12382,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12416,7 +12416,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12450,7 +12450,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12484,7 +12484,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12518,7 +12518,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12552,7 +12552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12586,7 +12586,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12620,7 +12620,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12654,7 +12654,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12688,7 +12688,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12724,7 +12724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12760,7 +12760,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12796,7 +12796,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12832,7 +12832,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12868,7 +12868,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12904,7 +12904,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12940,7 +12940,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -12976,7 +12976,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13012,7 +13012,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13048,7 +13048,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13084,7 +13084,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13120,7 +13120,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13156,7 +13156,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13192,7 +13192,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13228,7 +13228,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13264,7 +13264,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13300,7 +13300,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13336,7 +13336,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13372,7 +13372,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13408,7 +13408,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13444,7 +13444,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13480,7 +13480,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13516,7 +13516,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13552,7 +13552,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13588,7 +13588,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13624,7 +13624,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13660,7 +13660,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13694,7 +13694,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13728,7 +13728,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13762,7 +13762,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13796,7 +13796,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13830,7 +13830,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13864,7 +13864,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13898,7 +13898,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13932,7 +13932,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -13966,7 +13966,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14000,7 +14000,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14034,7 +14034,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14068,7 +14068,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14102,7 +14102,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14136,7 +14136,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14170,7 +14170,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14204,7 +14204,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14273,7 +14273,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14307,7 +14307,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14341,7 +14341,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14375,7 +14375,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14409,7 +14409,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14443,7 +14443,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14477,7 +14477,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14511,7 +14511,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14545,7 +14545,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14579,7 +14579,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14613,7 +14613,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14647,7 +14647,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14681,7 +14681,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14715,7 +14715,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14749,7 +14749,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14783,7 +14783,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14817,7 +14817,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14851,7 +14851,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14885,7 +14885,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14919,7 +14919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14953,7 +14953,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -14987,7 +14987,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15021,7 +15021,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15055,7 +15055,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15089,7 +15089,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15123,7 +15123,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15157,7 +15157,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15191,7 +15191,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15225,7 +15225,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15259,7 +15259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15293,7 +15293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15327,7 +15327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15361,7 +15361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15395,7 +15395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15429,7 +15429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15463,7 +15463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15534,7 +15534,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15570,7 +15570,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15606,7 +15606,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15642,7 +15642,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15678,7 +15678,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15714,7 +15714,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15750,7 +15750,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15786,7 +15786,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15822,7 +15822,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15858,7 +15858,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15894,7 +15894,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15930,7 +15930,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -15966,7 +15966,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16002,7 +16002,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16038,7 +16038,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16074,7 +16074,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16110,7 +16110,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16146,7 +16146,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16182,7 +16182,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16218,7 +16218,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16254,7 +16254,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16290,7 +16290,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16326,7 +16326,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16362,7 +16362,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16398,7 +16398,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16434,7 +16434,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16470,7 +16470,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16506,7 +16506,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16542,7 +16542,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16578,7 +16578,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16612,7 +16612,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16646,7 +16646,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16680,7 +16680,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16714,7 +16714,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16748,7 +16748,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16782,7 +16782,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16816,7 +16816,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16850,7 +16850,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16884,7 +16884,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16918,7 +16918,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16952,7 +16952,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -16986,7 +16986,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17020,7 +17020,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17054,7 +17054,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17088,7 +17088,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17122,7 +17122,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17156,7 +17156,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17190,7 +17190,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17224,7 +17224,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17259,7 +17259,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17293,7 +17293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17327,7 +17327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17361,7 +17361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17395,7 +17395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17429,7 +17429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17463,7 +17463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17497,7 +17497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17531,7 +17531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17565,7 +17565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17599,7 +17599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17633,7 +17633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17667,7 +17667,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17701,7 +17701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17735,7 +17735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17769,7 +17769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17803,7 +17803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: USER
         value: prow
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17837,7 +17837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17910,7 +17910,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -17983,7 +17983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18017,7 +18017,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18051,7 +18051,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18085,7 +18085,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18119,7 +18119,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18153,7 +18153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18187,7 +18187,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18221,7 +18221,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18255,7 +18255,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18293,7 +18293,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18327,7 +18327,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18361,7 +18361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18395,7 +18395,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18429,7 +18429,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18463,7 +18463,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171218-a18c352b4-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18497,7 +18497,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18531,7 +18531,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18565,7 +18565,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18599,7 +18599,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18633,7 +18633,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18667,7 +18667,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18701,7 +18701,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18735,7 +18735,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18769,7 +18769,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18803,7 +18803,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18837,7 +18837,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18871,7 +18871,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18905,7 +18905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18939,7 +18939,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -18973,7 +18973,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19007,7 +19007,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19041,7 +19041,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19075,7 +19075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19109,7 +19109,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19145,7 +19145,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19181,7 +19181,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19217,7 +19217,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19253,7 +19253,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19289,7 +19289,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19325,7 +19325,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19361,7 +19361,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19397,7 +19397,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19433,7 +19433,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19469,7 +19469,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19505,7 +19505,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19541,7 +19541,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19578,7 +19578,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19614,7 +19614,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19650,7 +19650,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19686,7 +19686,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19722,7 +19722,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19758,7 +19758,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19794,7 +19794,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19830,7 +19830,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19866,7 +19866,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19902,7 +19902,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19938,7 +19938,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -19974,7 +19974,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20010,7 +20010,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20046,7 +20046,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20082,7 +20082,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20116,7 +20116,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20152,7 +20152,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20195,7 +20195,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20414,7 +20414,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20457,7 +20457,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20500,7 +20500,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20543,7 +20543,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20586,7 +20586,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20629,7 +20629,7 @@ periodics:
         value: /etc/aws-ssh/aws-ssh-private
       - name: JENKINS_AWS_SSH_PUBLIC_KEY_FILE
         value: /etc/aws-ssh/aws-ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20670,7 +20670,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20905,7 +20905,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20944,7 +20944,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -20983,7 +20983,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21022,7 +21022,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21061,7 +21061,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21100,7 +21100,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21139,7 +21139,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21178,7 +21178,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21295,7 +21295,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21334,7 +21334,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21373,7 +21373,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21412,7 +21412,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21451,7 +21451,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21490,7 +21490,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21529,7 +21529,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21568,7 +21568,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21607,7 +21607,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21646,7 +21646,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21685,7 +21685,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21724,7 +21724,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21763,7 +21763,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21802,7 +21802,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21919,7 +21919,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21958,7 +21958,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -21997,7 +21997,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -22036,7 +22036,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -22075,7 +22075,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -22114,7 +22114,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -22153,7 +22153,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -22192,7 +22192,7 @@ periodics:
         value: /etc/ssh-key-secret/ssh-public
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -22214,7 +22214,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --bare
       - --timeout=260
@@ -22262,7 +22262,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --bare
       - --timeout=260
@@ -22310,7 +22310,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --bare
       - --timeout=80
@@ -22358,7 +22358,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --bare
       - --timeout=80
@@ -22446,7 +22446,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --bare
       - --timeout=140
@@ -22494,7 +22494,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --bare
       - --timeout=1100
@@ -22542,7 +22542,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --bare
       - --timeout=300
@@ -22590,7 +22590,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -22627,7 +22627,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -22664,7 +22664,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --repo=k8s.io/kubernetes=release-1.9
       - --timeout=90
@@ -22701,7 +22701,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -22738,7 +22738,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -22775,7 +22775,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -22812,7 +22812,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -22849,7 +22849,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -22886,7 +22886,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.8
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.8
       args:
       - --repo=k8s.io/kubernetes=release-1.8
       - --timeout=90
@@ -22923,7 +22923,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.7
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.7
       args:
       - --repo=k8s.io/kubernetes=release-1.7
       - --timeout=90
@@ -22960,7 +22960,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-1.6
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-1.6
       args:
       - --repo=k8s.io/kubernetes=release-1.6
       - --timeout=90
@@ -23010,7 +23010,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23045,7 +23045,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23080,7 +23080,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23115,7 +23115,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23150,7 +23150,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23185,7 +23185,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23220,7 +23220,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23255,7 +23255,7 @@ periodics:
       - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
         value: /etc/ssh-key-secret/ssh-public
       # TODO(krzyzacy): use stable tag once verify it works
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       volumeMounts:
       - mountPath: /etc/service-account
         name: service
@@ -23278,7 +23278,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - "--repo=k8s.io/kubernetes=master"
       - "--repo=k8s.io/perf-tests=master"
@@ -23314,7 +23314,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20171222-40e8b22e3-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
       args:
       - "--repo=k8s.io/perf-tests=master"
       - "--root=/go/src"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1204,7 +1204,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
+      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -2828,7 +2828,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-unit),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
+      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -2921,7 +2921,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-kubernetes-verify),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
+      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -3614,7 +3614,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
+      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -5238,7 +5238,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-unit),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
+      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"
@@ -5331,7 +5331,7 @@ presubmits:
     trigger: "(?m)^/test( all| pull-security-kubernetes-verify),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
+      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
         args:
         - "--clean"
         - "--job=$(JOB_NAME)"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -652,7 +652,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -754,7 +754,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -854,7 +854,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -952,7 +952,7 @@ presubmits:
       trigger: "(?m)^/test pull-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-jenkins/pr-logs"
@@ -3065,7 +3065,7 @@ presubmits:
       - release-1.8 # different target set
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -3167,7 +3167,7 @@ presubmits:
       - release-1.8
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -3267,7 +3267,7 @@ presubmits:
       - release-1.6
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -3364,7 +3364,7 @@ presubmits:
       trigger: "(?m)^/test pull-security-kubernetes-e2e-kubeadm-gce-canary,?(\\s+|$)"
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=github.com/kubernetes-security/$(REPO_NAME)=$(PULL_REFS)"
           - "--upload=gs://kubernetes-security-jenkins/pr-logs"
@@ -5841,7 +5841,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -5965,7 +5965,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -6008,7 +6008,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -6132,7 +6132,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -6175,7 +6175,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -6304,7 +6304,7 @@ postsubmits:
       agent: kubernetes
       spec:
         containers:
-        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+        - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
           args:
           - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
           - "--clean"
@@ -6751,7 +6751,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -6794,7 +6794,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -6828,7 +6828,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -6871,7 +6871,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -6914,7 +6914,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -6957,7 +6957,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -7000,7 +7000,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -7043,7 +7043,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--clean"
@@ -20692,7 +20692,7 @@ periodics:
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+    - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
       args:
       - "--repo=k8s.io/kubernetes=release-1.7"
       - "--clean"
@@ -23644,7 +23644,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=release-1.6"
         - "--clean"
@@ -23769,7 +23769,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -23814,7 +23814,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=release-1.7"
         - "--clean"
@@ -23937,7 +23937,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -23982,7 +23982,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=release-1.8"
         - "--clean"
@@ -24112,7 +24112,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=release-1.9"
         - "--clean"
@@ -24155,7 +24155,7 @@ periodics:
     agent: kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20171222-8930625d5
+      - image: gcr.io/k8s-testimages/e2e-kubeadm:v20180102-d372fdd96
         args:
         - "--repo=k8s.io/kubernetes=release-1.9"
         - "--clean"

--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -36,7 +36,7 @@ import time
 ORIG_CWD = os.getcwd()  # Checkout changes cwd
 
 # Note: This variable is managed by experiment/bump_e2e_image.sh.
-DEFAULT_KUBEKINS_TAG = 'v20171222-40e8b22e3-master'
+DEFAULT_KUBEKINS_TAG = 'v20180102-0e2b24a0b-master'
 
 def test_infra(*paths):
     """Return path relative to root of test-infra repo."""


### PR DESCRIPTION
Bumping images to pick up fixes including:

- #6106 (better docker in docker cleanup)
- #6096 (hopefully correct logging of image tag in build log)
- #5907 (logging when we flush memory in kubetest)

/area images