### PR TITLE
Fix Tide's usage of incorrect constants while creating status contexts.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -36,7 +36,7 @@ PLANK_VERSION            ?= 0.64
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
 JENKINS-OPERATOR_VERSION ?= 0.61
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.17
+TIDE_VERSION             ?= 0.18
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.17
+        image: gcr.io/k8s-prow/tide:0.18
         args:
         - --dry-run=false
         ports:

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -127,11 +127,11 @@ func byRepoAndNumber(prs []PullRequest) map[string]map[int]PullRequest {
 
 // Returns expected status state and description.
 // TODO(spxtr): Useful information such as "missing label: foo."
-func expectedStatus(pr PullRequest, pool map[string]map[int]PullRequest) (githubql.StatusState, string) {
+func expectedStatus(pr PullRequest, pool map[string]map[int]PullRequest) (string, string) {
 	if _, ok := pool[string(pr.Repository.NameWithOwner)][int(pr.Number)]; !ok {
-		return githubql.StatusStatePending, statusNotInPool
+		return github.StatusPending, statusNotInPool
 	}
-	return githubql.StatusStateSuccess, statusInPool
+	return github.StatusSuccess, statusInPool
 }
 
 func (c *Controller) setStatuses(all, pool []PullRequest) error {
@@ -146,14 +146,14 @@ func (c *Controller) setStatuses(all, pool []PullRequest) error {
 				actualDesc = string(ctx.Description)
 			}
 		}
-		if wantState != actualState || wantDesc != actualDesc {
+		if wantState != strings.ToLower(string(actualState)) || wantDesc != actualDesc {
 			if err := c.ghc.CreateStatus(
 				string(pr.Repository.Owner.Login),
 				string(pr.Repository.Name),
 				string(pr.HeadRef.Target.OID),
 				github.Status{
 					Context:     statusContext,
-					State:       string(wantState),
+					State:       wantState,
 					Description: wantDesc,
 					TargetURL:   c.ca.Config().Tide.TargetURL,
 				}); err != nil {

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -337,8 +337,12 @@ func (f *fgc) Merge(org, repo string, number int, details github.MergeDetails) e
 }
 
 func (f *fgc) CreateStatus(org, repo, ref string, s github.Status) error {
-	f.setStatus = true
-	return nil
+	switch s.State {
+	case github.StatusSuccess, github.StatusError, github.StatusPending, github.StatusFailure:
+		f.setStatus = true
+		return nil
+	}
+	return fmt.Errorf("invalid 'state' value: %q", s.State)
 }
 
 func TestSetStatuses(t *testing.T) {


### PR DESCRIPTION
Github doesn't accept status context state values like "SUCCESS" or "PENDING". It only accepts the lowercase constants "success", "pending"...

ref #6010 
/cc @spxtr 
  