### PR TITLE
Avoid Jenkins operator panic

### DIFF
--- a/prow/jenkins/jenkins.go
+++ b/prow/jenkins/jenkins.go
@@ -107,9 +107,12 @@ func (jb *JenkinsBuild) BuildID() string {
 	for _, action := range jb.Actions {
 		for _, p := range action.Parameters {
 			if p.Name == buildID || p.Name == newBuildID {
-				// This is not safe as far as Go is concerned. Consider
-				// stop using Jenkins if this ever breaks.
-				return p.Value.(string)
+				value, ok := p.Value.(string)
+				if !ok {
+					logrus.Errorf("Cannot determine %s value for %#v", p.Name, jb)
+					continue
+				}
+				return value
 			}
 		}
 	}


### PR DESCRIPTION
@stevekuznetsov we hit this in the new origin master (`jenkins-origin-operator`).
```
{"client":"jenkins","component":"jenkins-operator","level":"debug","msg":"GetEnqueuedBuilds","time":"2018-01-05T00:25:51Z"}
panic: interface conversion: interface {} is nil, not string
goroutine 1 [running]:
k8s.io/test-infra/prow/jenkins.(*JenkinsBuild).BuildID(0xc420d72cf8, 0x0, 0xc420a017d0)
	/go/src/k8s.io/test-infra/prow/jenkins/jenkins.go:112 +0x11b
k8s.io/test-infra/prow/jenkins.(*Client).GetEnqueuedBuilds(0xc420190ea0, 0xc420af0540, 0x4, 0x4, 0x29, 0xc42093cb70, 0xf)
	/go/src/k8s.io/test-infra/prow/jenkins/jenkins.go:359 +0x2d1
k8s.io/test-infra/prow/jenkins.(*Client).ListBuilds(0xc420190ea0, 0xc420af0540, 0x4, 0x4, 0x4, 0x4, 0x114)
	/go/src/k8s.io/test-infra/prow/jenkins/jenkins.go:299 +0x6a
k8s.io/test-infra/prow/jenkins.(*Controller).Sync(0xc42008e420, 0x93fe53d5ac5, 0xb30ee0)
	/go/src/k8s.io/test-infra/prow/jenkins/controller.go:157 +0x2da
main.main()
	/go/src/k8s.io/test-infra/prow/cmd/jenkins-operator/main.go:140 +0xa5c
```