### PR TITLE
Add setup for ingress-gce CI tests

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -170,6 +170,23 @@
       "sig-multicluster"
     ]
   },
+  "ci-ingress-gce-e2e": {
+    "args": [
+      "--build-ingressgce",
+      "--cluster=",
+      "--extract=ci/latest",
+      "--gcp-project=e2e-ingress-gce",
+      "--gcp-zone=us-central1-f",
+      "--ginkgo-parallel",
+      "--provider=gce",
+      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
+      "--timeout=320m"
+    ],
+    "scenario": "kubernetes_e2e",
+    "sigOwners": [
+      "sig-network"
+    ]
+  },
   "ci-kops-build": {
     "args": [
       "make",

--- a/jobs/config_test.py
+++ b/jobs/config_test.py
@@ -795,6 +795,9 @@ class JobTest(unittest.TestCase):
             'ci-cri-containerd-node-e2e': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-serial': 'cri-containerd-node-e2e-*',
             'ci-cri-containerd-node-e2e-flaky': 'cri-containerd-node-e2e-*',
+            # ingress-GCE e2e jobs
+            'pull-ingress-gce-e2e': 'e2e-ingress-gce',
+            'ci-ingress-gce-e2e': 'e2e-ingress-gce',
         }
         for soak_prefix in [
                 'ci-kubernetes-soak-gce-1.5',

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -6824,7 +6824,52 @@ periodics:
         secretName: ssh-key-secret
     - name: var-lib-docker
       emptyDir: {}
-
+- name: ci-ingress-gce-e2e
+  agent: kubernetes
+  interval: 60m
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20180108-bf63630a9-master
+      args:
+      - "--repo=k8s.io/ingress-gce=master"
+      - "--root=/go/src/"
+      - "--clean"
+      - "--timeout=320"
+      env:
+      - name: DOCKER_IN_DOCKER_ENABLED
+        value: true
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/service-account/service-account.json
+      - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-private
+      - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
+        value: /etc/ssh-key-secret/ssh-public
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - name: service
+        mountPath: /etc/service-account
+        readOnly: true
+      - mountPath: /etc/ssh-key-secret
+        name: ssh
+        readOnly: true
+      - name: docker-graph
+        mountPath: /docker-graph
+      ports:
+      - containerPort: 9999
+        hostPort: 9999
+    volumes:
+    - name: service
+      secret:
+        secretName: service-account
+    - name: ssh
+      secret:
+        defaultMode: 256
+        secretName: ssh-key-secret
+    - name: docker-graph
+      hostPath:
+        path: /mnt/disks/ssd0/docker-graph
 - name: ci-kubernetes-bazel-build
   interval: 6h
   agent: kubernetes
@@ -24624,4 +24669,3 @@ periodics:
     - name: service
       secret:
         secretName: service-account
-

--- a/testgrid/config/config.yaml
+++ b/testgrid/config/config.yaml
@@ -109,6 +109,8 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
+- name: ci-ingress-gce-e2e
+  gcs_prefix: kubernetes-jenkins/logs/ci-ingress-gce-e2e
 - name: ci-kubernetes-build-1.9
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-build-1.9
 - name: ci-kubernetes-build
@@ -3870,6 +3872,10 @@ dashboards:
     test_group_name: ci-kubernetes-e2e-gci-gce-ingress
     alert_options:
       alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
+  - name: ingress-gce-e2e
+    test_group_name: ci-ingress-gce-e2e
+    alert_options:
+      alert_mail_to_addresses: 'kubernetes-sig-network-test-failures@googlegroups.com'
   - name: gci-gce-ingress-release-1.6
     test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-ingress
     alert_options:
@@ -5273,4 +5279,3 @@ dashboard_groups:
   - sig-gcp-release-1.7
   - sig-gcp-release-1.6
   - sig-gcp-ubuntu
-


### PR DESCRIPTION
This PR adds another job for ingress-gce e2e. The new job is a periodic which runs every hour and runs e2e tests in k/k against ingress-gce HEAD. 

Currently, there is a job called ci-kubernetes-e2e-gci-gce-ingress which is similar to this job but instead of testing against ingress-gce HEAD, its tests against the latest release image. 

Also made changes to add this new job to testgrid.
  