### PR TITLE
let heapster job run from prow natively

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10927,6 +10927,11 @@
     ]
   },
   "pull-heapster-e2e-prow": {
+    "args": [
+      "make",
+      "test-unit",
+      "test-integration"
+    ],
     "scenario": "execute",
     "sigOwners": [
       "sig-instrumentation"

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -360,7 +360,12 @@ presubmits:
     trigger: "(?m)^/test pull-heapster-e2e-prow,?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/heapster-test:0.8
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20180102-0e2b24a0b-master
+        args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--clean"
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json


### PR DESCRIPTION
the `heapster-test` image is basically kubekins + runner, try to call the make command directly and see what will happen (I suspect we'll still need to run this with docker-in-docker though)

follow up https://github.com/kubernetes/test-infra/pull/6057
/assign @x13n @BenTheElder 