### PR TITLE
Implement a tool for cloning repositories

### DIFF
--- a/prow/.gitignore
+++ b/prow/.gitignore
@@ -10,3 +10,4 @@ cmd/horologium/horologium
 cmd/plank/plank
 cmd/jenkins-operator/jenkins-operator
 cmd/tide/tide
+cmd/clonerefs/clonerefs

--- a/prow/BUILD
+++ b/prow/BUILD
@@ -17,6 +17,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//prow/cmd/branchprotector:all-srcs",
+        "//prow/cmd/clonerefs:all-srcs",
         "//prow/cmd/config:all-srcs",
         "//prow/cmd/deck:all-srcs",
         "//prow/cmd/hook:all-srcs",
@@ -44,6 +45,7 @@ filegroup(
         "//prow/plank:all-srcs",
         "//prow/pluginhelp:all-srcs",
         "//prow/plugins:all-srcs",
+        "//prow/pod-utils/clone:all-srcs",
         "//prow/repoowners:all-srcs",
         "//prow/report:all-srcs",
         "//prow/slack:all-srcs",

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -37,6 +37,8 @@ PLANK_VERSION            ?= 0.64
 JENKINS-OPERATOR_VERSION ?= 0.61
 # TIDE_VERSION is the version of the tide image
 TIDE_VERSION             ?= 0.18
+# CLONEREFS_VERSION is the version of the clonerefs image
+CLONEREFS_VERSION        ?=0.1
 
 # These are the usual GKE variables.
 PROJECT       ?= k8s-prow
@@ -165,4 +167,9 @@ tide-deployment: get-cluster-credentials
 mem-range-deployment: get-build-cluster-credentials
 	kubectl apply -f cluster/mem_limit_range.yaml
 
-.PHONY: hook-image hook-deployment hook-service sinker-image sinker-deployment deck-image deck-deployment deck-service splice-image splice-deployment tot-image tot-service tot-deployment horologium-image horologium-deployment plank-image plank-deployment jenkins-operator-image jenkins-operator-deployment tide-image tide-deployment mem-range-deployment
+clonerefs-image: git-image
+	CGO_ENABLED=0 go build -o cmd/clonerefs/clonerefs k8s.io/test-infra/prow/cmd/clonerefs
+	docker build -t "$(REGISTRY)/$(PROJECT)/clonerefs:$(CLONEREFS_VERSION)" $(DOCKER_LABELS) cmd/clonerefs
+	$(PUSH) "$(REGISTRY)/$(PROJECT)/clonerefs:$(CLONEREFS_VERSION)"
+
+.PHONY: hook-image hook-deployment hook-service sinker-image sinker-deployment deck-image deck-deployment deck-service splice-image splice-deployment tot-image tot-service tot-deployment horologium-image horologium-deployment plank-image plank-deployment jenkins-operator-image jenkins-operator-deployment tide-image tide-deployment mem-range-deployment clonerefs-image

--- a/prow/cmd/clonerefs/BUILD
+++ b/prow/cmd/clonerefs/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/clonerefs",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/kube:go_default_library",
+        "//prow/pjutil:go_default_library",
+        "//prow/pod-utils/clone:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "clonerefs",
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/cmd/clonerefs",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/cmd/clonerefs/Dockerfile
+++ b/prow/cmd/clonerefs/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-prow/git:0.1
+LABEL maintainer="skuznets@redhat.com"
+
+COPY clonerefs /clonerefs
+ENTRYPOINT ["/clonerefs"]

--- a/prow/cmd/clonerefs/OWNERS
+++ b/prow/cmd/clonerefs/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- stevekuznetsov

--- a/prow/cmd/clonerefs/main.go
+++ b/prow/cmd/clonerefs/main.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/pod-utils/clone"
+)
+
+type gitRefs struct {
+	gitRefs []kube.Refs
+}
+
+func (r *gitRefs) String() string {
+	representation := bytes.Buffer{}
+	for _, ref := range r.gitRefs {
+		fmt.Fprintf(&representation, "%s,%s=%s", ref.Org, ref.Repo, ref.String())
+	}
+	return representation.String()
+}
+
+// Set parses out a kube.Refs from the user string.
+// The following example shows all possible fields:
+//   org,repo=base-ref:base-sha[,pull-number:pull-sha]...
+// For the base ref and every pull number, the SHAs
+// are optional and any number of them may be set or
+// unset.
+func (r *gitRefs) Set(value string) error {
+	gitRef, err := clone.ParseRefs(value)
+	if err != nil {
+		return err
+	}
+	r.gitRefs = append(r.gitRefs, gitRef)
+	return nil
+}
+
+var (
+	srcRoot = flag.String("src-root", "", "Where to root source checkouts")
+	log     = flag.String("log", "", "Where to write logs")
+)
+
+func main() {
+	var gitRefs gitRefs
+	flag.Var(&gitRefs, "repo", "Mapping of Git URI to refs to check out, can be provided more than once")
+	flag.Parse()
+
+	if *srcRoot == "" {
+		logrus.Fatal("No source root specified")
+	}
+
+	if *log == "" {
+		logrus.Fatal("No log file specified")
+	}
+
+	jobRefs, err := pjutil.ResolveSpecFromEnv()
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not determine job refs")
+	}
+
+	results := []clone.Record{
+		clone.Run(jobRefs.Refs, *srcRoot),
+	}
+	for _, gitRef := range gitRefs.gitRefs {
+		results = append(results, clone.Run(gitRef, *srcRoot))
+	}
+
+	logData, err := json.Marshal(results)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to marshal clone records")
+	} else {
+		if err := ioutil.WriteFile(*log, logData, 0755); err != nil {
+			logrus.WithError(err).Fatal("Failed to write clone records")
+		}
+	}
+}

--- a/prow/pod-utils/OWNERS
+++ b/prow/pod-utils/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- stevekuznetsov

--- a/prow/pod-utils/clone/BUILD
+++ b/prow/pod-utils/clone/BUILD
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "clone.go",
+        "format.go",
+        "parse.go",
+        "types.go",
+    ],
+    importpath = "k8s.io/test-infra/prow/pod-utils/clone",
+    visibility = ["//visibility:public"],
+    deps = ["//prow/kube:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["parse_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/test-infra/prow/pod-utils/clone",
+    deps = ["//prow/kube:go_default_library"],
+)

--- a/prow/pod-utils/clone/OWNERS
+++ b/prow/pod-utils/clone/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- stevekuznetsov

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clone
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"k8s.io/test-infra/prow/kube"
+)
+
+func Run(refs kube.Refs, dir string) Record {
+	repositoryURL := fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
+	cloneDir := fmt.Sprintf("%s/src/github.com/%s/%s", dir, refs.Org, refs.Repo)
+	record := Record{Refs: refs}
+
+	commands := []cloneCommand{
+		func() (string, string, error) {
+			return fmt.Sprintf("os.MkdirAll(%s, 0755)", cloneDir), "", os.MkdirAll(cloneDir, 0755)
+		},
+	}
+
+	commands = append(commands, shellCloneCommand(cloneDir, "git", "init"))
+	commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, refs.BaseRef))
+
+	var checkout string
+	if refs.BaseSHA != "" {
+		checkout = refs.BaseSHA
+	} else {
+		checkout = "FETCH_HEAD"
+	}
+	commands = append(commands, shellCloneCommand(cloneDir, "git", "checkout", checkout))
+
+	for _, prRef := range refs.Pulls {
+		commands = append(commands, shellCloneCommand(cloneDir, "git", "fetch", repositoryURL, fmt.Sprintf("pull/%d/head", prRef.Number)))
+		var prCheckout string
+		if prRef.SHA != "" {
+			prCheckout = prRef.SHA
+		} else {
+			prCheckout = "FETCH_HEAD"
+		}
+		commands = append(commands, shellCloneCommand(cloneDir, "git", "merge", prCheckout))
+	}
+
+	for _, command := range commands {
+		formattedCommand, output, err := command()
+		record.Commands = append(record.Commands, Command{Command: formattedCommand, Output: output, Error: err.Error()})
+		if err != nil {
+			break
+		}
+	}
+
+	return record
+}
+
+type cloneCommand func() (string, string, error)
+
+func shellCloneCommand(dir, command string, args ...string) cloneCommand {
+	output := bytes.Buffer{}
+	cmd := exec.Command(command, args...)
+	cmd.Dir = dir
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+
+	return func() (string, string, error) {
+		err := cmd.Run()
+		return strings.Join(append([]string{command}, args...), " "), output.String(), err
+	}
+}

--- a/prow/pod-utils/clone/format.go
+++ b/prow/pod-utils/clone/format.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clone
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// FormatRecord describes the record in a human-readable
+// manner for inclusion into build logs
+func FormatRecord(record Record) string {
+	output := bytes.Buffer{}
+	if record.Failed {
+		fmt.Fprint(&output, "# FAILED!")
+	}
+	fmt.Fprintf(&output, "# Cloning %s/%s at %s", record.Refs.Org, record.Refs.Repo, record.Refs.BaseRef)
+	if record.Refs.BaseSHA != "" {
+		fmt.Fprintf(&output, "(%s)", record.Refs.BaseSHA)
+	}
+	output.WriteString("\n")
+	if len(record.Refs.Pulls) > 0 {
+		output.WriteString("# Checking out pulls:\n")
+		for _, pull := range record.Refs.Pulls {
+			fmt.Fprintf(&output, "#\t%d", pull.Number)
+			if pull.SHA != "" {
+				fmt.Fprintf(&output, "(%s)", pull.SHA)
+			}
+			fmt.Fprint(&output, "\n")
+		}
+	}
+	for _, command := range record.Commands {
+		fmt.Fprintf(&output, "$ %s\n", command.Command)
+		fmt.Fprint(&output, command.Output)
+		if command.Error != "" {
+			fmt.Fprintf(&output, "# Error: %s\n", command.Error)
+		}
+	}
+
+	return output.String()
+}

--- a/prow/pod-utils/clone/parse.go
+++ b/prow/pod-utils/clone/parse.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clone
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/test-infra/prow/kube"
+)
+
+// ParseRefs parses a human-provided string into the repo
+// that should be cloned and the refs that need to be
+// checked out once it is. The format is:
+//   org,repo=base-ref[:base-sha][,pull-id[:pull-sha]]...
+// For the base ref and pull IDs, a SHA may optionally be
+// provided or may be omitted for the latest available SHA.
+// Examples:
+//   kubernetes,test-infra=master
+//   kubernetes,test-infra=master:abcde12
+//   kubernetes,test-infra=master:abcde12,34
+//   kubernetes,test-infra=master:abcde12,34:fghij56
+//   kubernetes,test-infra=master,34:fghij56
+//   kubernetes,test-infra=master:abcde12,34:fghij56,78
+func ParseRefs(value string) (kube.Refs, error) {
+	gitRef := kube.Refs{}
+	values := strings.SplitN(value, "=", 2)
+	if len(values) != 2 {
+		return gitRef, fmt.Errorf("refspec %s invalid: does not contain '='", value)
+	}
+	info := values[0]
+	allRefs := values[1]
+
+	infoValues := strings.SplitN(info, ",", 2)
+	if len(infoValues) != 2 {
+		return gitRef, fmt.Errorf("refspec %s invalid: does not contain 'org,repo' as prefix", value)
+	}
+	gitRef.Org = infoValues[0]
+	gitRef.Repo = infoValues[1]
+
+	refValues := strings.Split(allRefs, ",")
+	if len(refValues) == 1 && refValues[0] == "" {
+		return gitRef, fmt.Errorf("refspec %s invalid: does not contain any refs", value)
+	}
+	baseRefParts := strings.Split(refValues[0], ":")
+	if len(baseRefParts) != 1 && len(baseRefParts) != 2 {
+		return gitRef, fmt.Errorf("refspec %s invalid: malformed base ref", refValues[0])
+	}
+	gitRef.BaseRef = baseRefParts[0]
+	if len(baseRefParts) == 2 {
+		gitRef.BaseSHA = baseRefParts[1]
+	}
+	for _, refValue := range refValues[1:] {
+		refParts := strings.Split(refValue, ":")
+		if len(refParts) != 1 && len(refParts) != 2 {
+			return gitRef, fmt.Errorf("refspec %s invalid: malformed pull ref", refValue)
+		}
+		pullNumber, err := strconv.Atoi(refParts[0])
+		if err != nil {
+			return gitRef, fmt.Errorf("refspec %s invalid: pull request identifier not a number: %v", refValue, err)
+		}
+		pullRef := kube.Pull{
+			Number: pullNumber,
+		}
+		if len(refParts) == 2 {
+			pullRef.SHA = refParts[1]
+		}
+		gitRef.Pulls = append(gitRef.Pulls, pullRef)
+	}
+
+	return gitRef, nil
+}

--- a/prow/pod-utils/clone/parse_test.go
+++ b/prow/pod-utils/clone/parse_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clone
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/test-infra/prow/kube"
+)
+
+func TestParseRefs(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		value     string
+		expected  kube.Refs
+		expectErr bool
+	}{
+		{
+			name:  "base branch only",
+			value: "org,repo=branch",
+			expected: kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "base branch and sha",
+			value: "org,repo=branch:sha",
+			expected: kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+				BaseSHA: "sha",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "base branch and pr number only",
+			value: "org,repo=branch,1",
+			expected: kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+				Pulls:   []kube.Pull{{Number: 1}},
+			},
+			expectErr: false,
+		},
+		{
+			name:  "base branch and pr number and sha",
+			value: "org,repo=branch,1:sha",
+			expected: kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+				Pulls:   []kube.Pull{{Number: 1, SHA: "sha"}},
+			},
+			expectErr: false,
+		},
+		{
+			name:  "base branch, sha, pr number and sha",
+			value: "org,repo=branch:sha,1:pull-sha",
+			expected: kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+				BaseSHA: "sha",
+				Pulls:   []kube.Pull{{Number: 1, SHA: "pull-sha"}},
+			},
+			expectErr: false,
+		},
+		{
+			name:  "base branch and multiple prs",
+			value: "org,repo=branch,1,2,3",
+			expected: kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+				Pulls:   []kube.Pull{{Number: 1}, {Number: 2}, {Number: 3}},
+			},
+			expectErr: false,
+		},
+		{
+			name:  "base branch and multiple prs with shas",
+			value: "org,repo=branch:sha,1:pull-1-sha,2:pull-2-sha,3:pull-3-sha",
+			expected: kube.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "branch",
+				BaseSHA: "sha",
+				Pulls:   []kube.Pull{{Number: 1, SHA: "pull-1-sha"}, {Number: 2, SHA: "pull-2-sha"}, {Number: 3, SHA: "pull-3-sha"}},
+			},
+			expectErr: false,
+		},
+		{
+			name:      "no org or repo",
+			value:     "branch:sha",
+			expectErr: true,
+		},
+		{
+			name:      "no repo",
+			value:     "org=branch",
+			expectErr: true,
+		},
+		{
+			name:      "no refs",
+			value:     "org,repo=",
+			expectErr: true,
+		},
+		{
+			name:      "malformed base ref",
+			value:     "org,repo=branch:whatever:sha",
+			expectErr: true,
+		},
+		{
+			name:      "malformed pull ref",
+			value:     "org,repo=branch:sha,1:what:ever",
+			expectErr: true,
+		},
+		{
+			name:      "malformed pull nuber",
+			value:     "org,repo=branch:sha,NaN:sha",
+			expectErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actual, err := ParseRefs(testCase.value)
+		if testCase.expectErr && err == nil {
+			t.Errorf("%s: expected an error but got none", testCase.name)
+		}
+		if !testCase.expectErr && err != nil {
+			t.Errorf("%s: expected no error but got %v", testCase.name, err)
+		}
+
+		if !testCase.expectErr && !reflect.DeepEqual(actual, testCase.expected) {
+			t.Errorf("%s: incorrect refs parsed:\nexpected\n\t%v,\ngot:\n\t%v", testCase.name, testCase.expected, actual)
+		}
+	}
+}

--- a/prow/pod-utils/clone/types.go
+++ b/prow/pod-utils/clone/types.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clone
+
+import (
+	"k8s.io/test-infra/prow/kube"
+)
+
+// Record is a trace of what the desired
+// git state was, what steps we took to get there,
+// and whether or not we were successful.
+type Record struct {
+	Refs     kube.Refs `json:"refs"`
+	Commands []Command `json:"commands"`
+	Failed   bool      `json:"failed"`
+}
+
+// Command is a trace of a command executed
+// while achieving the desired git state.
+type Command struct {
+	Command string `json:"command"`
+	Output  string `json:"output,omitempty"`
+	Error   string `json:"error,omitempty"`
+}


### PR DESCRIPTION
The `clonerefs` tool uses the Prow-provided environment in `$JOB_SPEC`
as well as user-provided flags to determine which repositories to clone
and what refs to check out in those repositories. Failures in the clone
process will not kill the tool, so a set of successful and failed clones
can be reported via the output JSON file.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/area prow
/cc @fejta @kargakis @spxtr 
/assign @BenTheElder @cjwagner 

The original DD said that this program should never exit non-zero but I'm not entirely certain how we can do that and somehow still manage to communicate the fact that something went wrong to a downstream container. We do not exit with a non-zero status if we encounter an error cloning things, but if we hit an error *e.g.* writing to the JSON file we use as outut... not sure we can successfully continue in the job anyway.