### PR TITLE
Add --stage to ingress-gce job config

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10848,6 +10848,7 @@
       "--extract=local",
       "--gcp-zone=us-central1-f",
       "--provider=gce",
+      "--stage=gs://kubernetes-release-pull/ci/pull-ingress-gce-e2e",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
       "--timeout=60m"
     ],


### PR DESCRIPTION
Kubetest was not able able to extract the k8s binaries without --stage. This PR adds --stage to ensure the binaries are found. 