### PR TITLE
try pinning docker in bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -96,11 +96,13 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
     $(lsb_release -cs) stable"
 
 # Install Docker
-# TODO(bentheelder): this is a bit of a hack, look into alternatives.
+# TODO(bentheelder): the `sed` is a bit of a hack, look into alternatives.
 # Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
 # We're already inside docker though so we can be sure these are already mounted.
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
+# TODO(benthelder): update docker version. This is pinned because of
+# https://github.com/kubernetes/test-infra/issues/6187
 RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce=17.09.1~ce-0~debian && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -102,7 +102,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce && \
+    apt-get install -y --no-install-recommends docker-ce=17.09.1~ce-0~debian && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 
 


### PR DESCRIPTION
xref: https://github.com/kubernetes/test-infra/issues/6187#issuecomment-356199897
This pins the `docker-ce` package to the last known-good version as a possible solution to the `pull-kubernetes-cross` image pull timeout errors.

/area images
/hold