### PR TITLE
ingress-gce config fix

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -124,8 +124,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
         args:
-        - "--repo=k8s.io/ingress-gce=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes=master"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src/k8s.io"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -124,8 +124,9 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/gcloud-in-go:v20171113-192bec25
         args:
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--root=/go/src"
+        - "--repo=k8s.io/ingress-gce=$(PULL_REFS)"
+        - "--repo=k8s.io/kubernetes=master"
+        - "--root=/go/src/k8s.io"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"
         env:


### PR DESCRIPTION
This fix ensures that kubernetes is checked out in the appropriate place