### PR TITLE
Add bazel rules for aws-janitor

### DIFF
--- a/jenkins/BUILD
+++ b/jenkins/BUILD
@@ -1,6 +1,3 @@
-# The aws-janitor is not properly vendored in this repo
-# gazelle:exclude aws-janitor
-
 py_test(
     name = "bootstrap_test",
     srcs = [
@@ -36,6 +33,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//jenkins/aws-janitor:all-srcs",
         "//jenkins/job-configs:all-srcs",
     ],
     tags = ["automanaged"],

--- a/jenkins/aws-janitor/BUILD
+++ b/jenkins/aws-janitor/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/jenkins/aws-janitor",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//vendor/github.com/aws/aws-sdk-go/aws:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/awserr:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/aws/session:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/autoscaling:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/ec2:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/iam:go_default_library",
+        "//vendor/github.com/aws/aws-sdk-go/service/s3:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "aws-janitor",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/jenkins/aws-janitor",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
The dep story is kinda a mess right now.

I kept each step as a separate commit. I can't tell if my favorite part was manually having to remove a bazel dependency or running `prune-libraries.sh` three times, because it kept failing when trying to delete a dependency.

/hold