### PR TITLE
Remove slash at the end of Swagger spec URL

### DIFF
--- a/experiment/coverage/apicoverage.go
+++ b/experiment/coverage/apicoverage.go
@@ -57,6 +57,9 @@ func parseOpenAPI(rawdata []byte) apiArray {
 	}
 
 	for path, pathItem := range swaggerSpec.Paths.Paths {
+		// Some paths contain "/" at the end of swagger spec, here removes "/" for comparing them easily later.
+		path = strings.TrimRight(path, "/")
+
 		// Standard HTTP methods: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#path-item-object
 		methods := []string{"get", "put", "post", "delete", "options", "head", "patch"}
 		for _, method := range methods {

--- a/experiment/coverage/apicoverage.go
+++ b/experiment/coverage/apicoverage.go
@@ -117,7 +117,7 @@ func parseAPILog(fp io.Reader) apiArray {
 		}
 		api := apiData{
 			Method: method,
-			URL:    "/" + parsedURL.Path,
+			URL:    parsedURL.Path,
 		}
 		apisLog = append(apisLog, api)
 	}

--- a/experiment/coverage/apicoverage.go
+++ b/experiment/coverage/apicoverage.go
@@ -47,8 +47,6 @@ type apiData struct {
 
 type apiArray []apiData
 
-var reOpenapi = regexp.MustCompile(`({\S+?})`)
-
 func parseOpenAPI(rawdata []byte) apiArray {
 	var swaggerSpec spec.Swagger
 	var apisOpenapi apiArray
@@ -136,6 +134,8 @@ func getAPILog(restlog string) apiArray {
 
 	return parseAPILog(fp)
 }
+
+var reOpenapi = regexp.MustCompile(`({\S+?})`)
 
 func getTestedAPIs(apisOpenapi, apisLogs apiArray) apiArray {
 	var found bool

--- a/experiment/coverage/apicoverage_test.go
+++ b/experiment/coverage/apicoverage_test.go
@@ -34,10 +34,10 @@ func equalAPIArray(a, b apiArray) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for i := range a {
+	for _, i := range a {
 		found := false
-		for j := range b {
-			if i == j {
+		for _, j := range b {
+			if i.Method == j.Method && i.URL == j.URL {
 				found = true
 				break
 			}

--- a/experiment/coverage/apicoverage_test.go
+++ b/experiment/coverage/apicoverage_test.go
@@ -71,6 +71,15 @@ func TestParseOpenAPI(t *testing.T) {
 			},
 		},
 		{
+			Rawdata: []byte(`{"paths": {"/api/v1/": {
+				"get": {"description": "verify the end of / is removed"},
+				"post": {"description": "ditto"}}}}`),
+			Expected: apiArray{
+				{Method: "GET", URL: "/api/v1"},
+				{Method: "POST", URL: "/api/v1"},
+			},
+		},
+		{
 			Rawdata: []byte(`{"paths": {
 			"/resources": {
 				"get": {"description": "get available resources"},

--- a/experiment/coverage/apicoverage_test.go
+++ b/experiment/coverage/apicoverage_test.go
@@ -133,6 +133,40 @@ I0919 15:34:14.943642    6611 round_trippers.go:414] GET https://k8s-api/api/v1/
 	}
 }
 
+func TestGetTestedAPIs(t *testing.T) {
+	testCases := []struct {
+		apisOpenapi apiArray
+		apisLogs    apiArray
+		Expected    apiArray
+	}{
+		{
+			apisOpenapi: apiArray{
+				{Method: "GET", URL: "/api/v1/foo"},
+				{Method: "POST", URL: "/api/v1/foo"},
+				{Method: "GET", URL: "/api/v1/bar"},
+				{Method: "POST", URL: "/api/v1/bar"},
+			},
+			apisLogs: apiArray{
+				{Method: "GET", URL: "/api/v1/foo"},
+				{Method: "GET", URL: "/api/v1/bar"},
+				{Method: "GET", URL: "/api/v1/foo"},
+			},
+			Expected: apiArray{
+				{Method: "GET", URL: "/api/v1/foo"},
+				{Method: "GET", URL: "/api/v1/bar"},
+			},
+		},
+	}
+	for _, test := range testCases {
+		res := getTestedAPIs(test.apisOpenapi, test.apisLogs)
+		if !equalAPIArray(res, test.Expected) {
+			t.Errorf("APILog did not match expected for test")
+			t.Errorf("Actual: %#v", res)
+			t.Errorf("Expected: %#v", test.Expected)
+		}
+	}
+}
+
 func TestGetTestedAPIsByLevel(t *testing.T) {
 	testCases := []struct {
 		Negative       bool


### PR DESCRIPTION
If containing slash(/) at the end of URL at Swagger spec, current
apicoverage doesn't consider the corresponding APIs not-tested. For
example, "GET /api/v1" API is tested actually, but apicoverage doesn't
show the API as tested because of "GET /api/v1/" on Swagger spec.
This patch fixes it by removing slash from OpenAPI data.

fixes: #6181 