### PR TITLE
Introduce Material Design framework to Prow Dashboard

### DIFF
--- a/prow/cmd/deck/static/index.html
+++ b/prow/cmd/deck/static/index.html
@@ -6,52 +6,68 @@
         <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513905648">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
         <script type="text/javascript" src="script.js"></script>
         <script type="text/javascript" src="data.js?var=allBuilds"></script>
         <script type="text/javascript" src="extensions/script.js"></script>
+        <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
     </head>
     <body>
-        <header>
-            <ul>
-                <li><a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"></img></a><a href="/" class="current"><h1>Prow Status</h1></a></li>
-                <li><a href="/plugin-help.html"><h1>Plugin Help</h1></a></li>
-                <li><a href="/tide.html"><h1>Tide Status</h1></a></li>
-            </ul>
-        </header>
-        <aside>
-        <div>
-            <ul class="noBullets">
-                <li>Filter</li>
-                <li><select id="type" onchange="redraw();"><option>all job types</option></select></li>
-                <li><select id="repo" onchange="redraw();"><option>all repositories</option></select></li>
-                &gt;&gt;
-                <li><select id="pull" onchange="redraw();"><option>all pull requests</option></select></li>
-                <li><select id="author" onchange="redraw();"><option>all authors</option></select></li>
-                <li><select id="job" onchange="redraw();"><option>all jobs</option></select></li>
-                <li><select id="state" onchange="redraw();"><option>all states</option></select></li>
-            </ul>
-        </div>
-        </aside>
-        <article>
-        <table id="builds">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                    <th>Repository</th>
-                    <th>Revision</th>
-                    <th>Job</th>
-                    <th>Started</th>
-                    <th>Duration</th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-        </article>
-        <div id="rerun">
-            <div id="rerun-content"></div>
+        <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+            <header class="mdl-layout__header">
+                <div class="mdl-layout__header-row">
+                    <a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"/></a>
+                    <span class="mdl-layout-title header-title">Prow Status</span>
+                </div>
+            </header>
+            <div class="mdl-layout__drawer">
+                <span class="mdl-layout-title">Prow Dashboard</span>
+                <nav class="mdl-navigation">
+                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/">Prow Status</a>
+                    <a class="mdl-navigation__link" href="/plugin-help.html">Plugin Help</a>
+                    <a class="mdl-navigation__link" href="/tide.html">Tide Status</a>
+                </nav>
+            </div>
+            <main class="mdl-layout__content">
+                <div class="page-content">
+                    <aside>
+                        <div class="card-box">
+                            <ul class="noBullets">
+                                <li>Filter</li>
+                                <li><select id="type" onchange="redraw();"><option>all job types</option></select></li>
+                                <li><select id="repo" onchange="redraw();"><option>all repositories</option></select></li>
+                                &gt;&gt;
+                                <li><select id="pull" onchange="redraw();"><option>all pull requests</option></select></li>
+                                <li><select id="author" onchange="redraw();"><option>all authors</option></select></li>
+                                <li><select id="job" onchange="redraw();"><option>all jobs</option></select></li>
+                                <li><select id="state" onchange="redraw();"><option>all states</option></select></li>
+                            </ul>
+                        </div>
+                    </aside>
+                    <article>
+                        <table id="builds">
+                            <thead>
+                            <tr>
+                                <th></th>
+                                <th></th>
+                                <th></th>
+                                <th>Repository</th>
+                                <th>Revision</th>
+                                <th>Job</th>
+                                <th>Started</th>
+                                <th>Duration</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            </tbody>
+                        </table>
+                    </article>
+                    <div id="rerun">
+                        <div id="rerun-content"></div>
+                    </div>
+                </div>
+            </main>
         </div>
     </body>
 </html>

--- a/prow/cmd/deck/static/plugin-help-script.js
+++ b/prow/cmd/deck/static/plugin-help-script.js
@@ -63,6 +63,7 @@ function applicablePlugins(repoSel, repoPlugins) {
 function addSection(div, section, elem) {
     var h4 = document.createElement("h4");
     h4.appendChild(document.createTextNode(section));
+    h4.className = "plugin-section-header";
     div.appendChild(h4);
     elem.className = "indented";
     div.appendChild(elem);
@@ -113,6 +114,7 @@ function redrawHelpTable(repo, names, helpMap, tableParent) {
 
         var div = document.createElement("div");
         div.style.display = "none";
+        div.className = "plugin-description";
         if (help) {
             addTextSection(div, "Description", help.Description);
             addTextSection(div, "Who can use", help.WhoCanUse);
@@ -138,13 +140,14 @@ function redrawHelpTable(repo, names, helpMap, tableParent) {
             div.appendChild(p);
         }
 
-        var pluginHeader = document.createElement("h3");
-        pluginHeader.className = "plugin";
+        var pluginHeader = document.createElement("div");
+        pluginHeader.className = "plugin-header";
         pluginHeader.appendChild(document.createTextNode(closedArrow + name));
         pluginHeader.addEventListener("click", clickHandler(div), true);
         var outerDiv = document.createElement("div");
         outerDiv.appendChild(pluginHeader);
         outerDiv.appendChild(div);
+        outerDiv.className = "plugin-help-row";
         var tr = document.createElement("tr");
         tr.appendChild(outerDiv);
         tr.id = "plugin-" + name;

--- a/prow/cmd/deck/static/plugin-help.html
+++ b/prow/cmd/deck/static/plugin-help.html
@@ -6,48 +6,62 @@
         <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513905648">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
         <script type="text/javascript" src="plugin-help-script.js"></script>
         <script type="text/javascript" src="plugin-help.js?var=allHelp"></script>
         <script type="text/javascript" src="extensions/script.js"></script>
+        <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
     </head>
     <body>
-        <header>
-            <ul>
-                <li><a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"></img></a><a href="/"><h1>Prow Status</h1></a></li>
-                <li><a href="/plugin-help.html" class="current"><h1>Plugin Help</h1></a></li>
-                <li><a href="/tide.html"><h1>Tide Status</h1></a></li>
-            </ul>
-        </header>
-        <aside>
-        <div>
-            <ul class="noBullets">
-                <li>Plugin help for</li>
-                <li><select id="repo" onchange="redraw();"><option>all plugins</option></select></li>
-                <li>(click a plugin below to expand/hide help)</li>
-            </ul>
+        <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+            <header class="mdl-layout__header">
+                <div class="mdl-layout__header-row">
+                    <a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"/></a>
+                    <span class="mdl-layout-title header-title">Plugin Help</span>
+                </div>
+            </header>
+            <div class="mdl-layout__drawer">
+                <span class="mdl-layout-title">Prow Dashboard</span>
+                <nav class="mdl-navigation">
+                    <a class="mdl-navigation__link" href="/">Prow Status</a>
+                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/plugin-help.html">Plugin Help</a>
+                    <a class="mdl-navigation__link" href="/tide.html">Tide Status</a>
+                </nav>
+            </div>
+            <main class="mdl-layout__content">
+                <aside>
+                    <div class="card-box">
+                        <ul class="noBullets">
+                            <li>Plugin help for</li>
+                            <li><select id="repo" onchange="redraw();"><option>all plugins</option></select></li>
+                            <li>(click a plugin below to expand/hide help)</li>
+                        </ul>
+                    </div>
+                </aside>
+                <article id="normal-plugins">
+                    <table class="headered">
+                        <thead>
+                        <tr>
+                            <th class="plugins-header">Normal Plugins</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                    </table>
+                </article>
+                <article id="external-plugins">
+                    <table class="headered">
+                        <thead>
+                        <tr>
+                            <th class="plugins-header">External Plugins</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                    </table>
+                </article>
+            </main>
         </div>
-        </aside>
-        <article id="normal-plugins">
-        <table class="headered">
-            <thead>
-                <tr>
-                    <th><h2>Normal Plugins</h2></th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-        </article>
-        <article id="external-plugins">
-        <table class="headered">
-            <thead>
-                <tr>
-                    <th><h2>External Plugins</h2></th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-        </article>
     </body>
 </html>

--- a/prow/cmd/deck/static/style.css
+++ b/prow/cmd/deck/static/style.css
@@ -3,80 +3,25 @@ body {
     line-height: 1.4;
     background: #f4f4f4;
     color: #444;
-    padding: 0;
-    margin: 0;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-}
-
-header {
-    background-color: #3f51b5;
-    color: white;
-    padding: .1em;
-    box-shadow: 0px 0px .5em #666;
-}
-
-header a {
-    color: inherit !important;
-}
-
-header a.logo {
-    height: 2.5em;
-    padding: 0;
-    margin: 0;
-    margin-top: .2em;
 }
 
 a.current {
     text-decoration: underline !important;
 }
 
-img.logo {
-    height: inherit;
+.header-title {
+    margin-left: 24px;
 }
 
-header ul {
-    list-style-type: none;
-    overflow: auto;
-    width: 100%;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: space-between;
+.logo {
+    height: 48px;
+    width: 48px;
 }
-
-header ul li {
-    display: inline;
-    list-style-type: none;
-    padding-left: .5em;
-    padding-right: .5em;
-    list-style: none;
-    display: inline-block;
-}
-
-header ul li:first-child {
-    margin: 0;
-    padding-left: .25em;
-    padding-right: .25em;
-    display: flex;
-}
-
-header ul li:first-child a:first-child {
-   padding-right: .5em;
-}
-
 
 h1 {
     font-weight: normal;
     font-size: 2em;
     margin: 2px;
-}
-
-h2, h3 {
-    font-weight: bold;
-    margin: 0;
 }
 
 h4 {
@@ -93,23 +38,6 @@ p, pre, ul, ol {
 
 ul.indented {
     margin-left: 0;
-}
-
-div {
-    padding-left: 20px;
-}
-
-h3.plugin {
-    color: blue;
-    cursor: pointer;
-}
-
-div {
-    background: #fff;
-    padding: 8px;
-    border-radius: 2px;
-    box-shadow: 0 0 4px #e0e0e0;
-    margin-top: 8px;
 }
 
 aside {
@@ -265,6 +193,49 @@ span.label:hover {
     font-weight: bold;
 }
 
+.plugin-details {
+    margin: 8px 24px;
+}
+
+.plugin-header {
+    color: blue;
+    cursor: pointer;
+    margin: 0 8px;
+}
+
+.plugins-header {
+    font-weight: bold;
+    font-size: 24px;
+    padding: 24px 0;
+}
+
+.plugin-help-row {
+    background-color: #fff;
+    font-size: 18px;
+    font-weight: bold;
+    margin: 4px 0;
+    padding: 12px 0;
+}
+
+.plugin-description {
+    border-radius: 2px;
+    box-shadow: 0 0 4px #e0e0e0;
+    margin: 8px;
+    padding: 8px;
+}
+
+.plugin-section-header {
+    font-size: 16px;
+    font-weight: bold;
+    margin: 0;
+}
+
+.card-box {
+    background-color: white;
+    border-radius: 2px;
+    box-shadow: 0 0 4px #e0e0e0;
+    padding: 8px 8px;
+}
 
 /* Known GitHub Labels, can be overriden in extensions/style.css */
 /* NOTE: spaces must be stripped from the label name */

--- a/prow/cmd/deck/static/tide.html
+++ b/prow/cmd/deck/static/tide.html
@@ -7,38 +7,52 @@
         <link rel="stylesheet" type="text/css" href="style.css?reload-me-please=1513905648">
         <link rel="stylesheet" type="text/css" href="extensions/style.css">
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+        <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
         <script type="text/javascript" src="tidescript.js?reload-me-please=1513905648"></script>
         <script type="text/javascript" src="tide.js?var=tideData"></script>
         <script type="text/javascript" src="extensions/script.js"></script>
+        <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
     </head>
     <body>
-        <header>
-            <ul>
-                <li><a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"></img></a><a href="/"><h1>Prow Status</h1></a></li>
-                <li><a href="/plugin-help.html"><h1>Plugin Help</h1></a></li>
-                <li><a href="/tide.html" class="current"><h1>Tide Status</h1></a></li>
-            </ul>
-        </header>
-        <article>
-            <div>
-                <h4>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></h4>
-                <h4>Your Pull Request must also match one of these GitHub search queries (you can click them to check):</h4>
-                <ul id="queries"></ul>
+        <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+            <header class="mdl-layout__header">
+                <div class="mdl-layout__header-row">
+                    <a href="https://github.com/kubernetes/test-infra" class="logo"><img src="/logo.svg" alt="kubernetes logo" class="logo"/></a>
+                    <span class="mdl-layout-title header-title">Tide Status</span>
+                </div>
+            </header>
+            <div class="mdl-layout__drawer">
+                <span class="mdl-layout-title">Prow Dashboard</span>
+                <nav class="mdl-navigation">
+                    <a class="mdl-navigation__link" href="/">Prow Status</a>
+                    <a class="mdl-navigation__link" href="/plugin-help.html">Plugin Help</a>
+                    <a class="mdl-navigation__link mdl-navigation__link--current" href="/tide.html">Tide Status</a>
+                </nav>
             </div>
-        </article>
-        <article>
-        <table id="pools">
-            <thead>
-                <th>Repo</th>
-                <th>State</th>
-                <th>Batch</th>
-                <th>Passing</th>
-                <th>Pending</th>
-                <th>Missing</th>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-        </article>
+            <main class="mdl-layout__content">
+                <article>
+                    <div class="card-box">
+                        <p><strong>All <a href="https://help.github.com/articles/about-required-status-checks/">GitHub statuses</a> on a Pull Request must be passing / green for automatic merge&nbsp;<span class="success">✓</span></strong></p>
+                        <p><strong>Your Pull Request must also match one of these GitHub search queries (you can click them to check):</strong></p>
+                        <ul id="queries"></ul>
+                    </div>
+                </article>
+                <article>
+                    <table id="pools">
+                        <thead>
+                        <th>Repo</th>
+                        <th>State</th>
+                        <th>Batch</th>
+                        <th>Passing</th>
+                        <th>Pending</th>
+                        <th>Missing</th>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                    </table>
+                </article>
+            </main>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
* Introduces the Material Design framework to Prow Dashboard.
* Moves all links on the header to a side-drawer.
* Fixes some style accordingly to the changes. Specifically, some styling classes in html files and plugin-help-script.js are changed to adopt the new styling framework and to keep the appearance as the origin. 
* The changes should be reviewed by others folks to make sure that it does not clash with external styling. 

![header](https://user-images.githubusercontent.com/24363693/34700736-6b15bb88-f499-11e7-99af-97a9d47ce724.png)
![drawer](https://user-images.githubusercontent.com/24363693/34700737-6da40292-f499-11e7-8afd-6f83935691dc.png)
![plugginhelp](https://user-images.githubusercontent.com/24363693/34701195-abba05fc-f49b-11e7-801a-3dce67d105b3.png)
![tidestatus](https://user-images.githubusercontent.com/24363693/34701202-b21f4092-f49b-11e7-81eb-7abb9d69eda5.png)

  