### PR TITLE
Convert pull-ingress-gce-e2e to pull-ingress-gce-test 

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -10954,19 +10954,12 @@
       "sig-instrumentation"
     ]
   },
-  "pull-ingress-gce-e2e": {
+  "pull-ingress-gce-test": {
     "args": [
-      "--build-ingressgce",
-      "--cluster=",
-      "--extract=ci/latest",
-      "--gcp-project=e2e-ingress-gce",
-      "--gcp-zone=us-central1-f",
-      "--ginkgo-parallel",
-      "--provider=gce",
-      "--test_args=--ginkgo.focus=\\[Feature:Ingress\\]",
-      "--timeout=90m"
+      "make",
+      "test"
     ],
-    "scenario": "kubernetes_e2e",
+    "scenario": "execute",
     "sigOwners": [
       "sig-network"
     ]

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -182,13 +182,13 @@ presubmits:
         hostPath:
           path: /mnt/disks/ssd0
   kubernetes/ingress-gce:
-  - name: pull-ingress-gce-e2e
+  - name: pull-ingress-gce-test
     agent: kubernetes
-    context: pull-ingress-gce-e2e
+    context: pull-ingress-gce-test
     branches:
     - master
-    rerun_command: "/test pull-ingress-gce-e2e"
-    trigger: "(?m)^/test( all| pull-ingress-gce-e2e),?(\\s+|$)"
+    rerun_command: "/test pull-ingress-gce-test"
+    trigger: "(?m)^/test( all| pull-ingress-gce-test),?(\\s+|$)"
     always_run: true
     spec:
       containers:
@@ -203,19 +203,12 @@ presubmits:
           value: true
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
-        - name: JENKINS_GCE_SSH_PRIVATE_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-private
-        - name: JENKINS_GCE_SSH_PUBLIC_KEY_FILE
-          value: /etc/ssh-key-secret/ssh-public
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         volumeMounts:
         - name: service
           mountPath: /etc/service-account
-          readOnly: true
-        - mountPath: /etc/ssh-key-secret
-          name: ssh
           readOnly: true
         - name: docker-graph
           mountPath: /docker-graph
@@ -226,10 +219,6 @@ presubmits:
       - name: service
         secret:
           secretName: service-account
-      - name: ssh
-        secret:
-          defaultMode: 256
-          secretName: ssh-key-secret
       - name: docker-graph
         hostPath:
           path: /mnt/disks/ssd0/docker-graph


### PR DESCRIPTION
This PR converts pull-ingress-gce-e2e to pull-ingress-gce-test which runs unit tests. The reason for this is that the current e2e tests for ingress take around 45 minutes and having them as presubmits on a PR would reduce velocity. The job ci-ingress-gce-e2e will now run all e2e tests and any we add in the future