### PR TITLE
Make Gubernator read secrets from datastore on instance startup.

### DIFF
--- a/gubernator/.gitignore
+++ b/gubernator/.gitignore
@@ -1,5 +1,3 @@
-github/webhook_secret
-secrets.json
 .coverage
 htmlcov/
 node_modules

--- a/gubernator/Makefile
+++ b/gubernator/Makefile
@@ -6,15 +6,7 @@ PROJECT ?= k8s-gubernator
 .PHONY: migrate versions deploy all
 all: versions
 
-github/webhook_secret:
-	@echo TODO(kubernetes/test-infra/3884): deploy without needing this file
-	@echo Ask Google GKE EngProd how to create this file.
-
-secrets.json:
-	@echo TODO(kubernetes/test-infra/3884): deploy without needing this file
-	@echo Ask Google GKE EngProd how to create this file.
-
-deploy: github/webhook_secret secrets.json
+deploy:
 	gcloud app deploy --version="$(VERSION)" --project="$(PROJECT)" --no-promote --quiet
 	cd github && gcloud app deploy --version="$(VERSION)" --project="$(PROJECT)" --no-promote --quiet
 

--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -29,22 +29,8 @@ only updates after the webhook is added will be shown on the dashboard.
 
 # Deployment
 
-- Get the "Gubernator Github Webhook Secret" (ask test-infra for help) and write
-  it to `github/webhook_secret`.
-- Set up `secrets.json` to support Github [OAuth logins](https://github.com/settings/applications).
-  The skeleton might look like:
-
-```json
-    {
-        "k8s-gubernator.appspot.com": {
-            "session": "(128+  bits of entropy for signing secure cookies)",
-            "github_client": {
-                "id": "(client_id for the oauth application)",
-                "secret": "(client_secret for the oauth application)"
-            }
-        }
-    }
-```
+- Visit /config on the new deployment to configure Github [OAuth logins](https://github.com/settings/applications)
+  and webhook secrets.
 
 # GCS Layout
 
@@ -115,3 +101,8 @@ the different types of jobs:
                 └── job_name         # all builds for the job for this pr live here
                     └── build_number # contains job artifacts, as above
 ```
+
+# Migrations
+
+1. 2018-01-09: Github webhook and oauth secrets must be reconfigured. Visit
+   /config on your deployment to enter the new values.

--- a/gubernator/app.yaml
+++ b/gubernator/app.yaml
@@ -25,6 +25,10 @@ handlers:
   static_dir: static
   application_readable: true
 
+- url: /config
+  script: main.app
+  login: admin
+
 - url: .*
   script: main.app
   secure: always

--- a/gubernator/github/handlers.py
+++ b/gubernator/github/handlers.py
@@ -29,24 +29,23 @@ from google.appengine.ext import deferred
 
 import classifier
 import models
-from .. import secrets
+from .. import secrets  # erick-lint: disable=relative-import purely for pylint
 
 
-WEBHOOK_SECRET = None
-
+_webhook_secret = None
 def get_webhook_secret():
-    global WEBHOOK_SECRET  # pylint: disable=global-statement
-    if not WEBHOOK_SECRET:
+    global _webhook_secret  # pylint: disable=global-statement
+    if not _webhook_secret:
         try:
-            WEBHOOK_SECRET = secrets.get('github_webhook_secret', per_host=False)
+            _webhook_secret = secrets.get('github_webhook_secret', per_host=False)
         except KeyError:
             logging.exception('unable to load webhook secret')
             return ''
-    return WEBHOOK_SECRET
+    return _webhook_secret
 
 
 def make_signature(body):
-    hmac_instance = hmac.HMAC(WEBHOOK_SECRET, body, hashlib.sha1)
+    hmac_instance = hmac.HMAC(get_webhook_secret(), body, hashlib.sha1)
     return 'sha1=' + hmac_instance.hexdigest()
 
 

--- a/gubernator/github/handlers.py
+++ b/gubernator/github/handlers.py
@@ -29,13 +29,20 @@ from google.appengine.ext import deferred
 
 import classifier
 import models
+from .. import secrets
 
 
-try:
-    WEBHOOK_SECRET = open('webhook_secret').read().strip()
-except IOError:
-    logging.warning('unable to load webhook secret')
-    WEBHOOK_SECRET = 'default'
+WEBHOOK_SECRET = None
+
+def get_webhook_secret():
+    global WEBHOOK_SECRET  # pylint: disable=global-statement
+    if not WEBHOOK_SECRET:
+        try:
+            WEBHOOK_SECRET = secrets.get('github_webhook_secret', per_host=False)
+        except KeyError:
+            logging.exception('unable to load webhook secret')
+            return ''
+    return WEBHOOK_SECRET
 
 
 def make_signature(body):

--- a/gubernator/github/main_test.py
+++ b/gubernator/github/main_test.py
@@ -52,6 +52,7 @@ class AppTest(TestBase):
     def setUp(self):
         self.init_stubs()
         self.taskqueue = self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
+        handlers.WEBHOOK_SECRET = 'asdf'
 
     def get_response(self, event, body):
         if isinstance(body, dict):

--- a/gubernator/github/main_test.py
+++ b/gubernator/github/main_test.py
@@ -52,7 +52,7 @@ class AppTest(TestBase):
     def setUp(self):
         self.init_stubs()
         self.taskqueue = self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME)
-        handlers.WEBHOOK_SECRET = 'asdf'
+        handlers._webhook_secret = 'asdf'  # pylint: disable=protected-access
 
     def get_response(self, event, body):
         if isinstance(body, dict):

--- a/gubernator/github_auth.py
+++ b/gubernator/github_auth.py
@@ -45,8 +45,9 @@ class Endpoint(view_base.BaseHandler):
                 self.app.config['github_client'] = secrets.get('github_client')
             except KeyError:
                 self.abort(500,
-                           body_template='An admin must <a href="/config">'
-                           'configure Github secrets</a> first.')
+                           body_template=(
+                           'An admin must <a href="/config">'
+                           'configure Github secrets</a> first.'))
         client = self.app.config['github_client']
         return client['id'], client['secret']
 

--- a/gubernator/github_auth.py
+++ b/gubernator/github_auth.py
@@ -34,14 +34,20 @@ from webapp2_extras import security
 
 from google.appengine.api import urlfetch
 
+import secrets
 import view_base
 
 
 class Endpoint(view_base.BaseHandler):
     def github_client(self):
+        if not self.app.config['github_client']:
+            try:
+                self.app.config['github_client'] = secrets.get('github_client')
+            except KeyError:
+                self.abort(500,
+                           body_template='An admin must <a href="/config">'
+                           'configure Github secrets</a> first.')
         client = self.app.config['github_client']
-        if not client:
-            self.abort(500)
         return client['id'], client['secret']
 
     def maybe_redirect(self, target):
@@ -53,7 +59,6 @@ class Endpoint(view_base.BaseHandler):
 
     def get(self, arg):
         # Documentation here: https://developer.github.com/v3/oauth/
-
         client_id, client_secret = self.github_client()
 
         if arg.endswith('/done'):

--- a/gubernator/github_auth_test.py
+++ b/gubernator/github_auth_test.py
@@ -30,6 +30,7 @@ main.app.config['github_client'] = {
     'id': CLIENT_ID,
     'secret': CLIENT_SECRET,
 }
+main.app.config['webapp2_extras.sessions']['secret_key'] = 'abcd'
 
 app = webtest.TestApp(main.app)
 

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -64,24 +64,27 @@ class ConfigHandler(view_base.BaseHandler):
         self.render('config.html', {'hostname': hostname})
 
     def post(self):
-        self.response.headers['Content-Type'] = 'text/plain'
         if users.is_current_user_admin():
+            oauth_set = False
+            webhook_set = False
+
             github_id = self.request.get('github_id')
             github_secret = self.request.get('github_secret')
             if github_id and github_secret:
                 value = {'id': github_id, 'secret': github_secret}
                 secrets.put('github_client', value)
                 app.config['github_client'] = value
-                self.response.write('set github oauth client!\n')
+                oauth_set = True
             github_webhook_secret = self.request.get('github_webhook_secret')
             if github_webhook_secret:
                 secrets.put('github_webhook_secret',
                             github_webhook_secret,
                             per_host=False)
-                self.response.write('set github webhook secret!\n')
-            self.response.write('done.')
+                webhook_set = True
+            self.render('config.html',
+                        {'hostname': hostname, 'oauth_set': oauth_set, 'webhook_set': webhook_set})
         else:
-            self.response.write('not admin, ignoring.')
+            self.abort(403)
 
 
 app = webapp2.WSGIApplication([

--- a/gubernator/main.py
+++ b/gubernator/main.py
@@ -14,55 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import logging
-import os
-
 import yaml
 import webapp2
-from webapp2_extras import security
 
-from google.appengine.api import app_identity
-from google.appengine.api import modules
+from google.appengine.api import users
 
 import github_auth
 import view_base
 import view_build
 import view_logs
 import view_pr
+import secrets
 
 
-hostname = app_identity.get_default_version_hostname()
-if 'testbed' not in os.environ.get('SERVER_SOFTWARE', 'testbed'):
-    current_version = modules.modules.get_current_version_name()
-    if modules.modules.get_default_version() != current_version:
-        hostname = '%s-dot-%s' % (current_version, hostname)
-
-def get_secret(key):
-    data = json.load(open('secrets.json'))
-    return data[hostname][key]
-
-
-def get_session_secret():
-    try:
-        return str(get_secret('session'))
-    except (IOError, KeyError):
-        if hostname:  # no scary error messages when testing
-            logging.error(
-                'unable to load secret key! sessions WILL NOT persist!')
-        # This fallback is enough for testing, but in production
-        # will end up invalidating sessions whenever a different instance
-        # is created.
-        return security.generate_random_string(entropy=256)
-
-
-def get_github_client():
-    try:
-        return get_secret('github_client')
-    except (IOError, KeyError):
-        if hostname:
-            logging.warning('no github client id found')
-        return None
+hostname = secrets.get_hostname()
 
 
 def get_app_config():
@@ -71,14 +36,14 @@ def get_app_config():
 
 config = {
     'webapp2_extras.sessions': {
-        'secret_key': get_session_secret(),
+        'secret_key': None,  # filled in on the first request
         'cookie_args': {
             # we don't have SSL For local development
             'secure': hostname and 'appspot.com' in hostname,
             'httponly': True,
         },
     },
-    'github_client': get_github_client(),
+    'github_client': None,  # filled in the first time auth is needed
 }
 
 config.update(get_app_config())
@@ -87,9 +52,37 @@ class Warmup(webapp2.RequestHandler):
     """Warms up gubernator."""
     def get(self):
         """Receives the warmup request."""
-        # TODO(fejta): warmup something useful
+        self.app.config['github_client'] = secrets.get('github_client')
+
         self.response.headers['Content-Type'] = 'text/plain'
         self.response.write('Warmup successful')
+
+
+class ConfigHandler(view_base.BaseHandler):
+    """Handles admin config of gubernator."""
+    def get(self):
+        self.render('config.html', {'hostname': hostname})
+
+    def post(self):
+        self.response.headers['Content-Type'] = 'text/plain'
+        if users.is_current_user_admin():
+            github_id = self.request.get('github_id')
+            github_secret = self.request.get('github_secret')
+            if github_id and github_secret:
+                value = {'id': github_id, 'secret': github_secret}
+                secrets.put('github_client', value)
+                app.config['github_client'] = value
+                self.response.write('set github oauth client!\n')
+            github_webhook_secret = self.request.get('github_webhook_secret')
+            if github_webhook_secret:
+                secrets.put('github_webhook_secret',
+                            github_webhook_secret,
+                            per_host=False)
+                self.response.write('set github webhook secret!\n')
+            self.response.write('done.')
+        else:
+            self.response.write('not admin, ignoring.')
+
 
 app = webapp2.WSGIApplication([
     ('/_ah/warmup', Warmup),
@@ -102,5 +95,6 @@ app = webapp2.WSGIApplication([
     (r'/pr/?', view_pr.PRDashboard),
     (r'/pr/([-\w]+)', view_pr.PRDashboard),
     (r'/pr/(.*/build-log.txt)', view_pr.PRBuildLogHandler),
-    (r'/github_auth(.*)', github_auth.Endpoint)
+    (r'/github_auth(.*)', github_auth.Endpoint),
+    (r'/config', ConfigHandler),
 ], debug=True, config=config)

--- a/gubernator/secrets.py
+++ b/gubernator/secrets.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.appengine.ext import ndb
+
+from google.appengine.api import modules
+from google.appengine.api import app_identity
+
+def get_hostname():
+    hostname = app_identity.get_default_version_hostname()
+    if 'testbed' not in os.environ.get('SERVER_SOFTWARE', 'testbed'):
+        current_version = modules.modules.get_current_version_name()
+        if current_version and modules.modules.get_default_version() != current_version:
+            hostname = '%s-dot-%s' % (current_version, hostname)
+    return hostname
+
+class Secret(ndb.Model):
+    value = ndb.JsonProperty()
+
+    @staticmethod
+    def make_key(key, per_host):
+        if per_host:
+            return ndb.Key(Secret, '%s\t%s' % (get_hostname(), key))
+        return ndb.Key(Secret, key)
+
+    @staticmethod
+    def make(key, value, per_host):
+        return Secret(key=Secret.make_key(key, per_host), value=value)
+
+
+def get(key, per_host=True):
+    data = Secret.make_key(key, per_host).get()
+    if not data:
+        raise KeyError
+    return data.value
+
+
+def put(key, value, per_host=True):
+    Secret.make(key, value, per_host).put()

--- a/gubernator/templates/config.html
+++ b/gubernator/templates/config.html
@@ -1,0 +1,16 @@
+% extends 'base.html'
+% block header
+<h1>Gubernator Admin Config Page</h1>
+% endblock
+% block content
+<form method="post">
+<p>These values come from the <a href="https://github.com/settings/developers">OAuth Apps Tab</a> on Github.
+<p>New apps should be registered with "Homepage URL" set to https://{{hostname}} and "Authorization callback URL" set to https://{{hostname}}/github_auth.
+<p>GitHub OAuth Client Id: <input type="text" name="github_id"><br>
+GitHub OAuth Client Secret: <input type="text" name="github_secret"><br>
+<hr>
+<p>This value must match whatever is entered on GitHub when registering hooks to receive.
+<p>GitHub Webhook Secret: <input type="text" name="github_webhook_secret"><br>
+<input type="submit" value="Submit">
+</form>
+% endblock

--- a/gubernator/templates/config.html
+++ b/gubernator/templates/config.html
@@ -13,4 +13,10 @@ GitHub OAuth Client Secret: <input type="text" name="github_secret"><br>
 <p>GitHub Webhook Secret: <input type="text" name="github_webhook_secret"><br>
 <input type="submit" value="Submit">
 </form>
+% if oauth_set
+<h2>OAuth secrets set!</h2>
+% endif
+% if webhook_set
+<h2>Github Webhook secret set!</h2>
+% endif
 % endblock


### PR DESCRIPTION
This means that no secrets.json is required, so automated deployments from a fresh clone will work!

Fixes #3884.