### PR TITLE
Remove k8s checkout from config

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10876,7 +10876,7 @@
     "args": [
       "--build-ingressgce",
       "--cluster=",
-      "--extract=ci",
+      "--extract=ci/latest",
       "--gcp-project=e2e-ingress-gce",
       "--gcp-zone=us-central1-f",
       "--ginkgoParallel=",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -185,9 +185,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
         args:
-        - "--repo=k8s.io/kubernetes=master"
         - "--repo=k8s.io/ingress-gce=$(PULL_REFS)"
-        - "--repo=k8s.io/release"
         - "--root=/go/src/"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--clean"


### PR DESCRIPTION
Remove k8s repo checkout from config for ingress-gce. This is not needed anymore since we extract the binaries 
  