### PR TITLE
Revert pull-kubernetes-cross image bump.

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1234,7 +1234,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"
@@ -3644,7 +3644,7 @@ presubmits:
     run_if_changed: '^(build\/|hack\/lib\/)|(Makefile)|(.*_(windows|linux|osx|unsupported)(_test)?\.go)$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20180102-695ace192
+      - image: gcr.io/k8s-testimages/bootstrap:v20171210-9bf1eccaf
         args:
         - "--clean"
         - "--git-cache=/root/.cache/git"


### PR DESCRIPTION
The version bump to `pull-kubernetes-cross` in #6125 seems to correspond chronologically with the start of the failures https://prow.k8s.io/?type=presubmit&job=pull-kubernetes-cross. I'm not sure what the problem is, but reverting to the previous image will hopefully fix the job for the time being.

ref https://github.com/kubernetes/kubernetes/issues/57822

/cc @krzyzacy @ixdy 