### PR TITLE
test-infra: Ensure bazel build //... and bazel test //... pass

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -5512,9 +5512,9 @@ presubmits:
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--" # end bootstrap args, scenario args below
-        - "--build=//... -//vendor/..."
+        - "--build=//..."
         - "--install=gubernator/test_requirements.txt"
-        - "--test=//... //hack:verify-all -//vendor/..."
+        - "--test=//..."
         - "--test-args=--test_output=errors"
         env:
         - name: TEST_TMPDIR
@@ -6414,9 +6414,9 @@ postsubmits:
         - "--upload=gs://kubernetes-jenkins/logs"
         - "--" # end bootstrap args, scenario args below
         - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
-        - "--build=//... -//vendor/..."
+        - "--build=//..."
         - "--install=gubernator/test_requirements.txt"
-        - "--test=//... //hack:verify-all -//vendor/..."
+        - "--test=//..."
         - "--test-args=--test_output=errors"
         env:
         - name: TEST_TMPDIR
@@ -23400,9 +23400,9 @@ periodics:
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--" # end bootstrap args, scenario args below
       - "--batch" # mitigation for https://github.com/bazelbuild/bazel/issues/4311
-      - "--build=//... -//vendor/..."
+      - "--build=//..."
       - "--install=gubernator/test_requirements.txt"
-      - "--test=//... //hack:verify-all -//vendor/..."
+      - "--test=//..."
       - "--test-args=--test_output=errors"
       env:
       - name: TEST_TMPDIR


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/6141, make sure we just use `//...` for `ci-test-infra-bazel` (CI and Periodic) and `pull-test-infra-bazel-canary`.

/area jobs
/area bazel
  