### PR TITLE
Revert "cover more test case for ipvs ci job"

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -8804,7 +8804,7 @@
       "--kubernetes-anywhere-kubernetes-version=ci/latest",
       "--kubernetes-anywhere-proxy-mode=ipvs",
       "--provider=kubernetes-anywhere",
-      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\]|\\[sig-network\\]\\sServices --minStartupPods=8",
+      "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[Feature:BootstrapTokens\\]|\\[Feature:NodeAuthorizer\\] --minStartupPods=8",
       "--timeout=300m"
     ],
     "scenario": "kubernetes_e2e",


### PR DESCRIPTION
Reverts kubernetes/test-infra#6119

Some test case `[sig-network] Services should be able to create a functioning NodePort service` can't pass, because kubeadm build cluster, node don't have external IP, so can't access from the outside. More detail see this issue: kubernetes/kubernetes#57819

I'm trying to solve this problem, but seems like gonna take lots time. So maybe it's good to revert that pr and add those test case after I solve this problem.

Sorry about that. : (