### PR TITLE
Add release repo to ingress-gce config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -187,6 +187,7 @@ presubmits:
         args:
         - "--repo=k8s.io/kubernetes=master"
         - "--repo=k8s.io/ingress-gce=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
         - "--root=/go/src/"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"


### PR DESCRIPTION
This PR adds the k/release repo to the ingress-gce config. This fixes the issue of push-build.sh not being available to kubetest