### PR TITLE
Update go.k8s.io/oncall link to release managers

### DIFF
--- a/jenkins/oncall.html
+++ b/jenkins/oncall.html
@@ -57,7 +57,7 @@ img { padding-left: 10px; max-width: 125px; }
 <h1>Kubernetes Oncall Rotation</h1>
 <p>Updated: <span id="updated">Never</span></a>
 <div id="oncall">Loading...</div>
-<div><h2>release managers: <a href="https://github.com/kubernetes/community/wiki#release-managers">see wiki</a></h2></div>
+<div><h2>release managers: <a href="https://github.com/kubernetes/sig-release/blob/master/release-managers.md#release-managers">on GitHub</a></h2></div>
 <sub><a href="https://storage.googleapis.com/kubernetes-jenkins/oncall.json">data source</a></sub>
 </body>
 </html>


### PR DESCRIPTION
The wiki is no more (https://github.com/kubernetes/community/issues/116, https://github.com/kubernetes/sig-release/pull/42) so update to the new location of this table.

/cc @spiffxp @kubernetes/sig-release-pr-reviews 