### PR TITLE
Change Tide's 'Missing' column to indicate that tests may be failing.

### DIFF
--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -108,6 +108,10 @@ th {
     color: #333;
 }
 
+.hidden {
+    display: none;
+}
+
 .triggered, .pending, .success, .failure, .error, .aborted {
     font-weight: bold;
 }
@@ -167,6 +171,11 @@ a:link {
     line-height: 1.75;
     color: black;
     list-style-type: disc;
+}
+
+#info-div h4 {
+    cursor: pointer;
+    margin-top: 0.6em;
 }
 
 

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -33,11 +33,15 @@
             </div>
             <main class="mdl-layout__content">
                 <article>
-                    <div class="card-box">
-                        <p><strong>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></strong></p>
-                        <p><strong>Prow test results are ignored if they do not test the Pull Request against the most recent commit on the branch.</strong></p>
-                        <p><strong>Your Pull Request must also match one of these GitHub search queries (you can click them to check):</strong></p>
-                        <ul id="queries"></ul>
+                    <div id="info-div" class="card-box">
+                        <h4>Merge Requirements: (click to expand)</h4>
+                        <span class="hidden">
+                            <hr>
+                            <p><strong>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></strong></p>
+                            <p><strong>Prow test results are ignored if they do not test the Pull Request against the most recent commit on the branch.</strong></p>
+                            <p><strong>Your Pull Request must also match one of these GitHub search queries (you can click them to check):</strong></p>
+                            <ul id="queries"></ul>
+                        </span>
                     </div>
                 </article>
                 <article>

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -35,6 +35,7 @@
                 <article>
                     <div class="card-box">
                         <p><strong>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></strong></p>
+                        <p><strong>Prow test results are ignored if they do not test the Pull Request against the most recent commit on the branch.</strong></p>
                         <p><strong>Your Pull Request must also match one of these GitHub search queries (you can click them to check):</strong></p>
                         <ul id="queries"></ul>
                     </div>
@@ -47,7 +48,7 @@
                         <th>Batch</th>
                         <th>Passing</th>
                         <th>Pending</th>
-                        <th>Missing</th>
+                        <th>Failing or Untested</th>
                         </thead>
                         <tbody>
                         </tbody>

--- a/prow/cmd/deck/static/tidescript.js
+++ b/prow/cmd/deck/static/tidescript.js
@@ -1,6 +1,10 @@
 "use strict";
 
 window.onload = function() {
+    var infoDiv = document.getElementById("info-div");
+    var infoH2 = infoDiv.getElementsByTagName("h4")[0];
+    infoH2.addEventListener("click", infoToggle(infoDiv.getElementsByTagName("span")[0]), true);
+
     redraw();
 };
 
@@ -23,6 +27,18 @@ function configure() {
     }
     if (branding.header_color !== '') {
         document.getElementsByTagName('header')[0].style.backgroundColor = branding.header_color;
+    }
+}
+
+function infoToggle(toToggle) {
+    return function(event) {
+        if (toToggle.className == "hidden") {
+            toToggle.className = "";
+            event.target.textContent = "Merge Requirements: (click to collapse)";
+        } else {
+            toToggle.className = "hidden";
+            event.target.textContent = "Merge Requirements: (click to expand)";
+        }
     }
 }
 


### PR DESCRIPTION
If a user sees that their PR is listed as `Missing` on the Tide dashboard they probably won't know what that means or may think it means that their PR could not be found by Tide.

`Missing` really means one of three things:
- Tide could not find test results or running tests for at least one job for the PR (PR has not run all test jobs)
- Tide found tests associated with the PR for all jobs, but some job does not have results or is not currently running against the current repo HEAD. (PR does not have up to date run for each test job)
- Tide found up-to-date tests for the PR, tested against the current repo HEAD, but at least one such test failed. (PR has up-to-date test that is failing)

The column title should indicate that PRs in the column are either failing tests or have old test results that are no longer valid. 