### PR TITLE
Ingress-gce e2e modifications

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10842,15 +10842,15 @@
   },
   "pull-ingress-gce-e2e": {
     "args": [
-      "--build",
       "--build-ingressgce",
       "--cluster=",
-      "--extract=local",
+      "--extract=ci",
+      "--gcp-project=e2e-ingress-gce",
       "--gcp-zone=us-central1-f",
+      "--ginkgoParallel=",
       "--provider=gce",
-      "--stage=gs://kubernetes-release-pull/ci/pull-ingress-gce-e2e",
       "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
-      "--timeout=60m"
+      "--timeout=90m"
     ],
     "scenario": "kubernetes_e2e",
     "sigOwners": [

--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -121,16 +122,28 @@ func (b *buildFederationStrategy) Build() error {
 
 func (b *buildIngressGCEStrategy) Build() error {
 	// Currently, this is the only strategy.
-	var target = "push-e2e"
+	target := "push-e2e"
 
+	// Make sure we are in the ingress-gce repo before getting the image tag.
+	err := os.Chdir(k8s("ingress-gce"))
+	if err != nil {
+		return fmt.Errorf("error during ingress-gce build: %v", err)
+	}
 	// Get image tag (git command is how ingress-gce Makefile generates the tag).
-	var c = exec.Command("git", "describe", "--tags", "--always", "--dirty")
-	var o, _ = c.Output()
-
+	c := exec.Command("git", "describe", "--tags", "--always", "--dirty")
+	o, err := c.Output()
+	if err != nil {
+		return fmt.Errorf("error during ingress-gce build: %v", err)
+	}
 	// Make sure that kube-up uses the correct glbc image by exporting as
 	// environment variable
-	var e = fmt.Sprintf("GCE_GLBC_IMAGE=gcr.io/google_containers/ingress-gce-e2e-glbc-amd64:%s", o)
-	finishRunning(exec.Command("export", e))
+	e := fmt.Sprintf("gcr.io/e2e-ingress-gce/ingress-gce-e2e-glbc-amd64:%s", o)
+	os.Setenv("GCE_GLBC_IMAGE", e)
+	// Ensure we are back in /go/src/k8s.io so that k8s binaries are acquired properly.
+	err = os.Chdir(k8s())
+	if err != nil {
+		return fmt.Errorf("error during ingress-gce build: %v", err)
+	}
 
 	return finishRunning(exec.Command("make", "-C", k8s("ingress-gce"), target))
 }

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -369,14 +369,14 @@ func complete(o *options) error {
 		}
 	}
 
+	if err := acquireIngressGCE(o); err != nil {
+		return fmt.Errorf("failed to acquire ingress-gce binaries: %v", err)
+	}
 	if err := acquireKubernetes(o); err != nil {
 		return fmt.Errorf("failed to acquire k8s binaries: %v", err)
 	}
 	if err := acquireFederation(o); err != nil {
 		return fmt.Errorf("failed to acquire federation binaries: %v", err)
-	}
-	if err := acquireIngressGCE(o); err != nil {
-		return fmt.Errorf("failed to acquire ingress-gce binaries: %v", err)
 	}
 	if o.extract.Enabled() {
 		if err := os.Chdir("kubernetes"); err != nil {


### PR DESCRIPTION
This makes sure that when the git tag is retrieved that we are actually in the ingress-gce repo. 

Also increase the job timeout to 90m and point to specific project
  
  