### PR TITLE
Make verify-vendor.sh executable and fix bug

### DIFF
--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-script="$(dirname ${BASH_SOURCE})/prune-libraries.sh"  --check
-if ! "$script" ; then
-  echo "Run $script --fix"
+script="$(dirname ${BASH_SOURCE})/prune-libraries.sh"
+if ! "${script}" --check; then
+  echo "Run ${script} --fix"
   exit 1
 fi


### PR DESCRIPTION
Fixes two small bugs:

```console
$ ./hack/verify-vendor.sh
bash: ./hack/verify-vendor.sh: Permission denied
$ bash hack/verify-vendor.sh 
hack/verify-vendor.sh: line 16: --check: command not found
hack/verify-vendor.sh: line 17: : command not found
Run  --fix
```

Still not sure how we want to run this on Prow. Can you call bazel from inside a bazel test?

/assign @fejta 