### PR TITLE
Make Tide's set status contexts on PRs with deleted HeadRefs.

### DIFF
--- a/prow/Makefile
+++ b/prow/Makefile
@@ -36,7 +36,7 @@ PLANK_VERSION            ?= 0.65
 # JENKINS-OPERATOR_VERSION is the version of the jenkins-operator image
 JENKINS-OPERATOR_VERSION ?= 0.61
 # TIDE_VERSION is the version of the tide image
-TIDE_VERSION             ?= 0.19
+TIDE_VERSION             ?= 0.20
 # CLONEREFS_VERSION is the version of the clonerefs image
 CLONEREFS_VERSION        ?=0.1
 

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:0.19
+        image: gcr.io/k8s-prow/tide:0.20
         args:
         - --dry-run=false
         ports:

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -1271,7 +1271,8 @@ func (c *Client) GetFile(org, repo, filepath, commit string) ([]byte, error) {
 
 // Query runs a GraphQL query using shurcooL/githubql's client.
 func (c *Client) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {
-	c.log("Query", q, vars)
+	// Don't log query here because Query is typically called multiple times to get all pages.
+	// Instead log once per search and include total search cost.
 	return c.gqlc.Query(ctx, q, vars)
 }
 

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -145,7 +145,9 @@ func TestAccumulateBatch(t *testing.T) {
 		var pulls []PullRequest
 		for _, p := range test.pulls {
 			pr := PullRequest{Number: githubql.Int(p.number)}
-			pr.HeadRef.Target.OID = githubql.String(p.sha)
+			pr.Commits.Nodes = []struct {
+				Commit Commit
+			}{{Commit: Commit{OID: githubql.String(p.sha)}}}
 			pulls = append(pulls, pr)
 		}
 		var pjs []kube.ProwJob
@@ -678,12 +680,11 @@ func TestPickBatch(t *testing.T) {
 		pr.Number = githubql.Int(i)
 		pr.Commits.Nodes = []struct {
 			Commit Commit
-		}{{}}
+		}{{Commit: Commit{OID: githubql.String(fmt.Sprintf("origin/pr-%d", i))}}}
 		pr.Commits.Nodes[0].Commit.Status.Contexts = append(pr.Commits.Nodes[0].Commit.Status.Contexts, Context{State: githubql.StatusStateSuccess})
 		if !testpr.success {
 			pr.Commits.Nodes[0].Commit.Status.Contexts[0].State = githubql.StatusStateFailure
 		}
-		pr.HeadRef.Target.OID = githubql.String(fmt.Sprintf("origin/pr-%d", i))
 		sp.prs = append(sp.prs, pr)
 	}
 	c := &Controller{
@@ -892,8 +893,7 @@ func TestTakeAction(t *testing.T) {
 				pr.Number = githubql.Int(i)
 				pr.Commits.Nodes = []struct {
 					Commit Commit
-				}{{}}
-				pr.HeadRef.Target.OID = githubql.String(fmt.Sprintf("origin/pr-%d", i))
+				}{{Commit: Commit{OID: githubql.String(fmt.Sprintf("origin/pr-%d", i))}}}
 				sp.prs = append(sp.prs, pr)
 				prs = append(prs, pr)
 			}


### PR DESCRIPTION
fixes #6153 
I tested this out in dryrun with the production queries and without dryrun on a test repo.
/cc @spxtr 